### PR TITLE
Throw Exception in case we have a failed entry to ensure Abortion of the Transaction (EXPOSUREAPP-2405)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CachedKeyFileHolder.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CachedKeyFileHolder.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.io.File
+import java.io.IOException
 import java.util.Collections
 import java.util.Date
 import java.util.UUID
@@ -121,7 +122,10 @@ object CachedKeyFileHolder {
             deferredQueries.awaitAll()
             Timber.v("${failedEntryCacheKeys.size} failed entries ")
             // For an error we clear the cache to try again
-            keyCache.clear(failedEntryCacheKeys)
+            if (failedEntryCacheKeys.isNotEmpty()) {
+                keyCache.clear(failedEntryCacheKeys)
+                throw IOException("failed to download all key files, at least one failing request.")
+            }
             keyCache.getFilesFromEntries()
                 .also { it.forEach { file -> Timber.v("cached file:${file.path}") } }
         }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/CachedKeyFileHolderTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/CachedKeyFileHolderTest.kt
@@ -38,7 +38,6 @@ class CachedKeyFileHolderTest {
         every { KeyCacheRepository.getDateRepository(any()) } returns keyCacheRepository
         mockkObject(CachedKeyFileHolder)
         coEvery { keyCacheRepository.deleteOutdatedEntries(any()) } just Runs
-        coEvery { keyCacheRepository.clear(any()) } just Runs
     }
 
     /**
@@ -65,7 +64,6 @@ class CachedKeyFileHolderTest {
                 keyCacheRepository.deleteOutdatedEntries(any())
                 CachedKeyFileHolder["getMissingDaysFromDiff"](arrayListOf<String>())
                 keyCacheRepository.getDates()
-                keyCacheRepository.clear(emptyList())
                 keyCacheRepository.getFilesFromEntries()
             }
         }


### PR DESCRIPTION
Signed-off-by: d067928 <jakob.moeller@sap.com>

This is done to ensure we do not submit files with remaining files after a failure is cleared in the Download Cache. Testable by provoking a download failure and not seeing exposure checks anymore as well as an IOException wrapped by a Transaction Exception if done in foreground
