### PR TITLE
Correct Protobuf format (EXPOSUREAPP-3071, EXPOSUREAPP-3049)

### DIFF
--- a/Server-Protocol-Buffer/src/main/proto/applicationConfiguration.proto
+++ b/Server-Protocol-Buffer/src/main/proto/applicationConfiguration.proto
@@ -13,7 +13,9 @@ message ApplicationConfiguration {
 
     ApplicationVersionConfiguration appVersion = 5;
 
-    repeated string supportedCountries = 6;
+    AppFeatures appFeatures = 6;
+
+    repeated string supportedCountries = 7;
 }
 
 message RiskScoreParameters {
@@ -128,4 +130,13 @@ message SemanticVersion {
     uint32 major = 1;
     uint32 minor = 2;
     uint32 patch = 3;
+}
+
+message AppFeatures {
+    repeated AppFeature app_features = 1;
+}
+
+message AppFeature {
+    string label = 1;
+    int32 value = 2;
 }


### PR DESCRIPTION
Correct a missmatch between app and server protobuf format.

App:
https://github.com/corona-warn-app/cwa-app-android/blob/release/1.5.x/Server-Protocol-Buffer/src/main/proto/applicationConfiguration.proto

Server:
https://github.com/corona-warn-app/cwa-server/blob/master/common/protocols/src/main/proto/app/coronawarn/server/common/protocols/internal/app_config.proto

## How to test
* Build the version, switch environments, check UI and log for supportedCountries data.