### PR TITLE
Changed time zones to UTC for checking quota reset status

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/viewmodel/TracingViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/viewmodel/TracingViewModel.kt
@@ -64,10 +64,10 @@ class TracingViewModel : ViewModel() {
             try {
 
                 // get the current date and the date the diagnosis keys were fetched the last time
-                val currentDate = DateTime(Instant.now(), DateTimeZone.getDefault())
+                val currentDate = DateTime(Instant.now(), DateTimeZone.UTC)
                 val lastFetch = DateTime(
                     LocalData.lastTimeDiagnosisKeysFromServerFetch(),
-                    DateTimeZone.getDefault()
+                    DateTimeZone.UTC
                 )
 
                 // check if the keys were not already retrieved today

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/worker/DiagnosisKeyRetrievalOneTimeWorker.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/worker/DiagnosisKeyRetrievalOneTimeWorker.kt
@@ -35,10 +35,10 @@ class DiagnosisKeyRetrievalOneTimeWorker(val context: Context, workerParams: Wor
 
         var result = Result.success()
         try {
-            val currentDate = DateTime(Instant.now(), DateTimeZone.getDefault())
+            val currentDate = DateTime(Instant.now(), DateTimeZone.UTC)
             val lastFetch = DateTime(
                 LocalData.lastTimeDiagnosisKeysFromServerFetch(),
-                DateTimeZone.getDefault()
+                DateTimeZone.UTC
             )
             if (LocalData.lastTimeDiagnosisKeysFromServerFetch() == null ||
                 currentDate.withTimeAtStartOfDay() != lastFetch.withTimeAtStartOfDay()


### PR DESCRIPTION
<!--
Thank you for supporting us with your Pull Request! 🙌 ❤️
Before submitting, please take the time to check the points below and provide some descriptive information.
-->

## Checklist

* [ ] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [x] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) - Pull Requests that are not linked to an issue with you as an assignee will be closed, except for minor fixes for typos or grammar mistakes in *documentation or code comments*.
* [x] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [x] Make sure that your PR does not contain changes in text files, therefore the PR must not contain changes in values/strings/* and / or assets/* (see issue #332 for further information)
* [x] Make sure that your PR does not contain compiled sources (already set by the default .gitignore) and / or binary files

## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->

Exposure Notifications framework is resetting quota at midnight UTC, not at midnight in current time zone. This is possibly related to the issue of error 39508 when there is no error 10: https://github.com/corona-warn-app/cwa-app-android/issues/774.

Current design allows for initiating `RetrieveDiagnosisKeysTransaction` at 15:00 CEST and then next day again at 01:00 CEST. This will result in exceeded quota, as it corresponds to 13:00 UTC and 23:00 UTC on the same day.

fix #822 
