### PR TITLE
Added 'Check is running' card during launch time background execution after 24 hours (closes EXPOSUREAPP-1556)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/viewmodel/TracingViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/viewmodel/TracingViewModel.kt
@@ -71,6 +71,7 @@ class TracingViewModel : ViewModel() {
                         currentDate.withTimeAtStartOfDay() != lastFetch.withTimeAtStartOfDay()
                 val isNetworkEnabled = ConnectivityHelper.isNetworkEnabled(CoronaWarnApplication.getAppContext())
                 if (keysWereNotRetrievedToday && isNetworkEnabled) {
+                    TracingRepository.isRefreshing.value = true
                     RetrieveDiagnosisKeysTransaction.start()
                     refreshLastTimeDiagnosisKeysFetchedDate()
                     TimerHelper.checkManualKeyRetrievalTimer()
@@ -83,6 +84,7 @@ class TracingViewModel : ViewModel() {
             } catch (e: TransactionException) {
                 e.cause?.report(INTERNAL)
             }
+           TracingRepository.isRefreshing.value = false
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/viewmodel/TracingViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/viewmodel/TracingViewModel.kt
@@ -84,7 +84,7 @@ class TracingViewModel : ViewModel() {
             } catch (e: TransactionException) {
                 e.cause?.report(INTERNAL)
             }
-           TracingRepository.isRefreshing.value = false
+            TracingRepository.isRefreshing.value = false
         }
     }
 


### PR DESCRIPTION
## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [x] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) - Pull Requests that are not linked to an issue with you as an assignee will be closed, except for minor fixes for typos or grammar mistakes in *documentation or code comments*.
* [x] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [x] Make sure that your PR does not contain changes in text files, therefore the PR must not contain changes in values/strings/* and / or assets/* (see issue #332 for further information)
* [x] Make sure that your PR does not contain compiled sources (already set by the default .gitignore) and / or binary files

## Description
A small addition to show the 'Check is running' card when the background execution occurs at launch after a 24 hour period.

closes Jira task EXPOSUREAPP-1556 