### PR TITLE
Revert "Update UTC time to LocalTime (#1041) (EXPOSUREAPP-1863)"

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/transaction/RetrieveDiagnosisKeysTransaction.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/transaction/RetrieveDiagnosisKeysTransaction.kt
@@ -124,10 +124,10 @@ object RetrieveDiagnosisKeysTransaction : Transaction() {
     }
 
     suspend fun startWithConstraints() {
-        val currentDate = DateTime(Instant.now(), DateTimeZone.getDefault())
+        val currentDate = DateTime(Instant.now(), DateTimeZone.UTC)
         val lastFetch = DateTime(
             LocalData.lastTimeDiagnosisKeysFromServerFetch(),
-            DateTimeZone.getDefault()
+            DateTimeZone.UTC
         )
         if (LocalData.lastTimeDiagnosisKeysFromServerFetch() == null ||
             currentDate.withTimeAtStartOfDay() != lastFetch.withTimeAtStartOfDay()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/viewmodel/TracingViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/viewmodel/TracingViewModel.kt
@@ -64,10 +64,10 @@ class TracingViewModel : ViewModel() {
             try {
 
                 // get the current date and the date the diagnosis keys were fetched the last time
-                val currentDate = DateTime(Instant.now(), DateTimeZone.getDefault())
+                val currentDate = DateTime(Instant.now(), DateTimeZone.UTC)
                 val lastFetch = DateTime(
                     LocalData.lastTimeDiagnosisKeysFromServerFetch(),
-                    DateTimeZone.getDefault()
+                    DateTimeZone.UTC
                 )
 
                 // check if the keys were not already retrieved today


### PR DESCRIPTION
This reverts commit 2ba3ec0f

This is done as the UTC communication was done falsely by Google and will be corrected in the docs. No action is necessary on our side.

Signed-off-by: d067928 <jakob.moeller@sap.com>

This PR can be tested by checking if Rate Limiting applies when a device is fetching at 0.00-1.59 UTC and after 2.00 UTC. If the Rate Limiting would use Local Date Time, a device set to GMT+2 would result in Rate Limiting. this is not the case.