### PR TITLE
Reverted replaced wording (EXPOSUREAPP-2638) (#1153)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/formatter/FormatterRiskHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/formatter/FormatterRiskHelper.kt
@@ -142,7 +142,7 @@ fun formatRiskContact(riskLevelScore: Int?, matchedKeysCount: Int?): String {
         }
         RiskLevelConstants.LOW_LEVEL_RISK -> {
             if (matchedKeysCount == 0) {
-                appContext.getString(R.string.risk_card_body_contact_low_risk)
+                appContext.getString(R.string.risk_card_body_contact)
             } else {
                 resources.getQuantityString(
                     R.plurals.risk_card_body_contact_value,

--- a/Corona-Warn-App/src/main/res/values-bg/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-bg/strings.xml
@@ -135,8 +135,6 @@
 
     <!-- XTXT: risk card - no contact yet -->
     <string name="risk_card_body_contact">"До момента няма излагане на риск"</string>
-    <!-- XTXT: risk card - no exposures with low risk -->
-    <string name="risk_card_body_contact_low_risk">"До момента няма излагане на нисък риск"</string>
     <!-- XTXT: risk card - number of contacts for one or more -->
     <plurals name="risk_card_body_contact_value">
         <item quantity="one">"%1$s излагане на нисък риск"</item>

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -135,16 +135,14 @@
 
     <!-- XTXT: risk card - no contact yet -->
     <string name="risk_card_body_contact">"Bisher keine Risiko-Begegnungen"</string>
-    <!-- XTXT: risk card - no exposures with low risk -->
-    <string name="risk_card_body_contact_low_risk">"Bisher keine Begegnungen mit niedrigem Risiko"</string>
     <!-- XTXT: risk card - number of contacts for one or more -->
     <plurals name="risk_card_body_contact_value">
-        <item quantity="one">"%1$s Risiko-Begegnung mit niedrigem Risiko"</item>
-        <item quantity="other">"%1$s Risiko-Begegnungen mit niedrigem Risiko"</item>
+        <item quantity="one">"%1$s Begegnung mit niedrigem Risiko"</item>
+        <item quantity="other">"%1$s Begegnungen mit niedrigem Risiko"</item>
         <item quantity="zero">"Bisher keine Begegnungen mit niedrigem Risiko"</item>
-        <item quantity="two">"%1$s Risiko-Begegnungen mit niedrigem Risiko"</item>
-        <item quantity="few">"%1$s Risiko-Begegnungen mit niedrigem Risiko"</item>
-        <item quantity="many">"%1$s Risiko-Begegnungen mit niedrigem Risiko"</item>
+        <item quantity="two">"%1$s Begegnungen mit niedrigem Risiko"</item>
+        <item quantity="few">"%1$s Begegnungen mit niedrigem Risiko"</item>
+        <item quantity="many">"%1$s Begegnungen mit niedrigem Risiko"</item>
     </plurals>
     <!-- XTXT: risk card - number of contacts for one or more -->
     <plurals name="risk_card_body_contact_value_high_risk">

--- a/Corona-Warn-App/src/main/res/values-en/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-en/strings.xml
@@ -135,8 +135,6 @@
 
     <!-- XTXT: risk card - no contact yet -->
     <string name="risk_card_body_contact">"No exposure up to now"</string>
-    <!-- XTXT: risk card - no exposures with low risk -->
-    <string name="risk_card_body_contact_low_risk">"No exposure with low risk so far"</string>
     <!-- XTXT: risk card - number of contacts for one or more -->
     <plurals name="risk_card_body_contact_value">
         <item quantity="one">"%1$s exposure with low risk"</item>

--- a/Corona-Warn-App/src/main/res/values-pl/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-pl/strings.xml
@@ -135,8 +135,6 @@
 
     <!-- XTXT: risk card - no contact yet -->
     <string name="risk_card_body_contact">"Brak narażenia do tej pory"</string>
-    <!-- XTXT: risk card - no exposures with low risk -->
-    <string name="risk_card_body_contact_low_risk">"Brak narażenia z niskim ryzykiem do tej pory"</string>
     <!-- XTXT: risk card - number of contacts for one or more -->
     <plurals name="risk_card_body_contact_value">
         <item quantity="one">"%1$s narażenie z niskim ryzykiem"</item>

--- a/Corona-Warn-App/src/main/res/values-ro/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-ro/strings.xml
@@ -135,8 +135,6 @@
 
     <!-- XTXT: risk card - no contact yet -->
     <string name="risk_card_body_contact">"Nicio expunere până acum"</string>
-    <!-- XTXT: risk card - no exposures with low risk -->
-    <string name="risk_card_body_contact_low_risk">"Nicio expunere cu risc redus până acum"</string>
     <!-- XTXT: risk card - number of contacts for one or more -->
     <plurals name="risk_card_body_contact_value">
         <item quantity="one">"%1$s expunere cu risc redus"</item>

--- a/Corona-Warn-App/src/main/res/values-tr/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-tr/strings.xml
@@ -135,8 +135,6 @@
 
     <!-- XTXT: risk card - no contact yet -->
     <string name="risk_card_body_contact">"Şu ana dek hiçbir maruz kalma yok"</string>
-    <!-- XTXT: risk card - no exposures with low risk -->
-    <string name="risk_card_body_contact_low_risk">"Şu ana dek hiçbir düşük riskli maruz kalma yok"</string>
     <!-- XTXT: risk card - number of contacts for one or more -->
     <plurals name="risk_card_body_contact_value">
         <item quantity="one">"%1$s kez düşük riskli maruz kalma"</item>

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -137,8 +137,6 @@
 
     <!-- XTXT: risk card - no contact yet -->
     <string name="risk_card_body_contact">"No exposure up to now"</string>
-    <!-- XTXT: risk card - no exposures with low risk -->
-    <string name="risk_card_body_contact_low_risk">"No exposure with low risk so far"</string>
     <!-- XTXT: risk card - number of contacts for one or more -->
     <plurals name="risk_card_body_contact_value">
         <item quantity="one">"%1$s exposure with low risk"</item>

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/formatter/FormatterRiskHelperTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/formatter/FormatterRiskHelperTest.kt
@@ -95,7 +95,6 @@ class FormatterRiskHelperTest {
 
     private fun formatRiskContactBase(iRiskLevelScore: Int?, iMatchedKeysCount: Int?, sValue: String) {
         every { context.getString(R.string.risk_card_body_contact) } returns R.string.risk_card_body_contact.toString()
-        every { context.getString(R.string.risk_card_body_contact_low_risk) } returns R.string.risk_card_body_contact_low_risk.toString()
 
         val result = formatRiskContact(riskLevelScore = iRiskLevelScore, matchedKeysCount = iMatchedKeysCount)
         assertThat(
@@ -105,7 +104,6 @@ class FormatterRiskHelperTest {
 
     private fun formatRiskContactLastBase(iRiskLevelScore: Int?, iDaysSinceLastExposure: Int?, sValue: String) {
         every { context.getString(R.string.risk_card_body_contact) } returns R.string.risk_card_body_contact.toString()
-        every { context.getString(R.string.risk_card_body_contact_low_risk) } returns R.string.risk_card_body_contact_low_risk.toString()
 
         val result =
             formatRiskContactLast(riskLevelScore = iRiskLevelScore, daysSinceLastExposure = iDaysSinceLastExposure)
@@ -584,7 +582,7 @@ class FormatterRiskHelperTest {
         formatRiskContactBase(
             iRiskLevelScore = RiskLevelConstants.LOW_LEVEL_RISK,
             iMatchedKeysCount = 0,
-            sValue = context.getString(R.string.risk_card_body_contact_low_risk)
+            sValue = context.getString(R.string.risk_card_body_contact)
         )
         formatRiskContactBase(
             iRiskLevelScore = RiskLevelConstants.LOW_LEVEL_RISK,


### PR DESCRIPTION
* Fix: No exposure with low risk so far

* Fixed klint issues (#1144)

* restored reverted replaced wording for lint

* https://github.com/corona-warn-app/cwa-app-android/pull/1153#discussion_r487801724

* fixed term