### PR TITLE
Added info about en-i13n project which enables whitelisting the app on rooted device

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ The goal of this project is to develop the official Corona-Warn-App for Germany 
 
 ## Known Issues
 
-* The Exposure Notification API is going to block you from successfully testing the Application unless you are whitelisted inside GMS; **Shoutout to @pocmo for working on a demo mode to test unreleased app versions in advance without whitelisting (issue [#321](https://github.com/corona-warn-app/cwa-app-android/issues/321))**, if you want to contribute you can reach out [here](https://github.com/pocmo/cwa-app-android) for the time being - thank you!
+* The Exposure Notification API is going to block you from successfully testing the Application unless you are whitelisted inside GMS, possible solutions include:
+  * [en-i13n project](https://github.com/kbobrowski/en-i13n) which enables you to locally whitelist any application (requires rooted device)
+  * for non-rooted devices - **shoutout to @pocmo for working on a demo mode to test unreleased app versions in advance without whitelisting (issue [#321](https://github.com/corona-warn-app/cwa-app-android/issues/321))**, if you want to contribute you can reach out [here](https://github.com/pocmo/cwa-app-android) for the time being - thank you!
 * The Storage is currently based on Encrypted Shared Preferences and SQL Cipher (SQLite) - this could change in the future
 * Test Coverage is generally low and needs to be improved. We appreciate your help here!
 * In General every TODO comment within the code or the documentation can be regarded as an issue. You are free to tackle the TODOs anytime!


### PR DESCRIPTION
## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->

Information about [en-i13n project](https://github.com/kbobrowski/en-i13n) could be added in README, to increase awareness about possible way to become whitelisted on rooted device and test dev version of the app before it is released.

This has already proven beneficial in finding bugs responsible for #737 #822 and testing pull requests #771 #818 and probably others as well.

Would solve / contribute to solving:
- https://github.com/corona-warn-app/cwa-documentation/issues/214
- https://github.com/corona-warn-app/cwa-app-android/issues/321
- #75 
- https://github.com/corona-warn-app/cwa-backlog/issues/2
- #714 
- other issues that will come up in the future, as community would be able to test the application before it is rolled out via Play Store

This is working only by temporarily modifying Java Class Library used by GMS, and it all happens only in memory. There is no modification of GMS code, and any obfuscation that GMS is using is not revealed (full implementation of used hooks is [here](https://github.com/kbobrowski/en-i13n/blob/master/src/allow.ts)). Since it does not rely on obfuscated GMS classes it should robustly work across GMS updates without modifications.

It also allows affected Android 6 devices to patch a bug in GMS causing error 10 (#737) and successfully provide Diagnosis Keys to the framework.