### PR TITLE
fix: prevent overlapping texts for some languages (EXPOSUREAPP-1950)

### DIFF
--- a/Corona-Warn-App/src/deviceForTesters/res/layout/fragment_main.xml
+++ b/Corona-Warn-App/src/deviceForTesters/res/layout/fragment_main.xml
@@ -96,9 +96,12 @@
                     style="@style/bodyButton"
                     android:layout_width="@dimen/match_constraint"
                     android:layout_height="wrap_content"
+                    android:layout_marginEnd="@dimen/spacing_small"
                     android:focusable="false"
+                    android:contentDescription="@{FormatterSettingsHelper.formatTracingContentDescription(tracingViewModel.isTracingEnabled(), settingsViewModel.isBluetoothEnabled(), settingsViewModel.isConnectionEnabled(), settingsViewModel.isLocationEnabled())}"
                     android:text="@{FormatterSettingsHelper.formatTracingDescription(tracingViewModel.isTracingEnabled(), settingsViewModel.isBluetoothEnabled(), settingsViewModel.isConnectionEnabled(), settingsViewModel.isLocationEnabled())}"
                     app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/main_tracing_icon"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
 

--- a/Corona-Warn-App/src/main/res/layout/fragment_main.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_main.xml
@@ -101,10 +101,12 @@
                     style="@style/bodyButton"
                     android:layout_width="@dimen/match_constraint"
                     android:layout_height="wrap_content"
+                    android:layout_marginEnd="@dimen/spacing_small"
                     android:focusable="false"
                     android:contentDescription="@{FormatterSettingsHelper.formatTracingContentDescription(tracingViewModel.isTracingEnabled(), settingsViewModel.isBluetoothEnabled(), settingsViewModel.isConnectionEnabled(), settingsViewModel.isLocationEnabled())}"
                     android:text="@{FormatterSettingsHelper.formatTracingDescription(tracingViewModel.isTracingEnabled(), settingsViewModel.isBluetoothEnabled(), settingsViewModel.isConnectionEnabled(), settingsViewModel.isLocationEnabled())}"
                     app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/main_tracing_icon"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
 


### PR DESCRIPTION
- prevent overlapping text with tracing status icon [EXPOSUREAPP-1950, EXPOSUREAPP-1949]
- add a missing content description to deviceForTesters variant