### PR TITLE
Legal Textchange: Cross Country Exposure Logging Screen (EXPOSUREAPP-2924)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/fragment_interoperability_configuration.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_interoperability_configuration.xml
@@ -44,6 +44,7 @@
                 app:firstSection="@{@string/interoperability_configuration_first_section}"
                 app:secondSection="@{@string/interoperability_configuration_second_section}"
                 app:countryListTitle="@{@string/interoperability_configuration_list_title}"
+                app:fourthSection="@{@string/interoperability_configuration_information}"
                 app:countryData="@{countryData}"
                 app:isOnboarding="@{false}"
                 app:isRiskdetection="@{true}"

--- a/Corona-Warn-App/src/main/res/layout/include_interoperability.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_interoperability.xml
@@ -30,6 +30,10 @@
             type="String" />
 
         <variable
+            name="fourthSection"
+            type="String" />
+
+        <variable
             name="footerTitle"
             type="String" />
 
@@ -192,6 +196,18 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/interoperability_header" />
+
+            <TextView
+                android:id="@+id/label_interoperability_subtitle4"
+                style="@style/body1"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacing_normal"
+                android:text="@{fourthSection}"
+                android:visibility="@{FormatterHelper.formatVisibilityText(fourthSection)}"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/country_list_overview" />
 
             <androidx.constraintlayout.widget.Barrier
                 android:id="@+id/country_list_barrier"

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -1316,11 +1316,13 @@
     <!-- XHED: Header of interoperability information/configuration view -->
     <string name="interoperability_configuration_title">Länderübergreifende Risiko-Ermittlung</string>
     <!-- XTXT: First section after the header of the interoperability information/configuration view -->
-    <string name="interoperability_configuration_first_section">Die Corona-Warn-App warnt länderübergreifend vor möglichen Infektionen, indem Daten über eine europäische Infrastruktur ausgetauscht werden.</string>
+    <string name="interoperability_configuration_first_section">Mehrere Länder arbeiten zusammen, um über den gemeinsam betriebenen Austausch- Server  länderübergreifende Warnungen zu ermöglichen. So können bei der Risiko-Ermittlung auch die Kontakte  mit Nutzern einer offiziellen Corona-App anderer teilnehmender Länder berücksichtigt werden.</string>
     <!-- XTXT: Second section after the header of the interoperability information/configuration view -->
-    <string name="interoperability_configuration_second_section">Es werden keine persönlichen Daten ausgetauscht. Für den länderübergreifenden Datenaustausch über die Corona-Warn-App fallen keine zusätzlichen Kosten für Sie an.</string>
+    <string name="interoperability_configuration_second_section">Hierfür lädt die App täglich eine aktuelle Liste mit den Zufalls-IDs aller Nutzer herunter, die diese über ihre App geteilt haben. Diese Liste wird dann mit den von Ihrem Smartphone aufgezeichneten Zufalls-IDs  verglichen. Der tägliche Download der Liste mit den Zufalls-IDs ist für Sie kostenlos – Ihr Datenvolumen wird nicht belastet und es fallen im europäischen Ausland keine Roaming-Gebühren an.</string>
     <!-- XHED: Header right above the country list in the interoperability information/configuration view -->
-    <string name="interoperability_configuration_list_title">Derzeit nehmen die folgenden Länder teil:</string>
+    <string name="interoperability_configuration_list_title">Derzeit nehmen die folgenden Länder an der länderübergreifenden Risiko-Ermittlung teil:</string>
+    <!-- XTXT: Text right under the country list in the interoperability information/configuration view -->
+    <string name="interoperability_configuration_information">Die Datenschutzerklärung der App (einschließlich Informationen zur Datenverarbeitung für die länderübergreifende Risiko-Ermittlung) finden Sie unter dem Menüpunkt „App-Informationen“ > „Datenschutz“.</string>
 
     <!-- XHED: Sub header introducing interoperability in the tracing step of onboarding -->
     <string name="interoperability_onboarding_title">Länderübergreifende\nRisiko-Ermittlung</string>

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -1329,6 +1329,8 @@
     <string name="interoperability_configuration_second_section"></string>
     <!-- XHED: Header right above the country list in the interoperability information/configuration view -->
     <string name="interoperability_configuration_list_title"></string>
+    <!-- XTXT: Text right under the country list in the interoperability information/configuration view -->
+    <string name="interoperability_configuration_information"></string>
 
     <!-- XHED: Sub header introducing interoperability in the tracing step of onboarding -->
     <string name="interoperability_onboarding_title"></string>


### PR DESCRIPTION
** String XY was only added but the TextView to display it after the list is missing. **

Updated strings:
* `interoperability_configuration_first_section`
* `interoperability_configuration_second_section`
* `interoperability_configuration_list_title`

Added strings:
* `interoperability_configuration_information `

## Screenshots: Exposure Tracing > European wide

<kbd><img src="https://user-images.githubusercontent.com/54317407/94920435-354d2180-04ae-11eb-9bf0-2e03605d439a.gif" /></kbd>




