### PR TITLE
Separated logic for new day check (related issue: #912)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/viewmodel/TracingViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/viewmodel/TracingViewModel.kt
@@ -17,8 +17,6 @@ import de.rki.coronawarnapp.transaction.RiskLevelTransaction
 import de.rki.coronawarnapp.util.ConnectivityHelper
 import de.rki.coronawarnapp.util.TimeAndDateExtensions
 import kotlinx.coroutines.launch
-import org.joda.time.DateTime
-import org.joda.time.DateTimeZone
 import org.joda.time.Instant
 import timber.log.Timber
 import java.util.Date
@@ -66,7 +64,7 @@ class TracingViewModel : ViewModel() {
 
                 // check if the keys were not already retrieved today
                 val keysWereNotRetrievedToday = TimeAndDateExtensions
-                    .calculateIfCurrentTimeIsNewDay(
+                    .calculateIfGivenTimeIsNewDay(Instant.now(),
                         LocalData.lastTimeDiagnosisKeysFromServerFetch())
 
                 // check if the network is enabled to make the server fetch

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/viewmodel/TracingViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/viewmodel/TracingViewModel.kt
@@ -15,6 +15,7 @@ import de.rki.coronawarnapp.timer.TimerHelper
 import de.rki.coronawarnapp.transaction.RetrieveDiagnosisKeysTransaction
 import de.rki.coronawarnapp.transaction.RiskLevelTransaction
 import de.rki.coronawarnapp.util.ConnectivityHelper
+import de.rki.coronawarnapp.util.TimeAndDateExtensions
 import kotlinx.coroutines.launch
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
@@ -63,17 +64,10 @@ class TracingViewModel : ViewModel() {
         viewModelScope.launch {
             try {
 
-                // get the current date and the date the diagnosis keys were fetched the last time
-                val currentDate = DateTime(Instant.now(), DateTimeZone.UTC)
-                val lastFetch = DateTime(
-                    LocalData.lastTimeDiagnosisKeysFromServerFetch(),
-                    DateTimeZone.UTC
-                )
-
                 // check if the keys were not already retrieved today
-                val keysWereNotRetrievedToday =
-                    LocalData.lastTimeDiagnosisKeysFromServerFetch() == null ||
-                            currentDate.withTimeAtStartOfDay() != lastFetch.withTimeAtStartOfDay()
+                val keysWereNotRetrievedToday = TimeAndDateExtensions
+                    .calculateIfCurrentTimeIsNewDay(
+                        LocalData.lastTimeDiagnosisKeysFromServerFetch())
 
                 // check if the network is enabled to make the server fetch
                 val isNetworkEnabled =

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/TimeAndDateExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/TimeAndDateExtensions.kt
@@ -78,24 +78,34 @@ object TimeAndDateExtensions {
         return TimeUnit.MILLISECONDS.toDays(millionSeconds)
     }
 
-    private fun isDifferentDay(currentTime: Instant, referenceDate: Date,
-                               timeZone: DateTimeZone): Boolean {
+    private fun doesQuotaResetAtMidnightUTC(): Boolean {
+        return QUOTA_RESET_AT_MIDNIGHT_UTC
+    }
+
+    private fun doesQuotaResetAtMidnightLocalTime(): Boolean {
+        return QUOTA_RESET_AT_MIDNIGHT_LOCAL_TIME
+    }
+
+    private fun isDifferentDay(
+        currentTime: Instant,
+        referenceDate: Date,
+        timeZone: DateTimeZone
+    ): Boolean {
         val currentDateInTimeZone = DateTime(currentTime, timeZone)
         val referenceDateInTimeZone = DateTime(referenceDate, timeZone)
         return currentDateInTimeZone.withTimeAtStartOfDay() !=
                 referenceDateInTimeZone.withTimeAtStartOfDay()
     }
 
-    fun calculateIfCurrentTimeIsNewDay(referenceDate: Date?): Boolean {
+    fun calculateIfGivenTimeIsNewDay(now: Instant, referenceDate: Date?): Boolean {
         return if (referenceDate == null) {
             true
         } else {
-            val now = Instant.now()
             var isNewDay = true
-            if (QUOTA_RESET_AT_MIDNIGHT_UTC) {
+            if (doesQuotaResetAtMidnightUTC()) {
                 isNewDay = isNewDay && isDifferentDay(now, referenceDate, DateTimeZone.UTC)
             }
-            if (QUOTA_RESET_AT_MIDNIGHT_LOCAL_TIME) {
+            if (doesQuotaResetAtMidnightLocalTime()) {
                 isNewDay = isNewDay && isDifferentDay(now, referenceDate, DateTimeZone.getDefault())
             }
             isNewDay

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/TimeAndDateExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/TimeAndDateExtensions.kt
@@ -17,6 +17,8 @@ object TimeAndDateExtensions {
     private const val MS_TO_DAYS = (1000 * 60 * 60 * 24)
     private const val MS_TO_HOURS = (1000 * 60 * 60)
     private const val MS_TO_SECONDS = 1000
+    private const val QUOTA_RESET_AT_MIDNIGHT_UTC = true
+    private const val QUOTA_RESET_AT_MIDNIGHT_LOCAL_TIME = false
 
     fun getCurrentHourUTC(): Int = DateTime(Instant.now(), DateTimeZone.UTC).hourOfDay().get()
 
@@ -74,5 +76,29 @@ object TimeAndDateExtensions {
     fun calculateDays(firstDate: Long, secondDate: Long): Long {
         val millionSeconds = secondDate - firstDate
         return TimeUnit.MILLISECONDS.toDays(millionSeconds)
+    }
+
+    private fun isDifferentDay(currentTime: Instant, referenceDate: Date,
+                               timeZone: DateTimeZone): Boolean {
+        val currentDateInTimeZone = DateTime(currentTime, timeZone)
+        val referenceDateInTimeZone = DateTime(referenceDate, timeZone)
+        return currentDateInTimeZone.withTimeAtStartOfDay() !=
+                referenceDateInTimeZone.withTimeAtStartOfDay()
+    }
+
+    fun calculateIfCurrentTimeIsNewDay(referenceDate: Date?): Boolean {
+        return if (referenceDate == null) {
+            true
+        } else {
+            val now = Instant.now()
+            var isNewDay = true
+            if (QUOTA_RESET_AT_MIDNIGHT_UTC) {
+                isNewDay = isNewDay && isDifferentDay(now, referenceDate, DateTimeZone.UTC)
+            }
+            if (QUOTA_RESET_AT_MIDNIGHT_LOCAL_TIME) {
+                isNewDay = isNewDay && isDifferentDay(now, referenceDate, DateTimeZone.getDefault())
+            }
+            isNewDay
+        }
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/worker/DiagnosisKeyRetrievalOneTimeWorker.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/worker/DiagnosisKeyRetrievalOneTimeWorker.kt
@@ -5,9 +5,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import de.rki.coronawarnapp.storage.LocalData
 import de.rki.coronawarnapp.transaction.RetrieveDiagnosisKeysTransaction
-import org.joda.time.DateTime
-import org.joda.time.DateTimeZone
-import org.joda.time.Instant
+import de.rki.coronawarnapp.util.TimeAndDateExtensions
 import timber.log.Timber
 
 /**
@@ -35,14 +33,9 @@ class DiagnosisKeyRetrievalOneTimeWorker(val context: Context, workerParams: Wor
 
         var result = Result.success()
         try {
-            val currentDate = DateTime(Instant.now(), DateTimeZone.UTC)
-            val lastFetch = DateTime(
-                LocalData.lastTimeDiagnosisKeysFromServerFetch(),
-                DateTimeZone.UTC
-            )
-            if (LocalData.lastTimeDiagnosisKeysFromServerFetch() == null ||
-                currentDate.withTimeAtStartOfDay() != lastFetch.withTimeAtStartOfDay()
-            ) {
+            val keysWereNotRetrievedToday = TimeAndDateExtensions.calculateIfCurrentTimeIsNewDay(
+                LocalData.lastTimeDiagnosisKeysFromServerFetch())
+            if (keysWereNotRetrievedToday) {
                 RetrieveDiagnosisKeysTransaction.start()
             }
         } catch (e: Exception) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/worker/DiagnosisKeyRetrievalOneTimeWorker.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/worker/DiagnosisKeyRetrievalOneTimeWorker.kt
@@ -6,6 +6,7 @@ import androidx.work.WorkerParameters
 import de.rki.coronawarnapp.storage.LocalData
 import de.rki.coronawarnapp.transaction.RetrieveDiagnosisKeysTransaction
 import de.rki.coronawarnapp.util.TimeAndDateExtensions
+import org.joda.time.Instant
 import timber.log.Timber
 
 /**
@@ -33,7 +34,8 @@ class DiagnosisKeyRetrievalOneTimeWorker(val context: Context, workerParams: Wor
 
         var result = Result.success()
         try {
-            val keysWereNotRetrievedToday = TimeAndDateExtensions.calculateIfCurrentTimeIsNewDay(
+            val keysWereNotRetrievedToday = TimeAndDateExtensions.calculateIfGivenTimeIsNewDay(
+                Instant.now(),
                 LocalData.lastTimeDiagnosisKeysFromServerFetch())
             if (keysWereNotRetrievedToday) {
                 RetrieveDiagnosisKeysTransaction.start()

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/TimeAndDateExtensionsTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/TimeAndDateExtensionsTest.kt
@@ -2,9 +2,12 @@ package de.rki.coronawarnapp.util
 
 import de.rki.coronawarnapp.CoronaWarnApplication
 import de.rki.coronawarnapp.util.TimeAndDateExtensions.calculateDays
+import de.rki.coronawarnapp.util.TimeAndDateExtensions.calculateIfGivenTimeIsNewDay
 import de.rki.coronawarnapp.util.TimeAndDateExtensions.getCurrentHourUTC
 import io.mockk.MockKAnnotations
+import io.mockk.every
 import io.mockk.mockkObject
+import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import org.hamcrest.CoreMatchers
 import org.hamcrest.MatcherAssert
@@ -26,6 +29,9 @@ class TimeAndDateExtensionsTest {
     fun setUp() {
         MockKAnnotations.init(this)
         mockkObject(CoronaWarnApplication)
+        mockkObject(TimeAndDateExtensions)
+        mockkStatic(DateTimeZone::class)
+        every { DateTimeZone.getDefault() } returns DateTimeZone.forOffsetHours(2)
     }
 
     @Test
@@ -41,6 +47,77 @@ class TimeAndDateExtensionsTest {
 
         val result = calculateDays(firstDate = lFirstDate, secondDate = lSecondDate)
         MatcherAssert.assertThat(result, CoreMatchers.`is`(TimeUnit.MILLISECONDS.toDays(lSecondDate - lFirstDate)))
+    }
+
+    @Test
+    fun calculateIfGivenTimeIsNewDayTest() {
+        // only local time
+        every { TimeAndDateExtensions["doesQuotaResetAtMidnightUTC"]() } returns false
+        every { TimeAndDateExtensions["doesQuotaResetAtMidnightLocalTime"]() } returns true
+
+        run {
+            val now = Instant.parse("2020-01-02T01:00:00.00+02")
+            val reference = Instant.parse("2020-01-01T15:00:00.00+02").toDate()
+
+            val result = calculateIfGivenTimeIsNewDay(now, reference)
+            MatcherAssert.assertThat(result, CoreMatchers.`is`(true))
+        }
+
+        // only UTC time
+        every { TimeAndDateExtensions["doesQuotaResetAtMidnightUTC"]() } returns true
+        every { TimeAndDateExtensions["doesQuotaResetAtMidnightLocalTime"]() } returns false
+
+        run {
+            val now = Instant.parse("2020-01-02T01:00:00.00+02")
+            val reference = Instant.parse("2020-01-01T15:00:00.00+02").toDate()
+
+            val result = calculateIfGivenTimeIsNewDay(now, reference)
+            MatcherAssert.assertThat(result, CoreMatchers.`is`(false))
+        }
+
+        run {
+            val now = Instant.parse("2020-01-02T03:00:00.00+02")
+            val reference = Instant.parse("2020-01-01T15:00:00.00+02").toDate()
+
+            val result = calculateIfGivenTimeIsNewDay(now, reference)
+            MatcherAssert.assertThat(result, CoreMatchers.`is`(true))
+        }
+
+        run {
+            val now = Instant.parse("2020-01-02T03:00:00.00+02")
+            val reference = Instant.parse("2020-01-02T01:00:00.00+02").toDate()
+
+            val result = calculateIfGivenTimeIsNewDay(now, reference)
+            MatcherAssert.assertThat(result, CoreMatchers.`is`(true))
+        }
+
+        // both UTC and local time
+        every { TimeAndDateExtensions["doesQuotaResetAtMidnightUTC"]() } returns true
+        every { TimeAndDateExtensions["doesQuotaResetAtMidnightLocalTime"]() } returns true
+
+        run {
+            val now = Instant.parse("2020-01-02T01:00:00.00+02")
+            val reference = Instant.parse("2020-01-01T15:00:00.00+02").toDate()
+
+            val result = calculateIfGivenTimeIsNewDay(now, reference)
+            MatcherAssert.assertThat(result, CoreMatchers.`is`(false))
+        }
+
+        run {
+            val now = Instant.parse("2020-01-02T03:00:00.00+02")
+            val reference = Instant.parse("2020-01-01T15:00:00.00+02").toDate()
+
+            val result = calculateIfGivenTimeIsNewDay(now, reference)
+            MatcherAssert.assertThat(result, CoreMatchers.`is`(true))
+        }
+
+        run {
+            val now = Instant.parse("2020-01-02T03:00:00.00+02")
+            val reference = Instant.parse("2020-01-02T01:00:00.00+02").toDate()
+
+            val result = calculateIfGivenTimeIsNewDay(now, reference)
+            MatcherAssert.assertThat(result, CoreMatchers.`is`(false))
+        }
     }
 
     @After

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/TimeAndDateExtensionsTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/TimeAndDateExtensionsTest.kt
@@ -49,75 +49,39 @@ class TimeAndDateExtensionsTest {
         MatcherAssert.assertThat(result, CoreMatchers.`is`(TimeUnit.MILLISECONDS.toDays(lSecondDate - lFirstDate)))
     }
 
+    private fun assertNewDay(nowDateIso: String, referenceDateIso: String, isNewDay: Boolean) {
+        val now = Instant.parse(nowDateIso)
+        val reference = Instant.parse(referenceDateIso).toDate()
+
+        val result = calculateIfGivenTimeIsNewDay(now, reference)
+        MatcherAssert.assertThat(result, CoreMatchers.`is`(isNewDay))
+    }
+
     @Test
     fun calculateIfGivenTimeIsNewDayTest() {
         // only local time
         every { TimeAndDateExtensions["doesQuotaResetAtMidnightUTC"]() } returns false
         every { TimeAndDateExtensions["doesQuotaResetAtMidnightLocalTime"]() } returns true
 
-        run {
-            val now = Instant.parse("2020-01-02T01:00:00.00+02")
-            val reference = Instant.parse("2020-01-01T15:00:00.00+02").toDate()
-
-            val result = calculateIfGivenTimeIsNewDay(now, reference)
-            MatcherAssert.assertThat(result, CoreMatchers.`is`(true))
-        }
+        assertNewDay("2020-01-02T01:00:00.00+02", "2020-01-01T15:00:00.00+02", true)
+        assertNewDay("2020-01-02T03:00:00.00+02", "2020-01-01T15:00:00.00+02", true)
+        assertNewDay("2020-01-02T03:00:00.00+02", "2020-01-02T01:00:00.00+02", false)
 
         // only UTC time
         every { TimeAndDateExtensions["doesQuotaResetAtMidnightUTC"]() } returns true
         every { TimeAndDateExtensions["doesQuotaResetAtMidnightLocalTime"]() } returns false
 
-        run {
-            val now = Instant.parse("2020-01-02T01:00:00.00+02")
-            val reference = Instant.parse("2020-01-01T15:00:00.00+02").toDate()
-
-            val result = calculateIfGivenTimeIsNewDay(now, reference)
-            MatcherAssert.assertThat(result, CoreMatchers.`is`(false))
-        }
-
-        run {
-            val now = Instant.parse("2020-01-02T03:00:00.00+02")
-            val reference = Instant.parse("2020-01-01T15:00:00.00+02").toDate()
-
-            val result = calculateIfGivenTimeIsNewDay(now, reference)
-            MatcherAssert.assertThat(result, CoreMatchers.`is`(true))
-        }
-
-        run {
-            val now = Instant.parse("2020-01-02T03:00:00.00+02")
-            val reference = Instant.parse("2020-01-02T01:00:00.00+02").toDate()
-
-            val result = calculateIfGivenTimeIsNewDay(now, reference)
-            MatcherAssert.assertThat(result, CoreMatchers.`is`(true))
-        }
+        assertNewDay("2020-01-02T01:00:00.00+02", "2020-01-01T15:00:00.00+02", false)
+        assertNewDay("2020-01-02T03:00:00.00+02", "2020-01-01T15:00:00.00+02", true)
+        assertNewDay("2020-01-02T03:00:00.00+02", "2020-01-02T01:00:00.00+02", true)
 
         // both UTC and local time
         every { TimeAndDateExtensions["doesQuotaResetAtMidnightUTC"]() } returns true
         every { TimeAndDateExtensions["doesQuotaResetAtMidnightLocalTime"]() } returns true
 
-        run {
-            val now = Instant.parse("2020-01-02T01:00:00.00+02")
-            val reference = Instant.parse("2020-01-01T15:00:00.00+02").toDate()
-
-            val result = calculateIfGivenTimeIsNewDay(now, reference)
-            MatcherAssert.assertThat(result, CoreMatchers.`is`(false))
-        }
-
-        run {
-            val now = Instant.parse("2020-01-02T03:00:00.00+02")
-            val reference = Instant.parse("2020-01-01T15:00:00.00+02").toDate()
-
-            val result = calculateIfGivenTimeIsNewDay(now, reference)
-            MatcherAssert.assertThat(result, CoreMatchers.`is`(true))
-        }
-
-        run {
-            val now = Instant.parse("2020-01-02T03:00:00.00+02")
-            val reference = Instant.parse("2020-01-02T01:00:00.00+02").toDate()
-
-            val result = calculateIfGivenTimeIsNewDay(now, reference)
-            MatcherAssert.assertThat(result, CoreMatchers.`is`(false))
-        }
+        assertNewDay("2020-01-02T01:00:00.00+02", "2020-01-01T15:00:00.00+02", false)
+        assertNewDay("2020-01-02T03:00:00.00+02", "2020-01-01T15:00:00.00+02", true)
+        assertNewDay("2020-01-02T03:00:00.00+02", "2020-01-02T01:00:00.00+02", false)
     }
 
     @After


### PR DESCRIPTION
<!--
Thank you for supporting us with your Pull Request! 🙌 ❤️
Before submitting, please take the time to check the points below and provide some descriptive information.
-->

## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [x] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [x] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) - Pull Requests that are not linked to an issue with you as an assignee will be closed, except for minor fixes for typos or grammar mistakes in *documentation or code comments*.
* [x] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [x] Make sure that your PR does not contain changes in text files, therefore the PR must not contain changes in values/strings/* and / or assets/* (see issue #332 for further information)
* [x] Make sure that your PR does not contain compiled sources (already set by the default .gitignore) and / or binary files

## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->

GMS may be changing the way "day" is defined for quota on `provideDiagnosisKeys`, currently it is defined as starting and ending at midnight UTC, but it may change to local time in future versions of GMS (related issue: https://github.com/corona-warn-app/cwa-app-android/issues/912, see https://github.com/corona-warn-app/cwa-app-android/issues/912#issuecomment-663903532).

Separating logic for determining if a new day has started may make it easier to handle potential transition to new mechanism. If both `QUOTA_RESET_AT_MIDNIGHT_UTC` and `QUOTA_RESET_AT_MIDNIGHT_LOCAL_TIME` would be set to true then it should handle both mechanisms.
