### PR TITLE
Verification process error handling

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/service/submission/SubmissionService.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/service/submission/SubmissionService.kt
@@ -49,7 +49,7 @@ object SubmissionService {
         deleteTeleTAN()
     }
 
-    suspend fun asyncRequestAuthCode(registrationToken : String): String {
+    suspend fun asyncRequestAuthCode(registrationToken: String): String {
         val authCode = WebRequestBuilder.asyncGetTan(TAN_REQUEST_URL, registrationToken)
         return authCode
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/service/submission/SubmissionService.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/service/submission/SubmissionService.kt
@@ -49,10 +49,7 @@ object SubmissionService {
         deleteTeleTAN()
     }
 
-    suspend fun asyncRequestAuthCode(): String {
-        val registrationToken =
-            LocalData.registrationToken() ?: throw NoRegistrationTokenSetException()
-
+    suspend fun asyncRequestAuthCode(registrationToken : String): String {
         val authCode = WebRequestBuilder.asyncGetTan(TAN_REQUEST_URL, registrationToken)
         return authCode
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/transaction/SubmitDiagnosisKeysTransaction.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/transaction/SubmitDiagnosisKeysTransaction.kt
@@ -52,7 +52,7 @@ object SubmitDiagnosisKeysTransaction : Transaction() {
          * RETRIEVE TAN
          ****************************************************/
         val authCode = executeState(RETRIEVE_TAN) {
-            SubmissionService.asyncRequestAuthCode()
+            SubmissionService.asyncRequestAuthCode(registrationToken)
         }
         /****************************************************
          * RETRIEVE TEMPORARY EXPOSURE KEY HISTORY

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -473,5 +473,9 @@
     <string name="test_api_body_my_keys">My keys (count: %1$d) </string>
     <string name="test_api_body_other_keys">Other key </string>
     <string name="test_api_calculate_risk_level">Calculate Risk Level</string>
+    <string name="submission_en_disabled_dialog_headline">Bitte einschalten</string>
+    <string name="submission_en_disabled_dialog_body">Die Risiko-Ermittlung muss aktiv sein, damit die Schlüssel übertragen werden können. Wollen Sie den entsprechenden Dialog öffnen?</string>
+    <string name="submission_en_disabled_dialog_button_positive">Ja</string>
+    <string name="submission_en_disabled_dialog_button_negative">Nein</string>
 
 </resources>


### PR DESCRIPTION
* Show a dialog if users try to submit their diagnosis keys, even though the exposure notification framework is disabled
* Texts are still WiP