### PR TITLE
Added Dockerfile for Reproducible Builds #467

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:20.04
+
+
+RUN apt-get update -y && \
+    apt-get install -y software-properties-common && \
+    apt-get update -y && \
+    apt-get install -y \
+        openjdk-8-jdk \
+        wget unzip && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get autoremove -y && \
+    apt-get clean
+
+ENV ANDROID_SDK_FILENAME android-sdk_r24.4.1-linux.tgz
+ENV ANDROID_SDK_URL https://dl.google.com/android/${ANDROID_SDK_FILENAME}
+ENV ANDROID_API_LEVELS android-29
+ENV ANDROID_BUILD_TOOLS_VERSION 29.0.3
+ENV ANDROID_HOME /usr/local/android-sdk-linux
+ENV PATH ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools
+RUN cd /usr/local/ && \
+    wget -q ${ANDROID_SDK_URL} && \
+    tar -xzf ${ANDROID_SDK_FILENAME} && \
+    rm ${ANDROID_SDK_FILENAME} 
+RUN echo y | android update sdk --no-ui -a --filter ${ANDROID_API_LEVELS}
+RUN echo y | android update sdk --no-ui -a --filter extra-android-m2repository,extra-android-support,extra-google-google_play_services,extra-google-m2repository
+RUN echo y | android update sdk --no-ui -a --filter tools,platform-tools,build-tools-${ANDROID_BUILD_TOOLS_VERSION}
+RUN rm -rf ${ANDROID_HOME}/tools && unzip ${ANDROID_HOME}/temp/*.zip -d ${ANDROID_HOME}


### PR DESCRIPTION
# Description

This concerns #467 

In order to make builds reproducible, a stable build environment is needed. This Dockerfile aims to provide such an environment.

I verified that it is possible to build the app using this Image (`docker build -t cwa . && docker run --rm -v $(pwd):/project -w /project cwa ./gradlew quickBuild`)

I didn't verify that the produced build is indeed deterministic.

The Dockerfile is inspired by https://github.com/signalapp/Signal-Android/blob/master/Dockerfile but I'm not sure if a licence notice is needed, since it differs substiancially. If it is needed, i'll be glad to add one.