### PR TITLE
Fetch Diagnosis Keys for current day (contributes to corona-warn-app/cwa-documentation#236)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CachedKeyFileHolder.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CachedKeyFileHolder.kt
@@ -104,12 +104,14 @@ object CachedKeyFileHolder {
                         .map { url -> async { url.createDayEntryForUrl() } }
                 )
             }
+            // there is no check if the date is available, since we want to get
+            // Diagnosis Keys for a day which is not yet complete
             val missingHours = getMissingHoursFromDiff(currentDate)
             if (missingHours.isNotEmpty()) {
                 deferredQueries.addAll(
                     missingHours
                         .map { getURLForHour(currentDate.toServerFormat(), it) }
-                        .map { url -> async { url.createHourEntryForUrl() }}
+                        .map { url -> async { url.createHourEntryForUrl() } }
                 )
             }
             // execute the query plan

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CachedKeyFileHolder.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CachedKeyFileHolder.kt
@@ -143,6 +143,8 @@ object CachedKeyFileHolder {
 
     /**
      * Calculates the missing hours based on current missing entries in the cache
+     *
+     * @param day current day
      */
     private suspend fun getMissingHoursFromDiff(day: Date): List<String> {
         val cacheEntries = keyCache.getHours()
@@ -183,6 +185,7 @@ object CachedKeyFileHolder {
      * given from the URL that is based on this String
      *
      * @param cache the given cache entries
+     * @param day current day
      */
     private fun String.hourEntryCacheMiss(cache: List<KeyCacheEntity>, day: Date) = !cache
         .map { hour -> hour.id }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/CachedKeyFileHolderTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/CachedKeyFileHolderTest.kt
@@ -48,10 +48,12 @@ class CachedKeyFileHolderTest {
         val date = Date()
 
         coEvery { keyCacheRepository.getDates() } returns listOf()
+        coEvery { keyCacheRepository.getHours() } returns listOf()
         coEvery { keyCacheRepository.getFilesFromEntries() } returns listOf()
         every { CachedKeyFileHolder["isLast3HourFetchEnabled"]() } returns false
         every { CachedKeyFileHolder["checkForFreeSpace"]() } returns Unit
         every { CachedKeyFileHolder["getDatesFromServer"]() } returns arrayListOf<String>()
+        every { CachedKeyFileHolder["getHoursFromServer"](any<Date>()) } returns arrayListOf<String>()
 
         runBlocking {
 
@@ -63,6 +65,8 @@ class CachedKeyFileHolderTest {
                 keyCacheRepository.deleteOutdatedEntries()
                 CachedKeyFileHolder["getMissingDaysFromDiff"](arrayListOf<String>())
                 keyCacheRepository.getDates()
+                CachedKeyFileHolder["getMissingHoursFromDiff"](any<Date>())
+                keyCacheRepository.getHours()
                 keyCacheRepository.getFilesFromEntries()
             }
         }


### PR DESCRIPTION
<!-- 
Thank you for supporting us with your Pull Request! 🙌 ❤️  
Before submitting, please take the time to check the points below and provide some descriptive information.
-->

## Checklist

* [ ] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [x] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [x] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [x] Make sure that your PR does not contain changes in strings.xml (see issue #332)
* [x] Make sure that your PR does not contain compiled sources (already set by the default .gitignore) and / or binary files

## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->

Currently only daily bundles of Diagnosis Keys are fetched, which introduces in worst-case additional 24 hours delay in exposure notification. Fetching hourly Diagnosis Keys decreases this delay and aligns Android implementation with [iOS implementation](https://github.com/corona-warn-app/cwa-app-ios/blob/6c7878166df0aeb16fac019730007ecf64e479ff/src/xcode/ENA/ENA/Source/Client/Client.swift#L216).

Unit test is extended but I have not tested it with live API.

Contributes to corona-warn-app/cwa-documentation#236
