### PR TITLE
Revert "Consolidate all number of retrieve diagnosis keys into one (#1088) (EXPOSUREAPP-2405, EXPOSUREAPP-2470) in DEV for 1.4 RCs

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/transaction/RetrieveDiagnosisKeysTransaction.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/transaction/RetrieveDiagnosisKeysTransaction.kt
@@ -316,11 +316,13 @@ object RetrieveDiagnosisKeysTransaction : Transaction() {
         exportFiles: Collection<File>,
         exposureConfiguration: ExposureConfiguration?
     ) = executeState(API_SUBMISSION) {
-        InternalExposureNotificationClient.asyncProvideDiagnosisKeys(
-            exportFiles,
-            exposureConfiguration,
-            token
-        )
+        exportFiles.forEach { batch ->
+            InternalExposureNotificationClient.asyncProvideDiagnosisKeys(
+                listOf(batch),
+                exposureConfiguration,
+                token
+            )
+        }
         Timber.tag(TAG).d("Diagnosis Keys provided successfully, Token: $token")
     }
 


### PR DESCRIPTION
This reverts commit 6e8b0535

The revert is done as we will only release the changed behaviour of the API Submission to Google in 1.5 and keep this in the interoperability feature branch

Signed-off-by: d067928 <jakob.moeller@sap.com>
