### PR TITLE
Disallow scrolling tan entry text view (closes #546)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/view/UnscrollableEditText.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/view/UnscrollableEditText.kt
@@ -2,9 +2,10 @@ package de.rki.coronawarnapp.ui.view
 
 import android.content.Context
 import android.util.AttributeSet
+import androidx.appcompat.widget.AppCompatEditText
 
 class UnscrollableEditText(context: Context, attributeSet: AttributeSet) :
-    androidx.appcompat.widget.AppCompatEditText(context, attributeSet) {
+    AppCompatEditText(context, attributeSet) {
     override fun onSelectionChanged(selStart: Int, selEnd: Int) {
         super.onSelectionChanged(selStart, selEnd)
         text?.length?.let { setSelection(it) }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/view/UnscrollableEditText.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/view/UnscrollableEditText.kt
@@ -1,0 +1,12 @@
+package de.rki.coronawarnapp.ui.view
+
+import android.content.Context
+import android.util.AttributeSet
+
+class UnscrollableEditText(context: Context, attributeSet: AttributeSet) :
+    androidx.appcompat.widget.AppCompatEditText(context, attributeSet) {
+    override fun onSelectionChanged(selStart: Int, selEnd: Int) {
+        super.onSelectionChanged(selStart, selEnd)
+        text?.length?.let { setSelection(it) }
+    }
+}

--- a/Corona-Warn-App/src/main/res/layout/view_tan_input_edittext.xml
+++ b/Corona-Warn-App/src/main/res/layout/view_tan_input_edittext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <EditText
+    <de.rki.coronawarnapp.ui.view.UnscrollableEditText
         android:id="@+id/tan_input_edittext"
         style="@style/tanInputEdittext" />
 


### PR DESCRIPTION
## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [x] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) (if applicable)
* [ ] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [x] Make sure that your PR does not contain changes in strings.xml (see issue #332)
* [x] Make sure that your PR does not contain compiled sources (already set by the default .gitignore) and / or binary files

## Description
This PR fixes #546 by implementing and using a new EditText that resets selection on selection changed events.
