### PR TITLE
Fixed tracing stop announcement and added missing links in terms and conditions (EXPOSUREAPP-1693, EXPOSUREAPP-1798)

### DIFF
--- a/Corona-Warn-App/src/main/assets/terms_de.html
+++ b/Corona-Warn-App/src/main/assets/terms_de.html
@@ -464,7 +464,7 @@
 </p>
 <p>
     Eine ausführliche Anleitung zur Einrichtung der App unter iOS und Android
-    finden Sie unter [<em>Link</em>]. Die Anleitung dient lediglich der
+    finden Sie unter https://www.coronawarn.app/de/. Die Anleitung dient lediglich der
     Erläuterung und ist nicht Teil dieser Nutzungsbedingungen.
 </p>
 <p>

--- a/Corona-Warn-App/src/main/assets/terms_tr.html
+++ b/Corona-Warn-App/src/main/assets/terms_tr.html
@@ -441,7 +441,7 @@
 </p>
 <p>
     iOS ve Android uyarınca UYGULAMA'nın ayarlanması ile ilgili ayrıntılı
-    talimatı [<em>Link</em>] bulabilirsiniz. Kılavuz sadece aydınlatma amacı
+    talimatı https://www.coronawarn.app/en/ bulabilirsiniz. Kılavuz sadece aydınlatma amacı
     taşır ve bu kullanım koşullarının bir parçası değildir.
 </p>
 <p>

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsTracingFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsTracingFragment.kt
@@ -106,9 +106,9 @@ class SettingsTracingFragment : Fragment(),
             // Make sure that listener is called by user interaction
             if (switch.tag != IGNORE_CHANGE_TAG) {
                 startStopTracing()
-                //focus on the body text after to announce the tracing status for accessibility reasons
-                binding.settingsTracingSwitchRow.settingsSwitchRowHeaderBody.
-                    sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED)
+                // Focus on the body text after to announce the tracing status for accessibility reasons
+                binding.settingsTracingSwitchRow.settingsSwitchRowHeaderBody
+                    .sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED)
             }
         }
         row.setOnClickListener {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsTracingFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsTracingFragment.kt
@@ -24,6 +24,7 @@ import de.rki.coronawarnapp.util.ExternalActionHelper
 import de.rki.coronawarnapp.util.IGNORE_CHANGE_TAG
 import de.rki.coronawarnapp.util.formatter.formatTracingSwitchEnabled
 import de.rki.coronawarnapp.worker.BackgroundWorkScheduler
+import kotlinx.android.synthetic.main.fragment_settings_tracing.view.*
 import kotlinx.coroutines.launch
 
 /**
@@ -105,6 +106,9 @@ class SettingsTracingFragment : Fragment(),
             // Make sure that listener is called by user interaction
             if (switch.tag != IGNORE_CHANGE_TAG) {
                 startStopTracing()
+                //focus on the body text after to announce the tracing status for accessibility reasons
+                binding.settingsTracingSwitchRow.settingsSwitchRowHeaderBody.sendAccessibilityEvent(AccessibilityEvent.TYPE_ANNOUNCEMENT)
+
             }
         }
         row.setOnClickListener {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsTracingFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsTracingFragment.kt
@@ -107,8 +107,8 @@ class SettingsTracingFragment : Fragment(),
             if (switch.tag != IGNORE_CHANGE_TAG) {
                 startStopTracing()
                 //focus on the body text after to announce the tracing status for accessibility reasons
-                binding.settingsTracingSwitchRow.settingsSwitchRowHeaderBody.sendAccessibilityEvent(AccessibilityEvent.TYPE_ANNOUNCEMENT)
-
+                binding.settingsTracingSwitchRow.settingsSwitchRowHeaderBody.
+                    sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED)
             }
         }
         row.setOnClickListener {


### PR DESCRIPTION
## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) - Pull Requests that are not linked to an issue with you as an assignee will be closed, except for minor fixes for typos or grammar mistakes in *documentation or code comments*.
* [ ] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [x] Make sure that your PR does not contain changes in text files, therefore the PR must not contain changes in values/strings/* and / or assets/* (see issue #332 for further information)
* [x] Make sure that your PR does not contain compiled sources (already set by the default .gitignore) and / or binary files

## Description
- replaced the placeholder link with the actual link in terms and conditions
- focused on tracing status after the switch has been clicked to announce the status after.

Closes JIRA task EXPOSUREAPP-1693 and EXPOSUREAPP-1798
