### PR TITLE
Hide app content in app launcher (EXPOSUREAPP-2612)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/CoronaWarnApplication.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/CoronaWarnApplication.kt
@@ -5,6 +5,7 @@ import android.app.Application
 import android.content.Context
 import android.content.IntentFilter
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.work.Configuration
 import androidx.work.WorkManager
@@ -82,10 +83,11 @@ class CoronaWarnApplication : Application(), HasAndroidInjector {
                 localBM.unregisterReceiver(it)
                 errorReceiver = null
             }
+            disableAppLauncherPreviewAndScreenshots(activity)
         }
 
         override fun onActivityStarted(activity: Activity) {
-            // NOOP
+            enableAppLauncherPreviewAndScreenshots(activity)
         }
 
         override fun onActivityDestroyed(activity: Activity) {
@@ -97,7 +99,7 @@ class CoronaWarnApplication : Application(), HasAndroidInjector {
         }
 
         override fun onActivityStopped(activity: Activity) {
-            // NOOP
+            disableAppLauncherPreviewAndScreenshots(activity)
         }
 
         override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
@@ -113,7 +115,16 @@ class CoronaWarnApplication : Application(), HasAndroidInjector {
             errorReceiver = ErrorReportReceiver(activity).also {
                 localBM.registerReceiver(it, IntentFilter(ERROR_REPORT_LOCAL_BROADCAST_CHANNEL))
             }
+            enableAppLauncherPreviewAndScreenshots(activity)
         }
+    }
+
+    private fun enableAppLauncherPreviewAndScreenshots(activity: Activity) {
+        activity.window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+    }
+
+    private fun disableAppLauncherPreviewAndScreenshots(activity: Activity) {
+        activity.window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
     }
 
     companion object {


### PR DESCRIPTION
**Description**
- The app preview in the app launcher is blank (no content)
- The ability to create screenshots withing the app is not affected

**How to test**
Run the app and validate the above-mentioned criteria on any screen you can navigate to:

- You should be able to take screenshots of any screen
- The app launcher shall not show the app's content (on none-rooted devices)

**Screenshots**
![Screenshot_20201013-113702](https://user-images.githubusercontent.com/56824/95844724-87f9c980-0d49-11eb-8249-c3d516fadca6.png)
![Screenshot_20201013-113712](https://user-images.githubusercontent.com/56824/95844728-8a5c2380-0d49-11eb-8f39-93135741b74c.png)

