### PR TITLE
Energy optimized and manual check warning dialogs (EXPOSUREAPP-1853)

### DIFF
--- a/Corona-Warn-App/src/device/java/de.rki.coronawarnapp/ui/main/MainFragment.kt
+++ b/Corona-Warn-App/src/device/java/de.rki.coronawarnapp/ui/main/MainFragment.kt
@@ -1,6 +1,9 @@
 package de.rki.coronawarnapp.ui.main
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
+import android.provider.Settings
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -19,6 +22,7 @@ import de.rki.coronawarnapp.ui.doNavigate
 import de.rki.coronawarnapp.ui.viewmodel.SettingsViewModel
 import de.rki.coronawarnapp.ui.viewmodel.SubmissionViewModel
 import de.rki.coronawarnapp.ui.viewmodel.TracingViewModel
+import de.rki.coronawarnapp.util.ConnectivityHelper
 import de.rki.coronawarnapp.util.DialogHelper
 import de.rki.coronawarnapp.util.ExternalActionHelper
 import kotlinx.coroutines.Dispatchers
@@ -71,6 +75,7 @@ class MainFragment : Fragment() {
         setContentDescription()
 
         showOneTimeTracingExplanationDialog()
+        showEnergySavingExplanationDialog()
     }
 
     override fun onResume() {
@@ -214,6 +219,40 @@ class MainFragment : Fragment() {
                             },
                             {}
                         ))
+                }
+            }
+        }
+    }
+
+
+    private fun showEnergySavingExplanationDialog() {
+
+        // check if the dialog explaining the effects of energy saver mode were already shown and if energy saver is enabled
+        if (!LocalData.energySavingExplanationDialogWasShown() && ConnectivityHelper.isEnergySaverEnabled(requireActivity())) {
+            lifecycleScope.launch {
+
+                withContext(Dispatchers.Main) {
+
+                    val dialog = DialogHelper.DialogInstance(
+                        requireActivity(),
+                        R.string.onboarding_energy_saving_dialog_headline,
+                        R.string.onboarding_energy_saving_dialog_body,
+                        R.string.onboarding_energy_saving_dialog_button_positive,
+                        R.string.onboarding_energy_saving_dialog_button_negative,
+                        false,
+                        {
+                            // go to battery saver
+                            ExternalActionHelper.toBatterySaverSettings(requireContext())
+                            LocalData.energySavingExplanationDialogWasShown(true)
+
+                        },
+                        {
+                            // keep battery saver enabled
+                            LocalData.energySavingExplanationDialogWasShown(true)
+
+                        })
+                    DialogHelper.showDialog(dialog)
+
                 }
             }
         }

--- a/Corona-Warn-App/src/device/java/de.rki.coronawarnapp/ui/main/MainFragment.kt
+++ b/Corona-Warn-App/src/device/java/de.rki.coronawarnapp/ui/main/MainFragment.kt
@@ -221,7 +221,6 @@ class MainFragment : Fragment() {
         }
     }
 
-
     private fun showEnergyOptimizedExplanationDialog() {
 
         // check if the dialog explaining the effects of energy saver mode were already shown and if energy saver is enabled
@@ -241,15 +240,12 @@ class MainFragment : Fragment() {
                             // go to battery optimization
                             ExternalActionHelper.toBatteryOptimizationSettings(requireContext())
                             LocalData.energyOptimizedExplanationDialogWasShown(true)
-
                         },
                         {
                             // keep battery optimization enabled
                             LocalData.energyOptimizedExplanationDialogWasShown(true)
-
                         })
                     DialogHelper.showDialog(dialog)
-
                 }
             }
         }

--- a/Corona-Warn-App/src/device/java/de.rki.coronawarnapp/ui/main/MainFragment.kt
+++ b/Corona-Warn-App/src/device/java/de.rki.coronawarnapp/ui/main/MainFragment.kt
@@ -25,6 +25,7 @@ import de.rki.coronawarnapp.ui.viewmodel.TracingViewModel
 import de.rki.coronawarnapp.util.ConnectivityHelper
 import de.rki.coronawarnapp.util.DialogHelper
 import de.rki.coronawarnapp.util.ExternalActionHelper
+import de.rki.coronawarnapp.util.PowerManagementHelper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -75,7 +76,7 @@ class MainFragment : Fragment() {
         setContentDescription()
 
         showOneTimeTracingExplanationDialog()
-        showEnergySavingExplanationDialog()
+        showEnergyOptimizedExplanationDialog()
     }
 
     override fun onResume() {
@@ -225,30 +226,30 @@ class MainFragment : Fragment() {
     }
 
 
-    private fun showEnergySavingExplanationDialog() {
+    private fun showEnergyOptimizedExplanationDialog() {
 
         // check if the dialog explaining the effects of energy saver mode were already shown and if energy saver is enabled
-        if (!LocalData.energySavingExplanationDialogWasShown() && ConnectivityHelper.isEnergySaverEnabled(requireActivity())) {
+        if (!LocalData.energyOptimizedExplanationDialogWasShown() && !PowerManagementHelper.isIgnoringBatteryOptimizations(requireActivity())) {
             lifecycleScope.launch {
 
                 withContext(Dispatchers.Main) {
 
                     val dialog = DialogHelper.DialogInstance(
                         requireActivity(),
-                        R.string.onboarding_energy_saving_dialog_headline,
-                        R.string.onboarding_energy_saving_dialog_body,
-                        R.string.onboarding_energy_saving_dialog_button_positive,
-                        R.string.onboarding_energy_saving_dialog_button_negative,
+                        R.string.onboarding_energy_optimized_dialog_headline,
+                        R.string.onboarding_energy_optimized_dialog_body,
+                        R.string.onboarding_energy_optimized_dialog_button_positive,
+                        R.string.onboarding_energy_optimized_dialog_button_negative,
                         false,
                         {
-                            // go to battery saver
-                            ExternalActionHelper.toBatterySaverSettings(requireContext())
-                            LocalData.energySavingExplanationDialogWasShown(true)
+                            // go to battery optimization
+                            ExternalActionHelper.toBatteryOptimizationSettings(requireContext())
+                            LocalData.energyOptimizedExplanationDialogWasShown(true)
 
                         },
                         {
-                            // keep battery saver enabled
-                            LocalData.energySavingExplanationDialogWasShown(true)
+                            // keep battery optimization enabled
+                            LocalData.energyOptimizedExplanationDialogWasShown(true)
 
                         })
                     DialogHelper.showDialog(dialog)

--- a/Corona-Warn-App/src/device/java/de.rki.coronawarnapp/ui/main/MainFragment.kt
+++ b/Corona-Warn-App/src/device/java/de.rki.coronawarnapp/ui/main/MainFragment.kt
@@ -1,9 +1,6 @@
 package de.rki.coronawarnapp.ui.main
 
-import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
-import android.provider.Settings
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -22,7 +19,6 @@ import de.rki.coronawarnapp.ui.doNavigate
 import de.rki.coronawarnapp.ui.viewmodel.SettingsViewModel
 import de.rki.coronawarnapp.ui.viewmodel.SubmissionViewModel
 import de.rki.coronawarnapp.ui.viewmodel.TracingViewModel
-import de.rki.coronawarnapp.util.ConnectivityHelper
 import de.rki.coronawarnapp.util.DialogHelper
 import de.rki.coronawarnapp.util.ExternalActionHelper
 import de.rki.coronawarnapp.util.PowerManagementHelper

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/LocalData.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/LocalData.kt
@@ -334,9 +334,9 @@ object LocalData {
      *
      * @return boolean if user has seen the energy saving explanation dialog
      */
-    fun energySavingExplanationDialogWasShown(): Boolean = getSharedPreferenceInstance().getBoolean(
+    fun energyOptimizedExplanationDialogWasShown(): Boolean = getSharedPreferenceInstance().getBoolean(
         CoronaWarnApplication.getAppContext()
-            .getString(R.string.preference_energy_saving_explanation_shown),
+            .getString(R.string.preference_energy_optimized_explanation_shown),
         false
     )
 
@@ -346,11 +346,11 @@ object LocalData {
      *
      * @param value boolean if onboarding in relation to energy saving was completed
      */
-    fun energySavingExplanationDialogWasShown(value: Boolean) =
+    fun energyOptimizedExplanationDialogWasShown(value: Boolean) =
         getSharedPreferenceInstance().edit(true) {
             putBoolean(
                 CoronaWarnApplication.getAppContext()
-                    .getString(R.string.preference_energy_saving_explanation_shown), value
+                    .getString(R.string.preference_energy_optimized_explanation_shown), value
             )
         }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/LocalData.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/LocalData.kt
@@ -328,6 +328,32 @@ object LocalData {
             )
         }
 
+    /**
+     * Gets the boolean if the user has seen the energy saving explanation dialog
+     * from the EncryptedSharedPrefs
+     *
+     * @return boolean if user has seen the energy saving explanation dialog
+     */
+    fun energySavingExplanationDialogWasShown(): Boolean = getSharedPreferenceInstance().getBoolean(
+        CoronaWarnApplication.getAppContext()
+            .getString(R.string.preference_energy_saving_explanation_shown),
+        false
+    )
+
+    /**
+     * Sets the boolean if the user has seen the energy saving explanation dialog
+     * from the EncryptedSharedPrefs
+     *
+     * @param value boolean if onboarding in relation to energy saving was completed
+     */
+    fun energySavingExplanationDialogWasShown(value: Boolean) =
+        getSharedPreferenceInstance().edit(true) {
+            putBoolean(
+                CoronaWarnApplication.getAppContext()
+                    .getString(R.string.preference_energy_saving_explanation_shown), value
+            )
+        }
+
     /****************************************************
      * SERVER FETCH DATA
      ****************************************************/

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingNotificationsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingNotificationsFragment.kt
@@ -57,6 +57,7 @@ class OnboardingNotificationsFragment : Fragment() {
     private fun setButtonOnClickListener() {
         binding.onboardingButtonNext.setOnClickListener {
             checkForBackgroundJobDisabled()
+            checkForEnergySavingEnabled()
         }
         binding.onboardingButtonBack.buttonIcon.setOnClickListener {
             (activity as OnboardingActivity).goBack()
@@ -71,7 +72,37 @@ class OnboardingNotificationsFragment : Fragment() {
         }
     }
 
+    private fun checkForEnergySavingEnabled() {
+        if (ConnectivityHelper.isEnergySaverEnabled(requireActivity())) {
+            showEnergySavingEnabledForBackground()
+        } else {
+            navigateToMain()
+        }
+    }
+
     private fun showBackgroundJobDisabledNotification() {
+        val dialog = DialogHelper.DialogInstance(
+            requireActivity(),
+            R.string.onboarding_background_fetch_dialog_headline,
+            R.string.onboarding_background_fetch_dialog_body,
+            R.string.onboarding_background_fetch_dialog_button_positive,
+            R.string.onboarding_background_fetch_dialog_button_negative,
+            false,
+            {
+                val intent = Intent(
+                    ACTION_APPLICATION_DETAILS_SETTINGS,
+                    Uri.fromParts("package", requireContext().packageName, null)
+                )
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                startActivity(intent)
+            },
+            {
+                navigateToMain()
+            })
+        DialogHelper.showDialog(dialog)
+    }
+
+    private fun showEnergySavingEnabledForBackground() {
         val dialog = DialogHelper.DialogInstance(
             requireActivity(),
             R.string.onboarding_background_fetch_dialog_headline,

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingNotificationsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingNotificationsFragment.kt
@@ -128,10 +128,7 @@ class OnboardingNotificationsFragment : Fragment() {
             {
                 // keep battery optimization enabled
                 LocalData.energyOptimizedExplanationDialogWasShown(true)
-                //HERE!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                 showManualCheckingRequiredDialog()
-                navigateToMain()
-
             })
         DialogHelper.showDialog(dialog)
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingNotificationsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingNotificationsFragment.kt
@@ -89,19 +89,16 @@ class OnboardingNotificationsFragment : Fragment() {
             R.string.onboarding_background_fetch_dialog_body,
             R.string.onboarding_background_fetch_dialog_button_positive,
             R.string.onboarding_background_fetch_dialog_button_negative,
-            false,
-            {
+            false, {
                 val intent = Intent(
                     ACTION_APPLICATION_DETAILS_SETTINGS,
                     Uri.fromParts("package", requireContext().packageName, null)
                 )
                 intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 startActivity(intent)
-
                 // show battery optimization system dialog after background processing dialog
                 checkForEnergyOptimizedEnabled()
-            },
-            {
+            }, {
                 // declined, show additional dialog explaining manual risk calculation
                 showManualCheckingRequiredDialog()
             })
@@ -115,14 +112,12 @@ class OnboardingNotificationsFragment : Fragment() {
             R.string.onboarding_energy_optimized_dialog_body,
             R.string.onboarding_energy_optimized_dialog_button_positive,
             R.string.onboarding_energy_optimized_dialog_button_negative,
-            false,
-            {
+            false, {
                 // go to battery optimization
                 ExternalActionHelper.toBatteryOptimizationSettings(requireContext())
                 LocalData.energyOptimizedExplanationDialogWasShown(true)
                 navigateToMain()
-            },
-            {
+            }, {
                 // keep battery optimization enabled
                 LocalData.energyOptimizedExplanationDialogWasShown(true)
                 showManualCheckingRequiredDialog()
@@ -137,8 +132,7 @@ class OnboardingNotificationsFragment : Fragment() {
             R.string.onboarding_manual_required_dialog_body,
             R.string.onboarding_manual_required_dialog_button,
             null,
-            false,
-            {
+            false, {
                 navigateToMain()
             }
         )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingNotificationsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingNotificationsFragment.kt
@@ -60,7 +60,6 @@ class OnboardingNotificationsFragment : Fragment() {
     private fun setButtonOnClickListener() {
         binding.onboardingButtonNext.setOnClickListener {
             checkForBackgroundJobDisabled()
-            //checkForEnergySavingEnabled()
         }
         binding.onboardingButtonBack.buttonIcon.setOnClickListener {
             (activity as OnboardingActivity).goBack()
@@ -105,7 +104,6 @@ class OnboardingNotificationsFragment : Fragment() {
             {
                 // declined, show additional dialog explaining manual risk calculation
                 showManualCheckingRequiredDialog()
-
             })
         DialogHelper.showDialog(dialog)
     }
@@ -123,7 +121,6 @@ class OnboardingNotificationsFragment : Fragment() {
                 ExternalActionHelper.toBatteryOptimizationSettings(requireContext())
                 LocalData.energyOptimizedExplanationDialogWasShown(true)
                 navigateToMain()
-
             },
             {
                 // keep battery optimization enabled

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingNotificationsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingNotificationsFragment.kt
@@ -13,8 +13,10 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.fragment.app.Fragment
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.FragmentOnboardingNotificationsBinding
+import de.rki.coronawarnapp.storage.LocalData
 import de.rki.coronawarnapp.util.ConnectivityHelper
 import de.rki.coronawarnapp.util.DialogHelper
+import de.rki.coronawarnapp.util.ExternalActionHelper
 
 /**
  * This fragment ask the user if he wants to get notifications and finishes the onboarding afterwards.
@@ -57,7 +59,7 @@ class OnboardingNotificationsFragment : Fragment() {
     private fun setButtonOnClickListener() {
         binding.onboardingButtonNext.setOnClickListener {
             checkForBackgroundJobDisabled()
-            checkForEnergySavingEnabled()
+            //checkForEnergySavingEnabled()
         }
         binding.onboardingButtonBack.buttonIcon.setOnClickListener {
             (activity as OnboardingActivity).goBack()
@@ -105,21 +107,21 @@ class OnboardingNotificationsFragment : Fragment() {
     private fun showEnergySavingEnabledForBackground() {
         val dialog = DialogHelper.DialogInstance(
             requireActivity(),
-            R.string.onboarding_background_fetch_dialog_headline,
-            R.string.onboarding_background_fetch_dialog_body,
-            R.string.onboarding_background_fetch_dialog_button_positive,
-            R.string.onboarding_background_fetch_dialog_button_negative,
+            R.string.onboarding_energy_saving_dialog_headline,
+            R.string.onboarding_energy_saving_dialog_body,
+            R.string.onboarding_energy_saving_dialog_button_positive,
+            R.string.onboarding_energy_saving_dialog_button_negative,
             false,
             {
-                val intent = Intent(
-                    ACTION_APPLICATION_DETAILS_SETTINGS,
-                    Uri.fromParts("package", requireContext().packageName, null)
-                )
-                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                startActivity(intent)
+                // go to battery saver
+                ExternalActionHelper.toBatterySaverSettings(requireContext())
+                LocalData.energySavingExplanationDialogWasShown(true)
+
             },
             {
-                navigateToMain()
+                // keep battery saver enabled
+                LocalData.energySavingExplanationDialogWasShown(true)
+
             })
         DialogHelper.showDialog(dialog)
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsTracingFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsTracingFragment.kt
@@ -188,7 +188,7 @@ class SettingsTracingFragment : Fragment(),
             null,
             false,
             {
-                //close dialog
+                // close dialog
             }
         )
         DialogHelper.showDialog(dialog)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsTracingFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsTracingFragment.kt
@@ -153,12 +153,6 @@ class SettingsTracingFragment : Fragment(),
                     BackgroundWorkScheduler.stopWorkScheduler()
                 } else {
                     // tracing was already activated
-                    // check if background processing is switched off, if it is, show the manual calculation dialog explanation before turning on.
-                    if (!PowerManagementHelper.isIgnoringBatteryOptimizations(requireActivity()))
-                    {
-                        showManualCheckingRequiredDialog()
-                    }
-
                     if (LocalData.initialTracingActivationTimestamp() != null) {
                         internalExposureNotificationPermissionHelper.requestPermissionToStartTracing()
                     } else {
@@ -166,6 +160,11 @@ class SettingsTracingFragment : Fragment(),
                         // ask for consent via dialog for initial tracing activation when tracing was not
                         // activated during onboarding
                         showConsentDialog()
+                        // check if background processing is switched off, if it is, show the manual calculation dialog explanation before turning on.
+                        if (!PowerManagementHelper.isIgnoringBatteryOptimizations(requireActivity()))
+                        {
+                            showManualCheckingRequiredDialog()
+                        }
                     }
                 }
             } catch (exception: Exception) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsTracingFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsTracingFragment.kt
@@ -23,7 +23,6 @@ import de.rki.coronawarnapp.util.DialogHelper
 import de.rki.coronawarnapp.util.ExternalActionHelper
 import de.rki.coronawarnapp.util.IGNORE_CHANGE_TAG
 import de.rki.coronawarnapp.util.PowerManagementHelper
-//import de.rki.coronawarnapp.util.*
 import de.rki.coronawarnapp.util.formatter.formatTracingSwitchEnabled
 import de.rki.coronawarnapp.worker.BackgroundWorkScheduler
 import kotlinx.coroutines.launch

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsTracingFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsTracingFragment.kt
@@ -16,14 +16,12 @@ import de.rki.coronawarnapp.exception.reporting.report
 import de.rki.coronawarnapp.nearby.InternalExposureNotificationClient
 import de.rki.coronawarnapp.nearby.InternalExposureNotificationPermissionHelper
 import de.rki.coronawarnapp.storage.LocalData
-import de.rki.coronawarnapp.storage.SettingsRepository.isLocationEnabled
 import de.rki.coronawarnapp.ui.main.MainActivity
 import de.rki.coronawarnapp.ui.viewmodel.SettingsViewModel
 import de.rki.coronawarnapp.ui.viewmodel.TracingViewModel
 import de.rki.coronawarnapp.util.*
 import de.rki.coronawarnapp.util.formatter.formatTracingSwitchEnabled
 import de.rki.coronawarnapp.worker.BackgroundWorkScheduler
-import kotlinx.android.synthetic.main.fragment_settings_tracing.view.*
 import kotlinx.coroutines.launch
 
 /**

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsTracingFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsTracingFragment.kt
@@ -20,9 +20,7 @@ import de.rki.coronawarnapp.storage.SettingsRepository.isLocationEnabled
 import de.rki.coronawarnapp.ui.main.MainActivity
 import de.rki.coronawarnapp.ui.viewmodel.SettingsViewModel
 import de.rki.coronawarnapp.ui.viewmodel.TracingViewModel
-import de.rki.coronawarnapp.util.DialogHelper
-import de.rki.coronawarnapp.util.ExternalActionHelper
-import de.rki.coronawarnapp.util.IGNORE_CHANGE_TAG
+import de.rki.coronawarnapp.util.*
 import de.rki.coronawarnapp.util.formatter.formatTracingSwitchEnabled
 import de.rki.coronawarnapp.worker.BackgroundWorkScheduler
 import kotlinx.android.synthetic.main.fragment_settings_tracing.view.*
@@ -155,6 +153,12 @@ class SettingsTracingFragment : Fragment(),
                     BackgroundWorkScheduler.stopWorkScheduler()
                 } else {
                     // tracing was already activated
+                    // check if background processing is switched off, if it is, show the manual calculation dialog explanation before turning on.
+                    if (!PowerManagementHelper.isIgnoringBatteryOptimizations(requireActivity()))
+                    {
+                        showManualCheckingRequiredDialog()
+                    }
+
                     if (LocalData.initialTracingActivationTimestamp() != null) {
                         internalExposureNotificationPermissionHelper.requestPermissionToStartTracing()
                     } else {
@@ -173,6 +177,21 @@ class SettingsTracingFragment : Fragment(),
                 )
             }
         }
+    }
+
+    private fun showManualCheckingRequiredDialog() {
+        val dialog = DialogHelper.DialogInstance(
+            requireActivity(),
+            R.string.onboarding_manual_required_dialog_headline,
+            R.string.onboarding_manual_required_dialog_body,
+            R.string.onboarding_manual_required_dialog_button,
+            null,
+            false,
+            {
+                //close dialog
+            }
+        )
+        DialogHelper.showDialog(dialog)
     }
 
     private fun showConsentDialog() {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsTracingFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsTracingFragment.kt
@@ -185,8 +185,7 @@ class SettingsTracingFragment : Fragment(),
             R.string.onboarding_manual_required_dialog_body,
             R.string.onboarding_manual_required_dialog_button,
             null,
-            false,
-            {
+            false, {
                 // close dialog
             }
         )
@@ -200,8 +199,7 @@ class SettingsTracingFragment : Fragment(),
             R.string.onboarding_tracing_body_consent,
             R.string.onboarding_button_enable,
             R.string.onboarding_button_cancel,
-            true,
-            {
+            true, {
                 internalExposureNotificationPermissionHelper.requestPermissionToStartTracing()
             }, {
                 tracingViewModel.refreshIsTracingEnabled()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsTracingFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsTracingFragment.kt
@@ -19,7 +19,11 @@ import de.rki.coronawarnapp.storage.LocalData
 import de.rki.coronawarnapp.ui.main.MainActivity
 import de.rki.coronawarnapp.ui.viewmodel.SettingsViewModel
 import de.rki.coronawarnapp.ui.viewmodel.TracingViewModel
-import de.rki.coronawarnapp.util.*
+import de.rki.coronawarnapp.util.DialogHelper
+import de.rki.coronawarnapp.util.ExternalActionHelper
+import de.rki.coronawarnapp.util.IGNORE_CHANGE_TAG
+import de.rki.coronawarnapp.util.PowerManagementHelper
+//import de.rki.coronawarnapp.util.*
 import de.rki.coronawarnapp.util.formatter.formatTracingSwitchEnabled
 import de.rki.coronawarnapp.worker.BackgroundWorkScheduler
 import kotlinx.coroutines.launch

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsTracingFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsTracingFragment.kt
@@ -162,8 +162,7 @@ class SettingsTracingFragment : Fragment(),
                         // activated during onboarding
                         showConsentDialog()
                         // check if background processing is switched off, if it is, show the manual calculation dialog explanation before turning on.
-                        if (!PowerManagementHelper.isIgnoringBatteryOptimizations(requireActivity()))
-                        {
+                        if (!PowerManagementHelper.isIgnoringBatteryOptimizations(requireActivity())) {
                             showManualCheckingRequiredDialog()
                         }
                     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ConnectivityHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ConnectivityHelper.kt
@@ -12,6 +12,7 @@ import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import android.os.Build
+import android.os.PowerManager
 import androidx.core.location.LocationManagerCompat
 import de.rki.coronawarnapp.exception.ExceptionCategory
 import de.rki.coronawarnapp.exception.reporting.report
@@ -182,6 +183,22 @@ object ConnectivityHelper {
                 null
             )
         }
+    }
+
+    /**
+     * For API level 28+ check if energy saver mode is enabled
+     * Else always return false
+     *
+     * @param context the context
+     *
+     * @return Boolean
+     *
+     * @see isEnergySaverEnabled
+     */
+    fun isEnergySaverEnabled(context: Context): Boolean {
+        val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+        Timber.d("Power Saving mode is: "+powerManager.isPowerSaveMode)
+        return powerManager.isPowerSaveMode
     }
 
     /**

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ConnectivityHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ConnectivityHelper.kt
@@ -12,7 +12,6 @@ import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import android.os.Build
-import android.os.PowerManager
 import androidx.core.location.LocationManagerCompat
 import de.rki.coronawarnapp.exception.ExceptionCategory
 import de.rki.coronawarnapp.exception.reporting.report
@@ -184,7 +183,6 @@ object ConnectivityHelper {
             )
         }
     }
-
 
     /**
      * For API level 28+ check if background is restricted

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ConnectivityHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ConnectivityHelper.kt
@@ -185,21 +185,6 @@ object ConnectivityHelper {
         }
     }
 
-    /**
-     * For API level 28+ check if energy saver mode is enabled
-     * Else always return false
-     *
-     * @param context the context
-     *
-     * @return Boolean
-     *
-     * @see isEnergySaverEnabled
-     */
-    fun isEnergySaverEnabled(context: Context): Boolean {
-        val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
-        Timber.d("Power Saving mode is: "+powerManager.isPowerSaveMode)
-        return powerManager.isPowerSaveMode
-    }
 
     /**
      * For API level 28+ check if background is restricted

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ExternalActionHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ExternalActionHelper.kt
@@ -184,4 +184,17 @@ object ExternalActionHelper {
             )
         }
     }
+
+    fun toBatterySaverSettings(context: Context) {
+        try {
+            val intent = Intent(Settings.ACTION_BATTERY_SAVER_SETTINGS)
+            context.startActivity(intent)
+        } catch (exception: Exception) {
+            // catch generic exception on settings navigation
+            // most likely due to device / rom specific intent issue
+            ExternalActionException(exception).report(
+                ExceptionCategory.UI
+            )
+        }
+    }
 }

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -415,14 +415,20 @@
     <string name="onboarding_background_fetch_dialog_button_positive">"Geräteeinstellungen öffnen"</string>
     <!-- XBUT: onboarding(tracing) - dialog about background jobs, continue in app -->
     <string name="onboarding_background_fetch_dialog_button_negative">"Risiko-Ermittlung manuell starten"</string>
-    <!-- XACT: onboarding(tracing) - dialog about energy saving header text -->
-    <string name="onboarding_energy_saving_dialog_headline">"Priorisierte Hintergrundaktivität erlauben"</string>
-    <!-- YMSI: onboarding(tracing) - dialog about energy saving -->
-    <string name="onboarding_energy_saving_dialog_body">"Schalten Sie die Optimierung des Akku-Verbrauchs aus, damit die App jederzeit Ihren Risikostatus im Hintergrund ermitteln kann (empfohlen). Wenn Sie diese Einstellung nicht machen, kann die Risiko-Ermittlung nur manuell in der App angestoßen werden."</string>
-    <!-- XBUT: onboarding(tracing) - dialog about energy saving, open device settings -->
-    <string name="onboarding_energy_saving_dialog_button_positive">"Optimierung ausschalten"</string>
-    <!-- XBUT: onboarding(tracing) - dialog about energy saving, continue in app -->
-    <string name="onboarding_energy_saving_dialog_button_negative">"Einstellungen beibehalten"</string>
+    <!-- XACT: onboarding(tracing) - dialog about energy optimized header text -->
+    <string name="onboarding_energy_optimized_dialog_headline">"Priorisierte Hintergrundaktivität erlauben"</string>
+    <!-- YMSI: onboarding(tracing) - dialog about energy optimized -->
+    <string name="onboarding_energy_optimized_dialog_body">"Schalten Sie die Optimierung des Akku-Verbrauchs aus, damit die App jederzeit Ihren Risikostatus im Hintergrund ermitteln kann (empfohlen). Wenn Sie diese Einstellung nicht machen, kann die Risiko Berechnung nur manuell in der App angestoßen werden."</string>
+    <!-- XBUT: onboarding(tracing) - dialog about energy optimized, open device settings -->
+    <string name="onboarding_energy_optimized_dialog_button_positive">"Optimierung ausschalten"</string>
+    <!-- XBUT: onboarding(tracing) - dialog about energy optimized, continue in app -->
+    <string name="onboarding_energy_optimized_dialog_button_negative">"Einstellungen beibehalten"</string>
+    <!-- XACT: onboarding(tracing) - dialog about manual checking header text -->
+    <string name="onboarding_manual_required_dialog_headline">"Priorisierte Hintergrundaktivität deaktiviert"</string>
+    <!-- YMSI: onboarding(tracing) - dialog about manual checking -->
+    <string name="onboarding_manual_required_dialog_body">"Beachten Sie, dass Sie ohne Aktivierung der priorisierten Hintergrundaktivität die App einmal am Tag aufrufen müssen, damit Ihr Risikostatus aktualisiert wird. \n\n Sie können die priorisierte Hintergrundaktivität jederzeit in Ihren Einstellungen aktivieren."</string>
+    <!-- XBUT: onboarding(tracing) - dialog about manual checking button -->
+    <string name="onboarding_manual_required_dialog_button">"Ok"</string>
     <!-- XACT: onboarding(tracing) - illustraction description, header image -->
     <string name="onboarding_tracing_illustration_description">"Drei Personen haben die Risiko-Ermittlung auf ihren Smartphones aktiviert, ihre Begegnung wird daher aufgezeichnet."</string>
     <!-- XHED: onboarding(tracing) - location explanation for bluetooth headline -->

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -135,7 +135,7 @@
     <string name="risk_card_body_contact">"Bisher keine Risiko-Begegnungen"</string>
     <!-- XTXT: risk card - number of contacts for one or more -->
     <plurals name="risk_card_body_contact_value">
-        <item quantity="one">"%1$s Risiko-Begegnung"</item>
+        <item quantity="one">"%1$s Risiko-Begegnungen mit niedrigem Risiko"</item>
         <item quantity="other">"%1$s Risiko-Begegnungen"</item>
         <item quantity="zero">"%1$s Risiko-Begegnungen"</item>
         <item quantity="two">"%1$s Risiko-Begegnungen"</item>
@@ -415,6 +415,14 @@
     <string name="onboarding_background_fetch_dialog_button_positive">"Geräteeinstellungen öffnen"</string>
     <!-- XBUT: onboarding(tracing) - dialog about background jobs, continue in app -->
     <string name="onboarding_background_fetch_dialog_button_negative">"Risiko-Ermittlung manuell starten"</string>
+    <!-- XACT: onboarding(tracing) - dialog about energy saving header text -->
+    <string name="onboarding_energy_saving_dialog_headline">"temp battery saver"</string>
+    <!-- YMSI: onboarding(tracing) - dialog about energy saving -->
+    <string name="onboarding_energy_saving_dialog_body">"temp battery saver."</string>
+    <!-- XBUT: onboarding(tracing) - dialog about energy saving, open device settings -->
+    <string name="onboarding_energy_saving_dialog_button_positive">"yes"</string>
+    <!-- XBUT: onboarding(tracing) - dialog about energy saving, continue in app -->
+    <string name="onboarding_energy_saving_dialog_button_negative">"no"</string>
     <!-- XACT: onboarding(tracing) - illustraction description, header image -->
     <string name="onboarding_tracing_illustration_description">"Drei Personen haben die Risiko-Ermittlung auf ihren Smartphones aktiviert, ihre Begegnung wird daher aufgezeichnet."</string>
     <!-- XHED: onboarding(tracing) - location explanation for bluetooth headline -->

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -135,7 +135,7 @@
     <string name="risk_card_body_contact">"Bisher keine Risiko-Begegnungen"</string>
     <!-- XTXT: risk card - number of contacts for one or more -->
     <plurals name="risk_card_body_contact_value">
-        <item quantity="one">"%1$s Risiko-Begegnungen"</item>
+        <item quantity="one">"%1$s Risiko-Begegnung"</item>
         <item quantity="other">"%1$s Risiko-Begegnungen"</item>
         <item quantity="zero">"%1$s Risiko-Begegnungen"</item>
         <item quantity="two">"%1$s Risiko-Begegnungen"</item>

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -418,15 +418,15 @@
     <!-- XACT: onboarding(tracing) - dialog about energy optimized header text -->
     <string name="onboarding_energy_optimized_dialog_headline">"Priorisierte Hintergrundaktivität erlauben"</string>
     <!-- YMSI: onboarding(tracing) - dialog about energy optimized -->
-    <string name="onboarding_energy_optimized_dialog_body">"Schalten Sie die Optimierung des Akku-Verbrauchs aus, damit die App jederzeit Ihren Risikostatus im Hintergrund ermitteln kann (empfohlen). Wenn Sie diese Einstellung nicht machen, kann die Risiko Berechnung nur manuell in der App angestoßen werden."</string>
+    <string name="onboarding_energy_optimized_dialog_body">"Erlauben Sie die priorisierte Hintergrundaktivität, damit die App jederzeit Ihren Risikostatus im Hintergrund ermitteln kann (empfohlen). Damit wird die Optimierung des Akku-Verbrauchs ausschließlich für die Corona-Warn-App deaktiviert. Ein stark erhöhter Akku-Verbrauch ist hierbei nicht zu erwarten. \n\nWenn Sie diese Einstellung nicht erlauben, müssen Sie Ihren Risikostatus manuell in der App aktualisieren."</string>
     <!-- XBUT: onboarding(tracing) - dialog about energy optimized, open device settings -->
-    <string name="onboarding_energy_optimized_dialog_button_positive">"Optimierung ausschalten"</string>
+    <string name="onboarding_energy_optimized_dialog_button_positive">"Erlauben"</string>
     <!-- XBUT: onboarding(tracing) - dialog about energy optimized, continue in app -->
-    <string name="onboarding_energy_optimized_dialog_button_negative">"Einstellungen beibehalten"</string>
+    <string name="onboarding_energy_optimized_dialog_button_negative">"Nicht erlauben"</string>
     <!-- XACT: onboarding(tracing) - dialog about manual checking header text -->
     <string name="onboarding_manual_required_dialog_headline">"Priorisierte Hintergrundaktivität deaktiviert"</string>
     <!-- YMSI: onboarding(tracing) - dialog about manual checking -->
-    <string name="onboarding_manual_required_dialog_body">"Beachten Sie, dass Sie ohne Aktivierung der priorisierten Hintergrundaktivität die App einmal am Tag aufrufen müssen, damit Ihr Risikostatus aktualisiert wird. \n\n Sie können die priorisierte Hintergrundaktivität jederzeit in Ihren Einstellungen aktivieren."</string>
+    <string name="onboarding_manual_required_dialog_body">"Beachten Sie, dass Sie ohne Aktivierung der priorisierten Hintergrundaktivität die App einmal am Tag aufrufen müssen, um Ihren Risikostatus manuell aktualisieren zu können. \n\nSie können die priorisierte Hintergrundaktivität jederzeit in Ihren Einstellungen aktivieren. "</string>
     <!-- XBUT: onboarding(tracing) - dialog about manual checking button -->
     <string name="onboarding_manual_required_dialog_button">"Ok"</string>
     <!-- XACT: onboarding(tracing) - illustraction description, header image -->

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -416,13 +416,13 @@
     <!-- XBUT: onboarding(tracing) - dialog about background jobs, continue in app -->
     <string name="onboarding_background_fetch_dialog_button_negative">"Risiko-Ermittlung manuell starten"</string>
     <!-- XACT: onboarding(tracing) - dialog about energy saving header text -->
-    <string name="onboarding_energy_saving_dialog_headline">"temp battery saver"</string>
+    <string name="onboarding_energy_saving_dialog_headline">"Priorisierte Hintergrundaktivität erlauben"</string>
     <!-- YMSI: onboarding(tracing) - dialog about energy saving -->
-    <string name="onboarding_energy_saving_dialog_body">"temp battery saver."</string>
+    <string name="onboarding_energy_saving_dialog_body">"Schalten Sie die Optimierung des Akku-Verbrauchs aus, damit die App jederzeit Ihren Risikostatus im Hintergrund ermitteln kann (empfohlen). Wenn Sie diese Einstellung nicht machen, kann die Risiko-Ermittlung nur manuell in der App angestoßen werden."</string>
     <!-- XBUT: onboarding(tracing) - dialog about energy saving, open device settings -->
-    <string name="onboarding_energy_saving_dialog_button_positive">"yes"</string>
+    <string name="onboarding_energy_saving_dialog_button_positive">"Optimierung ausschalten"</string>
     <!-- XBUT: onboarding(tracing) - dialog about energy saving, continue in app -->
-    <string name="onboarding_energy_saving_dialog_button_negative">"no"</string>
+    <string name="onboarding_energy_saving_dialog_button_negative">"Einstellungen beibehalten"</string>
     <!-- XACT: onboarding(tracing) - illustraction description, header image -->
     <string name="onboarding_tracing_illustration_description">"Drei Personen haben die Risiko-Ermittlung auf ihren Smartphones aktiviert, ihre Begegnung wird daher aufgezeichnet."</string>
     <!-- XHED: onboarding(tracing) - location explanation for bluetooth headline -->

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -135,7 +135,7 @@
     <string name="risk_card_body_contact">"Bisher keine Risiko-Begegnungen"</string>
     <!-- XTXT: risk card - number of contacts for one or more -->
     <plurals name="risk_card_body_contact_value">
-        <item quantity="one">"%1$s Risiko-Begegnungen mit niedrigem Risiko"</item>
+        <item quantity="one">"%1$s Risiko-Begegnungen"</item>
         <item quantity="other">"%1$s Risiko-Begegnungen"</item>
         <item quantity="zero">"%1$s Risiko-Begegnungen"</item>
         <item quantity="two">"%1$s Risiko-Begegnungen"</item>

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -417,12 +417,6 @@
     <string name="onboarding_background_fetch_dialog_button_positive">"Open Device Settings"</string>
     <!-- XBUT: onboarding(tracing) - dialog about background jobs, continue in app -->
     <string name="onboarding_background_fetch_dialog_button_negative">"Start Exposure Logging Manually"</string>
-    <!-- XACT: onboarding(tracing) - dialog about manual checking header text -->
-    <string name="onboarding_manual_required_dialog_headline">""</string>
-    <!-- YMSI: onboarding(tracing) - dialog about manual checking -->
-    <string name="onboarding_manual_required_dialog_body">""</string>
-    <!-- XBUT: onboarding(tracing) - dialog about manual checking button -->
-    <string name="onboarding_manual_required_dialog_button">"Ok"</string>
     <!-- XACT: onboarding(tracing) - dialog about energy optimized header text -->
     <string name="onboarding_energy_optimized_dialog_headline">""</string>
     <!-- YMSI: onboarding(tracing) - dialog about energy optimized -->
@@ -431,6 +425,12 @@
     <string name="onboarding_energy_optimized_dialog_button_positive">""</string>
     <!-- XBUT: onboarding(tracing) - dialog about energy optimized, continue in app -->
     <string name="onboarding_energy_optimized_dialog_button_negative">""</string>
+    <!-- XACT: onboarding(tracing) - dialog about manual checking header text -->
+    <string name="onboarding_manual_required_dialog_headline">""</string>
+    <!-- YMSI: onboarding(tracing) - dialog about manual checking -->
+    <string name="onboarding_manual_required_dialog_body">""</string>
+    <!-- XBUT: onboarding(tracing) - dialog about manual checking button -->
+    <string name="onboarding_manual_required_dialog_button">"Ok"</string>
     <!-- XACT: onboarding(tracing) - illustraction description, header image -->
     <string name="onboarding_tracing_illustration_description">"Three people have activated exposure logging on their devices, which will log their encounters with each other."</string>
     <!-- XHED: onboarding(tracing) - location explanation for bluetooth headline -->

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -72,7 +72,7 @@
     <!-- NOTR -->
     <string name="preference_risk_days_explanation_shown"><xliff:g id="preference">"preference_risk_days_explanation_shown"</xliff:g></string>
     <!-- NOTR -->
-    <string name="preference_energy_saving_explanation_shown"><xliff:g id="preference">"preference_energy_saving_explanation_shown"</xliff:g></string>
+    <string name="preference_energy_optimized_explanation_shown"><xliff:g id="preference">"preference_energy_optimized_explanation_shown"</xliff:g></string>
 
     <!-- ####################################
                      Generics
@@ -417,14 +417,20 @@
     <string name="onboarding_background_fetch_dialog_button_positive">"Open Device Settings"</string>
     <!-- XBUT: onboarding(tracing) - dialog about background jobs, continue in app -->
     <string name="onboarding_background_fetch_dialog_button_negative">"Start Exposure Logging Manually"</string>
-    <!-- XACT: onboarding(tracing) - dialog about energy saving header text -->
-    <string name="onboarding_energy_saving_dialog_headline">""</string>
-    <!-- YMSI: onboarding(tracing) - dialog about energy saving -->
-    <string name="onboarding_energy_saving_dialog_body">""</string>
-    <!-- XBUT: onboarding(tracing) - dialog about energy saving, open device settings -->
-    <string name="onboarding_energy_saving_dialog_button_positive">""</string>
-    <!-- XBUT: onboarding(tracing) - dialog about energy saving, continue in app -->
-    <string name="onboarding_energy_saving_dialog_button_negative">""</string>
+    <!-- XACT: onboarding(tracing) - dialog about manual checking header text -->
+    <string name="onboarding_manual_required_dialog_headline">""</string>
+    <!-- YMSI: onboarding(tracing) - dialog about manual checking -->
+    <string name="onboarding_manual_required_dialog_body">""</string>
+    <!-- XBUT: onboarding(tracing) - dialog about manual checking button -->
+    <string name="onboarding_manual_required_dialog_button">"Ok"</string>
+    <!-- XACT: onboarding(tracing) - dialog about energy optimized header text -->
+    <string name="onboarding_energy_optimized_dialog_headline">""</string>
+    <!-- YMSI: onboarding(tracing) - dialog about energy optimized -->
+    <string name="onboarding_energy_optimized_dialog_body">""</string>
+    <!-- XBUT: onboarding(tracing) - dialog about energy optimized, open device settings -->
+    <string name="onboarding_energy_optimized_dialog_button_positive">""</string>
+    <!-- XBUT: onboarding(tracing) - dialog about energy optimized, continue in app -->
+    <string name="onboarding_energy_optimized_dialog_button_negative">""</string>
     <!-- XACT: onboarding(tracing) - illustraction description, header image -->
     <string name="onboarding_tracing_illustration_description">"Three people have activated exposure logging on their devices, which will log their encounters with each other."</string>
     <!-- XHED: onboarding(tracing) - location explanation for bluetooth headline -->

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -71,6 +71,8 @@
     <string name="preference_test_result_notification"><xliff:g id="preference">"preference_test_result_notification"</xliff:g></string>
     <!-- NOTR -->
     <string name="preference_risk_days_explanation_shown"><xliff:g id="preference">"preference_risk_days_explanation_shown"</xliff:g></string>
+    <!-- NOTR -->
+    <string name="preference_energy_saving_explanation_shown"><xliff:g id="preference">"preference_energy_saving_explanation_shown"</xliff:g></string>
 
     <!-- ####################################
                      Generics
@@ -415,6 +417,14 @@
     <string name="onboarding_background_fetch_dialog_button_positive">"Open Device Settings"</string>
     <!-- XBUT: onboarding(tracing) - dialog about background jobs, continue in app -->
     <string name="onboarding_background_fetch_dialog_button_negative">"Start Exposure Logging Manually"</string>
+    <!-- XACT: onboarding(tracing) - dialog about energy saving header text -->
+    <string name="onboarding_energy_saving_dialog_headline">""</string>
+    <!-- YMSI: onboarding(tracing) - dialog about energy saving -->
+    <string name="onboarding_energy_saving_dialog_body">""</string>
+    <!-- XBUT: onboarding(tracing) - dialog about energy saving, open device settings -->
+    <string name="onboarding_energy_saving_dialog_button_positive">""</string>
+    <!-- XBUT: onboarding(tracing) - dialog about energy saving, continue in app -->
+    <string name="onboarding_energy_saving_dialog_button_negative">""</string>
     <!-- XACT: onboarding(tracing) - illustraction description, header image -->
     <string name="onboarding_tracing_illustration_description">"Three people have activated exposure logging on their devices, which will log their encounters with each other."</string>
     <!-- XHED: onboarding(tracing) - location explanation for bluetooth headline -->


### PR DESCRIPTION

## Checklist

* [x] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [x] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) - Pull Requests that are not linked to an issue with you as an assignee will be closed, except for minor fixes for typos or grammar mistakes in *documentation or code comments*.
* [ ] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [x] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [ ] Make sure that your PR does not contain changes in text files, therefore the PR must not contain changes in values/strings/* and / or assets/* (see issue #332 for further information)
* [x] Make sure that your PR does not contain compiled sources (already set by the default .gitignore) and / or binary files

## Description
- Created a Dialog in MainFragment that shows once (shared pref boolean check), and if energy-optimized mode is enabled
- Created a shared pref in local data to store if the energy -optimized warning dialog has been shown
- Added strings required for dialog (Only DE confirmed)
- Adjusted existing dialog in onboarding process
- Added second dialog explaining manual checks, this is shown during onboarding and in SettingsTracingFragment.kt when tracing is enabled when background is not prioritized. 

Closes JIRA task EXPOSUREAPP-1853