### PR TITLE
Removed unnecessary space in DSGVO notice

### DIFF
--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -228,7 +228,7 @@
     <string name="onboarding_body_emphasized">@string/lorem_ipsum</string>
     <!-- 2 Privacy -->
     <string name="onboarding_privacy_headline">Datenschutz</string>
-    <string name="onboarding_privacy_subtitle">Verantwortliche Stelle im Sinne des Art. 4 Abs. 7 DSGVO: \n \n Robert Koch-Institut\nNordufer 20\n13353 Berlin</string>
+    <string name="onboarding_privacy_subtitle">Verantwortliche Stelle im Sinne des Art. 4 Abs. 7 DSGVO: \n \nRobert Koch-Institut\nNordufer 20\n13353 Berlin</string>
     <string name="onboarding_privacy_body">@string/lorem_ipsum</string>
     <string name="onboarding_privacy_body_emphasized">@string/lorem_ipsum</string>
     <!-- 3 Permission -->


### PR DESCRIPTION


 * No related issue.
 * The removed space caused a mis-alignment of the text:
![Screenshot_20200531-124623](https://user-images.githubusercontent.com/1698836/83351035-eb5a0080-a340-11ea-9819-7f56db43edb5.png)