### PR TITLE
Disable Jetifier (DEV)

### DIFF
--- a/Corona-Warn-App/build.gradle
+++ b/Corona-Warn-App/build.gradle
@@ -237,14 +237,16 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.preference:preference:1.1.1'
     implementation 'androidx.work:work-runtime-ktx:2.3.4'
-    implementation 'android.arch.lifecycle:extensions:2.2.0'
+
     implementation 'androidx.lifecycle:lifecycle-common-java8:2.2.0'
+    implementation 'androidx.lifecycle:lifecycle-process:2.2.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-savedstate:2.2.0'
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
+
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation "androidx.recyclerview:recyclerview:1.1.0"
     implementation "androidx.recyclerview:recyclerview-selection:1.1.0-rc02"
-
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0'
-
 
     // DAGGER
     implementation 'com.google.dagger:dagger:2.28.1'
@@ -266,8 +268,8 @@ dependencies {
     implementation files('libs\\play-services-nearby-exposurenotification-1.6.1-eap.aar')
 
     // Testing
-    testImplementation "android.arch.core:core-testing:1.1.1"
-    testImplementation('org.robolectric:robolectric:4.3.1') {
+    testImplementation "androidx.arch.core:core-testing:2.1.0"
+    testImplementation('org.robolectric:robolectric:4.4') {
         exclude group: 'com.google.protobuf'
     }
     testImplementation "io.mockk:mockk:1.10.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,6 @@
 # org.gradle.parallel=true
 #Wed May 20 08:50:55 CEST 2020
 kotlin.code.style=official
-android.enableJetifier=true
 org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 android.useAndroidX=true
 org.gradle.parallel=true


### PR DESCRIPTION
We can upgrade a couple of dependencies and then remove `enableJetifier` which will remove the jetifier compilation step speeding up builds.

## Test
Run the tests, CLEAN + BUILD the apk in all variants