### PR TITLE
Migrating dev accessibility changes to staging (EXPOSUREAPP-1540, EXPOSUREAPP-1541, EXPOSUREAPP-1542)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/SubmissionTestResultFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/SubmissionTestResultFragment.kt
@@ -127,6 +127,8 @@ class SubmissionTestResultFragment : Fragment() {
     private fun setButtonOnClickListener() {
         binding.submissionTestResultButtonPendingRefresh.setOnClickListener {
             submissionViewModel.refreshDeviceUIState()
+            binding.submissionTestResultCard.submissionTestResultCard.testResultCard
+                .sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED)
         }
 
         binding.submissionTestResultButtonPendingRemoveTest.setOnClickListener {

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_test_result.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_test_result.xml
@@ -40,7 +40,10 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <include
+            android:id="@+id/submission_test_result_card"
             layout="@layout/include_submission_test_result"
+            android:accessibilityLiveRegion="assertive"
+            android:importantForAccessibility="yes"
             android:layout_width="@dimen/match_constraint"
             android:layout_height="@dimen/match_constraint"
             android:layout_marginBottom="@dimen/button_padding_top_bottom"

--- a/Corona-Warn-App/src/main/res/layout/include_submission_tan.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_submission_tan.xml
@@ -40,6 +40,7 @@
                 android:layout_width="@dimen/match_constraint"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_large"
+                android:importantForAccessibility="no"
                 app:layout_constraintEnd_toStartOf="@+id/guideline_end"
                 app:layout_constraintStart_toStartOf="@+id/guideline_start"
                 app:layout_constraintTop_toBottomOf="@+id/submission_tan_body" />

--- a/Corona-Warn-App/src/main/res/layout/include_submission_test_result.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_submission_test_result.xml
@@ -26,6 +26,8 @@
                 android:layout_width="@dimen/match_constraint"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_small"
+                android:focusable="true"
+                android:importantForAccessibility="yes"
                 app:deviceUIState="@{submissionViewModel.deviceUiState}"
                 app:layout_constraintEnd_toEndOf="@+id/guideline_card_end"
                 app:layout_constraintStart_toStartOf="@+id/guideline_card_start"

--- a/Corona-Warn-App/src/main/res/layout/include_test_result_card.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_test_result_card.xml
@@ -17,6 +17,7 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/test_result_card"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@drawable/card_dark"

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -87,7 +87,7 @@
     <!-- XACT: menu description for screen readers -->
     <string name="accessibility_logo">"Corona-Warn-App"</string>
     <!-- XACT: button description for screen readers to be appended at the end of content without focusable subcontent that are explored by touch -->
-    <string name="accessibility_button">"Button"</string>
+    <string name="accessibility_button">"Taste"</string>
 
     <!-- ####################################
                      Menu


### PR DESCRIPTION
## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) - Pull Requests that are not linked to an issue with you as an assignee will be closed, except for minor fixes for typos or grammar mistakes in *documentation or code comments*.
* [] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [ ] Make sure that your PR does not contain changes in text files, therefore the PR must not contain changes in values/strings/* and / or assets/* (see issue #332 for further information)
* [x] Make sure that your PR does not contain compiled sources (already set by the default .gitignore) and / or binary files

## Description
- Fixed AccessibilityEvent type in SubmisstionTestResultFragment so that the result card is focused and therefore announced.
- Changed the xml attributes of the result card so that it can be focused with an id and gave it appropriate accessibility attributes for announcement.
- added correct German translation for button
- marked importantForAccesibility to no for TAN so that the double tap to activate speech is not spoken.

Closes re-opened accessibility JIRA tasks: EXPOSUREAPP-1540, EXPOSUREAPP-1541, EXPOSUREAPP-1542