### PR TITLE
Fix: Risk details back icon color

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/fragment_risk_details.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_risk_details.xml
@@ -51,7 +51,7 @@
                     android:layout_height="@dimen/icon_size_button"
                     android:contentDescription="@{@string/accessibility_back}"
                     android:src="@{@drawable/ic_close}"
-                    android:tint="@{FormatterRiskHelper.formatStableIconColor(tracingViewModel.riskLevel)}"
+                    android:tint="@{FormatterRiskHelper.formatStableTextColor(tracingViewModel.riskLevel)}"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
Exchanged formatter for the back icon in risk details.
![image](https://user-images.githubusercontent.com/64483219/84117275-90579600-aa31-11ea-83a4-0e76f8180750.png)
![image](https://user-images.githubusercontent.com/64483219/84117456-d44a9b00-aa31-11ea-848a-5ec5a879d0e5.png)

