### PR TITLE
Submission: Warning if user cancels submission (EXPOSUREAPP-2509)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/SubmissionResultPositiveOtherWarningFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/SubmissionResultPositiveOtherWarningFragment.kt
@@ -166,7 +166,7 @@ class SubmissionResultPositiveOtherWarningFragment : Fragment(),
             R.string.submission_error_dialog_confirm_cancellation_body,
             R.string.submission_error_dialog_confirm_cancellation_button_positive,
             R.string.submission_error_dialog_confirm_cancellation_button_negative,
-            false,
+            true,
             ::navigateToSubmissionResultFragment
         ))
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/SubmissionResultPositiveOtherWarningFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/SubmissionResultPositiveOtherWarningFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.accessibility.AccessibilityEvent
+import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Observer
@@ -39,6 +40,14 @@ class SubmissionResultPositiveOtherWarningFragment : Fragment(),
     private lateinit var internalExposureNotificationPermissionHelper:
             InternalExposureNotificationPermissionHelper
 
+    // Overrides default back behaviour
+    private val backCallback: OnBackPressedCallback =
+        object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                handleSubmissionCancellation()
+            }
+        }
+
     override fun onResume() {
         super.onResume()
         binding.submissionPositiveOtherPrivacyContainer.sendAccessibilityEvent(AccessibilityEvent.TYPE_ANNOUNCEMENT)
@@ -53,6 +62,7 @@ class SubmissionResultPositiveOtherWarningFragment : Fragment(),
         internalExposureNotificationPermissionHelper =
             InternalExposureNotificationPermissionHelper(this, this)
         _binding = FragmentSubmissionPositiveOtherWarningBinding.inflate(inflater)
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, backCallback)
         binding.submissionViewModel = submissionViewModel
         binding.lifecycleOwner = this
         return binding.root
@@ -139,8 +149,26 @@ class SubmissionResultPositiveOtherWarningFragment : Fragment(),
             initiateWarningOthers()
         }
         binding.submissionPositiveOtherWarningHeader.headerButtonBack.buttonIcon.setOnClickListener {
-            navigateToSubmissionResultFragment()
+            handleSubmissionCancellation()
         }
+    }
+
+    /**
+    * Opens a Dialog that warns user
+    * when they're about to cancel the submission flow
+    * @see DialogHelper
+    * @see navigateToSubmissionResultFragment
+    */
+    fun handleSubmissionCancellation() {
+        DialogHelper.showDialog(DialogHelper.DialogInstance(
+            requireActivity(),
+            R.string.submission_error_dialog_confirm_cancellation_title,
+            R.string.submission_error_dialog_confirm_cancellation_body,
+            R.string.submission_error_dialog_confirm_cancellation_button_positive,
+            R.string.submission_error_dialog_confirm_cancellation_button_negative,
+            false,
+            ::navigateToSubmissionResultFragment
+        ))
     }
 
     private fun navigateToSubmissionResultFragment() =

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -770,6 +770,15 @@
     <!-- XBUT: Positive button for submission tan redeemed -->
     <string name="submission_error_dialog_web_tan_redeemed_button_positive">"OK"</string>
 
+    <!-- XHED: Dialog title for keys submission process cancellation -->
+    <string name="submission_error_dialog_confirm_cancellation_title">"Wollen Sie wirklich abbrechen?"</string>
+    <!-- XMSG: Dialog body for keys submission process cancellation -->
+    <string name="submission_error_dialog_confirm_cancellation_body">"Ihre bisherigen Angaben werden nicht gespeichert."</string>
+    <!-- XBUT: Positive button for keys submission process cancellation -->
+    <string name="submission_error_dialog_confirm_cancellation_button_positive">"OK"</string>
+    <!-- XBUT: Positive button for keys submission process cancellation -->
+    <string name="submission_error_dialog_confirm_cancellation_button_negative">"Cancel"</string>
+
     <!-- Permission Rationale Dialog -->
     <!-- XHED: Dialog headline QR Scan permission rationale  -->
     <string name="submission_qr_code_scan_permission_rationale_dialog_headline">"Kamera-Zugriff benötigt"</string>

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -775,9 +775,9 @@
     <!-- XMSG: Dialog body for keys submission process cancellation -->
     <string name="submission_error_dialog_confirm_cancellation_body">"Ihre bisherigen Angaben werden nicht gespeichert."</string>
     <!-- XBUT: Positive button for keys submission process cancellation -->
-    <string name="submission_error_dialog_confirm_cancellation_button_positive">"OK"</string>
-    <!-- XBUT: Positive button for keys submission process cancellation -->
-    <string name="submission_error_dialog_confirm_cancellation_button_negative">"Cancel"</string>
+    <string name="submission_error_dialog_confirm_cancellation_button_positive">"Ja"</string>
+    <!-- XBUT: Negative button for keys submission process cancellation -->
+    <string name="submission_error_dialog_confirm_cancellation_button_negative">"Nein"</string>
 
     <!-- Permission Rationale Dialog -->
     <!-- XHED: Dialog headline QR Scan permission rationale  -->

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -772,6 +772,15 @@
     <!-- XBUT: Positive button for submission tan redeemed -->
     <string name="submission_error_dialog_web_tan_redeemed_button_positive">"OK"</string>
 
+    <!-- XHED: Dialog title for keys submission process cancellation -->
+    <string name="submission_error_dialog_confirm_cancellation_title">"Wollen Sie wirklich abbrechen?"</string>
+    <!-- XMSG: Dialog body for keys submission process cancellation -->
+    <string name="submission_error_dialog_confirm_cancellation_body">"Ihre bisherigen Angaben werden nicht gespeichert."</string>
+    <!-- XBUT: Positive button for keys submission process cancellation -->
+    <string name="submission_error_dialog_confirm_cancellation_button_positive">"OK"</string>
+    <!-- XBUT: Negative button for keys submission process cancellation -->
+    <string name="submission_error_dialog_confirm_cancellation_button_negative">"Cancel"</string>
+
     <!-- Permission Rationale Dialog -->
     <!-- XHED: Dialog headline QR Scan permission rationale  -->
     <string name="submission_qr_code_scan_permission_rationale_dialog_headline">"Camera authorization required"</string>

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -777,9 +777,9 @@
     <!-- XMSG: Dialog body for keys submission process cancellation -->
     <string name="submission_error_dialog_confirm_cancellation_body">"Ihre bisherigen Angaben werden nicht gespeichert."</string>
     <!-- XBUT: Positive button for keys submission process cancellation -->
-    <string name="submission_error_dialog_confirm_cancellation_button_positive">"OK"</string>
+    <string name="submission_error_dialog_confirm_cancellation_button_positive">"Ja"</string>
     <!-- XBUT: Negative button for keys submission process cancellation -->
-    <string name="submission_error_dialog_confirm_cancellation_button_negative">"Cancel"</string>
+    <string name="submission_error_dialog_confirm_cancellation_button_negative">"Nein"</string>
 
     <!-- Permission Rationale Dialog -->
     <!-- XHED: Dialog headline QR Scan permission rationale  -->


### PR DESCRIPTION
## Implementation screenshot
![submission_flow_cancelled](https://user-images.githubusercontent.com/54317407/92793929-d3b1ff80-f3a6-11ea-8773-94c80cfa7ef6.gif)




## Description
<!-- Please be brief in describing which issue is solved by your PR or which enhancement it brings -->
When a user presses the back navigation button on top or the back navigation button for Android system,
1. Users will get a warning message about cancelling the keys submission flow. They will have 2 options, Cancel and Ok respectively

2. If they choose **Yes** the user starts again from Testergebnis screen