### PR TITLE
Fix looping background restricition notification in onboarding (EXPOSUREAPP-1962)

### DIFF
--- a/Corona-Warn-App/src/device/java/de.rki.coronawarnapp/ui/main/MainFragment.kt
+++ b/Corona-Warn-App/src/device/java/de.rki.coronawarnapp/ui/main/MainFragment.kt
@@ -21,7 +21,6 @@ import de.rki.coronawarnapp.ui.viewmodel.SubmissionViewModel
 import de.rki.coronawarnapp.ui.viewmodel.TracingViewModel
 import de.rki.coronawarnapp.util.DialogHelper
 import de.rki.coronawarnapp.util.ExternalActionHelper
-import de.rki.coronawarnapp.util.PowerManagementHelper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -72,7 +71,6 @@ class MainFragment : Fragment() {
         setContentDescription()
 
         showOneTimeTracingExplanationDialog()
-        showEnergyOptimizedExplanationDialog()
     }
 
     override fun onResume() {
@@ -216,36 +214,6 @@ class MainFragment : Fragment() {
                             },
                             {}
                         ))
-                }
-            }
-        }
-    }
-
-    private fun showEnergyOptimizedExplanationDialog() {
-
-        // check if the dialog explaining the effects of energy saver mode were already shown and if energy saver is enabled
-        if (!LocalData.energyOptimizedExplanationDialogWasShown() && !PowerManagementHelper.isIgnoringBatteryOptimizations(requireActivity())) {
-            lifecycleScope.launch {
-
-                withContext(Dispatchers.Main) {
-
-                    val dialog = DialogHelper.DialogInstance(
-                        requireActivity(),
-                        R.string.onboarding_energy_optimized_dialog_headline,
-                        R.string.onboarding_energy_optimized_dialog_body,
-                        R.string.onboarding_energy_optimized_dialog_button_positive,
-                        R.string.onboarding_energy_optimized_dialog_button_negative,
-                        false,
-                        {
-                            // go to battery optimization
-                            ExternalActionHelper.toBatteryOptimizationSettings(requireContext())
-                            LocalData.energyOptimizedExplanationDialogWasShown(true)
-                        },
-                        {
-                            // keep battery optimization enabled
-                            LocalData.energyOptimizedExplanationDialogWasShown(true)
-                        })
-                    DialogHelper.showDialog(dialog)
                 }
             }
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/LocalData.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/LocalData.kt
@@ -352,32 +352,6 @@ object LocalData {
             )
         }
 
-    /**
-     * Gets the boolean if the user has seen the energy saving explanation dialog
-     * from the EncryptedSharedPrefs
-     *
-     * @return boolean if user has seen the energy saving explanation dialog
-     */
-    fun energyOptimizedExplanationDialogWasShown(): Boolean = getSharedPreferenceInstance().getBoolean(
-        CoronaWarnApplication.getAppContext()
-            .getString(R.string.preference_energy_optimized_explanation_shown),
-        false
-    )
-
-    /**
-     * Sets the boolean if the user has seen the energy saving explanation dialog
-     * from the EncryptedSharedPrefs
-     *
-     * @param value boolean if onboarding in relation to energy saving was completed
-     */
-    fun energyOptimizedExplanationDialogWasShown(value: Boolean) =
-        getSharedPreferenceInstance().edit(true) {
-            putBoolean(
-                CoronaWarnApplication.getAppContext()
-                    .getString(R.string.preference_energy_optimized_explanation_shown), value
-            )
-        }
-
     /****************************************************
      * SERVER FETCH DATA
      ****************************************************/

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/LocalData.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/LocalData.kt
@@ -73,6 +73,30 @@ object LocalData {
                 .getString(R.string.preference_onboarding_completed_timestamp), value
         )
     }
+
+    /**
+     * Gets the boolean if the user has received the background warning
+     * from the EncryptedSharedPrefs
+     *
+     * @return boolean if background warning was shown
+     */
+    fun isBackgroundCheckDone(): Boolean = getSharedPreferenceInstance().getBoolean(
+        CoronaWarnApplication.getAppContext().getString(R.string.preference_background_check_done),
+        false
+    )
+
+    /**
+     * Sets the boolean if the user has received the background warning
+     * from the EncryptedSharedPrefs
+     *
+     * @param value boolean if background warning was shown
+     */
+    fun isBackgroundCheckDone(value: Boolean) = getSharedPreferenceInstance().edit(true) {
+        putBoolean(
+            CoronaWarnApplication.getAppContext()
+                .getString(R.string.preference_background_check_done), value
+        )
+    }
     /****************************************************
      * TRACING DATA
      ****************************************************/

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainActivity.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainActivity.kt
@@ -107,11 +107,9 @@ class MainActivity : AppCompatActivity() {
             R.string.onboarding_energy_optimized_dialog_button_negative,
             false, {
                 // go to battery optimization
-                ExternalActionHelper.toBatteryOptimizationSettings(this)
-                LocalData.energyOptimizedExplanationDialogWasShown(true)
+                ExternalActionHelper.disableBatteryOptimizations(this)
             }, {
                 // keep battery optimization enabled
-                LocalData.energyOptimizedExplanationDialogWasShown(true)
                 showManualCheckingRequiredDialog()
             })
         DialogHelper.showDialog(dialog)
@@ -161,7 +159,7 @@ class MainActivity : AppCompatActivity() {
     private fun checkShouldDisplayBackgroundWarning() {
         if (!LocalData.isBackgroundCheckDone()) {
             LocalData.isBackgroundCheckDone(true)
-            if (!ConnectivityHelper.isBackgroundJobEnabled(this)) {
+            if (ConnectivityHelper.isBackgroundRestricted(this)) {
                 showBackgroundJobDisabledNotification()
             } else {
                 checkForEnergyOptimizedEnabled()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingNotificationsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingNotificationsFragment.kt
@@ -1,9 +1,6 @@
 package de.rki.coronawarnapp.ui.onboarding
 
-import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
-import android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -11,13 +8,7 @@ import android.view.accessibility.AccessibilityEvent
 import androidx.appcompat.app.AlertDialog
 import androidx.core.app.NotificationManagerCompat
 import androidx.fragment.app.Fragment
-import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.FragmentOnboardingNotificationsBinding
-import de.rki.coronawarnapp.storage.LocalData
-import de.rki.coronawarnapp.util.ConnectivityHelper
-import de.rki.coronawarnapp.util.DialogHelper
-import de.rki.coronawarnapp.util.ExternalActionHelper
-import de.rki.coronawarnapp.util.PowerManagementHelper
 
 /**
  * This fragment ask the user if he wants to get notifications and finishes the onboarding afterwards.

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingNotificationsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingNotificationsFragment.kt
@@ -59,87 +59,11 @@ class OnboardingNotificationsFragment : Fragment() {
 
     private fun setButtonOnClickListener() {
         binding.onboardingButtonNext.setOnClickListener {
-            checkForBackgroundJobDisabled()
+            navigateToMain()
         }
         binding.onboardingButtonBack.buttonIcon.setOnClickListener {
             (activity as OnboardingActivity).goBack()
         }
-    }
-
-    private fun checkForBackgroundJobDisabled() {
-        if (!ConnectivityHelper.isBackgroundJobEnabled(requireActivity())) {
-            showBackgroundJobDisabledNotification()
-        } else {
-            checkForEnergyOptimizedEnabled()
-        }
-    }
-
-    private fun checkForEnergyOptimizedEnabled() {
-        if (!PowerManagementHelper.isIgnoringBatteryOptimizations(requireActivity())) {
-            showEnergyOptimizedEnabledForBackground()
-        } else {
-            navigateToMain()
-        }
-    }
-
-    private fun showBackgroundJobDisabledNotification() {
-        val dialog = DialogHelper.DialogInstance(
-            requireActivity(),
-            R.string.onboarding_background_fetch_dialog_headline,
-            R.string.onboarding_background_fetch_dialog_body,
-            R.string.onboarding_background_fetch_dialog_button_positive,
-            R.string.onboarding_background_fetch_dialog_button_negative,
-            false, {
-                val intent = Intent(
-                    ACTION_APPLICATION_DETAILS_SETTINGS,
-                    Uri.fromParts("package", requireContext().packageName, null)
-                )
-                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-
-                navigateToMain()
-
-                startActivity(intent)
-                // show battery optimization system dialog after background processing dialog
-                checkForEnergyOptimizedEnabled()
-            }, {
-                // declined, show additional dialog explaining manual risk calculation
-                showManualCheckingRequiredDialog()
-            })
-        DialogHelper.showDialog(dialog)
-    }
-
-    private fun showEnergyOptimizedEnabledForBackground() {
-        val dialog = DialogHelper.DialogInstance(
-            requireActivity(),
-            R.string.onboarding_energy_optimized_dialog_headline,
-            R.string.onboarding_energy_optimized_dialog_body,
-            R.string.onboarding_energy_optimized_dialog_button_positive,
-            R.string.onboarding_energy_optimized_dialog_button_negative,
-            false, {
-                // go to battery optimization
-                ExternalActionHelper.toBatteryOptimizationSettings(requireContext())
-                LocalData.energyOptimizedExplanationDialogWasShown(true)
-                navigateToMain()
-            }, {
-                // keep battery optimization enabled
-                LocalData.energyOptimizedExplanationDialogWasShown(true)
-                showManualCheckingRequiredDialog()
-            })
-        DialogHelper.showDialog(dialog)
-    }
-
-    private fun showManualCheckingRequiredDialog() {
-        val dialog = DialogHelper.DialogInstance(
-            requireActivity(),
-            R.string.onboarding_manual_required_dialog_headline,
-            R.string.onboarding_manual_required_dialog_body,
-            R.string.onboarding_manual_required_dialog_button,
-            null,
-            false, {
-                navigateToMain()
-            }
-        )
-        DialogHelper.showDialog(dialog)
     }
 
     private fun navigateToMain() {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingNotificationsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingNotificationsFragment.kt
@@ -95,6 +95,9 @@ class OnboardingNotificationsFragment : Fragment() {
                     Uri.fromParts("package", requireContext().packageName, null)
                 )
                 intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+
+                navigateToMain()
+
                 startActivity(intent)
                 // show battery optimization system dialog after background processing dialog
                 checkForEnergyOptimizedEnabled()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ConnectivityHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ConnectivityHelper.kt
@@ -191,14 +191,28 @@ object ConnectivityHelper {
      * @param context the context
      *
      * @return Boolean
+     */
+    fun isBackgroundRestricted(context: Context): Boolean {
+        val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            activityManager.isBackgroundRestricted
+        } else false
+    }
+
+    /**
+     * Background jobs are enabled only if the battery optimization is enabled and
+     * the background activity is not restricted
+     *
+     * @param context the context
+     *
+     * @return Boolean
      *
      * @see isBackgroundRestricted
      */
     fun isBackgroundJobEnabled(context: Context): Boolean {
-        val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            !activityManager.isBackgroundRestricted && PowerManagementHelper.isIgnoringBatteryOptimizations(context)
-        } else true
+        return !isBackgroundRestricted(context) && PowerManagementHelper.isIgnoringBatteryOptimizations(
+            context
+        )
     }
 
     /**

--- a/Corona-Warn-App/src/main/res/values-bg/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-bg/strings.xml
@@ -12,6 +12,8 @@
     <!-- NOTR -->
     <string name="preference_onboarding_completed_timestamp"><xliff:g id="preference">"preference_onboarding_completed_timestamp"</xliff:g></string>
     <!-- NOTR -->
+    <string name="preference_background_check_done"><xliff:g id="preference">"preference_background_check_done"</xliff:g></string>
+    <!-- NOTR -->
     <string name="preference_reset_app"><xliff:g id="preference">"preference_reset_app"</xliff:g></string>
     <!-- NOTR -->
     <string name="preference_only_wifi"><xliff:g id="preference">"preference_only_wifi"</xliff:g></string>

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -12,6 +12,8 @@
     <!-- NOTR -->
     <string name="preference_onboarding_completed_timestamp"><xliff:g id="preference">"preference_onboarding_completed_timestamp"</xliff:g></string>
     <!-- NOTR -->
+    <string name="preference_background_check_done"><xliff:g id="preference">"preference_background_check_done"</xliff:g></string>
+    <!-- NOTR -->
     <string name="preference_reset_app"><xliff:g id="preference">"preference_reset_app"</xliff:g></string>
     <!-- NOTR -->
     <string name="preference_only_wifi"><xliff:g id="preference">"preference_only_wifi"</xliff:g></string>

--- a/Corona-Warn-App/src/main/res/values-en/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-en/strings.xml
@@ -12,6 +12,8 @@
     <!-- NOTR -->
     <string name="preference_onboarding_completed_timestamp"><xliff:g id="preference">"preference_onboarding_completed_timestamp"</xliff:g></string>
     <!-- NOTR -->
+    <string name="preference_background_check_done"><xliff:g id="preference">"preference_background_check_done"</xliff:g></string>
+    <!-- NOTR -->
     <string name="preference_reset_app"><xliff:g id="preference">"preference_reset_app"</xliff:g></string>
     <!-- NOTR -->
     <string name="preference_only_wifi"><xliff:g id="preference">"preference_only_wifi"</xliff:g></string>

--- a/Corona-Warn-App/src/main/res/values-pl/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-pl/strings.xml
@@ -12,6 +12,8 @@
     <!-- NOTR -->
     <string name="preference_onboarding_completed_timestamp"><xliff:g id="preference">"preference_onboarding_completed_timestamp"</xliff:g></string>
     <!-- NOTR -->
+    <string name="preference_background_check_done"><xliff:g id="preference">"preference_background_check_done"</xliff:g></string>
+    <!-- NOTR -->
     <string name="preference_reset_app"><xliff:g id="preference">"preference_reset_app"</xliff:g></string>
     <!-- NOTR -->
     <string name="preference_only_wifi"><xliff:g id="preference">"preference_only_wifi"</xliff:g></string>

--- a/Corona-Warn-App/src/main/res/values-ro/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-ro/strings.xml
@@ -12,6 +12,8 @@
     <!-- NOTR -->
     <string name="preference_onboarding_completed_timestamp"><xliff:g id="preference">"preference_onboarding_completed_timestamp"</xliff:g></string>
     <!-- NOTR -->
+    <string name="preference_background_check_done"><xliff:g id="preference">"preference_background_check_done"</xliff:g></string>
+    <!-- NOTR -->
     <string name="preference_reset_app"><xliff:g id="preference">"preference_reset_app"</xliff:g></string>
     <!-- NOTR -->
     <string name="preference_only_wifi"><xliff:g id="preference">"preference_only_wifi"</xliff:g></string>

--- a/Corona-Warn-App/src/main/res/values-tr/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-tr/strings.xml
@@ -12,6 +12,8 @@
     <!-- NOTR -->
     <string name="preference_onboarding_completed_timestamp"><xliff:g id="preference">"preference_onboarding_completed_timestamp"</xliff:g></string>
     <!-- NOTR -->
+    <string name="preference_background_check_done"><xliff:g id="preference">"preference_background_check_done"</xliff:g></string>
+    <!-- NOTR -->
     <string name="preference_reset_app"><xliff:g id="preference">"preference_reset_app"</xliff:g></string>
     <!-- NOTR -->
     <string name="preference_only_wifi"><xliff:g id="preference">"preference_only_wifi"</xliff:g></string>

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -12,6 +12,8 @@
     <!-- NOTR -->
     <string name="preference_onboarding_completed_timestamp"><xliff:g id="preference">"preference_onboarding_completed_timestamp"</xliff:g></string>
     <!-- NOTR -->
+    <string name="preference_background_check_done"><xliff:g id="preference">"preference_background_check_done"</xliff:g></string>
+    <!-- NOTR -->
     <string name="preference_reset_app"><xliff:g id="preference">"preference_reset_app"</xliff:g></string>
     <!-- NOTR -->
     <string name="preference_only_wifi"><xliff:g id="preference">"preference_only_wifi"</xliff:g></string>

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -75,8 +75,6 @@
     <string name="preference_risk_days_explanation_shown"><xliff:g id="preference">"preference_risk_days_explanation_shown"</xliff:g></string>
     <!-- NOTR -->
     <string name="preference_background_notification"><xliff:g id="preference">"preference_background_notification"</xliff:g></string>
-    <!-- NOTR -->
-    <string name="preference_energy_optimized_explanation_shown"><xliff:g id="preference">"preference_energy_optimized_explanation_shown"</xliff:g></string>
 
     <!-- ####################################
                      Generics


### PR DESCRIPTION
## Checklist

* [ ] Test your changes as thoroughly as possible before you commit them. Preferably, automate your test by unit/integration tests.
* [ ] If this PR comes from a fork, please [Allow edits from maintainers](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
* [ ] Set a speaking title. Format: {task_name} (closes #{issue_number}). For example: Use logger (closes # 41)
* [ ] [Link your Pull Request to an issue](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) - Pull Requests that are not linked to an issue with you as an assignee will be closed, except for minor fixes for typos or grammar mistakes in *documentation or code comments*.
* [ ] Create Work In Progress [WIP] pull requests only if you need clarification or an explicit review before you can continue your work item.
* [ ] Make sure that your PR is not introducing _unnecessary_ reformatting (e.g., introduced by on-save hooks in your IDE)
* [ ] Make sure that your PR does not contain changes in text files, therefore the PR must not contain changes in values/strings/* and / or assets/* (see issue #332 for further information)
* [ ] Make sure that your PR does not contain compiled sources (already set by the default .gitignore) and / or binary files

## Description
The current version of the cwa will keep displaying the battery optimization dialog when exiting the settings. This PR will close the onboarding before moving to the settings to prevent this loop.