### PR TITLE
Delay for Diagnosis Keys retrieval set to 2 hours (contributes to corona-warn-app/cwa-documentation#236)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/TimeVariables.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/TimeVariables.kt
@@ -93,18 +93,18 @@ object TimeVariables {
     private const val MILISECONDS_IN_A_SECOND = 1000
     private const val SECONDS_IN_A_MINUTES = 60
     private const val MINUTES_IN_AN_HOUR = 60
-    private const val HOURS_IN_AN_DAY = 24
+    private const val KEY_RETRIEVAL_DELAY_HOURS = 2
 
     /**
      * Delay in milliseconds for manual key retrieval process
      * Value for testing: 1 min =  1000 * 60 * 1
-     * Value: 24 hours = 1000 * 60 * 60 * 24 milliseconds
+     * Value: 2 hours = 1000 * 60 * 60 * 2 milliseconds
      */
     private val MANUAL_KEY_RETRIEVAL_DELAY =
         if (BuildConfig.FLAVOR == "deviceForTesters") {
             MILISECONDS_IN_A_SECOND * SECONDS_IN_A_MINUTES
         } else {
-            MILISECONDS_IN_A_SECOND * SECONDS_IN_A_MINUTES * MINUTES_IN_AN_HOUR * HOURS_IN_AN_DAY
+            MILISECONDS_IN_A_SECOND * SECONDS_IN_A_MINUTES * MINUTES_IN_AN_HOUR * KEY_RETRIEVAL_DELAY_HOURS
         }
 
     /**


### PR DESCRIPTION
<!-- 
Thank you for supporting us with your Pull Request! 🙌 ❤️  
Before submitting, please take the time to check the points below and provide some descriptive information.
-->

## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [x] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [x] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [x] Make sure that your PR does not contain changes in strings.xml (see issue #332)
* [x] Make sure that your PR does not contain compiled sources (already set by the default .gitignore) and / or binary files

## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->

Currently Diagnosis Keys are only fetched every 24 hours, which introduces additional 24 hours delay in exposure notification in a worst-case scenario (last synchronization performed just before relevant Diagnosis Key became available). Decreasing this value to 2 hours also decreases introduced delay to 2 hours in worst-case, and aligns Android implementation with [current iOS implementation](https://github.com/corona-warn-app/cwa-app-ios/blob/6c7878166df0aeb16fac019730007ecf64e479ff/src/xcode/ENA/ENA/Source/Models/Task%20Scheduling/ENATaskScheduler.swift#L28).

Contributes to corona-warn-app/cwa-documentation#236
