### PR TITLE
Improve keyfile checksum handling

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/server/DownloadInfo.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/server/DownloadInfo.kt
@@ -2,16 +2,16 @@ package de.rki.coronawarnapp.diagnosiskeys.server
 
 import okhttp3.Headers
 
-class KeyFileHeaderHook(
-    private val onEval: suspend KeyFileHeaderHook.(Headers) -> Boolean
-) : DiagnosisKeyServer.HeaderHook {
+data class DownloadInfo(
+    val headers: Headers,
+    val localMD5: String? = null
+) {
 
-    override suspend fun validate(headers: Headers): Boolean = onEval(headers)
+    val serverMD5 by lazy { headers.getPayloadChecksumMD5() }
 
-    fun Headers.getPayloadChecksumMD5(): String? {
-        // TODO Ping backend regarding alternative checksum sources
-        var fileMD5 = values("ETag").singleOrNull()
-        // The hash from these headers doesn't match, TODO EXPOSUREBACK-178
+    private fun Headers.getPayloadChecksumMD5(): String? {
+        // TODO EXPOSUREBACK-178
+        val fileMD5 = values("ETag").singleOrNull()
 //                var fileMD5 = headers.values("x-amz-meta-cwa-hash-md5").singleOrNull()
 //                if (fileMD5 == null) {
 //                    headers.values("x-amz-meta-cwa-hash").singleOrNull()

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/KeyFileDownloaderTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/KeyFileDownloaderTest.kt
@@ -2,6 +2,7 @@ package de.rki.coronawarnapp.diagnosiskeys.download
 
 import android.database.SQLException
 import de.rki.coronawarnapp.diagnosiskeys.server.DiagnosisKeyServer
+import de.rki.coronawarnapp.diagnosiskeys.server.DownloadInfo
 import de.rki.coronawarnapp.diagnosiskeys.server.LocationCode
 import de.rki.coronawarnapp.diagnosiskeys.storage.CachedKeyInfo
 import de.rki.coronawarnapp.diagnosiskeys.storage.KeyCacheRepository
@@ -104,7 +105,13 @@ class KeyFileDownloaderTest : BaseIOTest() {
             LocalTime.parse("22"), LocalTime.parse("23")
         )
         coEvery { diagnosisKeyServer.downloadKeyFile(any(), any(), any(), any(), any()) } answers {
-            mockDownloadServerDownload(arg(0), arg(1), arg(2), arg(3), arg(4))
+            mockDownloadServerDownload(
+                locationCode = arg(0),
+                day = arg(1),
+                hour = arg(2),
+                saveTo = arg(3),
+                precondition = arg(4)
+            )
         }
 
         coEvery { keyCache.createCacheEntry(any(), any(), any(), any()) } answers {
@@ -170,10 +177,15 @@ class KeyFileDownloaderTest : BaseIOTest() {
         day: LocalDate,
         hour: LocalTime? = null,
         saveTo: File,
-        validator: DiagnosisKeyServer.HeaderHook = object :
-            DiagnosisKeyServer.HeaderHook {}
-    ) {
+        precondition: suspend (DownloadInfo) -> Boolean = { true },
+        checksumServerMD5: String? = "serverMD5",
+        checksumLocalMD5: String? = "localMD5"
+    ): DownloadInfo {
         saveTo.writeText("$locationCode.$day.$hour")
+        return mockk<DownloadInfo>().apply {
+            every { serverMD5 } returns checksumServerMD5
+            every { localMD5 } returns checksumLocalMD5
+        }
     }
 
     private fun mockAddData(
@@ -185,8 +197,13 @@ class KeyFileDownloaderTest : BaseIOTest() {
     ): Pair<CachedKeyInfo, File> {
         val (keyInfo, file) = mockKeyCacheCreateEntry(type, location, day, hour)
         if (isCompleted) {
-            mockDownloadServerDownload(location, day, hour, file)
-            mockKeyCacheUpdateComplete(keyInfo, "checksum")
+            mockDownloadServerDownload(
+                locationCode = location,
+                day = day,
+                hour = hour,
+                saveTo = file
+            )
+            mockKeyCacheUpdateComplete(keyInfo, "serverMD5")
         }
         return keyRepoData[keyInfo.id]!! to file
     }
@@ -380,7 +397,13 @@ class KeyFileDownloaderTest : BaseIOTest() {
         coEvery { diagnosisKeyServer.downloadKeyFile(any(), any(), any(), any(), any()) } answers {
             dlCounter++
             if (dlCounter == 2) throw IOException("Timeout")
-            mockDownloadServerDownload(arg(0), arg(1), arg(2), arg(3), arg(4))
+            mockDownloadServerDownload(
+                locationCode = arg(0),
+                day = arg(1),
+                hour = arg(2),
+                saveTo = arg(3),
+                precondition = arg(4)
+            )
         }
 
         val downloader = createDownloader()
@@ -611,7 +634,13 @@ class KeyFileDownloaderTest : BaseIOTest() {
         coEvery { diagnosisKeyServer.downloadKeyFile(any(), any(), any(), any(), any()) } answers {
             dlCounter++
             if (dlCounter == 2) throw IOException("Timeout")
-            mockDownloadServerDownload(arg(0), arg(1), arg(2), arg(3), arg(4))
+            mockDownloadServerDownload(
+                locationCode = arg(0),
+                day = arg(1),
+                hour = arg(2),
+                saveTo = arg(3),
+                precondition = arg(4)
+            )
         }
 
         val downloader = createDownloader()
@@ -679,6 +708,76 @@ class KeyFileDownloaderTest : BaseIOTest() {
                 any(),
                 any()
             )
+        }
+    }
+
+    @Test
+    fun `store server md5`() {
+        coEvery { diagnosisKeyServer.getCountryIndex() } returns listOf(LocationCode("DE"))
+        coEvery { diagnosisKeyServer.getDayIndex(LocationCode("DE")) } returns listOf(
+            LocalDate.parse("2020-09-01")
+        )
+
+        val downloader = createDownloader()
+
+        runBlocking {
+            downloader.asyncFetchKeyFiles(
+                listOf(LocationCode("DE"))
+            ).size shouldBe 1
+        }
+
+        coVerify {
+            keyCache.createCacheEntry(
+                type = CachedKeyInfo.Type.COUNTRY_DAY,
+                location = LocationCode("DE"),
+                dayIdentifier = LocalDate.parse("2020-09-01"),
+                hourIdentifier = null
+            )
+        }
+        keyRepoData.size shouldBe 1
+        keyRepoData.values.forEach {
+            it.isDownloadComplete shouldBe true
+            it.checksumMD5 shouldBe "serverMD5"
+        }
+    }
+
+    @Test
+    fun `use local MD5 as fallback if there is none available from the server`() {
+        coEvery { diagnosisKeyServer.getCountryIndex() } returns listOf(LocationCode("DE"))
+        coEvery { diagnosisKeyServer.getDayIndex(LocationCode("DE")) } returns listOf(
+            LocalDate.parse("2020-09-01")
+        )
+        coEvery { diagnosisKeyServer.downloadKeyFile(any(), any(), any(), any(), any()) } answers {
+            mockDownloadServerDownload(
+                locationCode = arg(0),
+                day = arg(1),
+                hour = arg(2),
+                saveTo = arg(3),
+                precondition = arg(4),
+                checksumServerMD5 = null
+            )
+        }
+
+        val downloader = createDownloader()
+
+        runBlocking {
+            downloader.asyncFetchKeyFiles(
+                listOf(LocationCode("DE"))
+            ).size shouldBe 1
+        }
+
+        coVerify {
+            keyCache.createCacheEntry(
+                type = CachedKeyInfo.Type.COUNTRY_DAY,
+                location = LocationCode("DE"),
+                dayIdentifier = LocalDate.parse("2020-09-01"),
+                hourIdentifier = null
+            )
+        }
+        keyRepoData.size shouldBe 1
+        keyRepoData.values.forEach {
+            it.isDownloadComplete shouldBe true
+            it.checksumMD5 shouldBe "localMD5"
         }
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/server/DownloadInfoTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/server/DownloadInfoTest.kt
@@ -1,0 +1,19 @@
+package de.rki.coronawarnapp.diagnosiskeys.server
+
+import io.kotest.matchers.shouldBe
+import okhttp3.Headers
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class DownloadInfoTest : BaseTest() {
+
+    @Test
+    fun `extract server MD5`() {
+        val info = DownloadInfo(
+            headers = Headers.headersOf("ETAG", "serverMD5"),
+            localMD5 = "localMD5"
+        )
+        info.serverMD5 shouldBe "serverMD5"
+        info.localMD5 shouldBe "localMD5"
+    }
+}


### PR DESCRIPTION
## Description
* Make checksum retrieval the responsibility of `DiagnosisKeyServer` instead of `KeyFileDownloader` (cleaner)
* Favor the servers MD5 over our own (but use it as fallback) (when we add key validation, we ideally want the server provided checksum)

## How to test
* Review code changes + tests (isn't easily testable on device)
