### PR TITLE
Removed manual request of portrait screen orientation in Application class (no related issue)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/CoronaWarnApplication.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/CoronaWarnApplication.kt
@@ -1,11 +1,9 @@
 package de.rki.coronawarnapp
 
-import android.annotation.SuppressLint
 import android.app.Activity
 import android.app.Application
 import android.content.Context
 import android.content.IntentFilter
-import android.content.pm.ActivityInfo
 import android.os.Bundle
 import android.view.WindowManager
 import androidx.lifecycle.Lifecycle
@@ -93,7 +91,6 @@ class CoronaWarnApplication : Application(), LifecycleObserver,
         // does not override function. Empty on intention
     }
 
-    @SuppressLint("SourceLockedOrientationActivity")
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
         // prevents screenshot of the app for all activities,
         // except for deviceForTesters build flavor, which is used for testing
@@ -103,9 +100,6 @@ class CoronaWarnApplication : Application(), LifecycleObserver,
                 WindowManager.LayoutParams.FLAG_SECURE
             )
         }
-
-        // set screen orientation to portrait
-        activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT
     }
 
     override fun onActivityResumed(activity: Activity) {


### PR DESCRIPTION
 * Screen orientation is already set to portrait in AndroidManifest.xml
 * Since this is only a very minor change I skipped the creation of a dedicated issue

## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->

Currently, the app only supports portrait mode. Since #738, the screen orientation is now requested via the `AndroidManifext.xml` (See [l. 41](https://github.com/corona-warn-app/cwa-app-android/blob/5f7e2935ec1b0f94efdcfbd0d6370f5b168b4fd8/Corona-Warn-App/src/main/AndroidManifest.xml#L41),  [l. 51](https://github.com/corona-warn-app/cwa-app-android/blob/5f7e2935ec1b0f94efdcfbd0d6370f5b168b4fd8/Corona-Warn-App/src/main/AndroidManifest.xml#L51),  [l. 56](https://github.com/corona-warn-app/cwa-app-android/blob/5f7e2935ec1b0f94efdcfbd0d6370f5b168b4fd8/Corona-Warn-App/src/main/AndroidManifest.xml#L56)).

The only exception is `CaptureActivity` which uses `fullSensor` as seen in  [l. 61](https://github.com/corona-warn-app/cwa-app-android/blob/5f7e2935ec1b0f94efdcfbd0d6370f5b168b4fd8/Corona-Warn-App/src/main/AndroidManifest.xml#L61). 

@SebastianWolf-SAP - could you clarify on how the `CaptureActivity` should behave*? Neither before my change, nor after the change, the Capture Screen rotates to landscape (nor any other orientation). However, since the orientation is not locked via the application class's onActivty anymore, the `CaptureActivity` now should orient itself but it stays in portrait mode.

*Latest change in L61 was made by you, so I assume you are the best person to ask.