### PR TITLE
Double Timeout Variables for HTTP Requests and Triple the Timeout for the Transaction to ensure less timeouts are received with bad networking (EXPOSUREAPP-2190)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/http/config/HTTPVariables.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/http/config/HTTPVariables.kt
@@ -5,7 +5,7 @@ object HTTPVariables {
      * The maximal runtime of a transaction
      * In milliseconds
      */
-    private const val HTTP_CONNECTION_TIMEOUT = 10000L
+    private const val HTTP_CONNECTION_TIMEOUT = 20000L
 
     /**
      * Getter function for [HTTP_CONNECTION_TIMEOUT]
@@ -19,7 +19,7 @@ object HTTPVariables {
      * The maximal runtime of a transaction
      * In milliseconds
      */
-    private const val HTTP_READ_TIMEOUT = 10000L
+    private const val HTTP_READ_TIMEOUT = 20000L
 
     /**
      * Getter function for [HTTP_READ_TIMEOUT]
@@ -33,7 +33,7 @@ object HTTPVariables {
      * The maximal runtime of a transaction
      * In milliseconds
      */
-    private const val HTTP_WRITE_TIMEOUT = 10000L
+    private const val HTTP_WRITE_TIMEOUT = 20000L
 
     /**
      * Getter function for [HTTP_WRITE_TIMEOUT]

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/TimeVariables.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/TimeVariables.kt
@@ -34,7 +34,7 @@ object TimeVariables {
      * The maximal runtime of a transaction
      * In milliseconds
      */
-    private const val TRANSACTION_TIMEOUT = 60000L
+    private const val TRANSACTION_TIMEOUT = 180000L
 
     /**
      * Getter function for [TRANSACTION_TIMEOUT]

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/http/config/HTTPVariablesTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/http/config/HTTPVariablesTest.kt
@@ -7,16 +7,16 @@ class HTTPVariablesTest {
 
     @Test
     fun getHTTPConnectionTimeout() {
-        Assert.assertEquals(HTTPVariables.getHTTPConnectionTimeout(), 10000L)
+        Assert.assertEquals(HTTPVariables.getHTTPConnectionTimeout(), 20000L)
     }
 
     @Test
     fun getHTTPReadTimeout() {
-        Assert.assertEquals(HTTPVariables.getHTTPReadTimeout(), 10000L)
+        Assert.assertEquals(HTTPVariables.getHTTPReadTimeout(), 20000L)
     }
 
     @Test
     fun getHTTPWriteTimeout() {
-        Assert.assertEquals(HTTPVariables.getHTTPWriteTimeout(), 10000L)
+        Assert.assertEquals(HTTPVariables.getHTTPWriteTimeout(), 20000L)
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/TimeVariablesTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/TimeVariablesTest.kt
@@ -14,7 +14,7 @@ class TimeVariablesTest {
 
     @Test
     fun getTransactionTimeout() {
-        Assert.assertEquals(TimeVariables.getTransactionTimeout(), 60000L)
+        Assert.assertEquals(TimeVariables.getTransactionTimeout(), 180000L)
     }
 
     @Test


### PR DESCRIPTION
This PR is done to ensure that we receive less Timeouts during bad networking or situations where the key retrieval takes longer. The PR can be tested by manually throttling the device network throughput and experiencing no timeout with HTTP Requests above 10 seconds and Transactions above 60s