### PR TITLE
Storage check with optional allocation (EXPOSUREAPP-2259)

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -124,6 +124,7 @@
     </codeStyleSettings>
     <codeStyleSettings language="kotlin">
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+      <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
     </codeStyleSettings>
   </code_scheme>
 </component>

--- a/Corona-Warn-App/build.gradle
+++ b/Corona-Warn-App/build.gradle
@@ -37,7 +37,7 @@ android {
         versionName "1.3.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        
+
         resConfigs "de", "en", "tr", "bg", "pl", "ro"
 
         buildConfigField "String", "DOWNLOAD_CDN_URL", "\"$DOWNLOAD_CDN_URL\""
@@ -142,6 +142,9 @@ android {
     }
 
     testOptions {
+        unitTests.all {
+            useJUnitPlatform()
+        }
         unitTests {
             includeAndroidResources = true
             returnDefaultValues = true
@@ -205,10 +208,10 @@ task jacocoTestReportDeviceRelease(type: JacocoReport, dependsOn: 'testDeviceRel
     ]
 
     def classPaths = [
-        "**/intermediates/classes/deviceRelease/**",
-        "**/intermediates/javac/deviceRelease/*/classes/**", // Android Gradle Plugin 3.2.x support.
-        "**/intermediates/javac/deviceRelease/classes/**", // Android Gradle Plugin 3.4 and 3.5 support.
-        "**/tmp/kotlin-classes/deviceRelease/**"
+            "**/intermediates/classes/deviceRelease/**",
+            "**/intermediates/javac/deviceRelease/*/classes/**", // Android Gradle Plugin 3.2.x support.
+            "**/intermediates/javac/deviceRelease/classes/**", // Android Gradle Plugin 3.4 and 3.5 support.
+            "**/tmp/kotlin-classes/deviceRelease/**"
     ]
 
     def debugTree = fileTree(dir: "$buildDir", includes: classPaths, excludes: excludes)
@@ -242,16 +245,31 @@ dependencies {
     // noinspection GradleDependency - needed for SDK 23 compatibility, in combination with com.journeyapps:zxing-android-embedded:4.1.0
     implementation 'com.google.zxing:core:3.3.0'
 
-    // TESTING
-    testImplementation 'junit:junit:4.13'
+    // Testing
     testImplementation "android.arch.core:core-testing:1.1.1"
+    // TODO evaluate unused?, remove?
     testImplementation "org.mockito:mockito-core:3.3.3"
+    // TODO evaluate unused?, remove?
     testImplementation('org.robolectric:robolectric:4.3.1') {
         exclude group: 'com.google.protobuf'
     }
     testImplementation "io.mockk:mockk:1.10.0"
     testImplementation "com.squareup.okhttp3:mockwebserver:4.8.0"
     testImplementation 'org.hamcrest:hamcrest-library:2.2'
+
+    // Testing - jUnit4
+    testImplementation 'junit:junit:4.13'
+    testImplementation "org.junit.vintage:junit-vintage-engine:5.6.2"
+
+    // Testing - jUnit5
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.6.2"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.6.2"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:5.6.2"
+    testImplementation "io.kotest:kotest-runner-junit5:4.2.0"
+    testImplementation "io.kotest:kotest-assertions-core-jvm:4.2.0"
+    testImplementation "io.kotest:kotest-property-jvm:4.2.0"
+
+    // Testing - Instrumentation
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/Corona-Warn-App/build.gradle
+++ b/Corona-Warn-App/build.gradle
@@ -254,9 +254,6 @@ dependencies {
 
     // Testing
     testImplementation "android.arch.core:core-testing:1.1.1"
-    // TODO evaluate unused?, remove?
-    testImplementation "org.mockito:mockito-core:3.3.3"
-    // TODO evaluate unused?, remove?
     testImplementation('org.robolectric:robolectric:4.3.1') {
         exclude group: 'com.google.protobuf'
     }

--- a/Corona-Warn-App/src/main/assets/technical_de.html
+++ b/Corona-Warn-App/src/main/assets/technical_de.html
@@ -18,10 +18,6 @@
     Licensor: Joda.org
     Website: https://www.joda.org/joda-time/
     License: Apache 2.0</p>
-<p>Component: Mockito
-    Licensor: Mockito contributors
-    Website: https://site.mockito.org/
-    License: MIT</p>
 <p>Component: MockK
     Licensor: github.com/mockk
     Website: https://github.com/mockk/mockk
@@ -263,23 +259,6 @@ as modifying the License.
         <p>END OF TERMS AND CONDITIONS</p>
     </li>
 </ol>
-<p>The MIT License</p>
-<p>Copyright (c) 2007 Mockito contributors</p>
-<p>Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the &quot;Software&quot;), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:</p>
-<p>The above copyright notice and this permission notice shall be included in
-    all copies or substantial portions of the Software.</p>
-<p>THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-    THE SOFTWARE.</p>
 <p>The MIT License</p>
 <p>Copyright (c) 2010 Xtreme Labs, Pivotal Labs and Google Inc.</p>
 <p>Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/Corona-Warn-App/src/main/assets/technical_en.html
+++ b/Corona-Warn-App/src/main/assets/technical_en.html
@@ -18,10 +18,6 @@
     Licensor: Joda.org
     Website: https://www.joda.org/joda-time/
     License: Apache 2.0</p>
-<p>Component: Mockito
-    Licensor: Mockito contributors
-    Website: https://site.mockito.org/
-    License: MIT</p>
 <p>Component: MockK
     Licensor: github.com/mockk
     Website: https://github.com/mockk/mockk
@@ -263,23 +259,6 @@ as modifying the License.
         <p>END OF TERMS AND CONDITIONS</p>
     </li>
 </ol>
-<p>The MIT License</p>
-<p>Copyright (c) 2007 Mockito contributors</p>
-<p>Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the &quot;Software&quot;), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:</p>
-<p>The above copyright notice and this permission notice shall be included in
-    all copies or substantial portions of the Software.</p>
-<p>THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-    THE SOFTWARE.</p>
 <p>The MIT License</p>
 <p>Copyright (c) 2010 Xtreme Labs, Pivotal Labs and Google Inc.</p>
 <p>Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/Corona-Warn-App/src/main/assets/technical_tr.html
+++ b/Corona-Warn-App/src/main/assets/technical_tr.html
@@ -18,10 +18,6 @@
     Licensor: Joda.org
     Website: https://www.joda.org/joda-time/
     License: Apache 2.0</p>
-<p>Component: Mockito
-    Licensor: Mockito contributors
-    Website: https://site.mockito.org/
-    License: MIT</p>
 <p>Component: MockK
     Licensor: github.com/mockk
     Website: https://github.com/mockk/mockk
@@ -263,23 +259,6 @@ as modifying the License.
         <p>END OF TERMS AND CONDITIONS</p>
     </li>
 </ol>
-<p>The MIT License</p>
-<p>Copyright (c) 2007 Mockito contributors</p>
-<p>Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the &quot;Software&quot;), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:</p>
-<p>The above copyright notice and this permission notice shall be included in
-    all copies or substantial portions of the Software.</p>
-<p>THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-    THE SOFTWARE.</p>
 <p>The MIT License</p>
 <p>Copyright (c) 2010 Xtreme Labs, Pivotal Labs and Google Inc.</p>
 <p>Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/DeviceStorage.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/DeviceStorage.kt
@@ -7,15 +7,17 @@ import android.os.Build
 import android.os.storage.StorageManager
 import android.text.format.Formatter
 import androidx.annotation.WorkerThread
+import dagger.Reusable
 import de.rki.coronawarnapp.util.ApiLevel
 import de.rki.coronawarnapp.util.storage.StatsFsProvider
 import timber.log.Timber
 import java.io.File
 import java.io.IOException
 import java.util.UUID
+import javax.inject.Inject
 
-// TODO Add inject when #1069 is merged
-class DeviceStorage constructor(
+@Reusable
+class DeviceStorage @Inject constructor(
     private val context: Context,
     private val apiLevel: ApiLevel,
     private val statsFsProvider: StatsFsProvider

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/DeviceStorage.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/DeviceStorage.kt
@@ -1,0 +1,117 @@
+package de.rki.coronawarnapp.storage
+
+import android.annotation.TargetApi
+import android.app.usage.StorageStatsManager
+import android.content.Context
+import android.os.Build
+import android.os.storage.StorageManager
+import android.text.format.Formatter
+import de.rki.coronawarnapp.util.ApiLevel
+import de.rki.coronawarnapp.util.storage.StatsFsProvider
+import timber.log.Timber
+import java.io.File
+import java.util.UUID
+
+// TODO Add inject when #1069 is merged
+class DeviceStorage constructor(
+    private val context: Context,
+    private val apiLevel: ApiLevel,
+    private val statsFsProvider: StatsFsProvider
+) {
+
+    private val privateStorage = context.filesDir
+    private val storageManager by lazy { context.getSystemService(Context.STORAGE_SERVICE) as StorageManager }
+
+    @TargetApi(Build.VERSION_CODES.O)
+    private fun requestStorageAPI26Plus(targetPath: File, requiredBytes: Long = -1L): CheckResult {
+        Timber.tag(TAG).v(
+            "requestStorageAPI26Plus(path=%s, requiredBytes=%d)", targetPath, requiredBytes
+
+        )
+        val statsManager =
+            context.getSystemService(Context.STORAGE_STATS_SERVICE) as StorageStatsManager
+
+        val storageUUID: UUID = storageManager.getUuidForPath(targetPath)
+
+        val totalBytes = statsManager.getTotalBytes(storageUUID)
+        var availableBytes = statsManager.getFreeBytes(storageUUID)
+
+        if (availableBytes < requiredBytes) {
+            val allocatableBytes = storageManager.getAllocatableBytes(storageUUID)
+            if (allocatableBytes + availableBytes >= requiredBytes) {
+                val toAllocate = requiredBytes - availableBytes
+                Timber.tag(TAG).v(
+                    "Not enough free space, allocating %d on %s.", requiredBytes, targetPath
+                )
+                storageManager.allocateBytes(storageUUID, toAllocate)
+                availableBytes += toAllocate
+            }
+        }
+
+        return CheckResult(
+            path = targetPath,
+            isSpaceAvailable = availableBytes >= requiredBytes || requiredBytes == -1L,
+            freeBytes = availableBytes,
+            totalBytes = totalBytes
+        )
+    }
+
+    private fun requestStorageLegacy(targetPath: File, requiredBytes: Long = -1L): CheckResult {
+        Timber.tag(TAG).v(
+            "requestStorageAPI26Plus(path=%s, requiredBytes=%d)", targetPath, requiredBytes
+        )
+
+        val stats = statsFsProvider.createStats(targetPath)
+
+        return CheckResult(
+            path = targetPath,
+            isSpaceAvailable = stats.availableBytes >= requiredBytes || requiredBytes == -1L,
+            freeBytes = stats.availableBytes,
+            totalBytes = stats.totalBytes
+        )
+    }
+
+    private fun checkSpace(path: File, requiredBytes: Long = -1L): CheckResult =
+        try {
+            val result = if (apiLevel.hasAPILevel(Build.VERSION_CODES.O)) {
+                requestStorageAPI26Plus(path, requiredBytes)
+            } else {
+                requestStorageLegacy(path, requiredBytes)
+            }
+            Timber.tag(TAG).d("Requested %d from %s: %s", requiredBytes, path, result)
+            result
+        } catch (e: Exception) {
+            Timber.tag(TAG).e(e, "Failed to request %d on %s", requiredBytes, path)
+            // Android storage is a fickle beast
+            // If the space request fails, it's possible that the write attempt will still succeed
+            CheckResult(path, true, -1L, -1L)
+        }
+
+    /**
+     * Returns an **[CheckResult]** telling you how much private storage is available to us
+     * Pass **[requiredBytes]** if we should attempt to free space if not enough is available.
+     * This may cause the system to delete caches to free space.
+     * If there are any errors you'll get a result with **[CheckResult.isSpaceAvailable]**,
+     * but **[CheckResult.freeBytes]** == -1L
+     */
+    fun checkSpacePrivateStorage(requiredBytes: Long = -1L): CheckResult =
+        checkSpace(privateStorage, requiredBytes)
+
+    data class CheckResult(
+        val path: File,
+        val isSpaceAvailable: Boolean,
+        val freeBytes: Long,
+        val totalBytes: Long
+    ) {
+
+        fun getFormattedFreeSpace(context: Context): String =
+            Formatter.formatShortFileSize(context, freeBytes)
+
+        fun getFormattedTotalSpace(context: Context): String =
+            Formatter.formatShortFileSize(context, totalBytes)
+    }
+
+    companion object {
+        val TAG = DeviceStorage::class.java.simpleName
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/DeviceStorage.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/DeviceStorage.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.os.Build
 import android.os.storage.StorageManager
 import android.text.format.Formatter
+import androidx.annotation.WorkerThread
 import de.rki.coronawarnapp.util.ApiLevel
 import de.rki.coronawarnapp.util.storage.StatsFsProvider
 import timber.log.Timber
@@ -93,7 +94,10 @@ class DeviceStorage constructor(
      * This may cause the system to delete caches to free space.
      * If there are any errors you'll get a result with **[CheckResult.isSpaceAvailable]**,
      * but **[CheckResult.freeBytes]** == -1L
+     *
+     * Don't call this on the UI thread as the operation may block due to IO.
      */
+    @WorkerThread
     fun checkSpacePrivateStorage(requiredBytes: Long = -1L): CheckResult =
         checkSpace(privateStorage, requiredBytes)
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ApiLevel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ApiLevel.kt
@@ -10,6 +10,5 @@ class ApiLevel constructor(val currentLevel: Int = Build.VERSION.SDK_INT) {
     @Inject
     constructor() : this(Build.VERSION.SDK_INT)
 
-
     fun hasAPILevel(level: Int): Boolean = currentLevel >= level
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ApiLevel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ApiLevel.kt
@@ -1,0 +1,10 @@
+package de.rki.coronawarnapp.util
+
+import android.os.Build
+
+class ApiLevel constructor(apiLevel: Int = Build.VERSION.SDK_INT) {
+
+    val currentLevel = apiLevel
+
+    fun hasAPILevel(level: Int): Boolean = currentLevel >= level
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ApiLevel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ApiLevel.kt
@@ -1,10 +1,15 @@
 package de.rki.coronawarnapp.util
 
 import android.os.Build
+import javax.inject.Inject
+import javax.inject.Singleton
 
-class ApiLevel constructor(apiLevel: Int = Build.VERSION.SDK_INT) {
+@Singleton
+class ApiLevel constructor(val currentLevel: Int = Build.VERSION.SDK_INT) {
 
-    val currentLevel = apiLevel
+    @Inject
+    constructor() : this(Build.VERSION.SDK_INT)
+
 
     fun hasAPILevel(level: Int): Boolean = currentLevel >= level
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/di/AndroidModule.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/di/AndroidModule.kt
@@ -1,4 +1,4 @@
-package de.rki.coronawarnapp.util
+package de.rki.coronawarnapp.util.di
 
 import android.app.Application
 import android.content.Context

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/di/ApplicationComponent.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/di/ApplicationComponent.kt
@@ -8,7 +8,6 @@ import de.rki.coronawarnapp.receiver.ReceiverBinder
 import de.rki.coronawarnapp.risk.RiskModule
 import de.rki.coronawarnapp.service.ServiceBinder
 import de.rki.coronawarnapp.ui.ActivityBinder
-import de.rki.coronawarnapp.util.AndroidModule
 import javax.inject.Singleton
 
 @Singleton

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/storage/StatsFsProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/storage/StatsFsProvider.kt
@@ -1,0 +1,18 @@
+package de.rki.coronawarnapp.util.storage
+
+import android.os.StatFs
+import timber.log.Timber
+import java.io.File
+
+// TODO Add inject when #1069 is merged
+class StatsFsProvider {
+
+    fun createStats(path: File): StatFs {
+        Timber.tag(TAG).v("createStats(path=%s)", path)
+        return StatFs(path.path)
+    }
+
+    companion object {
+        val TAG = StatsFsProvider::class.java.simpleName
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/storage/StatsFsProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/storage/StatsFsProvider.kt
@@ -1,11 +1,13 @@
 package de.rki.coronawarnapp.util.storage
 
 import android.os.StatFs
+import dagger.Reusable
 import timber.log.Timber
 import java.io.File
+import javax.inject.Inject
 
-// TODO Add inject when #1069 is merged
-class StatsFsProvider {
+@Reusable
+class StatsFsProvider @Inject constructor() {
 
     fun createStats(path: File): StatFs {
         Timber.tag(TAG).v("createStats(path=%s)", path)

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/storage/DeviceStorageTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/storage/DeviceStorageTest.kt
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseIOTest
 import java.io.File
+import java.io.IOException
 import java.util.UUID
 
 class DeviceStorageTest : BaseIOTest() {
@@ -173,6 +174,34 @@ class DeviceStorageTest : BaseIOTest() {
             isSpaceAvailable = false,
             freeBytes = defaultFreeSpace,
             totalBytes = defaultTotalSpace
+        )
+    }
+
+    @Test
+    fun `check private storage space, error case`() {
+        every { storageManager.getUuidForPath(privateDataDir) } throws IOException("uh oh")
+
+        val deviceStorage = buildInstance()
+
+        deviceStorage.checkSpacePrivateStorage() shouldBe DeviceStorage.CheckResult(
+            path = privateDataDir,
+            isSpaceAvailable = true,
+            freeBytes = -1L,
+            totalBytes = -1L
+        )
+    }
+
+    @Test
+    fun `check private storage space, sub API26, error case`() {
+        every { statsFsProvider.createStats(privateDataDir) } throws IOException("uh oh")
+
+        val deviceStorage = buildInstance(level = legacyApiLevel)
+
+        deviceStorage.checkSpacePrivateStorage() shouldBe DeviceStorage.CheckResult(
+            path = privateDataDir,
+            isSpaceAvailable = true,
+            freeBytes = -1L,
+            totalBytes = -1L
         )
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/storage/DeviceStorageTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/storage/DeviceStorageTest.kt
@@ -1,0 +1,178 @@
+package de.rki.coronawarnapp.storage
+
+import android.app.usage.StorageStatsManager
+import android.content.Context
+import android.os.Build
+import android.os.StatFs
+import android.os.storage.StorageManager
+import de.rki.coronawarnapp.util.ApiLevel
+import de.rki.coronawarnapp.util.storage.StatsFsProvider
+import io.kotest.matchers.shouldBe
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseIOTest
+import java.io.File
+import java.util.UUID
+
+class DeviceStorageTest : BaseIOTest() {
+
+    @MockK
+    lateinit var context: Context
+
+    private val defaultApiLevel = ApiLevel(Build.VERSION_CODES.O)
+    private val legacyApiLevel = ApiLevel(Build.VERSION_CODES.M)
+
+    @MockK
+    lateinit var storageManager: StorageManager
+
+    @MockK
+    lateinit var storageStatsManager: StorageStatsManager
+
+    @MockK
+    lateinit var statsFsProvider: StatsFsProvider
+
+    private val privateDataDir = File(IO_TEST_BASEDIR, "privData")
+    private val privateDataDirUUID = UUID.randomUUID()
+
+    private val defaultAllocatableBytes = 512L
+    private val defaultFreeSpace = 1000 * 1024L
+    private val defaultTotalSpace = Long.MAX_VALUE
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this)
+
+        every { context.filesDir } returns privateDataDir
+        every { context.getSystemService(Context.STORAGE_SERVICE) } returns storageManager
+        every { context.getSystemService(Context.STORAGE_STATS_SERVICE) } returns storageStatsManager
+
+        every { storageManager.getUuidForPath(privateDataDir) } returns privateDataDirUUID
+        every { storageManager.getAllocatableBytes(privateDataDirUUID) } returns defaultAllocatableBytes
+        every { storageManager.allocateBytes(any<UUID>(), any()) } returns Unit
+
+        every { storageStatsManager.getFreeBytes(any()) } returns defaultFreeSpace
+        every { storageStatsManager.getTotalBytes(any()) } returns defaultTotalSpace
+
+        every { statsFsProvider.createStats(privateDataDir) } returns mockk<StatFs>().apply {
+            every { availableBytes } returns defaultFreeSpace
+            every { totalBytes } returns defaultTotalSpace
+        }
+    }
+
+    @AfterEach
+    fun teardown() {
+        clearAllMocks()
+
+        privateDataDir.deleteRecursively()
+    }
+
+    private fun buildInstance(level: ApiLevel = defaultApiLevel): DeviceStorage = DeviceStorage(
+        context = context,
+        apiLevel = level,
+        statsFsProvider = statsFsProvider
+    )
+
+    @Test
+    fun `check private storage space`() {
+        val deviceStorage = buildInstance()
+
+        deviceStorage.checkSpacePrivateStorage() shouldBe DeviceStorage.CheckResult(
+            path = privateDataDir,
+            isSpaceAvailable = true,
+            freeBytes = defaultFreeSpace,
+            totalBytes = defaultTotalSpace
+        )
+
+        verify { storageManager.getUuidForPath(any()) }
+        verify(exactly = 0) { statsFsProvider.createStats(any()) }
+
+        verify(exactly = 0) { storageManager.allocateBytes(any<UUID>(), any()) }
+    }
+
+    @Test
+    fun `check private storage space, sub API26`() {
+        val deviceStorage = buildInstance(level = legacyApiLevel)
+
+        deviceStorage.checkSpacePrivateStorage() shouldBe DeviceStorage.CheckResult(
+            path = privateDataDir,
+            isSpaceAvailable = true,
+            freeBytes = defaultFreeSpace,
+            totalBytes = defaultTotalSpace
+        )
+
+        verify(exactly = 0) { storageManager.getUuidForPath(any()) }
+        verify { statsFsProvider.createStats(any()) }
+    }
+
+    @Test
+    fun `request space from private storage successfully`() {
+        val deviceStorage = buildInstance()
+
+        deviceStorage.checkSpacePrivateStorage(requiredBytes = defaultFreeSpace) shouldBe DeviceStorage.CheckResult(
+            path = privateDataDir,
+            isSpaceAvailable = true,
+            freeBytes = defaultFreeSpace,
+            totalBytes = defaultTotalSpace
+        )
+
+        verify(exactly = 0) { storageManager.allocateBytes(any<UUID>(), any()) }
+    }
+
+    @Test
+    fun `request space from private storage successfully, sub API26`() {
+        val deviceStorage = buildInstance(level = legacyApiLevel)
+
+        deviceStorage.checkSpacePrivateStorage(requiredBytes = defaultFreeSpace) shouldBe DeviceStorage.CheckResult(
+            path = privateDataDir,
+            isSpaceAvailable = true,
+            freeBytes = defaultFreeSpace,
+            totalBytes = defaultTotalSpace
+        )
+    }
+
+    @Test
+    fun `request space from private storage wth allocation`() {
+        val deviceStorage = buildInstance()
+
+        val targetBytes = defaultFreeSpace + defaultAllocatableBytes
+        deviceStorage.checkSpacePrivateStorage(requiredBytes = targetBytes) shouldBe DeviceStorage.CheckResult(
+            path = privateDataDir,
+            isSpaceAvailable = true,
+            freeBytes = targetBytes,
+            totalBytes = defaultTotalSpace
+        )
+
+        verify { storageManager.allocateBytes(privateDataDirUUID, defaultAllocatableBytes) }
+    }
+
+    @Test
+    fun `request space from private storage unsuccessfully`() {
+        val deviceStorage = buildInstance()
+
+        deviceStorage.checkSpacePrivateStorage(requiredBytes = Long.MAX_VALUE) shouldBe DeviceStorage.CheckResult(
+            path = privateDataDir,
+            isSpaceAvailable = false,
+            freeBytes = defaultFreeSpace,
+            totalBytes = defaultTotalSpace
+        )
+    }
+
+    @Test
+    fun `request space from private storage unsuccessfully, sub API26`() {
+        val deviceStorage = buildInstance(level = legacyApiLevel)
+
+        deviceStorage.checkSpacePrivateStorage(requiredBytes = Long.MAX_VALUE) shouldBe DeviceStorage.CheckResult(
+            path = privateDataDir,
+            isSpaceAvailable = false,
+            freeBytes = defaultFreeSpace,
+            totalBytes = defaultTotalSpace
+        )
+    }
+}

--- a/Corona-Warn-App/src/test/java/testhelpers/BaseIOTest.kt
+++ b/Corona-Warn-App/src/test/java/testhelpers/BaseIOTest.kt
@@ -1,0 +1,8 @@
+package testhelpers
+
+abstract class BaseIOTest : BaseTest() {
+
+    companion object {
+        const val IO_TEST_BASEDIR = "build/tmp/unit_tests"
+    }
+}

--- a/Corona-Warn-App/src/test/java/testhelpers/BaseTest.kt
+++ b/Corona-Warn-App/src/test/java/testhelpers/BaseTest.kt
@@ -1,0 +1,12 @@
+package testhelpers
+
+import testhelpers.logging.JUnitTree
+import timber.log.Timber
+
+abstract class BaseTest {
+
+    init {
+        Timber.uprootAll()
+        Timber.plant(JUnitTree())
+    }
+}

--- a/Corona-Warn-App/src/test/java/testhelpers/logging/JUnitTree.kt
+++ b/Corona-Warn-App/src/test/java/testhelpers/logging/JUnitTree.kt
@@ -1,0 +1,22 @@
+package testhelpers.logging
+
+import android.util.Log
+
+import timber.log.Timber
+
+class JUnitTree(private val minLogLevel: Int = Log.VERBOSE) : Timber.DebugTree() {
+
+    private fun priorityToString(priority: Int): String = when (priority) {
+        Log.ERROR -> "E"
+        Log.WARN -> "W"
+        Log.INFO -> "I"
+        Log.DEBUG -> "D"
+        Log.VERBOSE -> "V"
+        else -> priority.toString()
+    }
+
+    override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+        if (priority < minLogLevel) return
+        println("${System.currentTimeMillis()} ${priorityToString(priority)}/$tag: $message")
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ subprojects {
     }
 
     ktlint {
-        debug = true
+        debug = false
         ignoreFailures = false
         coloredOutput = false
     }


### PR DESCRIPTION
Preparations for  future features that require increased storage space.
Prevent features from failing unexpectedly due to missing free space on storage.
We want to make the user aware of any possible concerns regarding available storage space.

This introduces a class `DeviceStorage` that can check the free space in our app's private storage.
On newer APIs (26+), the class will also attempt to allocate additional space by asking the system delete caches if possible.

This PR adds a few test dependencies and sets up some structures to improve unit testing, i.e. see `DeviceStorageTest`.

This PR is in draft mode until #1069 is merged, so that I can directly include DI annotations.