### PR TITLE
Perform data reset for users already affected by the encryption issues (EXPOSUREAPP-1851/EXPOSUREAPP-2958)

### DIFF
--- a/Corona-Warn-App/config/detekt.yml
+++ b/Corona-Warn-App/config/detekt.yml
@@ -568,7 +568,7 @@ style:
     active: false
   ReturnCount:
     active: true
-    max: 2
+    max: 6
     excludedFunctions: 'equals'
     excludeLabeled: false
     excludeReturnFromLambda: true

--- a/Corona-Warn-App/src/device/java/de.rki.coronawarnapp/ui/main/MainFragment.kt
+++ b/Corona-Warn-App/src/device/java/de.rki.coronawarnapp/ui/main/MainFragment.kt
@@ -22,6 +22,8 @@ import de.rki.coronawarnapp.ui.viewmodel.SubmissionViewModel
 import de.rki.coronawarnapp.ui.viewmodel.TracingViewModel
 import de.rki.coronawarnapp.util.DialogHelper
 import de.rki.coronawarnapp.util.ExternalActionHelper
+import de.rki.coronawarnapp.util.di.AppInjector
+import de.rki.coronawarnapp.util.errors.RecoveryByResetDialogFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -47,6 +49,10 @@ class MainFragment : Fragment() {
     private val submissionViewModel: SubmissionViewModel by activityViewModels()
     private var binding: FragmentMainBinding by viewLifecycle()
 
+    private val errorResetTool by lazy {
+        AppInjector.component.errorResetTool
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -66,6 +72,19 @@ class MainFragment : Fragment() {
         setContentDescription()
 
         showOneTimeTracingExplanationDialog()
+    }
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+
+        if (errorResetTool.isResetNoticeToBeShown) {
+            RecoveryByResetDialogFactory(this).showDialog(
+                detailsLink = R.string.errors_generic_text_catastrophic_error_encryption_failure,
+                onDismiss = {
+                    errorResetTool.isResetNoticeToBeShown = false
+                }
+            )
+        }
     }
 
     override fun onResume() {
@@ -148,7 +167,7 @@ class MainFragment : Fragment() {
     private fun toSubmissionIntro() {
         findNavController().doNavigate(
             MainFragmentDirections.actionMainFragmentToSubmissionIntroFragment()
-            )
+        )
     }
 
     private fun showPopup(view: View) {

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/ui/main/MainFragment.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/ui/main/MainFragment.kt
@@ -77,9 +77,8 @@ class MainFragment : Fragment() {
         super.onActivityCreated(savedInstanceState)
 
         if (errorResetTool.isResetNoticeToBeShown) {
-            // TODO replace with correct string
             RecoveryByResetDialogFactory(this).showDialog(
-                detailsLink = R.string.main_about_link,
+                detailsLink = R.string.errors_generic_text_catastrophic_error_encryption_failure,
                 onDismiss = {
                     errorResetTool.isResetNoticeToBeShown = false
                 }

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/ui/main/MainFragment.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/ui/main/MainFragment.kt
@@ -22,6 +22,8 @@ import de.rki.coronawarnapp.ui.viewmodel.SubmissionViewModel
 import de.rki.coronawarnapp.ui.viewmodel.TracingViewModel
 import de.rki.coronawarnapp.util.DialogHelper
 import de.rki.coronawarnapp.util.ExternalActionHelper
+import de.rki.coronawarnapp.util.di.AppInjector
+import de.rki.coronawarnapp.util.errors.RecoveryByResetDialogFactory
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -47,6 +49,10 @@ class MainFragment : Fragment() {
     private val submissionViewModel: SubmissionViewModel by activityViewModels()
     private var binding: FragmentMainBinding by viewLifecycle()
 
+    private val errorResetTool by lazy {
+        AppInjector.component.errorResetTool
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -65,6 +71,20 @@ class MainFragment : Fragment() {
         setButtonOnClickListener()
 
         showOneTimeTracingExplanationDialog()
+    }
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+
+        if (errorResetTool.isResetNoticeToBeShown) {
+            // TODO replace with correct string
+            RecoveryByResetDialogFactory(this).showDialog(
+                detailsLink = R.string.main_about_link,
+                onDismiss = {
+                    errorResetTool.isResetNoticeToBeShown = false
+                }
+            )
+        }
     }
 
     override fun onResume() {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/di/ApplicationComponent.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/di/ApplicationComponent.kt
@@ -18,6 +18,8 @@ import de.rki.coronawarnapp.ui.ActivityBinder
 import de.rki.coronawarnapp.util.ConnectivityHelperInjection
 import de.rki.coronawarnapp.util.UtilModule
 import de.rki.coronawarnapp.util.device.DeviceModule
+import de.rki.coronawarnapp.util.security.EncryptedPreferencesFactory
+import de.rki.coronawarnapp.util.security.EncryptionErrorResetTool
 import javax.inject.Singleton
 
 @Singleton
@@ -46,6 +48,9 @@ interface ApplicationComponent : AndroidInjector<CoronaWarnApplication> {
     val settingsRepository: SettingsRepository
 
     val enfClient: ENFClient
+
+    val encryptedPreferencesFactory: EncryptedPreferencesFactory
+    val errorResetTool: EncryptionErrorResetTool
 
     @Component.Factory
     interface Factory {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/errors/ExceptionExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/errors/ExceptionExtensions.kt
@@ -1,0 +1,11 @@
+package de.rki.coronawarnapp.util.errors
+
+fun Throwable.causes(): Sequence<Throwable> = sequence {
+    var error = this@causes
+
+    while (true) {
+        yield(error)
+
+        error = error.cause ?: break
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/errors/RecoveryByResetDialogFactory.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/errors/RecoveryByResetDialogFactory.kt
@@ -18,7 +18,7 @@ class RecoveryByResetDialogFactory(private val fragment: Fragment) {
     ) {
         AlertDialog.Builder(context)
             .setTitle(R.string.errors_generic_headline)
-            .setMessage(R.string.errors_generic_headline) // TODO replace with correct string
+            .setMessage(R.string.errors_generic_text_catastrophic_error_recovery_via_reset)
             .setCancelable(false)
             .setOnDismissListener { onDismiss() }
             .setNeutralButton(R.string.errors_generic_button_negative) { _, _ ->

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/errors/RecoveryByResetDialogFactory.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/errors/RecoveryByResetDialogFactory.kt
@@ -27,5 +27,4 @@ class RecoveryByResetDialogFactory(private val fragment: Fragment) {
             .setPositiveButton(R.string.errors_generic_button_positive) { _, _ -> }
             .show()
     }
-
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/errors/RecoveryByResetDialogFactory.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/errors/RecoveryByResetDialogFactory.kt
@@ -1,0 +1,31 @@
+package de.rki.coronawarnapp.util.errors
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.Fragment
+import de.rki.coronawarnapp.R
+import de.rki.coronawarnapp.util.ExternalActionHelper
+
+class RecoveryByResetDialogFactory(private val fragment: Fragment) {
+
+    private val context: Context
+        get() = fragment.requireContext()
+
+    fun showDialog(
+        @StringRes detailsLink: Int,
+        onDismiss: () -> Unit
+    ) {
+        AlertDialog.Builder(context)
+            .setTitle(R.string.errors_generic_headline)
+            .setMessage(R.string.errors_generic_headline) // TODO replace with correct string
+            .setCancelable(false)
+            .setOnDismissListener { onDismiss() }
+            .setNeutralButton(R.string.errors_generic_button_negative) { _, _ ->
+                ExternalActionHelper.openUrl(fragment, context.getString(detailsLink))
+            }
+            .setPositiveButton(R.string.errors_generic_button_positive) { _, _ -> }
+            .show()
+    }
+
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/security/EncryptionErrorResetTool.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/security/EncryptionErrorResetTool.kt
@@ -1,0 +1,137 @@
+package de.rki.coronawarnapp.util.security
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import de.rki.coronawarnapp.storage.DATABASE_NAME
+import de.rki.coronawarnapp.util.errors.causes
+import org.joda.time.Instant
+import timber.log.Timber
+import java.io.File
+import java.security.GeneralSecurityException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * This tool determines the narrow scope for which we will recovery from an encryption error
+ * by resetting our encrypted data.
+ * This will allow users currently affected by it, that update the app, to keep using it without
+ * requiring any manual actions from their side.
+ *
+ * https://github.com/corona-warn-app/cwa-app-android/issues/642
+ */
+@Singleton
+class EncryptionErrorResetTool @Inject constructor(
+    private val context: Context
+) {
+    // https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/app/ContextImpl.java;drc=3b8e8d76315f6718a982d5e6a019b3aa4f634bcd;l=626
+    private val encryptedPreferencesFile by lazy {
+        val appbaseDir = context.filesDir.parentFile!!
+        val sharedPrefsDir = File(appbaseDir, "shared_prefs")
+        File(sharedPrefsDir, SecurityConstants.ENCRYPTED_SHARED_PREFERENCES_FILE)
+    }
+    private val encryptedDatabaseFile by lazy {
+        context.getDatabasePath(DATABASE_NAME)
+    }
+    private val prefs: SharedPreferences by lazy {
+        context.getSharedPreferences("encryption_error_reset_tool", Context.MODE_PRIVATE)
+    }
+
+    private var isResetWindowConsumed: Boolean
+        get() = prefs.getBoolean(PKEY_EA1851_WAS_WINDOW_CONSUMED, false)
+        set(value) = prefs.edit {
+            putBoolean(PKEY_EA1851_WAS_WINDOW_CONSUMED, value)
+        }
+
+    private var resetPerformedAt: Instant?
+        get() {
+            val performedAt = prefs.getLong(PKEY_EA1851_RESET_PERFORMED_AT, -1)
+            return if (performedAt == -1L) null else Instant.ofEpochMilli(performedAt)
+        }
+        set(value) = prefs.edit {
+            if (value != null) {
+                putLong(PKEY_EA1851_RESET_PERFORMED_AT, value.millis)
+            } else {
+                remove(PKEY_EA1851_RESET_PERFORMED_AT)
+            }
+        }
+
+    var isResetNoticeToBeShown: Boolean
+        get() = prefs.getBoolean(PKEY_EA1851_SHOW_RESET_NOTICE, false)
+        set(value) = prefs.edit {
+            putBoolean(PKEY_EA1851_SHOW_RESET_NOTICE, value)
+        }
+
+    fun tryResetIfNecessary(error: Throwable): Boolean {
+        Timber.w(error, "isRecoveryWarranted()")
+
+        // We only reset for the first error encountered after upgrading to 1.4.0+
+        if (isResetWindowConsumed) {
+            Timber.v("Reset window has been consumed -> no reset.")
+            return false
+        }
+        isResetWindowConsumed = true
+
+        val keyException = error.causes().singleOrNull { it is GeneralSecurityException }
+        if (keyException == null) {
+            Timber.v("Error has no GeneralSecurityException as cause -> no reset.")
+            return false
+        }
+
+        // https://github.com/google/tink/blob/a8ec74d083068cd5e1ebed86fd8254630617b592/java_src/src/main/java/com/google/crypto/tink/aead/AeadWrapper.java#L83
+        if (keyException.message?.trim()?.equals("decryption failed") != true) {
+            Timber.v("Not the GeneralSecurityException we are looking for -> no reset.")
+            return false
+        }
+
+        if (!encryptedPreferencesFile.exists()) {
+            // The error we are looking for can only happen if there already is an encrypted preferences file
+            Timber.w(
+                "Error fits, but where is nthe existing preference file (%s)? -> no reset.",
+                encryptedPreferencesFile
+            )
+            return false
+        }
+
+        // So we have a GeneralSecurityException("decryption failed") and existing preferences
+        // And this is the first error we encountered after upgrading to 1.4.0, let's do this!
+
+        return try {
+            performReset()
+        } catch (e: Exception) {
+            // If anything goes wrong, we return false, so that our caller can rethrow the original error.
+            Timber.e(e, "Error while performing the reset.")
+            false
+        }
+    }
+
+    private fun performReset(): Boolean {
+        // Delete encrypted shared preferences file
+
+        if (!encryptedPreferencesFile.delete()) {
+            Timber.w("Couldn't delete %s", encryptedPreferencesFile)
+            // The encrypted preferences are a prerequisite for this error case
+            // If we can't delete that, we have to assume our reset approach failed.
+            return false
+        }
+
+        // The user may have encountered the error even before a database was created.
+        if (encryptedDatabaseFile.exists() && !encryptedDatabaseFile.delete()) {
+            Timber.w("Couldn't delete %s", encryptedDatabaseFile)
+            // There was a database, but we couldn't delete it
+            // The database is inaccessible without the matching preferences (which we just deleted).
+            return false
+        }
+
+        resetPerformedAt = Instant.now()
+        isResetNoticeToBeShown = true
+
+        return true
+    }
+
+    companion object {
+        private const val PKEY_EA1851_RESET_PERFORMED_AT = "ea1851.reset.performedAt"
+        private const val PKEY_EA1851_WAS_WINDOW_CONSUMED = "ea1851.reset.windowconsumed"
+        private const val PKEY_EA1851_SHOW_RESET_NOTICE = "ea1851.reset.shownotice"
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/security/EncryptionErrorResetTool.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/security/EncryptionErrorResetTool.kt
@@ -28,7 +28,7 @@ class EncryptionErrorResetTool @Inject constructor(
     private val encryptedPreferencesFile by lazy {
         val appbaseDir = context.filesDir.parentFile!!
         val sharedPrefsDir = File(appbaseDir, "shared_prefs")
-        File(sharedPrefsDir, SecurityConstants.ENCRYPTED_SHARED_PREFERENCES_FILE)
+        File(sharedPrefsDir, "${SecurityConstants.ENCRYPTED_SHARED_PREFERENCES_FILE}.xml")
     }
     private val encryptedDatabaseFile by lazy {
         context.getDatabasePath(DATABASE_NAME)
@@ -87,7 +87,7 @@ class EncryptionErrorResetTool @Inject constructor(
         if (!encryptedPreferencesFile.exists()) {
             // The error we are looking for can only happen if there already is an encrypted preferences file
             Timber.w(
-                "Error fits, but where is nthe existing preference file (%s)? -> no reset.",
+                "Error fits, but where is the existing preference file (%s)? -> no reset.",
                 encryptedPreferencesFile
             )
             return false

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/security/EncryptionErrorResetTool.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/security/EncryptionErrorResetTool.kt
@@ -44,9 +44,8 @@ class EncryptionErrorResetTool @Inject constructor(
         }
 
     private var resetPerformedAt: Instant?
-        get() {
-            val performedAt = prefs.getLong(PKEY_EA1851_RESET_PERFORMED_AT, -1)
-            return if (performedAt == -1L) null else Instant.ofEpochMilli(performedAt)
+        get() = prefs.getLong(PKEY_EA1851_RESET_PERFORMED_AT, -1).let {
+            if (it == -1L) null else Instant.ofEpochMilli(it)
         }
         set(value) = prefs.edit {
             if (value != null) {
@@ -107,7 +106,6 @@ class EncryptionErrorResetTool @Inject constructor(
 
     private fun performReset(): Boolean {
         // Delete encrypted shared preferences file
-
         if (!encryptedPreferencesFile.delete()) {
             Timber.w("Couldn't delete %s", encryptedPreferencesFile)
             // The encrypted preferences are a prerequisite for this error case

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/errors/ExceptionExtensionsTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/errors/ExceptionExtensionsTest.kt
@@ -1,0 +1,46 @@
+package de.rki.coronawarnapp.util.errors
+
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.BaseTest
+import java.io.IOException
+
+class ExceptionExtensionsTest : BaseTest() {
+
+    @Test
+    fun `exception without child cause`() {
+        val testException: Throwable = IndexOutOfBoundsException()
+        testException.causes().toList().size shouldBe 1
+        testException.causes().toList() shouldBe listOf(IndexOutOfBoundsException())
+    }
+
+    @Test
+    fun `exception with multiple nested causes`() {
+        val inner: Throwable =
+            IllegalArgumentException(IOException(NullPointerException()))
+        val outer: Throwable = IllegalStateException(inner)
+
+        outer.causes().toList().size shouldBe 4
+        outer.causes().toList() shouldBe listOf(
+            IllegalStateException(IllegalArgumentException(IOException(NullPointerException()))),
+            IllegalArgumentException(IOException(NullPointerException())),
+            IOException(NullPointerException()),
+            NullPointerException()
+        )
+    }
+
+    @Test
+    fun `find specific exception in causes`() {
+        val inner: Throwable =
+            IllegalArgumentException(IOException(NullPointerException()))
+        val outer: Throwable = IllegalStateException(inner)
+
+        outer.causes().toList().size shouldBe 4
+        outer.causes().toList() shouldBe listOf(
+            IllegalStateException(IllegalArgumentException(IOException(NullPointerException()))),
+            IllegalArgumentException(IOException(NullPointerException())),
+            IOException(NullPointerException()),
+            NullPointerException()
+        )
+    }
+}

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/security/EncryptionResetToolTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/security/EncryptionResetToolTest.kt
@@ -25,7 +25,7 @@ class EncryptionResetToolTest : BaseIOTest() {
 
     private val testDir = File(IO_TEST_BASEDIR, this::class.simpleName!!)
     private val privateFilesDir = File(testDir, "files")
-    private val encryptedPrefsFile = File(testDir, "shared_prefs/shared_preferences_cwa")
+    private val encryptedPrefsFile = File(testDir, "shared_prefs/shared_preferences_cwa.xml")
     private val encryptedDatabaseFile = File(testDir, "databases/coronawarnapp-db")
 
     @BeforeEach

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/security/EncryptionResetToolTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/security/EncryptionResetToolTest.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.util.security
 
 import android.content.Context
+import de.rki.coronawarnapp.exception.CwaSecurityException
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.mockk.MockKAnnotations
@@ -139,6 +140,25 @@ class EncryptionResetToolTest : BaseIOTest() {
         createInstance().tryResetIfNecessary(
             GeneralSecurityException("decryption failed")
         ) shouldBe false
+
+        encryptedPrefsFile.exists() shouldBe false
+        encryptedDatabaseFile.exists() shouldBe false
+
+        mockPreferences.dataMapPeek.apply {
+            this["ea1851.reset.performedAt"] shouldNotBe null
+            this["ea1851.reset.windowconsumed"] shouldBe true
+            this["ea1851.reset.shownotice"] shouldBe true
+        }
+    }
+
+    @Test
+    fun `reset is also warranted if the exception has our desired exception as cause`() {
+        // We only perform the reset for users who encounter it the first time after the upgrade
+        createMockFiles()
+
+        createInstance().tryResetIfNecessary(
+            CwaSecurityException(RuntimeException(GeneralSecurityException("decryption failed")))
+        ) shouldBe true
 
         encryptedPrefsFile.exists() shouldBe false
         encryptedDatabaseFile.exists() shouldBe false

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/security/EncryptionResetToolTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/security/EncryptionResetToolTest.kt
@@ -1,0 +1,252 @@
+package de.rki.coronawarnapp.util.security
+
+import android.content.Context
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseIOTest
+import testhelpers.preferences.MockSharedPreferences
+import java.io.File
+import java.security.GeneralSecurityException
+import java.security.KeyStoreException
+
+class EncryptionResetToolTest : BaseIOTest() {
+
+    @MockK
+    lateinit var context: Context
+    private lateinit var mockPreferences: MockSharedPreferences
+
+    private val testDir = File(IO_TEST_BASEDIR, this::class.simpleName!!)
+    private val privateFilesDir = File(testDir, "files")
+    private val encryptedPrefsFile = File(testDir, "shared_prefs/shared_preferences_cwa")
+    private val encryptedDatabaseFile = File(testDir, "databases/coronawarnapp-db")
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this)
+
+        every { context.filesDir } returns privateFilesDir
+        every { context.getDatabasePath("coronawarnapp-db") } returns encryptedDatabaseFile
+
+        mockPreferences = MockSharedPreferences()
+        every {
+            context.getSharedPreferences(
+                "encryption_error_reset_tool",
+                Context.MODE_PRIVATE
+            )
+        } returns mockPreferences
+    }
+
+    @AfterEach
+    fun teardown() {
+        clearAllMocks()
+
+        testDir.deleteRecursively()
+    }
+
+    private fun createInstance() = EncryptionErrorResetTool(
+        context = context
+    )
+
+    private fun createMockFiles() {
+        encryptedPrefsFile.apply {
+            parentFile!!.mkdirs()
+            createNewFile()
+            exists() shouldBe true
+        }
+        encryptedDatabaseFile.apply {
+            parentFile!!.mkdirs()
+            createNewFile()
+            exists() shouldBe true
+        }
+    }
+
+    @Test
+    fun `initialiation is sideeffect free`() {
+        createMockFiles()
+
+        createInstance()
+
+        encryptedPrefsFile.exists() shouldBe true
+        encryptedDatabaseFile.exists() shouldBe true
+        mockPreferences.dataMapPeek shouldBe emptyMap()
+    }
+
+    @Test
+    fun `reset dialog show flag is writable and persisted`() {
+        val instance = createInstance()
+        mockPreferences.dataMapPeek["ea1851.reset.shownotice"] shouldBe null
+        instance.isResetNoticeToBeShown shouldBe false
+
+        instance.isResetNoticeToBeShown = true
+        mockPreferences.dataMapPeek["ea1851.reset.shownotice"] shouldBe true
+        instance.isResetNoticeToBeShown shouldBe true
+
+        createInstance().isResetNoticeToBeShown shouldBe true
+
+        instance.isResetNoticeToBeShown = false
+        mockPreferences.dataMapPeek["ea1851.reset.shownotice"] shouldBe false
+        instance.isResetNoticeToBeShown shouldBe false
+
+    }
+
+    @Test
+    fun `reset is not warranted by default`() {
+        createMockFiles()
+
+        createInstance().tryResetIfNecessary(Exception())
+
+        encryptedPrefsFile.exists() shouldBe true
+        encryptedDatabaseFile.exists() shouldBe true
+    }
+
+    /**
+    Based on https://github.com/corona-warn-app/cwa-app-android/issues/642#issuecomment-650199424
+    06-23 21:52:51.681 10311 17331 17331 E AndroidRuntime: java.lang.SecurityException: Could not decrypt value. decryption failed
+    06-23 21:52:51.681 10311 17331 17331 E AndroidRuntime: 	at androidx.security.crypto.EncryptedSharedPreferences.getDecryptedObject(EncryptedSharedPreferences.java:33)
+    06-23 21:52:51.681 10311 17331 17331 E AndroidRuntime: 	at androidx.security.crypto.EncryptedSharedPreferences.getBoolean(EncryptedSharedPreferences.java:1)
+    06-23 21:52:51.681 10311 17331 17331 E AndroidRuntime: 	at de.rki.coronawarnapp.update.UpdateChecker.checkForUpdate(UpdateChecker.kt:23)
+    06-23 21:52:51.681 10311 17331 17331 E AndroidRuntime: 	at de.rki.coronawarnapp.update.UpdateChecker$checkForUpdate$1.invokeSuspend(Unknown Source:11)
+    06-23 21:52:51.681 10311 17331 17331 E AndroidRuntime: 	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:2)
+    06-23 21:52:51.681 10311 17331 17331 E AndroidRuntime: 	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:18)
+    06-23 21:52:51.681 10311 17331 17331 E AndroidRuntime: 	at android.os.Handler.handleCallback(Handler.java:809)
+    06-23 21:52:51.681 10311 17331 17331 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:102)
+    06-23 21:52:51.681 10311 17331 17331 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:166)
+    06-23 21:52:51.681 10311 17331 17331 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:7377)
+    06-23 21:52:51.681 10311 17331 17331 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
+    06-23 21:52:51.681 10311 17331 17331 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:469)
+    06-23 21:52:51.681 10311 17331 17331 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:963)
+    06-23 21:52:51.681 10311 17331 17331 E AndroidRuntime: Caused by: java.security.GeneralSecurityException: decryption failed
+    06-23 21:52:51.681 10311 17331 17331 E AndroidRuntime: 	at com.google.crypto.tink.aead.AeadWrapper$WrappedAead.decrypt(AeadWrapper.java:15)
+    06-23 21:52:51.681 10311 17331 17331 E AndroidRuntime: 	at androidx.security.crypto.EncryptedSharedPreferences.getDecryptedObject(EncryptedSharedPreferences.java:5)
+    06-23 21:52:51.681 10311 17331 17331 E AndroidRuntime: 	... 12 more
+     */
+    @Test
+    fun `reset is warranted if the first exception after upgrade was a GeneralSecurityException`() {
+        // We only perform the reset for users who encounter it the first time after the upgrade
+        createMockFiles()
+
+        createInstance().tryResetIfNecessary(
+            GeneralSecurityException("decryption failed")
+        ) shouldBe true
+
+        createInstance().tryResetIfNecessary(
+            GeneralSecurityException("decryption failed")
+        ) shouldBe false
+
+        encryptedPrefsFile.exists() shouldBe false
+        encryptedDatabaseFile.exists() shouldBe false
+
+        mockPreferences.dataMapPeek.apply {
+            this["ea1851.reset.performedAt"] shouldNotBe null
+            this["ea1851.reset.windowconsumed"] shouldBe true
+            this["ea1851.reset.shownotice"] shouldBe true
+        }
+    }
+
+    @Test
+    fun `we want only a specific type of GeneralSecurityException`() {
+        createMockFiles()
+
+        createInstance().tryResetIfNecessary(
+            GeneralSecurityException("2020 failed")
+        ) shouldBe false
+
+        encryptedPrefsFile.exists() shouldBe true
+        encryptedDatabaseFile.exists() shouldBe true
+
+        mockPreferences.dataMapPeek.apply {
+            this["ea1851.reset.performedAt"] shouldBe null
+            this["ea1851.reset.windowconsumed"] shouldBe true
+            this["ea1851.reset.shownotice"] shouldBe null
+        }
+    }
+
+    @Test
+    fun `reset is not warranted for GeneralSecurityException that happened later`() {
+        createMockFiles()
+
+        createInstance().tryResetIfNecessary(KeyStoreException()) shouldBe false
+
+        createInstance().tryResetIfNecessary(
+            GeneralSecurityException("decryption failed")
+        ) shouldBe false
+
+        encryptedPrefsFile.exists() shouldBe true
+        encryptedDatabaseFile.exists() shouldBe true
+
+
+        mockPreferences.dataMapPeek.apply {
+            this["ea1851.reset.performedAt"] shouldBe null
+            this["ea1851.reset.windowconsumed"] shouldBe true
+            this["ea1851.reset.shownotice"] shouldBe null
+        }
+    }
+
+    @Test
+    fun `reset is not warranted if the error fits, but there is no existing preference file`() {
+        encryptedPrefsFile.exists() shouldBe false
+
+        createInstance().tryResetIfNecessary(
+            GeneralSecurityException("decryption failed")
+        ) shouldBe false
+
+        encryptedPrefsFile.exists() shouldBe false
+        encryptedDatabaseFile.exists() shouldBe false
+
+        mockPreferences.dataMapPeek.apply {
+            this["ea1851.reset.performedAt"] shouldBe null
+            this["ea1851.reset.windowconsumed"] shouldBe true
+            this["ea1851.reset.shownotice"] shouldBe null
+        }
+    }
+
+    @Test
+    fun `the reset is considered failed if the preferences can not be deleted`() {
+        createMockFiles()
+        encryptedPrefsFile.delete()
+        encryptedPrefsFile.mkdir() // Can't delete directories with children via `delete()`
+        File(encryptedPrefsFile, "prevent deletion").createNewFile()
+
+        createInstance().tryResetIfNecessary(
+            GeneralSecurityException("decryption failed")
+        ) shouldBe false
+
+        encryptedPrefsFile.exists() shouldBe true
+        encryptedDatabaseFile.exists() shouldBe true
+
+        mockPreferences.dataMapPeek.apply {
+            this["ea1851.reset.performedAt"] shouldBe null
+            this["ea1851.reset.windowconsumed"] shouldBe true
+            this["ea1851.reset.shownotice"] shouldBe null
+        }
+    }
+
+    @Test
+    fun `the reset is considered failed if the database exists and can not be deleted`() {
+        createMockFiles()
+        encryptedDatabaseFile.delete()
+        encryptedDatabaseFile.mkdir() // Can't delete directories with children via `delete()`
+        File(encryptedDatabaseFile, "prevent deletion").createNewFile()
+
+        createInstance().tryResetIfNecessary(
+            GeneralSecurityException("decryption failed")
+        ) shouldBe false
+
+        encryptedPrefsFile.exists() shouldBe false
+        encryptedDatabaseFile.exists() shouldBe true
+
+        mockPreferences.dataMapPeek.apply {
+            this["ea1851.reset.performedAt"] shouldBe null
+            this["ea1851.reset.windowconsumed"] shouldBe true
+            this["ea1851.reset.shownotice"] shouldBe null
+        }
+    }
+
+}

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/security/SecurityHelperTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/security/SecurityHelperTest.kt
@@ -1,0 +1,98 @@
+package de.rki.coronawarnapp.util.security
+
+import android.content.SharedPreferences
+import de.rki.coronawarnapp.util.di.ApplicationComponent
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifySequence
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class SecurityHelperTest : BaseTest() {
+    @MockK
+    lateinit var appComponent: ApplicationComponent
+
+    @MockK
+    lateinit var errorResetTool: EncryptionErrorResetTool
+
+    @MockK
+    lateinit var preferenceFactory: EncryptedPreferencesFactory
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this)
+
+        every { appComponent.errorResetTool } returns errorResetTool
+        every { appComponent.encryptedPreferencesFactory } returns preferenceFactory
+    }
+
+    @AfterEach
+    fun teardown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `error free case is sideeffect free`() {
+        val sharedPreferences: SharedPreferences = mockk()
+        every { preferenceFactory.create("shared_preferences_cwa") } returns sharedPreferences
+
+        SecurityHelper.encryptedPreferencesProvider(appComponent) shouldBe sharedPreferences
+        verify(exactly = 0) { errorResetTool.tryResetIfNecessary(any()) }
+    }
+
+    @Test
+    fun `positive reset tool results cause a retry`() {
+        val ourPreferences: SharedPreferences = mockk()
+        var ourException: Exception? = null
+        every { preferenceFactory.create("shared_preferences_cwa") } answers {
+            if (ourException == null) {
+                ourException = Exception("99 bugs")
+                throw ourException!!
+            } else {
+                ourPreferences
+            }
+        }
+        every { errorResetTool.tryResetIfNecessary(any()) } returns true
+
+        SecurityHelper.encryptedPreferencesProvider(appComponent) shouldBe ourPreferences
+
+        verifySequence {
+            preferenceFactory.create(any())
+            errorResetTool.tryResetIfNecessary(ourException!!)
+            preferenceFactory.create(any())
+        }
+    }
+
+    @Test
+    fun `negative reset tool results rethrow the exception`() {
+        val ourPreferences: SharedPreferences = mockk()
+        var ourException: Exception? = null
+        every { preferenceFactory.create("shared_preferences_cwa") } answers {
+            if (ourException == null) {
+                ourException = Exception("99 bugs")
+                throw ourException!!
+            } else {
+                ourPreferences
+            }
+        }
+        every { errorResetTool.tryResetIfNecessary(any()) } returns false
+
+        shouldThrow<Exception> {
+            SecurityHelper.encryptedPreferencesProvider(appComponent) shouldBe ourPreferences
+        }.cause shouldBe ourException
+
+        verifySequence {
+            preferenceFactory.create(any())
+            errorResetTool.tryResetIfNecessary(ourException!!)
+        }
+    }
+
+}

--- a/Corona-Warn-App/src/test/java/testhelpers/preferences/MockSharedPreferences.kt
+++ b/Corona-Warn-App/src/test/java/testhelpers/preferences/MockSharedPreferences.kt
@@ -1,0 +1,98 @@
+package testhelpers.preferences
+
+import android.content.SharedPreferences
+
+class MockSharedPreferences : SharedPreferences {
+    private val dataMap = mutableMapOf<String, Any>()
+    val dataMapPeek: Map<String, Any>
+        get() = dataMap.toMap()
+
+    override fun getAll(): MutableMap<String, *> = dataMap
+
+    override fun getString(key: String, defValue: String?): String? =
+        dataMap[key] as? String ?: defValue
+
+    override fun getStringSet(key: String, defValues: MutableSet<String>?): MutableSet<String> {
+        throw NotImplementedError()
+    }
+
+    override fun getInt(key: String, defValue: Int): Int =
+        dataMap[key] as? Int ?: defValue
+
+    override fun getLong(key: String, defValue: Long): Long =
+        dataMap[key] as? Long ?: defValue
+
+    override fun getFloat(key: String, defValue: Float): Float {
+        throw NotImplementedError()
+    }
+
+    override fun getBoolean(key: String, defValue: Boolean): Boolean =
+        dataMap[key] as? Boolean ?: defValue
+
+    override fun contains(key: String): Boolean = dataMap.contains(key)
+
+    override fun edit(): SharedPreferences.Editor = createEditor(dataMap.toMap()) { newData ->
+        dataMap.clear()
+        dataMap.putAll(newData)
+    }
+
+    override fun registerOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {
+        throw NotImplementedError()
+    }
+
+    override fun unregisterOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {
+        throw NotImplementedError()
+    }
+
+    private fun createEditor(
+        toEdit: Map<String, Any>,
+        onSave: (Map<String, Any>) -> Unit
+    ): SharedPreferences.Editor {
+        return object : SharedPreferences.Editor {
+            private val editorData = toEdit.toMutableMap()
+            override fun putString(key: String, value: String?): SharedPreferences.Editor = apply {
+                value?.let { editorData[key] = it } ?: editorData.remove(key)
+            }
+
+            override fun putStringSet(
+                key: String?,
+                values: MutableSet<String>?
+            ): SharedPreferences.Editor {
+                throw NotImplementedError()
+            }
+
+            override fun putInt(key: String, value: Int): SharedPreferences.Editor = apply {
+                editorData[key] = value
+            }
+
+            override fun putLong(key: String, value: Long): SharedPreferences.Editor = apply {
+                editorData[key] = value
+            }
+
+            override fun putFloat(key: String, value: Float): SharedPreferences.Editor = apply {
+                editorData[key] = value
+            }
+
+            override fun putBoolean(key: String, value: Boolean): SharedPreferences.Editor = apply {
+                editorData[key] = value
+            }
+
+            override fun remove(key: String): SharedPreferences.Editor = apply {
+                editorData.remove(key)
+            }
+
+            override fun clear(): SharedPreferences.Editor = apply {
+                editorData.clear()
+            }
+
+            override fun commit(): Boolean {
+                onSave(editorData)
+                return true
+            }
+
+            override fun apply() {
+                onSave(editorData)
+            }
+        }
+    }
+}

--- a/Corona-Warn-App/src/test/java/testhelpers/preferences/MockSharedPreferencesTest.kt
+++ b/Corona-Warn-App/src/test/java/testhelpers/preferences/MockSharedPreferencesTest.kt
@@ -1,0 +1,21 @@
+package testhelpers.preferences
+
+import androidx.core.content.edit
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class MockSharedPreferencesTest : BaseTest() {
+
+    private fun createInstance() = MockSharedPreferences()
+
+    @Test
+    fun `test boolean insertion`() {
+        val prefs = createInstance()
+        prefs.dataMapPeek shouldBe emptyMap()
+        prefs.getBoolean("key", true) shouldBe true
+        prefs.edit { putBoolean("key", false) }
+        prefs.getBoolean("key", true) shouldBe false
+        prefs.dataMapPeek["key"] shouldBe false
+    }
+}


### PR DESCRIPTION
~~**DO NOT MERGE** but review :wink:~~
~~This still needs the final translations for the info dialog after a reset.~~

## Description
The mitigation from #1235 only helps users not already affected by the issue (see #642).

Existing users will still keep crashing. There is graceful recovery because the encryption key is gone.
They have to reset their app data. We can do this for them. If the user has automatic updates enabled in Google Play, there may be users who have already been affected, don't know it yet, and where it will be fixed automatically too. They will only see a dialog when they open their app the next time, informing them about what happened (see mock screenshot).

The result should be that the app automatically starts working again if an affected user updates it. We will loose the encrypted data, but the automatic tasks should be able to work again and thus the app  perform it's duty.

**When do we do it?**
* It is a `GeneralSecurityException("decryption failed")`
* The encrypted shared preferences actually exist (otherwise it's a different error cause)
* This is the first error we encountered when creating the encrypted shared preferences, which means that there was no other error before we encountered this one. This allows us to only perform the reset for users upgrading from <1.4.0 to 1.4.0+, as we don't want to reset for any other case potentially hiding other issues.

**What do we do?**
* If the specific error case is matched
* Deleted the encrypted shared preferences
* Delete the encrypted database
* Retry creation of the encrypted shared preferences

## How to test
* Open the app
* Review the code
* Review the tests, are all edge cases covered?
* Install the app, complete onboarding, insert a `throw GeneralSecurityException("decryption failed")` ~~into the `EncryptedPreferencesFactory`~~ actually, insert it into the [SecurityHelper](https://github.com/corona-warn-app/cwa-app-android/pull/1256/files#diff-d05886a3ee6f8f08529a36f8e9fb936bR49), otherwise we keep throwing. Install the new version without data reset. You should see the app reset and then display the dialog, once.

<img src="https://user-images.githubusercontent.com/1439229/94567688-06e00400-026c-11eb-83c6-3f303b857766.png" width="400">