### PR TITLE
fixed fake key submission not setting the cwa-fake header correctly

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/http/WebRequestBuilder.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/http/WebRequestBuilder.kt
@@ -179,8 +179,7 @@ class WebRequestBuilder(
         val submissionPayload = KeyExportFormat.SubmissionPayload.newBuilder()
             .addAllKeys(keyList)
             .build()
-        var fakeHeader = "0"
-        if (faked) fakeHeader = Math.random().toInt().toString()
+        val fakeHeader = if (faked) "1" else "0"
         submissionService.submitKeys(
             DiagnosisKeyConstants.DIAGNOSIS_KEYS_SUBMISSION_URL,
             authCode,


### PR DESCRIPTION
## Description
This PR accompanies issue #448, which discusses a potential oversight in the code, that could result in a bug later on. In short, Math.random().toInt().toString() will always be evaluated to "0", which defeats the point of the faked parameter.

In the checklist above, the check mark for the tests is missing, since there currently is no code path that executes the problematic statement.