### PR TITLE
Wrap EncryptedSharedPreferences initialization in a retry mechanism (EXPOSUREAPP-1851)

### DIFF
--- a/Corona-Warn-App/build.gradle
+++ b/Corona-Warn-App/build.gradle
@@ -323,7 +323,7 @@ dependencies {
     implementation 'joda-time:joda-time:2.10.6'
 
     // SECURITY
-    implementation "androidx.security:security-crypto:1.0.0-rc02"
+    implementation "androidx.security:security-crypto:1.0.0-rc03"
     implementation 'net.zetetic:android-database-sqlcipher:4.4.0'
     implementation 'org.conscrypt:conscrypt-android:2.4.0'
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/RetryMechanism.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/RetryMechanism.kt
@@ -52,8 +52,14 @@ object RetryMechanism {
         } else {
             val exp = 2.0.pow(attempt.count.toDouble())
             val calculatedDelay = (multiplier * exp).roundToLong()
-            val newDelay = calculatedDelay.coerceAtMost(maxDelay).coerceAtLeast(minDelay)
-            (attempt.lastDelay..newDelay).random()
+
+            val newDelay = if (calculatedDelay > attempt.lastDelay) {
+                (attempt.lastDelay..calculatedDelay).random()
+            } else {
+                (calculatedDelay..attempt.lastDelay).random()
+            }
+
+            newDelay.coerceAtMost(maxDelay).coerceAtLeast(minDelay)
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/RetryMechanism.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/RetryMechanism.kt
@@ -44,7 +44,7 @@ object RetryMechanism {
         maxTotalDelay: Long = 15 * 1000L, // 15 seconds total delay
         maxDelay: Long = 3 * 1000L, // 3 seconds max between retries
         minDelay: Long = 25, // Immediate retry
-        multiplier: Double = 1.0,
+        multiplier: Double = 1.5,
     ): (Attempt) -> Long? = { attempt ->
         if (attempt.totalDelay > maxTotalDelay) {
             Timber.w("Max retry duration exceeded.")

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/RetryMechanism.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/RetryMechanism.kt
@@ -40,11 +40,16 @@ object RetryMechanism {
         }
     }
 
+    private const val DEFAULT_TOTAL_MAX_RETRY = 15 * 1000L // 15 seconds total delay
+    private const val DEFAULT_MAX_DELAY = 3 * 1000L // 3 seconds max between retries
+    private const val DEFAULT_MIN_DELAY = 25L // Almost immediate retry
+    private const val DEFAULT_RETRY_MULTIPLIER = 1.5
+
     fun createDelayCalculator(
-        maxTotalDelay: Long = 15 * 1000L, // 15 seconds total delay
-        maxDelay: Long = 3 * 1000L, // 3 seconds max between retries
-        minDelay: Long = 25, // Immediate retry
-        multiplier: Double = 1.5,
+        maxTotalDelay: Long = DEFAULT_TOTAL_MAX_RETRY,
+        maxDelay: Long = DEFAULT_MAX_DELAY,
+        minDelay: Long = DEFAULT_MIN_DELAY,
+        multiplier: Double = DEFAULT_RETRY_MULTIPLIER
     ): (Attempt) -> Long? = { attempt ->
         if (attempt.totalDelay > maxTotalDelay) {
             Timber.w("Max retry duration exceeded.")

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/RetryMechanism.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/RetryMechanism.kt
@@ -1,0 +1,61 @@
+package de.rki.coronawarnapp.util
+
+import timber.log.Timber
+import kotlin.math.pow
+import kotlin.math.roundToLong
+
+object RetryMechanism {
+
+    fun <T> retryWithBackOff(
+        delayCalculator: (Attempt) -> Long? = createDelayCalculator(),
+        delayOperation: (Long) -> Unit = { Thread.sleep(it) },
+        action: () -> T
+    ): T {
+        var current = Attempt()
+        while (true) {
+            Timber.v("Executing attempt: %s", current)
+            try {
+                return action()
+            } catch (e: Exception) {
+                current = current.copy(exception = e)
+            }
+
+            val newDelay = delayCalculator(current)
+
+            if (newDelay == null) {
+                Timber.w("Retrycondition exceeded: %s", current)
+                throw current.exception!!
+            } else {
+                delayOperation(newDelay)
+            }
+
+            current = current.copy(
+                count = current.count + 1,
+                lastDelay = newDelay,
+                totalDelay = current.totalDelay + newDelay
+            )
+        }
+    }
+
+    fun createDelayCalculator(
+        maximumDelay: Long = 3 * 1000L, // 3 seconds max between retries
+        minimumDelay: Long = 0, // Immediate retry
+        multiplier: Double = 1.0,
+    ): (Attempt) -> Long? = { attempt ->
+        if (attempt.totalDelay > 10 * 1000L) {
+            Timber.w("Max retry duration exceeded.")
+            null
+        } else {
+            val exp = 2.0.pow(attempt.count.toDouble())
+            val calculatedDelay = (multiplier * exp).roundToLong()
+            calculatedDelay.coerceAtMost(maximumDelay).coerceAtLeast(minimumDelay)
+        }
+    }
+
+    data class Attempt(
+        val count: Int = 1,
+        val totalDelay: Long = 0L,
+        val lastDelay: Long = 0L,
+        val exception: Exception? = null
+    )
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/security/EncryptedPreferencesFactory.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/security/EncryptedPreferencesFactory.kt
@@ -31,7 +31,6 @@ class EncryptedPreferencesFactory @Inject constructor(
         RetryMechanism.retryWithBackOff {
             createInstance(fileName).also {
                 Timber.d("Instance created, %d entries.", it.all.size)
-                throw RuntimeException()
             }
         }
     } catch (e: Exception) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/security/EncryptedPreferencesFactory.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/security/EncryptedPreferencesFactory.kt
@@ -1,0 +1,39 @@
+package de.rki.coronawarnapp.util.security
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
+import de.rki.coronawarnapp.util.RetryMechanism
+import timber.log.Timber
+import java.security.KeyException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class EncryptedPreferencesFactory @Inject constructor(
+    private val context: Context,
+) {
+
+    private val masterKeyAlias by lazy {
+        MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+    }
+
+    private fun createInstance(fileName: String) = EncryptedSharedPreferences.create(
+        fileName,
+        masterKeyAlias,
+        context,
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+    )
+
+    fun create(fileName: String): SharedPreferences = try {
+        RetryMechanism.retryWithBackOff {
+            createInstance(fileName).also {
+                Timber.d("Instance created, %d entries.", it.all.size)
+            }
+        }
+    } catch (e: Exception) {
+        throw KeyException("Permantly failed to instantiate encrypted preferences", e)
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/security/EncryptedPreferencesFactory.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/security/EncryptedPreferencesFactory.kt
@@ -12,7 +12,7 @@ import javax.inject.Singleton
 
 @Singleton
 class EncryptedPreferencesFactory @Inject constructor(
-    private val context: Context,
+    private val context: Context
 ) {
 
     private val masterKeyAlias by lazy {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/security/EncryptedPreferencesFactory.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/security/EncryptedPreferencesFactory.kt
@@ -29,6 +29,7 @@ class EncryptedPreferencesFactory @Inject constructor(
 
     fun create(fileName: String): SharedPreferences = try {
         RetryMechanism.retryWithBackOff {
+            Timber.d("Creating EncryptedSharedPreferences instance.")
             createInstance(fileName).also {
                 Timber.d("Instance created, %d entries.", it.all.size)
             }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/security/EncryptedPreferencesFactory.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/security/EncryptedPreferencesFactory.kt
@@ -31,6 +31,7 @@ class EncryptedPreferencesFactory @Inject constructor(
         RetryMechanism.retryWithBackOff {
             createInstance(fileName).also {
                 Timber.d("Instance created, %d entries.", it.all.size)
+                throw RuntimeException()
             }
         }
     } catch (e: Exception) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/security/SecurityHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/security/SecurityHelper.kt
@@ -20,12 +20,9 @@
 package de.rki.coronawarnapp.util.security
 
 import android.annotation.SuppressLint
-import android.content.Context
 import android.content.SharedPreferences
 import android.os.Build
 import android.util.Base64
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKeys
 import de.rki.coronawarnapp.CoronaWarnApplication
 import de.rki.coronawarnapp.exception.CwaSecurityException
 import de.rki.coronawarnapp.util.security.SecurityConstants.CWA_APP_SQLITE_DB_PW
@@ -38,27 +35,13 @@ import java.security.SecureRandom
  * Key Store and Password Access
  */
 object SecurityHelper {
-    private val keyGenParameterSpec = MasterKeys.AES256_GCM_SPEC
-    private val masterKeyAlias = MasterKeys.getOrCreate(keyGenParameterSpec)
 
     val globalEncryptedSharedPreferencesInstance: SharedPreferences by lazy {
+        val factory = EncryptedPreferencesFactory(CoronaWarnApplication.getAppContext())
         withSecurityCatch {
-            CoronaWarnApplication.getAppContext()
-                .getEncryptedSharedPrefs(ENCRYPTED_SHARED_PREFERENCES_FILE)
+            factory.create(ENCRYPTED_SHARED_PREFERENCES_FILE)
         }
     }
-
-    /**
-     * Initializes the private encrypted key store
-     */
-    private fun Context.getEncryptedSharedPrefs(fileName: String) = EncryptedSharedPreferences
-        .create(
-            fileName,
-            masterKeyAlias,
-            this,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-        )
 
     private val String.toPreservedByteArray: ByteArray
         get() = Base64.decode(this, Base64.NO_WRAP)

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/RetryMechanismTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/RetryMechanismTest.kt
@@ -2,6 +2,7 @@ package de.rki.coronawarnapp.util
 
 import de.rki.coronawarnapp.util.RetryMechanism.createDelayCalculator
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.longs.beInRange
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -74,15 +75,15 @@ class RetryMechanismTest : BaseTest() {
     @Test
     fun `test clamping`() {
         val calculator = createDelayCalculator()
-        RetryMechanism.Attempt(count = -5, lastDelay = 25).let {
-            calculator(it) shouldBe 25
+        RetryMechanism.Attempt(count = -5, lastDelay = 20).let {
+            calculator(it) shouldBe 25 // -X .. 20  -> clamp to min (25)
         }
         RetryMechanism.Attempt(count = 100, lastDelay = 3 * 1000L).let {
-            calculator(it) shouldBe 3 * 1000L
+            calculator(it) shouldBe 3 * 1000L // lastDelay .. HugeNewDelay -> clamp to max (3k)
         }
 
-        RetryMechanism.Attempt(count = 1, lastDelay = 16 * 1000L).let {
-            calculator(it) shouldBe 3 * 1000L
+        RetryMechanism.Attempt(count = 10, lastDelay = 16 * 1000L).let {
+            calculator(it) shouldBe beInRange(1536L..3000L)
         }
         RetryMechanism.Attempt(count = 100, lastDelay = 1).let {
             calculator(it) shouldBe 3 * 1000L

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/RetryMechanismTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/RetryMechanismTest.kt
@@ -1,0 +1,91 @@
+package de.rki.coronawarnapp.util
+
+import de.rki.coronawarnapp.util.RetryMechanism.createDelayCalculator
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.instanceOf
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.util.UUID
+
+class RetryMechanismTest : BaseTest() {
+    @MockK lateinit var mockFunction: () -> String
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this)
+        every { mockFunction.invoke() } answers {
+            throw RuntimeException(UUID.randomUUID().toString())
+        }
+    }
+
+    @AfterEach
+    fun teardown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `simple retry`() {
+        val attempts = mutableListOf<RetryMechanism.Attempt>()
+        shouldThrow<RuntimeException> {
+            RetryMechanism.retryWithBackOff(
+                delayCalculator = createDelayCalculator(),
+                delayOperation = { Thread.sleep(it) },
+                retryCondition = {
+                    attempts.add(it)
+                    it.count < 3
+                },
+                action = mockFunction
+            )
+        }
+        verify(exactly = 3) { mockFunction() }
+
+        attempts[0].apply {
+            count shouldBe 1
+            totalDelay shouldBe 0L
+            lastDelay shouldBe 0L
+            exception should instanceOf(RuntimeException::class)
+        }
+        attempts[1].apply {
+            count shouldBe 2
+            totalDelay shouldBe lastDelay
+            lastDelay shouldBe totalDelay
+            exception should instanceOf(RuntimeException::class)
+        }
+        attempts[2].apply {
+            count shouldBe 3
+            totalDelay shouldBe attempts[1].totalDelay + lastDelay
+            lastDelay shouldBe totalDelay - attempts[1].totalDelay
+            exception should instanceOf(RuntimeException::class)
+        }
+        attempts[0].exception shouldNotBe attempts[1].exception
+        attempts[1].exception shouldNotBe attempts[2].exception
+    }
+
+    @Test
+    fun `test clamping`() {
+        val calculator = createDelayCalculator()
+        RetryMechanism.Attempt(count = -5, lastDelay = 25).let {
+            calculator(it) shouldBe 25
+        }
+        RetryMechanism.Attempt(count = 100, lastDelay = 3 * 1000L).let {
+            calculator(it) shouldBe 3 * 1000L
+        }
+
+        RetryMechanism.Attempt(count = 1, lastDelay = 16 * 1000L).let {
+            calculator(it) shouldBe 3 * 1000L
+        }
+        RetryMechanism.Attempt(count = 100, lastDelay = 1).let {
+            calculator(it) shouldBe 3 * 1000L
+        }
+    }
+}

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/security/EncryptedPreferencesFactoryTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/security/EncryptedPreferencesFactoryTest.kt
@@ -1,0 +1,35 @@
+package de.rki.coronawarnapp.util.security
+
+import android.content.Context
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.mockk.Called
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class EncryptedPreferencesFactoryTest : BaseTest() {
+    @MockK lateinit var context: Context
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this)
+    }
+
+    @AfterEach
+    fun teardown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `sideeffect free init`() {
+        shouldNotThrowAny {
+            EncryptedPreferencesFactory(context)
+        }
+        verify { context.getSharedPreferences(any(), any()) wasNot Called }
+    }
+}


### PR DESCRIPTION
_New PR to merge into 1.4.x instead of 1.5.x_

## Description
Wrapped the `EncryptedSharedPreferences` initialization in an exponential backoff mechanism with randomized delay, to mitigate issues caused by the system's keystore being busy. The idea is that after a few retries the congestion has cleared and we can get access to the system's keystore.

We'll retry for a maximum of 15s, delay at least 25ms and at most 3s between tries.

Should mitigate #642, possibly also  #1214, #1121.

Bug description:
* https://github.com/corona-warn-app/cwa-app-android/issues/642#issuecomment-697603175
* https://issuetracker.google.com/issues/158234058
* https://github.com/google/tink/issues/321

## How to test
* Difficult to reproduce :frowning_face: 
* Understand the bug as described above (see links), review the code.
* Add a test exception in the preference creation code, observe behavior.

<details>
<summary>Example log output</summary>

```kotlin
2020-09-23 00:34:12.839 4424-4424/de.rki.coronawarnapp.dev V/RetryMechanism: Executing attempt: Attempt(count=1, totalDelay=0, lastDelay=0, exception=null)
2020-09-23 00:34:12.839 4424-4424/de.rki.coronawarnapp.dev D/EncryptedPreferencesFactory$create: Creating EncryptedSharedPreferences instance.
2020-09-23 00:34:13.138 4424-4424/de.rki.coronawarnapp.dev V/RetryMechanism: Executing attempt: Attempt(count=2, totalDelay=25, lastDelay=25, exception=java.security.KeyException)
2020-09-23 00:34:13.139 4424-4424/de.rki.coronawarnapp.dev D/EncryptedPreferencesFactory$create: Creating EncryptedSharedPreferences instance.
2020-09-23 00:34:13.255 4424-4424/de.rki.coronawarnapp.dev V/RetryMechanism: Executing attempt: Attempt(count=3, totalDelay=50, lastDelay=25, exception=java.security.KeyException)
2020-09-23 00:34:13.255 4424-4424/de.rki.coronawarnapp.dev D/EncryptedPreferencesFactory$create: Creating EncryptedSharedPreferences instance.
2020-09-23 00:34:13.368 4424-4424/de.rki.coronawarnapp.dev V/RetryMechanism: Executing attempt: Attempt(count=4, totalDelay=75, lastDelay=25, exception=java.security.KeyException)
2020-09-23 00:34:13.368 4424-4424/de.rki.coronawarnapp.dev D/EncryptedPreferencesFactory$create: Creating EncryptedSharedPreferences instance.
2020-09-23 00:34:13.476 4424-4424/de.rki.coronawarnapp.dev V/RetryMechanism: Executing attempt: Attempt(count=5, totalDelay=100, lastDelay=25, exception=java.security.KeyException)
2020-09-23 00:34:13.477 4424-4424/de.rki.coronawarnapp.dev D/EncryptedPreferencesFactory$create: Creating EncryptedSharedPreferences instance.
2020-09-23 00:34:13.604 4424-4424/de.rki.coronawarnapp.dev V/RetryMechanism: Executing attempt: Attempt(count=6, totalDelay=144, lastDelay=44, exception=java.security.KeyException)
2020-09-23 00:34:13.604 4424-4424/de.rki.coronawarnapp.dev D/EncryptedPreferencesFactory$create: Creating EncryptedSharedPreferences instance.
2020-09-23 00:34:13.769 4424-4424/de.rki.coronawarnapp.dev V/RetryMechanism: Executing attempt: Attempt(count=7, totalDelay=208, lastDelay=64, exception=java.security.KeyException)
2020-09-23 00:34:13.769 4424-4424/de.rki.coronawarnapp.dev D/EncryptedPreferencesFactory$create: Creating EncryptedSharedPreferences instance.
2020-09-23 00:34:13.976 4424-4424/de.rki.coronawarnapp.dev V/RetryMechanism: Executing attempt: Attempt(count=8, totalDelay=331, lastDelay=123, exception=java.security.KeyException)
2020-09-23 00:34:13.977 4424-4424/de.rki.coronawarnapp.dev D/EncryptedPreferencesFactory$create: Creating EncryptedSharedPreferences instance.
2020-09-23 00:34:14.231 4424-4424/de.rki.coronawarnapp.dev V/RetryMechanism: Executing attempt: Attempt(count=9, totalDelay=490, lastDelay=159, exception=java.security.KeyException)
2020-09-23 00:34:14.231 4424-4424/de.rki.coronawarnapp.dev D/EncryptedPreferencesFactory$create: Creating EncryptedSharedPreferences instance.
2020-09-23 00:34:14.669 4424-4424/de.rki.coronawarnapp.dev V/RetryMechanism: Executing attempt: Attempt(count=10, totalDelay=849, lastDelay=359, exception=java.security.KeyException)
2020-09-23 00:34:14.670 4424-4424/de.rki.coronawarnapp.dev D/EncryptedPreferencesFactory$create: Creating EncryptedSharedPreferences instance.
2020-09-23 00:34:15.554 4424-4424/de.rki.coronawarnapp.dev V/RetryMechanism: Executing attempt: Attempt(count=11, totalDelay=1655, lastDelay=806, exception=java.security.KeyException)
2020-09-23 00:34:15.554 4424-4424/de.rki.coronawarnapp.dev D/EncryptedPreferencesFactory$create: Creating EncryptedSharedPreferences instance.
2020-09-23 00:34:18.114 4424-4424/de.rki.coronawarnapp.dev V/RetryMechanism: Executing attempt: Attempt(count=12, totalDelay=4136, lastDelay=2481, exception=java.security.KeyException)
2020-09-23 00:34:18.115 4424-4424/de.rki.coronawarnapp.dev D/EncryptedPreferencesFactory$create: Creating EncryptedSharedPreferences instance.
2020-09-23 00:34:20.963 4424-4424/de.rki.coronawarnapp.dev V/RetryMechanism: Executing attempt: Attempt(count=13, totalDelay=6775, lastDelay=2639, exception=java.security.KeyException)
2020-09-23 00:34:20.964 4424-4424/de.rki.coronawarnapp.dev D/EncryptedPreferencesFactory$create: Creating EncryptedSharedPreferences instance.
2020-09-23 00:34:24.171 4424-4424/de.rki.coronawarnapp.dev V/RetryMechanism: Executing attempt: Attempt(count=14, totalDelay=9775, lastDelay=3000, exception=java.security.KeyException)
2020-09-23 00:34:24.172 4424-4424/de.rki.coronawarnapp.dev D/EncryptedPreferencesFactory$create: Creating EncryptedSharedPreferences instance.
2020-09-23 00:34:27.382 4424-4424/de.rki.coronawarnapp.dev V/RetryMechanism: Executing attempt: Attempt(count=15, totalDelay=12775, lastDelay=3000, exception=java.security.KeyException)
2020-09-23 00:34:27.382 4424-4424/de.rki.coronawarnapp.dev D/EncryptedPreferencesFactory$create: Creating EncryptedSharedPreferences instance.
2020-09-23 00:34:30.534 4424-4424/de.rki.coronawarnapp.dev V/RetryMechanism: Executing attempt: Attempt(count=16, totalDelay=15775, lastDelay=3000, exception=java.security.KeyException)
2020-09-23 00:34:30.535 4424-4424/de.rki.coronawarnapp.dev D/EncryptedPreferencesFactory$create: Creating EncryptedSharedPreferences instance.
2020-09-23 00:34:30.778 4424-4424/de.rki.coronawarnapp.dev W/RetryMechanism$createDelayCalculator: Max retry duration exceeded.
2020-09-23 00:34:30.780 4424-4424/de.rki.coronawarnapp.dev W/RetryMechanism: Retrycondition exceeded: Attempt(count=16, totalDelay=15775, lastDelay=3000, exception=java.security.KeyException)
2020-09-23 00:34:30.782 4424-4424/de.rki.coronawarnapp.dev D/AndroidRuntime: Shutting down VM
2020-09-23 00:34:30.785 4424-4424/de.rki.coronawarnapp.dev E/AndroidRuntime: FATAL EXCEPTION: main
    Process: de.rki.coronawarnapp.dev, PID: 4424
    java.lang.RuntimeException: Unable to create application de.rki.coronawarnapp.CoronaWarnApplication: de.rki.coronawarnapp.exception.CwaSecurityException: something went wrong during a critical part of the application ensuring security, please referto the details for more information
        at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6717)
        at android.app.ActivityThread.access$1300(ActivityThread.java:237)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1913)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loop(Looper.java:223)
        at android.app.ActivityThread.main(ActivityThread.java:7656)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
     Caused by: de.rki.coronawarnapp.exception.CwaSecurityException: something went wrong during a critical part of the application ensuring security, please referto the details for more information
        at de.rki.coronawarnapp.util.security.SecurityHelper.withSecurityCatch(SecurityHelper.kt:97)
        at de.rki.coronawarnapp.util.security.SecurityHelper$globalEncryptedSharedPreferencesInstance$2.invoke(SecurityHelper.kt:41)
        at de.rki.coronawarnapp.util.security.SecurityHelper$globalEncryptedSharedPreferencesInstance$2.invoke(SecurityHelper.kt:37)
        at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:74)
        at de.rki.coronawarnapp.util.security.SecurityHelper.getGlobalEncryptedSharedPreferencesInstance(Unknown Source:2)
        at de.rki.coronawarnapp.storage.LocalData.getSharedPreferenceInstance(LocalData.kt:715)
        at de.rki.coronawarnapp.storage.LocalData.backgroundNotification(LocalData.kt:706)
        at de.rki.coronawarnapp.worker.BackgroundWorkHelper.sendDebugNotification(BackgroundWorkHelper.kt:95)
        at de.rki.coronawarnapp.CoronaWarnApplication.onCreate(CoronaWarnApplication.kt:99)
        at android.app.Instrumentation.callApplicationOnCreate(Instrumentation.java:1192)
        at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6712)
        at android.app.ActivityThread.access$1300(ActivityThread.java:237) 
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1913) 
        at android.os.Handler.dispatchMessage(Handler.java:106) 
        at android.os.Looper.loop(Looper.java:223) 
        at android.app.ActivityThread.main(ActivityThread.java:7656) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947) 
     Caused by: java.security.KeyException: Permantly failed to instantiate encrypted preferences
        at de.rki.coronawarnapp.util.security.EncryptedPreferencesFactory.create(EncryptedPreferencesFactory.kt:39)
        at de.rki.coronawarnapp.util.security.SecurityHelper$globalEncryptedSharedPreferencesInstance$2$1.invoke(SecurityHelper.kt:42)
        at de.rki.coronawarnapp.util.security.SecurityHelper$globalEncryptedSharedPreferencesInstance$2$1.invoke(SecurityHelper.kt:37)
        at de.rki.coronawarnapp.util.security.SecurityHelper.withSecurityCatch(SecurityHelper.kt:95)
        at de.rki.coronawarnapp.util.security.SecurityHelper$globalEncryptedSharedPreferencesInstance$2.invoke(SecurityHelper.kt:41) 
        at de.rki.coronawarnapp.util.security.SecurityHelper$globalEncryptedSharedPreferencesInstance$2.invoke(SecurityHelper.kt:37) 
        at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:74) 
        at de.rki.coronawarnapp.util.security.SecurityHelper.getGlobalEncryptedSharedPreferencesInstance(Unknown Source:2) 
        at de.rki.coronawarnapp.storage.LocalData.getSharedPreferenceInstance(LocalData.kt:715) 
        at de.rki.coronawarnapp.storage.LocalData.backgroundNotification(LocalData.kt:706) 
        at de.rki.coronawarnapp.worker.BackgroundWorkHelper.sendDebugNotification(BackgroundWorkHelper.kt:95) 
        at de.rki.coronawarnapp.CoronaWarnApplication.onCreate(CoronaWarnApplication.kt:99) 
        at android.app.Instrumentation.callApplicationOnCreate(Instrumentation.java:1192) 
        at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6712) 
        at android.app.ActivityThread.access$1300(ActivityThread.java:237) 
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1913) 
        at android.os.Handler.dispatchMessage(Handler.java:106) 
        at android.os.Looper.loop(Looper.java:223) 
        at android.app.ActivityThread.main(ActivityThread.java:7656) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947) 
     Caused by: java.security.KeyException
        at de.rki.coronawarnapp.util.security.EncryptedPreferencesFactory$create$1.invoke(EncryptedPreferencesFactory.kt:34)
        at de.rki.coronawarnapp.util.security.EncryptedPreferencesFactory$create$1.invoke(EncryptedPreferencesFactory.kt:14)
        at de.rki.coronawarnapp.util.RetryMechanism.retryWithBackOff(RetryMechanism.kt:19)
        at de.rki.coronawarnapp.util.RetryMechanism.retryWithBackOff$default(RetryMechanism.kt:12)
        at de.rki.coronawarnapp.util.security.EncryptedPreferencesFactory.create(EncryptedPreferencesFactory.kt:31)
        at de.rki.coronawarnapp.util.security.SecurityHelper$globalEncryptedSharedPreferencesInstance$2$1.invoke(SecurityHelper.kt:42) 
        at de.rki.coronawarnapp.util.security.SecurityHelper$globalEncryptedSharedPreferencesInstance$2$1.invoke(SecurityHelper.kt:37) 
        at de.rki.coronawarnapp.util.security.SecurityHelper.withSecurityCatch(SecurityHelper.kt:95) 
        at de.rki.coronawarnapp.util.security.SecurityHelper$globalEncryptedSharedPreferencesInstance$2.invoke(SecurityHelper.kt:41) 
        at de.rki.coronawarnapp.util.security.SecurityHelper$globalEncryptedSharedPreferencesInstance$2.invoke(SecurityHelper.kt:37) 
        at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:74) 
        at de.rki.coronawarnapp.util.security.SecurityHelper.getGlobalEncryptedSharedPreferencesInstance(Unknown Source:2) 
        at de.rki.coronawarnapp.storage.LocalData.getSharedPreferenceInstance(LocalData.kt:715) 
        at de.rki.coronawarnapp.storage.LocalData.backgroundNotification(LocalData.kt:706) 
        at de.rki.coronawarnapp.worker.BackgroundWorkHelper.sendDebugNotification(BackgroundWorkHelper.kt:95) 
        at de.rki.coronawarnapp.CoronaWarnApplication.onCreate(CoronaWarnApplication.kt:99) 
        at android.app.Instrumentation.callApplicationOnCreate(Instrumentation.java:1192) 
        at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6712) 
        at android.app.ActivityThread.access$1300(ActivityThread.java:237) 
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1913) 
        at android.os.Handler.dispatchMessage(Handler.java:106) 
        at android.os.Looper.loop(Looper.java:223) 
        at android.app.ActivityThread.main(ActivityThread.java:7656) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947) 
2020-09-23 00:34:30.823 4424-4424/de.rki.coronawarnapp.dev I/Process: Sending signal. PID: 4424 SIG: 9

```
</details>