### PR TITLE
Fix behavior of last 3 hours test mode switch (EXPOSUREAPP-3179)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/KeyFileDownloader.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/KeyFileDownloader.kt
@@ -92,6 +92,7 @@ class KeyFileDownloader @Inject constructor(
                         Timber.tag(TAG).w("Missing keyfile for : %s", keyInfo)
                         null
                     } else {
+                        Timber.tag(TAG).v("Providing available key: %s", keyInfo)
                         path
                     }
                 }
@@ -171,11 +172,21 @@ class KeyFileDownloader @Inject constructor(
         availableCountries: List<LocationCode>,
         itemLimit: Int
     ): List<CountryHours> {
-
         val availableHours = availableCountries.flatMap { location ->
             var remainingItems = itemLimit
             // Descending because we go backwards newest -> oldest
-            keyServer.getDayIndex(location).sortedDescending().mapNotNull { day ->
+            val indexWithToday = keyServer.getDayIndex(location).let {
+                val lastDayInIndex = it.maxOrNull()
+                Timber.tag(TAG).v("Last day in index: %s", lastDayInIndex)
+                if (lastDayInIndex != null) {
+                    it.plus(lastDayInIndex.plusDays(1))
+                } else {
+                    it
+                }
+            }
+            Timber.tag(TAG).v("Day index with (fake) today entry: %s", indexWithToday)
+
+            indexWithToday.sortedDescending().mapNotNull { day ->
                 // Limit reached, return null (filtered out) instead of new CountryHours object
                 if (remainingItems <= 0) return@mapNotNull null
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/server/DiagnosisKeyServer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/server/DiagnosisKeyServer.kt
@@ -110,6 +110,6 @@ class DiagnosisKeyServer @Inject constructor(
     companion object {
         private val TAG = DiagnosisKeyServer::class.java.simpleName
         private val DAY_FORMATTER = DateTimeFormat.forPattern("yyyy-MM-dd")
-        private val HOUR_FORMATTER = DateTimeFormat.forPattern("HH")
+        private val HOUR_FORMATTER = DateTimeFormat.forPattern("H")
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/KeyFileDownloaderTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/KeyFileDownloaderTest.kt
@@ -105,7 +105,7 @@ class KeyFileDownloaderTest : BaseIOTest() {
         } returns (0..23).map { "$it".hour }
         coEvery {
             server.getHourIndex("NL".loc, "2020-09-03".day)
-        } returns (0..23).map { "$it".hour }
+        } returns (0..12).map { "$it".hour }
 
         coEvery { server.downloadKeyFile(any(), any(), any(), any(), any()) } answers {
             mockDownloadServerDownload(
@@ -453,39 +453,39 @@ class KeyFileDownloaderTest : BaseIOTest() {
             keyCache.createCacheEntry(
                 type = Type.COUNTRY_HOUR,
                 location = "DE".loc,
-                dayIdentifier = "2020-09-02".day,
-                hourIdentifier = "23".hour
+                dayIdentifier = "2020-09-03".day,
+                hourIdentifier = "12".hour
             )
             keyCache.createCacheEntry(
                 type = Type.COUNTRY_HOUR,
                 location = "DE".loc,
-                dayIdentifier = "2020-09-02".day,
-                hourIdentifier = "22".hour
+                dayIdentifier = "2020-09-03".day,
+                hourIdentifier = "11".hour
             )
             keyCache.createCacheEntry(
                 type = Type.COUNTRY_HOUR,
                 location = "DE".loc,
-                dayIdentifier = "2020-09-02".day,
-                hourIdentifier = "21".hour
+                dayIdentifier = "2020-09-03".day,
+                hourIdentifier = "10".hour
             )
 
             keyCache.createCacheEntry(
                 type = Type.COUNTRY_HOUR,
                 location = "NL".loc,
-                dayIdentifier = "2020-09-02".day,
-                hourIdentifier = "23".hour
+                dayIdentifier = "2020-09-03".day,
+                hourIdentifier = "12".hour
             )
             keyCache.createCacheEntry(
                 type = Type.COUNTRY_HOUR,
                 location = "NL".loc,
-                dayIdentifier = "2020-09-02".day,
-                hourIdentifier = "22".hour
+                dayIdentifier = "2020-09-03".day,
+                hourIdentifier = "11".hour
             )
             keyCache.createCacheEntry(
                 type = Type.COUNTRY_HOUR,
                 location = "NL".loc,
-                dayIdentifier = "2020-09-02".day,
-                hourIdentifier = "21".hour
+                dayIdentifier = "2020-09-03".day,
+                hourIdentifier = "10".hour
             )
         }
         coVerify(exactly = 6) { keyCache.markKeyComplete(any(), any()) }
@@ -503,15 +503,15 @@ class KeyFileDownloaderTest : BaseIOTest() {
         mockAddData(
             type = Type.COUNTRY_HOUR,
             location = "DE".loc,
-            day = "2020-09-02".day,
-            hour = "22".hour,
+            day = "2020-09-03".day,
+            hour = "11".hour,
             isCompleted = true
         )
         mockAddData(
             type = Type.COUNTRY_HOUR,
             location = "NL".loc,
-            day = "2020-09-02".day,
-            hour = "22".hour,
+            day = "2020-09-03".day,
+            hour = "11".hour,
             isCompleted = true
         )
 
@@ -527,27 +527,27 @@ class KeyFileDownloaderTest : BaseIOTest() {
             keyCache.createCacheEntry(
                 type = Type.COUNTRY_HOUR,
                 location = "DE".loc,
-                dayIdentifier = "2020-09-02".day,
-                hourIdentifier = "23".hour
+                dayIdentifier = "2020-09-03".day,
+                hourIdentifier = "12".hour
             )
             keyCache.createCacheEntry(
                 type = Type.COUNTRY_HOUR,
                 location = "DE".loc,
-                dayIdentifier = "2020-09-02".day,
-                hourIdentifier = "21".hour
+                dayIdentifier = "2020-09-03".day,
+                hourIdentifier = "10".hour
             )
 
             keyCache.createCacheEntry(
                 type = Type.COUNTRY_HOUR,
                 location = "NL".loc,
-                dayIdentifier = "2020-09-02".day,
-                hourIdentifier = "23".hour
+                dayIdentifier = "2020-09-03".day,
+                hourIdentifier = "12".hour
             )
             keyCache.createCacheEntry(
                 type = Type.COUNTRY_HOUR,
                 location = "NL".loc,
-                dayIdentifier = "2020-09-02".day,
-                hourIdentifier = "21".hour
+                dayIdentifier = "2020-09-03".day,
+                hourIdentifier = "10".hour
             )
         }
         coVerify(exactly = 4) {
@@ -562,32 +562,32 @@ class KeyFileDownloaderTest : BaseIOTest() {
 
         val (staleKey1, _) = mockAddData(
             type = Type.COUNTRY_HOUR,
-            location = "NL".loc,
+            location = "DE".loc,
             day = "2020-09-02".day,
-            hour = "12".hour, // Stale hour
+            hour = "01".hour, // Stale hour
             isCompleted = true
         )
 
         val (staleKey2, _) = mockAddData(
             type = Type.COUNTRY_HOUR,
             location = "NL".loc,
-            day = "2020-09-01".day, // Stale day
-            hour = "22".hour,
+            day = "2020-09-02".day, // Stale day
+            hour = "01".hour,
             isCompleted = true
         )
 
         mockAddData(
             type = Type.COUNTRY_HOUR,
             location = "DE".loc,
-            day = "2020-09-02".day,
-            hour = "21".hour,
+            day = "2020-09-03".day,
+            hour = "10".hour,
             isCompleted = true
         )
         mockAddData(
             type = Type.COUNTRY_HOUR,
             location = "NL".loc,
-            day = "2020-09-02".day,
-            hour = "21".hour,
+            day = "2020-09-03".day,
+            hour = "10".hour,
             isCompleted = true
         )
 
@@ -601,27 +601,27 @@ class KeyFileDownloaderTest : BaseIOTest() {
             keyCache.createCacheEntry(
                 type = Type.COUNTRY_HOUR,
                 location = "DE".loc,
-                dayIdentifier = "2020-09-02".day,
-                hourIdentifier = "23".hour
+                dayIdentifier = "2020-09-03".day,
+                hourIdentifier = "12".hour
             )
             keyCache.createCacheEntry(
                 type = Type.COUNTRY_HOUR,
                 location = "DE".loc,
-                dayIdentifier = "2020-09-02".day,
-                hourIdentifier = "22".hour
+                dayIdentifier = "2020-09-03".day,
+                hourIdentifier = "11".hour
             )
 
             keyCache.createCacheEntry(
                 type = Type.COUNTRY_HOUR,
                 location = "NL".loc,
-                dayIdentifier = "2020-09-02".day,
-                hourIdentifier = "23".hour
+                dayIdentifier = "2020-09-03".day,
+                hourIdentifier = "12".hour
             )
             keyCache.createCacheEntry(
                 type = Type.COUNTRY_HOUR,
                 location = "NL".loc,
-                dayIdentifier = "2020-09-02".day,
-                hourIdentifier = "22".hour
+                dayIdentifier = "2020-09-03".day,
+                hourIdentifier = "11".hour
             )
         }
         coVerify(exactly = 4) {


### PR DESCRIPTION
Previously the days for which the last 3 hours were fetched, was the latest day in the servers index for a country, but if a day is not complete, the day will not be visible in the index. This PR fixes this behavior by artificially adding the one additional date (`LATEST_DAY_IN_INDEX+1DAY`).

## Testing
* Try it without this PR, check in the logs what the `KeyFileDownloader` downloads.
* Try with this PR, check that the actual last 3 hours are downloaded.