### PR TITLE
Added relative date formatting to risk card via DateUtils

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/formatter/FormatterRiskHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/formatter/FormatterRiskHelper.kt
@@ -9,7 +9,6 @@ import android.text.format.DateUtils
 import de.rki.coronawarnapp.CoronaWarnApplication
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.risk.RiskLevelConstants
-import java.text.DateFormat
 import java.util.Date
 
 /*Texter*/
@@ -191,7 +190,6 @@ fun formatRiskActiveTracingDaysInRetentionPeriod(
         else -> ""
     }
 }
-
 
 fun formatRelativeDateTimeString(appContext: Context, date: Date): CharSequence? =
     DateUtils.getRelativeDateTimeString(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/formatter/FormatterRiskHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/formatter/FormatterRiskHelper.kt
@@ -2,8 +2,10 @@
 
 package de.rki.coronawarnapp.util.formatter
 
+import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.drawable.Drawable
+import android.text.format.DateUtils
 import de.rki.coronawarnapp.CoronaWarnApplication
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.risk.RiskLevelConstants
@@ -190,6 +192,16 @@ fun formatRiskActiveTracingDaysInRetentionPeriod(
     }
 }
 
+
+fun formatRelativeDateTimeString(appContext: Context, date: Date): CharSequence? =
+    DateUtils.getRelativeDateTimeString(
+        appContext,
+        date.time,
+        DateUtils.DAY_IN_MILLIS,
+        DateUtils.DAY_IN_MILLIS * 2,
+        0
+    )
+
 /**
  * Formats the risk card text display of the last time diagnosis keys were
  * successfully fetched from the server
@@ -211,9 +223,7 @@ fun formatTimeFetched(
             if (lastTimeDiagnosisKeysFetched != null) {
                 appContext.getString(
                     R.string.risk_card_body_time_fetched,
-                    DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM).format(
-                        lastTimeDiagnosisKeysFetched
-                    )
+                    formatRelativeDateTimeString(appContext, lastTimeDiagnosisKeysFetched)
                 )
             } else {
                 appContext.getString(R.string.risk_card_body_not_yet_fetched)
@@ -228,10 +238,7 @@ fun formatTimeFetched(
                     if (lastTimeDiagnosisKeysFetched != null) {
                         appContext.getString(
                             R.string.risk_card_body_time_fetched,
-                            DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM)
-                                .format(
-                                    lastTimeDiagnosisKeysFetched
-                                )
+                            formatRelativeDateTimeString(appContext, lastTimeDiagnosisKeysFetched)
                         )
                     } else {
                         appContext.getString(R.string.risk_card_body_not_yet_fetched)


### PR DESCRIPTION
## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [ ] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [x] Make sure that your PR does not contain changes in strings.xml (see issue #72)
* [x] Make sure that your PR does not contain compiled sources (already set by the default .gitignore) and / or binary files

## Description
This PR adds support for relative time strings to the risk status card