### PR TITLE
fix typo: consistent naming of Corona-Warn-App

### DIFF
--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -133,9 +133,9 @@
     <string name="notification_id">
         <xliff:g id="notification_id">1</xliff:g>
     </string>
-    <string name="notification_name">Corona Warn App</string>
-    <string name="notification_description">Benachrichtigungen aus der Corona Warn App.</string>
-    <string name="notification_headline">Corona-Warn App</string>
+    <string name="notification_name">Corona-Warn-App</string>
+    <string name="notification_description">Benachrichtigungen aus der Corona-Warn-App.</string>
+    <string name="notification_headline">Corona-Warn-App</string>
     <string name="notification_body">Es gibt Neuigkeiten von Ihrer Corona-Warn-App</string>
 
     <!-- ####################################


### PR DESCRIPTION
<!-- 
Thank you for supporting us with your Pull Request! 🙌 ❤️  
Before submitting, please take the time to check the points below and provide some descriptive information.
-->

## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)

## Description
fix typo: most of the time, the app is called Corona-Warn-App
