### PR TITLE
Encounter with low risk missing link in risk details (EXPOSUREAPP-2883)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/RiskLevelRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/RiskLevelRepository.kt
@@ -9,7 +9,7 @@ object RiskLevelRepository {
     /**
      * LiveData variables that can be consumed in a ViewModel to observe RiskLevel changes
      */
-    val riskLevelScore = MutableLiveData(RiskLevelConstants.LOW_LEVEL_RISK)
+    val riskLevelScore = MutableLiveData(RiskLevelConstants.UNKNOWN_RISK_INITIAL)
     val riskLevelScoreLastSuccessfulCalculated =
         MutableLiveData(LocalData.lastSuccessfullyCalculatedRiskLevel().raw)
 
@@ -23,7 +23,7 @@ object RiskLevelRepository {
      * @param riskLevel
      */
     fun setRiskLevelScore(riskLevel: RiskLevel) {
-        val rawRiskLevel = 2//riskLevel.raw
+        val rawRiskLevel = riskLevel.raw
         riskLevelScore.postValue(rawRiskLevel)
 
         setLastCalculatedScore(rawRiskLevel)
@@ -37,7 +37,7 @@ object RiskLevelRepository {
      *
      */
     fun reset() {
-        riskLevelScore.postValue(RiskLevelConstants.LOW_LEVEL_RISK)
+        riskLevelScore.postValue(RiskLevelConstants.UNKNOWN_RISK_INITIAL)
     }
 
     /**
@@ -103,4 +103,3 @@ object RiskLevelRepository {
         }
     }
 }
-

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/RiskLevelRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/RiskLevelRepository.kt
@@ -9,7 +9,7 @@ object RiskLevelRepository {
     /**
      * LiveData variables that can be consumed in a ViewModel to observe RiskLevel changes
      */
-    val riskLevelScore = MutableLiveData(RiskLevelConstants.UNKNOWN_RISK_INITIAL)
+    val riskLevelScore = MutableLiveData(RiskLevelConstants.LOW_LEVEL_RISK)
     val riskLevelScoreLastSuccessfulCalculated =
         MutableLiveData(LocalData.lastSuccessfullyCalculatedRiskLevel().raw)
 
@@ -23,7 +23,7 @@ object RiskLevelRepository {
      * @param riskLevel
      */
     fun setRiskLevelScore(riskLevel: RiskLevel) {
-        val rawRiskLevel = riskLevel.raw
+        val rawRiskLevel = 2//riskLevel.raw
         riskLevelScore.postValue(rawRiskLevel)
 
         setLastCalculatedScore(rawRiskLevel)
@@ -37,7 +37,7 @@ object RiskLevelRepository {
      *
      */
     fun reset() {
-        riskLevelScore.postValue(RiskLevelConstants.UNKNOWN_RISK_INITIAL)
+        riskLevelScore.postValue(RiskLevelConstants.LOW_LEVEL_RISK)
     }
 
     /**
@@ -103,3 +103,4 @@ object RiskLevelRepository {
         }
     }
 }
+

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/riskdetails/RiskDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/riskdetails/RiskDetailsFragment.kt
@@ -68,7 +68,7 @@ class RiskDetailsFragment : Fragment() {
      */
     private fun setUpWebLinks() {
         binding.riskDetailsInformationLowriskBodyUrl
-            .convertToHyperlink(getString(R.string.onboarding_tracing_easy_language_explanation))
+            .convertToHyperlink(getString(R.string.risk_details_explanation_faq_body_with_link))
     }
 
     private fun setButtonOnClickListeners() {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/riskdetails/RiskDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/riskdetails/RiskDetailsFragment.kt
@@ -8,6 +8,7 @@ import android.view.accessibility.AccessibilityEvent
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
+import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.FragmentRiskDetailsBinding
 import de.rki.coronawarnapp.timer.TimerHelper
 import de.rki.coronawarnapp.ui.doNavigate
@@ -15,6 +16,7 @@ import de.rki.coronawarnapp.ui.main.MainActivity
 import de.rki.coronawarnapp.ui.viewLifecycle
 import de.rki.coronawarnapp.ui.viewmodel.SettingsViewModel
 import de.rki.coronawarnapp.ui.viewmodel.TracingViewModel
+import de.rki.coronawarnapp.util.convertToHyperlink
 
 /**
  * This is the detail view of the risk card if additional information for the user.
@@ -47,6 +49,7 @@ class RiskDetailsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setButtonOnClickListeners()
+        setUpWebLinks()
     }
 
     override fun onResume() {
@@ -58,6 +61,14 @@ class RiskDetailsFragment : Fragment() {
         TimerHelper.checkManualKeyRetrievalTimer()
         tracingViewModel.refreshActiveTracingDaysInRetentionPeriod()
         binding.riskDetailsContainer.sendAccessibilityEvent(AccessibilityEvent.TYPE_ANNOUNCEMENT)
+    }
+
+    /**
+     * Make the links clickable and convert to hyperlink
+     */
+    private fun setUpWebLinks() {
+        binding.riskDetailsInformationLowriskBodyUrl
+            .convertToHyperlink(getString(R.string.onboarding_tracing_easy_language_explanation))
     }
 
     private fun setButtonOnClickListeners() {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/formatter/FormatterRiskHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/formatter/FormatterRiskHelper.kt
@@ -584,6 +584,16 @@ fun formatVisibilityBehaviorIncreasedRisk(riskLevelScore: Int?): Int =
     formatVisibility(riskLevelScore == RiskLevelConstants.INCREASED_RISK)
 
 /**
+ * Format the risk details include display for suggested behavior depending on risk level
+ * Only applied in special case for low level risk
+ *
+ * @param riskLevelScore
+ * @return
+ */
+fun formatVisibilityBehaviorLowLevelRisk(riskLevelScore: Int?): Int =
+    formatVisibility(riskLevelScore == RiskLevelConstants.LOW_LEVEL_RISK)
+
+/**
  * Format the risk details period logged card display  depending on risk level
  * applied in case of low and high risk levels
  *

--- a/Corona-Warn-App/src/main/res/layout/fragment_risk_details.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_risk_details.xml
@@ -264,6 +264,20 @@
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@+id/risk_details_information_body" />
 
+                    <TextView
+                        android:id="@+id/risk_details_information_lowrisk_body_url"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/spacing_normal"
+                        android:text="@string/onboarding_tracing_easy_language_explanation"
+                        android:visibility="@{FormatterRiskHelper.formatVisibilityBehaviorLowLevelRisk(tracingViewModel.riskLevel)}"
+                        android:focusable="true"
+                        android:clickable="true"
+                        android:linksClickable="true"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@+id/risk_details_information_body_notice" />
+
                 </androidx.constraintlayout.widget.ConstraintLayout>
 
                 <androidx.constraintlayout.widget.Guideline
@@ -271,7 +285,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:orientation="vertical"
-                    app:layout_constraintGuide_begin="@dimen/guideline_start" />
+                    app:layout_constraintGuide_begin="@dimen/guideline_top" />
 
                 <androidx.constraintlayout.widget.Guideline
                     android:id="@+id/guideline_end"

--- a/Corona-Warn-App/src/main/res/layout/fragment_risk_details.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_risk_details.xml
@@ -269,7 +269,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="@dimen/spacing_normal"
-                        android:text="@string/onboarding_tracing_easy_language_explanation"
+                        android:text="@string/risk_details_explanation_faq_body_with_link"
                         android:visibility="@{FormatterRiskHelper.formatVisibilityBehaviorLowLevelRisk(tracingViewModel.riskLevel)}"
                         android:focusable="true"
                         android:clickable="true"

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -343,7 +343,7 @@
     <!-- XMSG: risk details - risk calculation wasn't possible for 24h, below behaviors -->
     <string name="risk_details_information_body_outdated_risk">"Ihre Risiko-Ermittlung konnte seit mehr als 24 Stunden nicht aktualisiert werden."</string>
     <!-- YTXT: risk details - low risk explanation text -->
-    <string name="risk_details_information_body_low_risk">"Sie haben ein niedriges Infektionsrisiko, da keine Begegnung mit nachweislich Corona-positiv getesteten Personen aufgezeichnet wurde oder sich Ihre Begegnung auf kurze Zeit und einen größeren Abstand beschränkt hat."</string>
+    <string name="risk_details_information_body_low_risk">"Sie hatten eine Begegnung mit einer nachweislich Corona-positiv getesteten Person. Ihr Infektionsrisiko ist dennoch niedrig, weil Ihre Begegnung aufgrund der kurzen Dauer oder größeren Entfernung als ein geringes Risiko eingestuft wird. Weitere Informationen finden Sie [in der FAQ](https://www.coronawarn.app/de/faq/#encounter_but_green)."</string>
     <!-- YTXT: risk details - low risk explanation text with encounter with low risk -->
     <string name="risk_details_information_body_low_risk_with_encounter">"Das Infektionsrisiko wird anhand der Daten der Risiko-Ermittlung unter Berücksichtigung des Abstands und der Dauer von Begegnungen mit nachweislich Corona-positiv getesteten Personen sowie deren vermutlicher Infektiosität lokal auf Ihrem Smartphone berechnet. Ihr Infektionsrisiko ist für niemanden einsehbar und wird nicht weitergegeben."</string>
     <!-- YTXT: risk details - increased risk explanation text with variable for day(s) since last contact -->

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -372,6 +372,8 @@
     <string name="risk_details_explanation_dialog_title">"Information zur Funktionsweise der Risiko-Ermittlung"</string>
     <!-- YTXT: one time risk explanation dialog - pointing to the faq page for more information-->
     <string name="risk_details_explanation_dialog_faq_body">"Weitere Informationen finden Sie in den FAQ."</string>
+    <!-- XLNK: risk explanations and informations - pointing to the faq page for more information and contains hyperlink-->
+    <string name="risk_details_explanation_faq_body_with_link"><a href="https://www.coronawarn.app/de/faq/#encounter_but_green">Weitere Informationen finden Sie in den FAQ.</a></string>
 
     <!-- ####################################
               Onboarding

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -343,7 +343,7 @@
     <!-- XMSG: risk details - risk calculation wasn't possible for 24h, below behaviors -->
     <string name="risk_details_information_body_outdated_risk">"Ihre Risiko-Ermittlung konnte seit mehr als 24 Stunden nicht aktualisiert werden."</string>
     <!-- YTXT: risk details - low risk explanation text -->
-    <string name="risk_details_information_body_low_risk">"Sie hatten eine Begegnung mit einer nachweislich Corona-positiv getesteten Person. Ihr Infektionsrisiko ist dennoch niedrig, weil Ihre Begegnung aufgrund der kurzen Dauer oder größeren Entfernung als ein geringes Risiko eingestuft wird. Weitere Informationen finden Sie [in der FAQ](https://www.coronawarn.app/de/faq/#encounter_but_green)."</string>
+    <string name="risk_details_information_body_low_risk">"Sie haben ein niedriges Infektionsrisiko, da keine Begegnung mit nachweislich Corona-positiv getesteten Personen aufgezeichnet wurde oder sich Ihre Begegnung auf kurze Zeit und einen größeren Abstand beschränkt hat."</string>
     <!-- YTXT: risk details - low risk explanation text with encounter with low risk -->
     <string name="risk_details_information_body_low_risk_with_encounter">"Das Infektionsrisiko wird anhand der Daten der Risiko-Ermittlung unter Berücksichtigung des Abstands und der Dauer von Begegnungen mit nachweislich Corona-positiv getesteten Personen sowie deren vermutlicher Infektiosität lokal auf Ihrem Smartphone berechnet. Ihr Infektionsrisiko ist für niemanden einsehbar und wird nicht weitergegeben."</string>
     <!-- YTXT: risk details - increased risk explanation text with variable for day(s) since last contact -->

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -345,7 +345,7 @@
     <!-- XMSG: risk details - risk calculation wasn't possible for 24h, below behaviors -->
     <string name="risk_details_information_body_outdated_risk">"Your exposure logging could not be updated for more than 24 hours."</string>
     <!-- YTXT: risk details - low risk explanation text -->
-    <string name="risk_details_information_body_low_risk"></string>
+    <string name="risk_details_information_body_low_risk">"You have a low risk of infection because no exposure to people later diagnosed with COVID-19 was logged, or because your encounters were only for a short time and at a greater distance."</string>
     <!-- YTXT: risk details - low risk explanation text with encounter with low risk -->
     <string name="risk_details_information_body_low_risk_with_encounter">"The risk of infection is calculated locally on your smartphone, using exposure logging data. The calculation also takes into account distance and duration of any exposure to persons diagnosed with COVID-19, as well as their potential infectiousness. Your risk of infection cannot be seen by or passed on to anyone else."</string>
     <!-- YTXT: risk details - increased risk explanation text with variable for day(s) since last contact -->

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -374,7 +374,8 @@
     <string name="risk_details_explanation_dialog_title">"Information about exposure logging functionality"</string>
     <!-- YTXT: one time risk explanation dialog - pointing to the faq page for more information-->
     <string name="risk_details_explanation_dialog_faq_body">"For further information, please see our FAQ page."</string>
-
+    <!-- XLNK: risk explanations and informations - pointing to the faq page for more information and contains hyperlink-->
+    <string name="risk_details_explanation_faq_body_with_link">"Lorem Ipsum <a href="https://www.coronawarn.app/de/faq/#encounter_but_green">Lorem ipsum.</a>"</string>
     <!-- ####################################
               Onboarding
     ###################################### -->

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -375,7 +375,7 @@
     <!-- YTXT: one time risk explanation dialog - pointing to the faq page for more information-->
     <string name="risk_details_explanation_dialog_faq_body">"For further information, please see our FAQ page."</string>
     <!-- XLNK: risk explanations and informations - pointing to the faq page for more information and contains hyperlink-->
-    <string name="risk_details_explanation_faq_body_with_link">"Lorem Ipsum <a href="https://www.coronawarn.app/de/faq/#encounter_but_green">Lorem ipsum.</a>"</string>
+    <string name="risk_details_explanation_faq_body_with_link"><a href="https://www.coronawarn.app/en/faq/#encounter_but_green">For further information, please see our FAQ page.</a>"</string>
     <!-- ####################################
               Onboarding
     ###################################### -->

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -345,7 +345,7 @@
     <!-- XMSG: risk details - risk calculation wasn't possible for 24h, below behaviors -->
     <string name="risk_details_information_body_outdated_risk">"Your exposure logging could not be updated for more than 24 hours."</string>
     <!-- YTXT: risk details - low risk explanation text -->
-    <string name="risk_details_information_body_low_risk">"You have a low risk of infection because no exposure to people later diagnosed with COVID-19 was logged, or because your encounters were only for a short time and at a greater distance."</string>
+    <string name="risk_details_information_body_low_risk"></string>
     <!-- YTXT: risk details - low risk explanation text with encounter with low risk -->
     <string name="risk_details_information_body_low_risk_with_encounter">"The risk of infection is calculated locally on your smartphone, using exposure logging data. The calculation also takes into account distance and duration of any exposure to persons diagnosed with COVID-19, as well as their potential infectiousness. Your risk of infection cannot be seen by or passed on to anyone else."</string>
     <!-- YTXT: risk details - increased risk explanation text with variable for day(s) since last contact -->


### PR DESCRIPTION
## Relates to
https://jira.itc.sap.com/browse/EXPOSUREAPP-2883

## Description
Fix of missing link if risk level is on low exposure state
Link is now referencing to:
https://www.coronawarn.app/de/faq/#encounter_but_green
or 
https://www.coronawarn.app/en/faq/#encounter_but_green  (as default language)

## Note
No text change applied, just added the missing link to the bottom

## Screenshots (new)
![wenn niedriges risiko](https://user-images.githubusercontent.com/46747780/94416647-63b1c080-017f-11eb-9fc4-8131bcfcef8d.png)
![dann link zum Faq](https://user-images.githubusercontent.com/46747780/94416651-644a5700-017f-11eb-9340-063528bd4a06.png)
