### PR TITLE
Remove manual set of screen orientation (Related to #779)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/CoronaWarnApplication.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/CoronaWarnApplication.kt
@@ -1,11 +1,9 @@
 package de.rki.coronawarnapp
 
-import android.annotation.SuppressLint
 import android.app.Activity
 import android.app.Application
 import android.content.Context
 import android.content.IntentFilter
-import android.content.pm.ActivityInfo
 import android.os.Bundle
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
@@ -110,9 +108,8 @@ class CoronaWarnApplication : Application(), HasAndroidInjector {
             // NOOP
         }
 
-        @SuppressLint("SourceLockedOrientationActivity")
         override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
-            activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT
+            // NOOP
         }
 
         override fun onActivityResumed(activity: Activity) {


### PR DESCRIPTION
## Description
Follow-Up PR for #779 

As @ironjan already mentioned in his PR before. We're setting the Screen Orientation within the manifest, so no need to set it manually in the CoronaWarnApplication.kt