### PR TITLE
readable ktlint output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ subprojects {
     ktlint {
         debug = true
         ignoreFailures = false
+        coloredOutput = false
     }
 }
 


### PR DESCRIPTION
## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes #41)
* [x] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [x] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [x] Make sure that your PR is not introducing _unncessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [x] Check our [Contribution Guidelines](https://github.com/corona-warn-app/cwa-app-android/blob/master/CONTRIBUTING.md)

## Description
This is a small change but I found this very annoying... this PR disables colored output of the ktlint plugin. As a result, the content of `build/reports/ktlint/ktlintMainSourceSetCheck.txt` changes from

```
[90m <file-path>/[0mSubmissionTanFragment.kt[90m:[0m29[90m:1:[0m Needless blank line(s)
```

to 

````
<file-path>/SubmissionTanFragment.kt:29:1: Needless blank line(s)
````