### PR TITLE
Fix: Line break on Imprint in german (EXPOSUREAPP-1530)

### DIFF
--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -722,7 +722,7 @@
     <!-- NOTR: subtitle for legal information page, open contact form for languages other than English and German -->
     <string name="information_legal_subtitle_contact_form_non_en_de">Contact Form in <a href="https://www.rki.de/SharedDocs/Kontaktformulare/en/Kontaktformulare/weitere/Corona-Warn-App/Corona-Warn-App_Integrator.html">English</a> or <a href="https://www.rki.de/SharedDocs/Kontaktformulare/weitere/Corona-Warn-App/Corona-Warn-App_Integrator.html">German</a></string>
     <!-- XHED: Headline for legal information page, tax section -->
-    <string name="information_legal_headline_taxid">"Umsatzsteueridentifikationsnummer"</string>
+    <string name="information_legal_headline_taxid">"Umsatzsteuer-\nIdentifikationsnummer"</string>
     <!-- YTXT: subtitle for legal information page, tax section -->
     <string name="information_legal_subtitle_taxid">"DE 165 893 430"</string>
     <!-- XACT: describes illustration -->


### PR DESCRIPTION
I added a hypen and a forced linebreak as the german word "Umsatzsteueridentifikationsnummer" is to long for most devices.
This word is now displayed over two lines:
![image](https://user-images.githubusercontent.com/64483219/92888032-43f76a00-f415-11ea-98de-f7d1ec9c42d7.png)
