### PR TITLE
Hotfix for non whitelisted devices

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/TimeVariables.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/TimeVariables.kt
@@ -187,7 +187,7 @@ object TimeVariables {
             .toMutableList()
 
         // by default the tracing is deactivated
-        // if the API is reachable we set the value accordingly
+        // if the API is reachable we set the value accordingly 
         var enIsEnabled = false
 
         try {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/TimeVariables.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/TimeVariables.kt
@@ -1,6 +1,9 @@
 package de.rki.coronawarnapp.risk
 
+import com.google.android.gms.common.api.ApiException
 import de.rki.coronawarnapp.CoronaWarnApplication
+import de.rki.coronawarnapp.exception.ExceptionCategory
+import de.rki.coronawarnapp.exception.report
 import de.rki.coronawarnapp.nearby.InternalExposureNotificationClient
 import de.rki.coronawarnapp.storage.LocalData
 import de.rki.coronawarnapp.storage.tracing.TracingIntervalRepository
@@ -183,9 +186,20 @@ object TimeVariables {
             .getIntervals()
             .toMutableList()
 
-        if (!InternalExposureNotificationClient.asyncIsEnabled()) {
+        // by default the tracing is deactivated
+        // if the API is reachable we set the value accordingly
+        var enIsEnabled = false
+
+        try {
+            enIsEnabled = !InternalExposureNotificationClient.asyncIsEnabled()
+        } catch (e: ApiException) {
+            e.report(ExceptionCategory.EXPOSURENOTIFICATION)
+        }
+
+        if (enIsEnabled) {
             val current = System.currentTimeMillis()
-            var lastTimeTracingWasNotActivated = LocalData.lastNonActiveTracingTimestamp() ?: current
+            var lastTimeTracingWasNotActivated =
+                LocalData.lastNonActiveTracingTimestamp() ?: current
 
             if (lastTimeTracingWasNotActivated < (current - getTimeRangeFromRetentionPeriod())) {
                 lastTimeTracingWasNotActivated = current - getTimeRangeFromRetentionPeriod()
@@ -193,6 +207,7 @@ object TimeVariables {
 
             inactiveTracingIntervals.add(Pair(lastTimeTracingWasNotActivated, current))
         }
+
         val finalTracingMS = tracingActiveMS - inactiveTracingIntervals
             .map { it.second - it.first }
             .sum()


### PR DESCRIPTION
fix that caused a crash for non whitelisted devices during the calculation of the active tracing time in the retention period