### PR TITLE
Remove unavailable test fragment from release navgraph and fix pkg/path

### DIFF
--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/TestForAPIFragment.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/TestForAPIFragment.kt
@@ -1,4 +1,4 @@
-package de.rki.coronawarnapp
+package de.rki.coronawarnapp.test
 
 import android.content.Intent
 import android.graphics.Bitmap
@@ -30,6 +30,7 @@ import com.google.zxing.BarcodeFormat
 import com.google.zxing.integration.android.IntentIntegrator
 import com.google.zxing.integration.android.IntentResult
 import com.google.zxing.qrcode.QRCodeWriter
+import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.FragmentTestForAPIBinding
 import de.rki.coronawarnapp.exception.ExceptionCategory
 import de.rki.coronawarnapp.exception.ExceptionCategory.INTERNAL

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/TestRiskLevelCalculationFragment.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/TestRiskLevelCalculationFragment.kt
@@ -1,4 +1,4 @@
-package de.rki.coronawarnapp
+package de.rki.coronawarnapp.test
 
 import android.content.Intent
 import android.os.Bundle
@@ -15,6 +15,7 @@ import com.google.android.gms.nearby.Nearby
 import com.google.android.gms.nearby.exposurenotification.ExposureInformation
 import com.google.zxing.integration.android.IntentIntegrator
 import com.google.zxing.integration.android.IntentResult
+import de.rki.coronawarnapp.CoronaWarnApplication
 import de.rki.coronawarnapp.databinding.FragmentTestRiskLevelCalculationBinding
 import de.rki.coronawarnapp.exception.ExceptionCategory
 import de.rki.coronawarnapp.exception.TransactionException
@@ -50,9 +51,9 @@ import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
 
 @Suppress("MagicNumber", "LongMethod")
-class TestRiskLevelCalculation : Fragment() {
+class TestRiskLevelCalculationFragment : Fragment() {
     companion object {
-        val TAG: String? = TestRiskLevelCalculation::class.simpleName
+        val TAG: String? = TestRiskLevelCalculationFragment::class.simpleName
     }
 
     private val tracingViewModel: TracingViewModel by activityViewModels()

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/ui/main/MainFragment.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/ui/main/MainFragment.kt
@@ -154,6 +154,8 @@ class MainFragment : Fragment() {
     private fun showPopup(view: View) {
         val popup = PopupMenu(requireContext(), view)
         popup.inflate(R.menu.menu_main)
+        // TODO we shouldn't have to duplicate the whole fragment to add these items
+        // In the future we'd like a DI'ed class that changes the navigation for this MainFragment?
         popup.setOnMenuItemClickListener {
             return@setOnMenuItemClickListener when (it.itemId) {
                 R.id.menu_help -> {

--- a/Corona-Warn-App/src/deviceForTesters/res/navigation/nav_graph.xml
+++ b/Corona-Warn-App/src/deviceForTesters/res/navigation/nav_graph.xml
@@ -174,7 +174,7 @@
     <!-- Submission -->
     <fragment
         android:id="@+id/testForAPIFragment"
-        android:name="de.rki.coronawarnapp.TestForAPIFragment"
+        android:name="de.rki.coronawarnapp.test.TestForAPIFragment"
         android:label="@layout/fragment_test_for_a_p_i"
         tools:layout="@layout/fragment_test_for_a_p_i" />
 
@@ -315,7 +315,7 @@
     </fragment>
     <fragment
         android:id="@+id/testRiskLevelCalculation"
-        android:name="de.rki.coronawarnapp.TestRiskLevelCalculation"
+        android:name="de.rki.coronawarnapp.test.TestRiskLevelCalculationFragment"
         android:label="fragment_test_risk_level_calculation"
         tools:layout="@layout/fragment_test_risk_level_calculation" />
 </navigation>

--- a/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
+++ b/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
@@ -38,9 +38,6 @@
         <action
             android:id="@+id/action_mainFragment_to_mainOverviewFragment"
             app:destination="@id/mainOverviewFragment" />
-        <action
-            android:id="@+id/action_mainFragment_to_testRiskLevelCalculation"
-            app:destination="@id/testRiskLevelCalculation" />
     </fragment>
 
     <fragment
@@ -168,7 +165,6 @@
         android:label="InformationTechnicalFragment"
         tools:layout="@layout/fragment_information_technical" />
 
-    <!-- Submission -->
     <fragment
         android:id="@+id/riskDetailsFragment"
         android:name="de.rki.coronawarnapp.ui.riskdetails.RiskDetailsFragment"
@@ -178,7 +174,7 @@
             android:id="@+id/action_riskDetailsFragment_to_settingsTracingFragment"
             app:destination="@id/settingsTracingFragment" />
     </fragment>
-
+    <!-- Submission -->
     <fragment
         android:id="@+id/submissionDispatcherFragment"
         android:name="de.rki.coronawarnapp.ui.submission.SubmissionDispatcherFragment"
@@ -304,9 +300,4 @@
             android:id="@+id/action_submissionContactFragment_to_submissionTanFragment"
             app:destination="@id/submissionTanFragment" />
     </fragment>
-    <fragment
-        android:id="@+id/testRiskLevelCalculation"
-        android:name="de.rki.coronawarnapp.TestRiskLevelCalculation"
-        android:label="fragment_test_risk_level_calculation"
-        tools:layout="@layout/fragment_test_risk_level_calculation" />
 </navigation>


### PR DESCRIPTION
This fixes flaky builds some of us were having.

* The `device`-navgraph contained references to test fragments that were only available on the `deviceForTesters` flavor.
* Fixed the path/package setup for `deviceForTesters` `java/de.rki.coronawarnapp` -> `java/de/rki/coronawarnapp`


**How to test**
* On `device`, install the app, click the submission card, check the menu, test entries are not there
* On `deviceForTesters`, install the app, click the submission card, check the menu, enter each test fragment
