### PR TITLE
Null View Bindings when view is destroyed (closes #104)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/TestForAPIFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/TestForAPIFragment.kt
@@ -102,7 +102,8 @@ class TestForAPIFragment : Fragment(), InternalExposureNotificationPermissionHel
     private val tracingViewModel: TracingViewModel by activityViewModels()
 
     // Data and View binding
-    private lateinit var binding: FragmentTestForAPIBinding
+    private var _binding: FragmentTestForAPIBinding? = null
+    private val binding: FragmentTestForAPIBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -111,7 +112,7 @@ class TestForAPIFragment : Fragment(), InternalExposureNotificationPermissionHel
     ): View? {
 
         // get the binding reference by inflating it with the current layout
-        binding = FragmentTestForAPIBinding.inflate(inflater)
+        _binding = FragmentTestForAPIBinding.inflate(inflater)
 
         // set the viewmmodel variable that will be used for data binding
         binding.tracingViewModel = tracingViewModel
@@ -121,6 +122,11 @@ class TestForAPIFragment : Fragment(), InternalExposureNotificationPermissionHel
 
         // Inflate the layout for this fragment
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/TestRiskLevelCalculation.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/TestRiskLevelCalculation.kt
@@ -54,19 +54,25 @@ class TestRiskLevelCalculation : Fragment() {
     private val tracingViewModel: TracingViewModel by activityViewModels()
     private val settingsViewModel: SettingsViewModel by activityViewModels()
     private val submissionViewModel: SubmissionViewModel by activityViewModels()
-    private lateinit var binding: FragmentTestRiskLevelCalculationBinding
+    private var _binding: FragmentTestRiskLevelCalculationBinding? = null
+    private val binding: FragmentTestRiskLevelCalculationBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentTestRiskLevelCalculationBinding.inflate(inflater)
+        _binding = FragmentTestRiskLevelCalculationBinding.inflate(inflater)
         binding.tracingViewModel = tracingViewModel
         binding.settingsViewModel = settingsViewModel
         binding.submissionViewModel = submissionViewModel
         binding.lifecycleOwner = this
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/information/InformationAboutFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/information/InformationAboutFragment.kt
@@ -16,18 +16,25 @@ class InformationAboutFragment : BaseFragment() {
         private val TAG: String? = InformationAboutFragment::class.simpleName
     }
 
-    private lateinit var binding: FragmentInformationAboutBinding
+    private var _binding: FragmentInformationAboutBinding? = null
+    private val binding: FragmentInformationAboutBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentInformationAboutBinding.inflate(inflater)
+        _binding = FragmentInformationAboutBinding.inflate(inflater)
         return binding.root
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         setButtonOnClickListener()
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/information/InformationContactFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/information/InformationContactFragment.kt
@@ -18,18 +18,25 @@ class InformationContactFragment : BaseFragment() {
         private val TAG: String? = InformationContactFragment::class.simpleName
     }
 
-    private lateinit var binding: FragmentInformationContactBinding
+    private var _binding: FragmentInformationContactBinding? = null
+    private val binding: FragmentInformationContactBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentInformationContactBinding.inflate(inflater)
+        _binding = FragmentInformationContactBinding.inflate(inflater)
         return binding.root
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         setButtonOnClickListener()
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/information/InformationFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/information/InformationFragment.kt
@@ -18,18 +18,25 @@ class InformationFragment : BaseFragment() {
         private val TAG: String? = InformationFragment::class.simpleName
     }
 
-    private lateinit var binding: FragmentInformationBinding
+    private var _binding: FragmentInformationBinding? = null
+    private val binding: FragmentInformationBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentInformationBinding.inflate(inflater)
+        _binding = FragmentInformationBinding.inflate(inflater)
         return binding.root
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         setButtonOnClickListener()
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/information/InformationLegalFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/information/InformationLegalFragment.kt
@@ -16,18 +16,25 @@ class InformationLegalFragment : BaseFragment() {
         private val TAG: String? = InformationLegalFragment::class.simpleName
     }
 
-    private lateinit var binding: FragmentInformationLegalBinding
+    private var _binding: FragmentInformationLegalBinding? = null
+    private val binding: FragmentInformationLegalBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentInformationLegalBinding.inflate(inflater)
+        _binding = FragmentInformationLegalBinding.inflate(inflater)
         return binding.root
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         setButtonOnClickListener()
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/information/InformationPrivacyFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/information/InformationPrivacyFragment.kt
@@ -16,18 +16,25 @@ class InformationPrivacyFragment : BaseFragment() {
         private val TAG: String? = InformationPrivacyFragment::class.simpleName
     }
 
-    private lateinit var binding: FragmentInformationPrivacyBinding
+    private var _binding: FragmentInformationPrivacyBinding? = null
+    private val binding: FragmentInformationPrivacyBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentInformationPrivacyBinding.inflate(inflater)
+        _binding = FragmentInformationPrivacyBinding.inflate(inflater)
         return binding.root
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         setButtonOnClickListener()
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/information/InformationTechnicalFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/information/InformationTechnicalFragment.kt
@@ -16,18 +16,25 @@ class InformationTechnicalFragment : BaseFragment() {
         private val TAG: String? = InformationTechnicalFragment::class.simpleName
     }
 
-    private lateinit var binding: FragmentInformationTechnicalBinding
+    private var _binding: FragmentInformationTechnicalBinding? = null
+    private val binding: FragmentInformationTechnicalBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentInformationTechnicalBinding.inflate(inflater)
+        _binding = FragmentInformationTechnicalBinding.inflate(inflater)
         return binding.root
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         setButtonOnClickListener()
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/information/InformationTermsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/information/InformationTermsFragment.kt
@@ -16,18 +16,25 @@ class InformationTermsFragment : BaseFragment() {
         private val TAG: String? = InformationTermsFragment::class.simpleName
     }
 
-    private lateinit var binding: FragmentInformationTermsBinding
+    private var _binding: FragmentInformationTermsBinding? = null
+    private val binding: FragmentInformationTermsBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentInformationTermsBinding.inflate(inflater)
+        _binding = FragmentInformationTermsBinding.inflate(inflater)
         return binding.root
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         setButtonOnClickListener()
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainFragment.kt
@@ -38,19 +38,25 @@ class MainFragment : BaseFragment() {
     private val tracingViewModel: TracingViewModel by activityViewModels()
     private val settingsViewModel: SettingsViewModel by activityViewModels()
     private val submissionViewModel: SubmissionViewModel by activityViewModels()
-    private lateinit var binding: FragmentMainBinding
+    private var _binding: FragmentMainBinding? = null
+    private val binding: FragmentMainBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentMainBinding.inflate(inflater)
+        _binding = FragmentMainBinding.inflate(inflater)
         binding.tracingViewModel = tracingViewModel
         binding.settingsViewModel = settingsViewModel
         binding.submissionViewModel = submissionViewModel
         binding.lifecycleOwner = this
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainOverviewFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainOverviewFragment.kt
@@ -20,15 +20,21 @@ class MainOverviewFragment : BaseFragment() {
         private val TAG: String? = MainOverviewFragment::class.simpleName
     }
 
-    private lateinit var binding: FragmentMainOverviewBinding
+    private var _binding: FragmentMainOverviewBinding? = null
+    private val binding: FragmentMainOverviewBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentMainOverviewBinding.inflate(inflater)
+        _binding = FragmentMainOverviewBinding.inflate(inflater)
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainShareFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainShareFragment.kt
@@ -23,17 +23,23 @@ class MainShareFragment : BaseFragment() {
     }
 
     private val tracingViewModel: TracingViewModel by activityViewModels()
-    private lateinit var binding: FragmentMainShareBinding
+    private var _binding: FragmentMainShareBinding? = null
+    private val binding: FragmentMainShareBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentMainShareBinding.inflate(inflater)
+        _binding = FragmentMainShareBinding.inflate(inflater)
         binding.tracingViewModel = tracingViewModel
         binding.lifecycleOwner = this
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingFragment.kt
@@ -15,15 +15,21 @@ class OnboardingFragment : BaseFragment() {
         private val TAG: String? = OnboardingFragment::class.simpleName
     }
 
-    private lateinit var binding: FragmentOnboardingBinding
+    private var _binding: FragmentOnboardingBinding? = null
+    private val binding: FragmentOnboardingBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentOnboardingBinding.inflate(inflater)
+        _binding = FragmentOnboardingBinding.inflate(inflater)
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingNotificationsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingNotificationsFragment.kt
@@ -20,15 +20,21 @@ class OnboardingNotificationsFragment : BaseFragment() {
         private val TAG: String? = OnboardingNotificationsFragment::class.simpleName
     }
 
-    private lateinit var binding: FragmentOnboardingNotificationsBinding
+    private var _binding: FragmentOnboardingNotificationsBinding? = null
+    private val binding: FragmentOnboardingNotificationsBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentOnboardingNotificationsBinding.inflate(inflater)
+        _binding = FragmentOnboardingNotificationsBinding.inflate(inflater)
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingPrivacyFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingPrivacyFragment.kt
@@ -15,15 +15,21 @@ class OnboardingPrivacyFragment : BaseFragment() {
         private val TAG: String? = OnboardingPrivacyFragment::class.simpleName
     }
 
-    private lateinit var binding: FragmentOnboardingPrivacyBinding
+    private var _binding: FragmentOnboardingPrivacyBinding? = null
+    private val binding: FragmentOnboardingPrivacyBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentOnboardingPrivacyBinding.inflate(inflater)
+        _binding = FragmentOnboardingPrivacyBinding.inflate(inflater)
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingTestFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingTestFragment.kt
@@ -15,15 +15,21 @@ class OnboardingTestFragment : BaseFragment() {
         private val TAG: String? = OnboardingTestFragment::class.simpleName
     }
 
-    private lateinit var binding: FragmentOnboardingTestBinding
+    private var _binding: FragmentOnboardingTestBinding? = null
+    private val binding: FragmentOnboardingTestBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentOnboardingTestBinding.inflate(inflater)
+        _binding = FragmentOnboardingTestBinding.inflate(inflater)
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingTracingFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingTracingFragment.kt
@@ -26,7 +26,8 @@ class OnboardingTracingFragment : BaseFragment(),
     }
 
     private lateinit var internalExposureNotificationPermissionHelper: InternalExposureNotificationPermissionHelper
-    private lateinit var binding: FragmentOnboardingTracingBinding
+    private var _binding: FragmentOnboardingTracingBinding? = null
+    private val binding: FragmentOnboardingTracingBinding get() = _binding!!
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         internalExposureNotificationPermissionHelper.onResolutionComplete(
@@ -46,8 +47,13 @@ class OnboardingTracingFragment : BaseFragment(),
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentOnboardingTracingBinding.inflate(inflater)
+        _binding = FragmentOnboardingTracingBinding.inflate(inflater)
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/riskdetails/RiskDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/riskdetails/RiskDetailsFragment.kt
@@ -26,21 +26,28 @@ class RiskDetailsFragment : BaseFragment() {
 
     private val tracingViewModel: TracingViewModel by activityViewModels()
     private val settingsViewModel: SettingsViewModel by activityViewModels()
-    private lateinit var binding: FragmentRiskDetailsBinding
+    private var _binding: FragmentRiskDetailsBinding? = null
+    private val binding: FragmentRiskDetailsBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentRiskDetailsBinding.inflate(inflater)
+        _binding = FragmentRiskDetailsBinding.inflate(inflater)
         binding.tracingViewModel = tracingViewModel
         binding.settingsViewModel = settingsViewModel
         binding.lifecycleOwner = this
         return binding.root
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         setButtonOnClickListeners()
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsFragment.kt
@@ -25,18 +25,24 @@ class SettingsFragment : BaseFragment() {
 
     private val tracingViewModel: TracingViewModel by activityViewModels()
     private val settingsViewModel: SettingsViewModel by activityViewModels()
-    private lateinit var binding: FragmentSettingsBinding
+    private var _binding: FragmentSettingsBinding? = null
+    private val binding: FragmentSettingsBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentSettingsBinding.inflate(inflater)
+        _binding = FragmentSettingsBinding.inflate(inflater)
         binding.tracingViewModel = tracingViewModel
         binding.settingsViewModel = settingsViewModel
         binding.lifecycleOwner = this
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsNotificationFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsNotificationFragment.kt
@@ -26,17 +26,23 @@ class SettingsNotificationFragment : Fragment() {
     }
 
     private val settingsViewModel: SettingsViewModel by activityViewModels()
-    private lateinit var binding: FragmentSettingsNotificationsBinding
+    private var _binding: FragmentSettingsNotificationsBinding? = null
+    private val binding: FragmentSettingsNotificationsBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentSettingsNotificationsBinding.inflate(inflater)
+        _binding = FragmentSettingsNotificationsBinding.inflate(inflater)
         binding.settingsViewModel = settingsViewModel
         binding.lifecycleOwner = this
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsResetFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsResetFragment.kt
@@ -30,15 +30,21 @@ class SettingsResetFragment : BaseFragment() {
         private val TAG: String? = SettingsResetFragment::class.simpleName
     }
 
-    private lateinit var binding: FragmentSettingsResetBinding
+    private var _binding: FragmentSettingsResetBinding? = null
+    private val binding: FragmentSettingsResetBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentSettingsResetBinding.inflate(inflater)
+        _binding = FragmentSettingsResetBinding.inflate(inflater)
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsTracingFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsTracingFragment.kt
@@ -39,7 +39,8 @@ class SettingsTracingFragment : BaseFragment(),
 
     private val tracingViewModel: TracingViewModel by activityViewModels()
     private val settingsViewModel: SettingsViewModel by activityViewModels()
-    private lateinit var binding: FragmentSettingsTracingBinding
+    private var _binding: FragmentSettingsTracingBinding? = null
+    private val binding: FragmentSettingsTracingBinding get() = _binding!!
 
     private lateinit var internalExposureNotificationPermissionHelper: InternalExposureNotificationPermissionHelper
 
@@ -48,14 +49,20 @@ class SettingsTracingFragment : BaseFragment(),
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentSettingsTracingBinding.inflate(inflater)
+        _binding = FragmentSettingsTracingBinding.inflate(inflater)
         binding.tracingViewModel = tracingViewModel
         binding.settingsViewModel = settingsViewModel
         binding.lifecycleOwner = this
         return binding.root
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         setButtonOnClickListener()
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/SubmissionContactFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/SubmissionContactFragment.kt
@@ -15,7 +15,8 @@ import de.rki.coronawarnapp.util.CallHelper
  */
 class SubmissionContactFragment : BaseFragment() {
 
-    private lateinit var binding: FragmentSubmissionContactBinding
+    private var _binding: FragmentSubmissionContactBinding? = null
+    private val binding: FragmentSubmissionContactBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -23,8 +24,13 @@ class SubmissionContactFragment : BaseFragment() {
         savedInstanceState: Bundle?
     ): View? {
         // get the binding reference by inflating it with the current layout
-        binding = FragmentSubmissionContactBinding.inflate(inflater)
+        _binding = FragmentSubmissionContactBinding.inflate(inflater)
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/SubmissionDispatcherFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/SubmissionDispatcherFragment.kt
@@ -16,16 +16,22 @@ class SubmissionDispatcherFragment : BaseFragment() {
         private val TAG: String? = SubmissionDispatcherFragment::class.simpleName
     }
 
-    private lateinit var binding: FragmentSubmissionDispatcherBinding
+    private var _binding: FragmentSubmissionDispatcherBinding? = null
+    private val binding: FragmentSubmissionDispatcherBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentSubmissionDispatcherBinding.inflate(inflater)
+        _binding = FragmentSubmissionDispatcherBinding.inflate(inflater)
         binding.lifecycleOwner = this
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/SubmissionDoneFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/SubmissionDoneFragment.kt
@@ -12,7 +12,8 @@ import de.rki.coronawarnapp.ui.BaseFragment
  */
 class SubmissionDoneFragment : BaseFragment() {
 
-    private lateinit var binding: FragmentSubmissionDoneBinding
+    private var _binding: FragmentSubmissionDoneBinding? = null
+    private val binding: FragmentSubmissionDoneBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -20,8 +21,13 @@ class SubmissionDoneFragment : BaseFragment() {
         savedInstanceState: Bundle?
     ): View? {
         // get the binding reference by inflating it with the current layout
-        binding = FragmentSubmissionDoneBinding.inflate(inflater)
+        _binding = FragmentSubmissionDoneBinding.inflate(inflater)
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/SubmissionIntroFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/SubmissionIntroFragment.kt
@@ -12,7 +12,8 @@ import de.rki.coronawarnapp.ui.BaseFragment
  */
 class SubmissionIntroFragment : BaseFragment() {
 
-    private lateinit var binding: FragmentSubmissionIntroBinding
+    private var _binding: FragmentSubmissionIntroBinding? = null
+    private val binding: FragmentSubmissionIntroBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -20,8 +21,13 @@ class SubmissionIntroFragment : BaseFragment() {
         savedInstanceState: Bundle?
     ): View? {
         // get the binding reference by inflating it with the current layout
-        binding = FragmentSubmissionIntroBinding.inflate(inflater)
+        _binding = FragmentSubmissionIntroBinding.inflate(inflater)
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/SubmissionQRCodeScanFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/SubmissionQRCodeScanFragment.kt
@@ -29,14 +29,15 @@ class SubmissionQRCodeScanFragment : BaseFragment() {
     }
 
     private val viewModel: SubmissionViewModel by viewModels()
-    private lateinit var binding: FragmentSubmissionQrCodeScanBinding
+    private var _binding: FragmentSubmissionQrCodeScanBinding? = null
+    private val binding: FragmentSubmissionQrCodeScanBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentSubmissionQrCodeScanBinding.inflate(inflater)
+        _binding = FragmentSubmissionQrCodeScanBinding.inflate(inflater)
         binding.lifecycleOwner = this
         return binding.root
     }
@@ -47,6 +48,11 @@ class SubmissionQRCodeScanFragment : BaseFragment() {
 
     private fun startDecode() {
         binding.submissionQrCodeScanPreview.decodeSingle { decodeCallback(it) }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/SubmissionRegisterDeviceFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/SubmissionRegisterDeviceFragment.kt
@@ -12,16 +12,22 @@ import de.rki.coronawarnapp.ui.viewmodel.SubmissionViewModel
 
 class SubmissionRegisterDeviceFragment : BaseFragment() {
     private val viewModel: SubmissionViewModel by activityViewModels()
-    private lateinit var binding: FragmentSubmissionRegisterDeviceBinding
+    private var _binding: FragmentSubmissionRegisterDeviceBinding? = null
+    private val binding: FragmentSubmissionRegisterDeviceBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = FragmentSubmissionRegisterDeviceBinding.inflate(inflater)
+        _binding = FragmentSubmissionRegisterDeviceBinding.inflate(inflater)
         binding.lifecycleOwner = this
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/SubmissionResultPositiveOtherWarningFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/SubmissionResultPositiveOtherWarningFragment.kt
@@ -25,7 +25,8 @@ class SubmissionResultPositiveOtherWarningFragment : BaseFragment(),
     private val submissionViewModel: SubmissionViewModel by activityViewModels()
     private val tracingViewModel: TracingViewModel by activityViewModels()
 
-    private lateinit var binding: FragmentSubmissionPositiveOtherWarningBinding
+    private var _binding: FragmentSubmissionPositiveOtherWarningBinding? = null
+    private val binding: FragmentSubmissionPositiveOtherWarningBinding get() = _binding!!
     private var submissionRequested = false
     private var submissionFailed = false
     private lateinit var internalExposureNotificationPermissionHelper:
@@ -55,9 +56,14 @@ class SubmissionResultPositiveOtherWarningFragment : BaseFragment(),
     ): View? {
         internalExposureNotificationPermissionHelper =
             InternalExposureNotificationPermissionHelper(this, this)
-        binding = FragmentSubmissionPositiveOtherWarningBinding.inflate(inflater)
+        _binding = FragmentSubmissionPositiveOtherWarningBinding.inflate(inflater)
         binding.lifecycleOwner = this
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/SubmissionSuccessDialogFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/SubmissionSuccessDialogFragment.kt
@@ -18,7 +18,8 @@ class SubmissionSuccessDialogFragment : DialogFragment() {
         private val TAG: String? = SubmissionSuccessDialogFragment::class.simpleName
     }
 
-    private lateinit var binding: FragmentSubmissionDialogBinding
+    private var _binding: FragmentSubmissionDialogBinding? = null
+    private val binding: FragmentSubmissionDialogBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -26,10 +27,15 @@ class SubmissionSuccessDialogFragment : DialogFragment() {
         savedInstanceState: Bundle?
     ): View? {
         // get the binding reference by inflating it with the current layout
-        binding = FragmentSubmissionDialogBinding.inflate(inflater)
+        _binding = FragmentSubmissionDialogBinding.inflate(inflater)
 
         // Inflate the layout for this fragment
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/SubmissionTanFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/SubmissionTanFragment.kt
@@ -14,7 +14,8 @@ import de.rki.coronawarnapp.ui.BaseFragment
 class SubmissionTanFragment : BaseFragment() {
 
     private val viewModel: SubmissionTanViewModel by activityViewModels()
-    private lateinit var binding: FragmentSubmissionTanBinding
+    private var _binding: FragmentSubmissionTanBinding? = null
+    private val binding: FragmentSubmissionTanBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -22,10 +23,15 @@ class SubmissionTanFragment : BaseFragment() {
         savedInstanceState: Bundle?
     ): View? {
         // get the binding reference by inflating it with the current layout
-        binding = FragmentSubmissionTanBinding.inflate(inflater)
+        _binding = FragmentSubmissionTanBinding.inflate(inflater)
         binding.viewmodel = viewModel
         binding.lifecycleOwner = this
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/SubmissionTestResultFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/SubmissionTestResultFragment.kt
@@ -23,7 +23,8 @@ class SubmissionTestResultFragment : BaseFragment() {
     private val submissionViewModel: SubmissionViewModel by activityViewModels()
     private val tracingViewModel: TracingViewModel by activityViewModels()
 
-    private lateinit var binding: FragmentSubmissionTestResultBinding
+    private var _binding: FragmentSubmissionTestResultBinding? = null
+    private val binding: FragmentSubmissionTestResultBinding get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -31,11 +32,16 @@ class SubmissionTestResultFragment : BaseFragment() {
         savedInstanceState: Bundle?
     ): View? {
         // get the binding reference by inflating it with the current layout
-        binding = FragmentSubmissionTestResultBinding.inflate(inflater)
+        _binding = FragmentSubmissionTestResultBinding.inflate(inflater)
         binding.submissionViewModel = submissionViewModel
         binding.lifecycleOwner = this
         // Inflate the layout for this fragment
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {


### PR DESCRIPTION
## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [x] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [x] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)

## Description
This PR nulls view bindings when the view is destroyed. It also includes missing super.onViewCreated(view, savedInstanceState) calls for consistency throughout the codebase
