### PR TITLE
Country list on Risiko-Ermittlung AFTER WLAN ON (EXPOSUREAPP-3152)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/interoperability/InteroperabilityConfigurationFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/interoperability/InteroperabilityConfigurationFragment.kt
@@ -30,7 +30,6 @@ class InteroperabilityConfigurationFragment :
     private val networkCallback = object : ConnectivityHelper.NetworkCallback() {
         override fun onNetworkAvailable() {
             vm.getAllCountries()
-            unregisterNetworkCallback()
         }
 
         override fun onNetworkUnavailable() {
@@ -91,5 +90,12 @@ class InteroperabilityConfigurationFragment :
     override fun onDestroy() {
         super.onDestroy()
         unregisterNetworkCallback()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (ConnectivityHelper.isNetworkEnabled(CoronaWarnApplication.getAppContext())) {
+            registerNetworkCallback()
+        }
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/interoperability/InteroperabilityConfigurationFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/interoperability/InteroperabilityConfigurationFragment.kt
@@ -93,4 +93,3 @@ class InteroperabilityConfigurationFragment :
         unregisterNetworkCallback()
     }
 }
-

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/interoperability/InteroperabilityConfigurationFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/interoperability/InteroperabilityConfigurationFragment.kt
@@ -30,7 +30,7 @@ class InteroperabilityConfigurationFragment :
         super.onViewCreated(view, savedInstanceState)
 
         if (ConnectivityHelper.isNetworkEnabled(CoronaWarnApplication.getAppContext())) {
-             vm.getAllCountries()
+            vm.getAllCountries()
         }
 
         vm.countryList.observe2(this) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/interoperability/InteroperabilityConfigurationFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/interoperability/InteroperabilityConfigurationFragment.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.provider.Settings
 import android.view.View
 import androidx.fragment.app.Fragment
+import de.rki.coronawarnapp.CoronaWarnApplication
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.FragmentInteroperabilityConfigurationBinding
 import de.rki.coronawarnapp.ui.main.MainActivity
@@ -25,20 +26,12 @@ class InteroperabilityConfigurationFragment :
 
     private val binding: FragmentInteroperabilityConfigurationBinding by viewBindingLazy()
 
-    private var isNetworkCallbackRegistered = false
-    private val networkCallback = object : ConnectivityHelper.NetworkCallback() {
-        override fun onNetworkAvailable() {
-            vm.getAllCountries()
-            unregisterNetworkCallback()
-        }
-
-        override fun onNetworkUnavailable() {
-            // NOOP
-        }
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+         if (ConnectivityHelper.isNetworkEnabled(CoronaWarnApplication.getAppContext())) {
+             vm.getAllCountries()
+         }
 
         vm.countryList.observe2(this) {
             binding.countryData = it
@@ -64,28 +57,10 @@ class InteroperabilityConfigurationFragment :
                 Intent(Settings.ACTION_SETTINGS)
             }
             startActivity(intent)
-            registerNetworkCallback()
-        }
-    }
-
-    private fun registerNetworkCallback() {
-        context?.let {
-            ConnectivityHelper.registerNetworkStatusCallback(it, networkCallback)
-            isNetworkCallbackRegistered = true
-        }
-    }
-
-    private fun unregisterNetworkCallback() {
-        if (isNetworkCallbackRegistered) {
-            context?.let {
-                ConnectivityHelper.unregisterNetworkStatusCallback(it, networkCallback)
-                isNetworkCallbackRegistered = false
-            }
         }
     }
 
     override fun onDestroy() {
         super.onDestroy()
-        unregisterNetworkCallback()
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/interoperability/InteroperabilityConfigurationFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/interoperability/InteroperabilityConfigurationFragment.kt
@@ -29,9 +29,9 @@ class InteroperabilityConfigurationFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-         if (ConnectivityHelper.isNetworkEnabled(CoronaWarnApplication.getAppContext())) {
+        if (ConnectivityHelper.isNetworkEnabled(CoronaWarnApplication.getAppContext())) {
              vm.getAllCountries()
-         }
+        }
 
         vm.countryList.observe2(this) {
             binding.countryData = it


### PR DESCRIPTION

## Description
Small fix for issue 3152 where the country list would not appear after switching Wifi off and then back on again because the network callbacks defined were not working properly. 

Adjusted the network connectivity check and is now working as expected.

## Test

- Install the App, switch of WLAN, 
- Do the onboarding > Contry list missing 
- on the Homescreen choose Exposure Logging > Country List - Country List Missing check device settings 
- go to homescreen
- go to smartphone settings, turn WLAN on
- go back to the app, check WLAN via "Häufige Fragen" > Browser starts, external website appears
- go back to the app, choose Exposure Logging > Country List - Country List Missing check device settings ---> **List should now appear where previously it did not.** 

