### PR TITLE
Added a loading indicator to the test result fragment

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/TestResultStatus.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/TestResultStatus.kt
@@ -1,5 +1,0 @@
-package de.rki.coronawarnapp.ui.submission
-
-enum class TestResultStatus {
-    IDLE, STARTED, FAILED, SUCCESS
-}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/formatter/FormatterSubmissionHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/formatter/FormatterSubmissionHelper.kt
@@ -7,15 +7,17 @@ import android.view.View
 import de.rki.coronawarnapp.CoronaWarnApplication
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.ui.submission.ApiRequestState
-import de.rki.coronawarnapp.ui.submission.TestResultStatus
 import de.rki.coronawarnapp.util.formatter.TestResult.INVALID
 import de.rki.coronawarnapp.util.formatter.TestResult.NEGATIVE
 import de.rki.coronawarnapp.util.formatter.TestResult.PENDING
 import de.rki.coronawarnapp.util.formatter.TestResult.POSITIVE
 import java.util.Date
 
-fun formatTestResultStatusVisibility(testResultStatus: TestResultStatus?): Int =
-    formatVisibility(testResultStatus != TestResultStatus.SUCCESS)
+fun formatTestResultSpinnerVisible(testResultStatus: ApiRequestState?): Int =
+    formatVisibility(testResultStatus != ApiRequestState.SUCCESS)
+
+fun formatTestResultVisible(testResultStatus: ApiRequestState?): Int =
+    formatVisibility(testResultStatus == ApiRequestState.SUCCESS)
 
 fun formatTestResultVirusNameTextVisible(testResult: TestResult?): Int {
     return when (testResult) {

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_test_result.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_test_result.xml
@@ -26,11 +26,23 @@
             app:layout_constraintTop_toTopOf="parent"
             app:title="@{@string/submission_test_result_headline}" />
 
+        <ProgressBar
+            android:id="@+id/submission_test_result_spinner"
+            style="?android:attr/progressBarStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="@{FormatterSubmissionHelper.formatTestResultSpinnerVisible(submissionViewModel.testResultState)}"
+            app:layout_constraintBottom_toBottomOf="@+id/submission_test_result_button_container"
+            app:layout_constraintEnd_toStartOf="@+id/submission_test_result_guideline_end"
+            app:layout_constraintStart_toStartOf="@+id/submission_test_result_guideline_start"
+            app:layout_constraintTop_toTopOf="@+id/submission_test_result_guideline_top" />
+
         <ScrollView
             android:layout_width="@dimen/match_constraint"
             android:layout_height="@dimen/match_constraint"
             android:layout_marginBottom="@dimen/spacing_normal"
             android:fillViewport="true"
+            android:visibility="@{FormatterSubmissionHelper.formatTestResultVisible(submissionViewModel.testResultState)}"
             app:layout_constraintBottom_toTopOf="@+id/submission_test_result_button_container"
             app:layout_constraintEnd_toStartOf="@+id/submission_test_result_guideline_end"
             app:layout_constraintStart_toStartOf="@+id/submission_test_result_guideline_start"
@@ -113,6 +125,7 @@
             android:id="@+id/submission_test_result_button_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:visibility="@{FormatterSubmissionHelper.formatTestResultVisible(submissionViewModel.testResultState)}"
             app:layout_constraintBottom_toBottomOf="@id/submission_test_result_guideline_bottom">
 
             <Button


### PR DESCRIPTION
## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes #41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [ ] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [x] Make sure that your PR is not introducing _unncessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [x] Check our [Contribution Guidelines](https://github.com/corona-warn-app/cwa-app-android/blob/master/CONTRIBUTING.md)

## Description
This PR adds a loading indicator to the test result fragment
![image](https://user-images.githubusercontent.com/65888067/83510159-d3af8300-a4cc-11ea-924c-6a6db8f643fd.png)

