### PR TITLE
Drop WindowManager.LayoutParams - FLAG_SECURE

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/CoronaWarnApplication.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/CoronaWarnApplication.kt
@@ -95,15 +95,6 @@ class CoronaWarnApplication : Application(), LifecycleObserver,
 
     @SuppressLint("SourceLockedOrientationActivity")
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
-        // prevents screenshot of the app for all activities,
-        // except for deviceForTesters build flavor, which is used for testing
-        if (BuildConfig.FLAVOR != "deviceForTesters") {
-            activity.window.setFlags(
-                WindowManager.LayoutParams.FLAG_SECURE,
-                WindowManager.LayoutParams.FLAG_SECURE
-            )
-        }
-
         // set screen orientation to portrait
         activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT
     }


### PR DESCRIPTION
This flag makes Android prohibit the app to appear in screenshots and screencasts:

https://developer.android.com/reference/android/view/WindowManager.LayoutParams#FLAG_SECURE

Using this flag drives users who want to take screenshots/casts towards circumventing this barrier. Ways of circumventing include:

- Using another Smartphone to take a photo of the app.
- Forking, applying the proposed change and compiling the app oneself.  
  (Once there is a way to run apps like this without Google Play Services.)
- Patching the installed app using XPosed.  
  <https://repo.xposed.info/module/fi.veetipaananen.android.disableflagsecure>
- Patching the Android framework Magisk.  
  <https://forum.xda-developers.com/apps/magisk/module-smali-patcher-0-7-t3680053>

As these ways to circumvent the flag exist, using this flag is essentially useless, because an app in question might always be "insecure" in the sense of this flag. All of these ways to circumvent are bad, as the inability to take screenshots compromises the ease of use, building and sideloading the app oneself requires additional effort and patching the app or the Android framework is dangerous. Even worse, the iOS version of this app does not use the equivalent iOS functionality, which demonstrates that it is not strictly necessary. In effect, using this flag compromises the rights of the user in favor of the app's rights. This is fundamentally immoral and can thus lessen the app's acceptance. Less acceptance leads to less installations and more untraced contacts, preventable infections and - in the worst case - unnecessary death. So please stop it.