### PR TITLE
WIP: Fix tracing status, verify activity by location check (closes #491)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/TracingRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/TracingRepository.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.storage
 
 import androidx.lifecycle.MutableLiveData
+import de.rki.coronawarnapp.CoronaWarnApplication
 import de.rki.coronawarnapp.exception.ExceptionCategory
 import de.rki.coronawarnapp.exception.TransactionException
 import de.rki.coronawarnapp.exception.reporting.report
@@ -8,6 +9,7 @@ import de.rki.coronawarnapp.nearby.InternalExposureNotificationClient
 import de.rki.coronawarnapp.risk.TimeVariables.getActiveTracingDaysInRetentionPeriod
 import de.rki.coronawarnapp.transaction.RetrieveDiagnosisKeysTransaction
 import de.rki.coronawarnapp.transaction.RiskLevelTransaction
+import de.rki.coronawarnapp.util.ConnectivityHelper
 import java.util.Date
 
 /**
@@ -70,7 +72,8 @@ object TracingRepository {
     suspend fun refreshIsTracingEnabled() {
         try {
             val isEnabled = InternalExposureNotificationClient.asyncIsEnabled()
-            isTracingEnabled.value = isEnabled
+            val isActive = ConnectivityHelper.isLocationEnabled(CoronaWarnApplication.getAppContext())
+            isTracingEnabled.value = isEnabled && isActive
         } catch (e: Exception) {
             // when API is not available, ensure tracing is displayed as off
             isTracingEnabled.postValue(false)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ConnectivityHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ConnectivityHelper.kt
@@ -6,11 +6,13 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.location.LocationManager
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import android.os.Build
+import androidx.core.location.LocationManagerCompat
 import de.rki.coronawarnapp.exception.ExceptionCategory
 import de.rki.coronawarnapp.exception.reporting.report
 import timber.log.Timber
@@ -169,6 +171,17 @@ object ConnectivityHelper {
         val activeNetwork: Network? = manager.activeNetwork
         val caps: NetworkCapabilities? = manager.getNetworkCapabilities(activeNetwork)
         return caps?.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED) ?: false
+    }
+
+    /**
+     * Get location enabled status.
+     *
+     * @return current location status
+     *
+     */
+    fun isLocationEnabled(context: Context): Boolean {
+        val manager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+        return LocationManagerCompat.isLocationEnabled(manager)
     }
 
     /**


### PR DESCRIPTION
 Fix for #491

## Problem description:
Please check issue.

In short: exposure logging is shown as active even when location is disabled and hence the underlying exposure notifications is not active.

## Proposed changes
Changes are kept to an absolute minimum.
1. An additional function is added to `ConnectivityHelper` to check whether location (GPS or FINE) is turned on. Location status can be queried without requiring ANY additional permissions!
2. The location status poll is coupled together with `refreshIsTracingEnabled` in `TracingRepository`. I specifically decided to put it in that place to avoid having to maintain any objects concerning "*location*".

## Known limitations
1. No UI elements: This PR provides the minimum changes required to fix the false reporting of the exposure logging status as detailed in the issue (which I see as the priority). In the very near future, App maintainers should add UI elements to guide the user through the location activation process similar to how its done for Bluetooth. This should come with an additional help page explaining why "location" is showing up in the UI, FAQ regarding data privacy etc.. Because all of this comes with a longer review process it is not part of this PR!
2. This additional check will only function on devices running **Android 5.0** and higher. Versions below that need the location permission to ask for location status - needless to say that this is out of the equation.
3. Testing: I'm not able to test the the modified code together with Google's Exposure Notifications API, because it probably whitelists a certain signature. That's why this PR is marked as WIP. I would invite one of the SAP devs to test the change.

Thanks to @kbobrowski  and @aurisnoctis for bringing up and discussing the issue.