### PR TITLE
Limit number of keys to be uploaded to server

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/transaction/SubmitDiagnosisKeysTransaction.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/transaction/SubmitDiagnosisKeysTransaction.kt
@@ -7,6 +7,7 @@ import de.rki.coronawarnapp.transaction.SubmitDiagnosisKeysTransaction.SubmitDia
 import de.rki.coronawarnapp.transaction.SubmitDiagnosisKeysTransaction.SubmitDiagnosisKeysTransactionState.RETRIEVE_TAN
 import de.rki.coronawarnapp.transaction.SubmitDiagnosisKeysTransaction.SubmitDiagnosisKeysTransactionState.RETRIEVE_TEMPORARY_EXPOSURE_KEY_HISTORY
 import de.rki.coronawarnapp.transaction.SubmitDiagnosisKeysTransaction.SubmitDiagnosisKeysTransactionState.SUBMIT_KEYS
+import de.rki.coronawarnapp.util.ProtoFormatConverterExtensions.limitKeyCount
 import de.rki.coronawarnapp.util.ProtoFormatConverterExtensions.transformKeyHistoryToExternalFormat
 
 /**
@@ -58,6 +59,7 @@ object SubmitDiagnosisKeysTransaction : Transaction() {
          ****************************************************/
         val temporaryExposureKeyList = executeState(RETRIEVE_TEMPORARY_EXPOSURE_KEY_HISTORY) {
             InternalExposureNotificationClient.asyncGetTemporaryExposureKeyHistory()
+                .limitKeyCount()
                 .transformKeyHistoryToExternalFormat()
         }
         /****************************************************

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ProtoFormatConverterExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ProtoFormatConverterExtensions.kt
@@ -9,6 +9,10 @@ object ProtoFormatConverterExtensions {
 
     private const val ROLLING_PERIOD = 144
     private const val DEFAULT_TRANSMISSION_RISK_LEVEL = 1
+    private const val MAXIMUM_KEYS = 14
+
+    fun List<TemporaryExposureKey>.limitKeyCount() =
+        this.sortedWith(compareBy({it.rollingStartIntervalNumber})).asReversed().take(MAXIMUM_KEYS)
 
     fun List<TemporaryExposureKey>.transformKeyHistoryToExternalFormat() = this.map {
         KeyExportFormat.TemporaryExposureKey.newBuilder()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ProtoFormatConverterExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ProtoFormatConverterExtensions.kt
@@ -12,7 +12,7 @@ object ProtoFormatConverterExtensions {
     private const val MAXIMUM_KEYS = 14
 
     fun List<TemporaryExposureKey>.limitKeyCount() =
-        this.sortedWith(compareBy({it.rollingStartIntervalNumber})).asReversed().take(MAXIMUM_KEYS)
+        this.sortedWith(compareBy({ it.rollingStartIntervalNumber })).asReversed().take(MAXIMUM_KEYS)
 
     fun List<TemporaryExposureKey>.transformKeyHistoryToExternalFormat() = this.map {
         KeyExportFormat.TemporaryExposureKey.newBuilder()


### PR DESCRIPTION
* the backend accepts at most 14 keys, therefore the keys are now being sorted and limited, so that if more keys are provided, the oldest one are not being sent.