### PR TITLE
Version Checker with Branching for Checks on provideDiagnosisKeys below v16 of ENF (EXPOSUREAPP-2213)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/InternalExposureNotificationClient.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/InternalExposureNotificationClient.kt
@@ -1,7 +1,5 @@
 package de.rki.coronawarnapp.nearby
 
-import com.google.android.gms.common.api.ApiException
-import com.google.android.gms.common.api.CommonStatusCodes.API_NOT_CONNECTED
 import com.google.android.gms.nearby.Nearby
 import com.google.android.gms.nearby.exposurenotification.ExposureConfiguration
 import com.google.android.gms.nearby.exposurenotification.ExposureConfiguration.ExposureConfigurationBuilder
@@ -17,8 +15,6 @@ import java.util.Date
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
-import kotlin.math.abs
-import kotlin.math.log10
 
 /**
  * Wrapper class for the Exposure Notification Client in the com.google.android.gms.nearby.Nearby
@@ -96,31 +92,7 @@ object InternalExposureNotificationClient {
             }
     }
 
-    /**
-     * Indicates if the client runs above a certain version
-     *
-     * @return isAboveVersion, if connected to an old version, return false
-     */
-    suspend fun asyncIsAboveVersion(version: Long): Boolean {
-        if (!version.versionLength.isCorrectVersionLength) {
-            throw IllegalArgumentException("given version has incorrect length")
-        }
-        return try {
-            version > getVersion()
-        } catch (e: ApiException) {
-            if (e.statusCode == API_NOT_CONNECTED) false else throw e
-        }
-    }
-
-    private val Int.isCorrectVersionLength get(): Boolean = this == 8
-
-    private val Long.versionLength
-        get(): Int = when (this) {
-            0L -> 1
-            else -> log10(abs(toDouble())).toInt() + 1
-        }
-
-    private suspend fun getVersion(): Long = suspendCoroutine { cont ->
+    suspend fun getVersion(): Long = suspendCoroutine { cont ->
         exposureNotificationClient.version
             .addOnSuccessListener {
                 cont.resume(it)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/transaction/RetrieveDiagnosisInjectionHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/transaction/RetrieveDiagnosisInjectionHelper.kt
@@ -1,10 +1,12 @@
 package de.rki.coronawarnapp.transaction
 
+import de.rki.coronawarnapp.util.GoogleAPIVersion
 import javax.inject.Inject
 import javax.inject.Singleton
 
 // TODO Remove once we have refactored the transaction and it's no longer a singleton
 @Singleton
 data class RetrieveDiagnosisInjectionHelper @Inject constructor(
-    val transactionScope: TransactionCoroutineScope
+    val transactionScope: TransactionCoroutineScope,
+    val googleAPIVersion: GoogleAPIVersion
 )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/transaction/RetrieveDiagnosisKeysTransaction.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/transaction/RetrieveDiagnosisKeysTransaction.kt
@@ -142,7 +142,9 @@ object RetrieveDiagnosisKeysTransaction : Transaction() {
         quotaChronology = GJChronology.getInstanceUTC()
     )
 
-    private val googleAPIVersion = GoogleAPIVersion()
+    private val googleAPIVersion: GoogleAPIVersion by lazy {
+        AppInjector.component.transRetrieveKeysInjection.googleAPIVersion
+    }
 
     suspend fun startWithConstraints() {
         val currentDate = DateTime(Instant.now(), DateTimeZone.UTC)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/GoogleAPIVersion.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/GoogleAPIVersion.kt
@@ -1,0 +1,34 @@
+package de.rki.coronawarnapp.util
+
+import com.google.android.gms.common.api.ApiException
+import com.google.android.gms.common.api.CommonStatusCodes
+import de.rki.coronawarnapp.nearby.InternalExposureNotificationClient
+import kotlin.math.abs
+
+class GoogleAPIVersion {
+    /**
+     * Indicates if the client runs above a certain version
+     *
+     * @return isAboveVersion, if connected to an old unsupported version, return false
+     */
+    suspend fun isAbove(compareVersion: Long): Boolean {
+        if (!compareVersion.isCorrectVersionLength) {
+            throw IllegalArgumentException("given version has incorrect length")
+        }
+        return try {
+            compareVersion > InternalExposureNotificationClient.getVersion()
+        } catch (apiException: ApiException) {
+            if (apiException.statusCode == CommonStatusCodes.API_NOT_CONNECTED) false
+            else throw apiException
+        }
+    }
+
+    // check if a raw long has the correct length to be considered an API version
+    private val Long.isCorrectVersionLength
+        get(): Boolean = abs(this).toString().length == GOOGLE_API_VERSION_FIELD_LENGTH
+
+    companion object {
+        private const val GOOGLE_API_VERSION_FIELD_LENGTH = 8
+        const val V16 = 16000000L
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/GoogleAPIVersion.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/GoogleAPIVersion.kt
@@ -16,7 +16,8 @@ class GoogleAPIVersion {
             throw IllegalArgumentException("given version has incorrect length")
         }
         return try {
-            compareVersion > InternalExposureNotificationClient.getVersion()
+            val currentVersion = InternalExposureNotificationClient.getVersion()
+            currentVersion >= compareVersion
         } catch (apiException: ApiException) {
             if (apiException.statusCode == CommonStatusCodes.API_NOT_CONNECTED) false
             else throw apiException

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/GoogleAPIVersion.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/GoogleAPIVersion.kt
@@ -2,10 +2,13 @@ package de.rki.coronawarnapp.util
 
 import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.common.api.CommonStatusCodes
+import dagger.Reusable
 import de.rki.coronawarnapp.nearby.InternalExposureNotificationClient
+import javax.inject.Inject
 import kotlin.math.abs
 
-class GoogleAPIVersion {
+@Reusable
+class GoogleAPIVersion @Inject constructor() {
     /**
      * Indicates if the client runs above a certain version
      *

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/transaction/RetrieveDiagnosisKeysTransactionTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/transaction/RetrieveDiagnosisKeysTransactionTest.kt
@@ -52,6 +52,9 @@ class RetrieveDiagnosisKeysTransactionTest {
                 any()
             )
         } returns mockk()
+        coEvery {
+            InternalExposureNotificationClient.getVersion()
+        } returns 17000000L
         coEvery { ApplicationConfigurationService.asyncRetrieveExposureConfiguration() } returns mockk()
         every { LocalData.googleApiToken(any()) } just Runs
         every { LocalData.lastTimeDiagnosisKeysFromServerFetch() } returns Date()

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/transaction/RetrieveDiagnosisKeysTransactionTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/transaction/RetrieveDiagnosisKeysTransactionTest.kt
@@ -4,6 +4,7 @@ import com.google.android.gms.nearby.exposurenotification.ExposureConfiguration
 import de.rki.coronawarnapp.nearby.InternalExposureNotificationClient
 import de.rki.coronawarnapp.service.applicationconfiguration.ApplicationConfigurationService
 import de.rki.coronawarnapp.storage.LocalData
+import de.rki.coronawarnapp.util.GoogleAPIVersion
 import de.rki.coronawarnapp.util.di.AppInjector
 import de.rki.coronawarnapp.util.di.ApplicationComponent
 import io.mockk.Runs
@@ -34,7 +35,8 @@ class RetrieveDiagnosisKeysTransactionTest {
         mockkObject(AppInjector)
         val appComponent = mockk<ApplicationComponent>().apply {
             every { transRetrieveKeysInjection } returns RetrieveDiagnosisInjectionHelper(
-                TransactionCoroutineScope()
+                TransactionCoroutineScope(),
+                GoogleAPIVersion()
             )
         }
         every { AppInjector.component } returns appComponent

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/GoogleAPIVersionTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/GoogleAPIVersionTest.kt
@@ -1,0 +1,79 @@
+package de.rki.coronawarnapp.util
+
+import com.google.android.gms.common.api.ApiException
+import com.google.android.gms.common.api.CommonStatusCodes.API_NOT_CONNECTED
+import com.google.android.gms.common.api.Status
+import de.rki.coronawarnapp.nearby.InternalExposureNotificationClient
+import io.kotest.matchers.shouldBe
+import io.mockk.Called
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class GoogleAPIVersionTest {
+
+    private lateinit var classUnderTest: GoogleAPIVersion
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(InternalExposureNotificationClient)
+        classUnderTest = GoogleAPIVersion()
+    }
+
+    @ExperimentalCoroutinesApi
+    @Test
+    fun `isAbove API v16 is true for v17`() {
+        coEvery { InternalExposureNotificationClient.getVersion() } returns 17000000L
+
+        runBlockingTest {
+            classUnderTest.isAbove(GoogleAPIVersion.V16) shouldBe true
+        }
+
+    }
+
+    @ExperimentalCoroutinesApi
+    @Test
+    fun `isAbove API v16 is false for v15`() {
+        coEvery { InternalExposureNotificationClient.getVersion() } returns 15000000L
+
+        runBlockingTest {
+            classUnderTest.isAbove(GoogleAPIVersion.V16) shouldBe false
+        }
+    }
+
+    @ExperimentalCoroutinesApi
+    @Test
+    fun `isAbove API v16 throws IllegalArgument for invalid version`() {
+        assertThrows<IllegalArgumentException> {
+            runBlockingTest {
+                classUnderTest.isAbove(1L)
+            }
+            coVerify {
+                InternalExposureNotificationClient.getVersion() wasNot Called
+            }
+        }
+    }
+
+    @ExperimentalCoroutinesApi
+    @Test
+    fun `isAbove API v16 false when APIException for too low version`() {
+        coEvery { InternalExposureNotificationClient.getVersion() } throws
+                ApiException(Status(API_NOT_CONNECTED))
+
+        runBlockingTest {
+            classUnderTest.isAbove(GoogleAPIVersion.V16) shouldBe false
+        }
+    }
+
+    @AfterEach
+    fun teardown() {
+        unmockkObject(InternalExposureNotificationClient)
+    }
+}

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/GoogleAPIVersionTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/GoogleAPIVersionTest.kt
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
+@ExperimentalCoroutinesApi
 internal class GoogleAPIVersionTest {
 
     private lateinit var classUnderTest: GoogleAPIVersion
@@ -27,7 +28,11 @@ internal class GoogleAPIVersionTest {
         classUnderTest = GoogleAPIVersion()
     }
 
-    @ExperimentalCoroutinesApi
+    @AfterEach
+    fun tearDown() {
+        unmockkObject(InternalExposureNotificationClient)
+    }
+
     @Test
     fun `isAbove API v16 is true for v17`() {
         coEvery { InternalExposureNotificationClient.getVersion() } returns 17000000L
@@ -38,7 +43,6 @@ internal class GoogleAPIVersionTest {
 
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `isAbove API v16 is false for v15`() {
         coEvery { InternalExposureNotificationClient.getVersion() } returns 15000000L
@@ -48,7 +52,6 @@ internal class GoogleAPIVersionTest {
         }
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `isAbove API v16 throws IllegalArgument for invalid version`() {
         assertThrows<IllegalArgumentException> {
@@ -61,7 +64,6 @@ internal class GoogleAPIVersionTest {
         }
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `isAbove API v16 false when APIException for too low version`() {
         coEvery { InternalExposureNotificationClient.getVersion() } throws
@@ -70,10 +72,5 @@ internal class GoogleAPIVersionTest {
         runBlockingTest {
             classUnderTest.isAbove(GoogleAPIVersion.V16) shouldBe false
         }
-    }
-
-    @AfterEach
-    fun teardown() {
-        unmockkObject(InternalExposureNotificationClient)
     }
 }


### PR DESCRIPTION
This PR features a small class for checking the API Version to branch off logic. It also includes a branching for provideDiagnosisKeys in the RetrieveDiagnosisKeysTransaction. It can be tested by comparing devices with different versions of GMS and seeing how many provideDiagnosisKeys calls are executed in the transaction.

Expectations:
- Versions always have exactly 8 digits, and can be compared by using their raw value
Cases:
- `<16xxxxxx` should query with 14 calls
- `<15xxxxxx` an exception is converted to 14 calls as we expect getVersion() to be unavailable due to a too old version of ENF
- `>=16xxxxxx` should query with 1 call