### PR TITLE
Remove RKI-Hotline from terms of use (tr, en) (EXPOSUREAPP-2633)

### DIFF
--- a/Corona-Warn-App/src/main/assets/terms_en.html
+++ b/Corona-Warn-App/src/main/assets/terms_en.html
@@ -59,9 +59,8 @@
     13353 Berlin ("RKI")
 </p>
 <p>
-    represented by its President. Please call the RKI on +49 30 187 545 100 or
-    email us at CoronaWarnApp@rki.de if you have any questions relating to
-    these Terms of Use or if you wish to submit any complaints or legal claims.
+    represented by its President. Please email us at CoronaWarnApp@rki.de if you have any questions
+    relating to these Terms of Use or if you wish to submit any complaints or legal claims.
 </p>
 <p>
     Please make sure that you read these Terms of Use carefully. These Terms of

--- a/Corona-Warn-App/src/main/assets/terms_tr.html
+++ b/Corona-Warn-App/src/main/assets/terms_tr.html
@@ -60,9 +60,8 @@
 </p>
 <p>
     Robert Koch-Institut'tür ("<strong>RKI</strong>"). Bu kullanım koşulları
-    ile ilgili soru, şikayet ya da istekleriniz için +49 30 18754-5100 numaralı
-    telefon ve CoronaWarnApp@rki.de e-posta adresi aracılığıyla RKI'ye
-    ulaşabilirsiniz.
+    ile ilgili soru, şikayet ya da istekleriniz için CoronaWarnApp@rki.de e-posta adresi
+    aracılığıyla RKI'ye ulaşabilirsiniz.
 </p>
 <p>
     Lütfen bu kullanım koşullarını dikkatlice okuyun. Bu kullanım koşulları,


### PR DESCRIPTION
## Description
Removed RKI-Hotline number from terms of use for turkish and english translation.
