### PR TITLE
Submission result request handling fix (EXPOSUREAPP-3001)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/viewmodel/SubmissionViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/viewmodel/SubmissionViewModel.kt
@@ -124,12 +124,21 @@ class SubmissionViewModel : ViewModel() {
         }
     }
 
-    fun refreshDeviceUIState(refreshTestResult: Boolean = true) =
+    fun refreshDeviceUIState(refreshTestResult: Boolean = true) {
+        var refresh = refreshTestResult
+
+        deviceUiState.value?.let {
+            if (it != DeviceUIState.PAIRED_NO_RESULT && it != DeviceUIState.UNPAIRED) {
+                refresh = false
+                Timber.d("refreshDeviceUIState: Change refresh to false because state ${it.name} doesn't require a refresh")
+            }
+        }
         executeRequestWithState(
-            { SubmissionRepository.refreshUIState(refreshTestResult) },
+            { SubmissionRepository.refreshUIState(refresh) },
             _uiStateState,
             _uiStateError
         )
+    }
 
     fun validateAndStoreTestGUID(rawResult: String) {
         val scanResult = QRScanResult(rawResult)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/viewmodel/SubmissionViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/viewmodel/SubmissionViewModel.kt
@@ -130,7 +130,7 @@ class SubmissionViewModel : ViewModel() {
         deviceUiState.value?.let {
             if (it != DeviceUIState.PAIRED_NO_RESULT && it != DeviceUIState.UNPAIRED) {
                 refresh = false
-                Timber.d("refreshDeviceUIState: Change refresh to false because state ${it.name} doesn't require a refresh")
+                Timber.d("refreshDeviceUIState: Change refresh, state ${it.name} doesn't require refresh")
             }
         }
         executeRequestWithState(


### PR DESCRIPTION
## Relates to
https://jira.itc.sap.com/browse/EXPOSUREAPP-3001

## Description
If you provide a testresult e.g. by QR Code the result is usually pending until the final result is there.
In case of a final Positiv Result the background requests (fetchTestResults) are stopped (this is expected behaviour).
In case of a final Negativ Result there was an ongoing resultFetching by App-Resuming in Background even the final result there. 
TestResult will only be fetched in correct states now.