### PR TITLE
Fix: Consolidate all number of retrieve diagnosis keys into one (EXPOSUREAPP-2405)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/transaction/RetrieveDiagnosisKeysTransaction.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/transaction/RetrieveDiagnosisKeysTransaction.kt
@@ -270,13 +270,11 @@ object RetrieveDiagnosisKeysTransaction : Transaction() {
         exportFiles: Collection<File>,
         exposureConfiguration: ExposureConfiguration?
     ) = executeState(API_SUBMISSION) {
-        exportFiles.forEach { batch ->
-            InternalExposureNotificationClient.asyncProvideDiagnosisKeys(
-                listOf(batch),
-                exposureConfiguration,
-                token
-            )
-        }
+        InternalExposureNotificationClient.asyncProvideDiagnosisKeys(
+            exportFiles,
+            exposureConfiguration,
+            token
+        )
         Timber.tag(TAG).d("Diagnosis Keys provided successfully, Token: $token")
     }
 


### PR DESCRIPTION
Instead of calling the ENF API once per day package we are calling it once with all day packages.

Collaboration with @jakobmoellersap  