### PR TITLE
Updated exposure tracing title (EXPOSUREAPP-2923)

### DIFF
--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -510,7 +510,7 @@
     <!-- XHED: settings(tracing) - page title -->
     <string name="settings_tracing_title">"Risiko-Ermittlung"</string>
     <!-- XHED: settings(tracing) - headline bellow illustration -->
-    <string name="settings_tracing_headline">"So funktioniert die Begegnungs-Aufzeichnung"</string>
+    <string name="settings_tracing_headline">"So funktioniert die Risiko-Ermittlung"</string>
     <!-- XTXT: settings(tracing) - explain text in settings overview under headline -->
     <string name="settings_tracing_body_description">"Erlauben Sie Erfassung und Weitergabe von COVID-19-Zufallscodes."</string>
     <!-- XTXT: settings(tracing) - shows status under header in home, active -->


### PR DESCRIPTION
Title wasn't updated as mentioned in the ticket, this is a follow up to https://github.com/corona-warn-app/cwa-app-android/pull/1280

Updated string: `settings_tracing_headline `

## Screenshot: Exposure Tracing

![image](https://user-images.githubusercontent.com/64483219/94897634-5a329c00-0490-11eb-82a0-0e2bab9d40fb.png)
