### PR TITLE
Show the correct error if the initial app config download fails (EXPOSUREAPP-2747)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/appconfig/AppConfigProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/appconfig/AppConfigProvider.kt
@@ -58,7 +58,12 @@ class AppConfigProvider @Inject constructor(
             downloadAppConfig()
         } catch (e: Exception) {
             Timber.w(e, "Failed to download latest AppConfig.")
-            null
+            if (configStorage.isAppConfigAvailable) {
+                null
+            } else {
+                Timber.e("No fallback available, rethrowing!")
+                throw e
+            }
         }
 
         val newConfigParsed = try {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/appconfig/AppConfigStorage.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/appconfig/AppConfigStorage.kt
@@ -13,6 +13,9 @@ class AppConfigStorage @Inject constructor(
     private val configDir = File(context.filesDir, "appconfig_storage")
     private val configFile = File(configDir, "appconfig")
 
+    val isAppConfigAvailable: Boolean
+        get() = configFile.exists() && configFile.length() > MIN_VALID_CONFIG_BYTES
+
     var appConfigRaw: ByteArray?
         get() {
             Timber.v("get() AppConfig")
@@ -36,4 +39,9 @@ class AppConfigStorage @Inject constructor(
                 configFile.delete()
             }
         }
+
+    companion object {
+        // The normal config is ~512B+, we just need to check for a non 0 value, 128 is fine.
+        private const val MIN_VALID_CONFIG_BYTES = 128
+    }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/appconfig/AppConfigProviderTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/appconfig/AppConfigProviderTest.kt
@@ -38,6 +38,7 @@ class AppConfigProviderTest : BaseIOTest() {
         testDir.mkdirs()
         testDir.exists() shouldBe true
 
+        every { appConfigStorage.isAppConfigAvailable } answers { mockConfigStorage != null }
         every { appConfigStorage.appConfigRaw } answers { mockConfigStorage }
         every { appConfigStorage.appConfigRaw = any() } answers { mockConfigStorage = arg(0) }
     }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/appconfig/AppConfigStorageTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/appconfig/AppConfigStorageTest.kt
@@ -37,6 +37,21 @@ class AppConfigStorageTest : BaseIOTest() {
     private fun createStorage() = AppConfigStorage(context)
 
     @Test
+    fun `config availability is determined by file existence and min size`() {
+        storageDir.mkdirs()
+        val storage = createStorage()
+        storage.isAppConfigAvailable shouldBe false
+        configPath.createNewFile()
+        storage.isAppConfigAvailable shouldBe false
+
+        configPath.writeBytes(ByteArray(128) { 1 })
+        storage.isAppConfigAvailable shouldBe false
+
+        configPath.writeBytes(ByteArray(129) { 1 })
+        storage.isAppConfigAvailable shouldBe true
+    }
+
+    @Test
     fun `simple read and write config`() {
         configPath.exists() shouldBe false
         val storage = createStorage()


### PR DESCRIPTION
Fixes a regression caused by the introduced app config caching.

If the initial app config download fails we showed the a generic "bad app config error" because the fallback mechanism failed too.
This changes it to instead show the initial download error if no fallback is available.