### PR TITLE
Calculate the apps versionName and versionCode (EXPOSUREAPP-2772)

### DIFF
--- a/Corona-Warn-App/build.gradle
+++ b/Corona-Warn-App/build.gradle
@@ -32,6 +32,11 @@ def environmentExtractor = { File path ->
 }
 
 android {
+    println("Current VERSION_MAJOR: ${VERSION_MAJOR}")
+    println("Current VERSION_MINOR: ${VERSION_MINOR}")
+    println("Current VERSION_PATCH: ${VERSION_PATCH}")
+    println("Current VERSION_BUILD: ${VERSION_BUILD}")
+
     compileSdkVersion 29
     buildToolsVersion "29.0.3"
 
@@ -39,8 +44,17 @@ android {
         applicationId 'de.rki.coronawarnapp'
         minSdkVersion 23
         targetSdkVersion 29
-        versionCode 47
-        versionName "1.5.0"
+
+        versionCode (
+                VERSION_MAJOR.toInteger() * 1000000
+                + VERSION_MINOR.toInteger() * 10000
+                + VERSION_PATCH.toInteger() * 100
+                + VERSION_BUILD.toInteger()
+        )
+        println("Used versionCode: $versionCode")
+
+        versionName "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}-RC${VERSION_BUILD}"
+        println("Used versionName: $versionName")
 
         testInstrumentationRunner "testhelpers.TestApplicationUIRunner"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,8 @@ org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 android.useAndroidX=true
 org.gradle.parallel=true
 org.gradle.dependency.verification.console=verbose
+# Versioning, this is used by the app & pipelines to calculate the current versionCode & versionName
+VERSION_MAJOR=1
+VERSION_MINOR=6
+VERSION_PATCH=0
+VERSION_BUILD=1

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,8 +16,3 @@ org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 android.useAndroidX=true
 org.gradle.parallel=true
 org.gradle.dependency.verification.console=verbose
-# Variables for Server URLs. The variables in local.properties will override these
-SUBMISSION_CDN_URL=https://submission.coronawarn.app
-DOWNLOAD_CDN_URL=https://svc90.main.px.t-online.de
-VERIFICATION_CDN_URL=https://verification.coronawarn.app
-PUB_KEYS_SIGNATURE_VERIFICATION=MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEc7DEstcUIRcyk35OYDJ95/hTg3UVhsaDXKT0zK7NhHPXoyzipEnOp3GyNXDVpaPi3cAfQmxeuFMZAIX2+6A5Xg==


### PR DESCRIPTION
Instead of manually increasing values everywhere, we define variables for `MAJOR`,`MINOR`,`PATCH` and `BUILD` in `gradle.properties`.

This attempts to solve two issues:
* Due to development on multiple release candidates, and the need for `versionCode` to increase, it can happen that due to a hotfix (version bump) on i.e. `release/1.4.x`, we need to update an APK build from `release/1.5.x` too, just to increase the `versionCode`. The current calculation scheme would space minor versions `10000` iterations apart. We also get `99` RCs, `99` patches, `99` minor updates, `99` :balloon:  and unlimited major versions of course.
* Pipelines can't easily read the `versionCode` configured (file format/formatting) in `build.gradle`, but can easily read the `bash` like syntax in `gradle.properties`. As long as the pipeline code calculated the `versionCode` the same way, it can easily get the version information.


Example output:
```bash
# In properties
VERSION_MAJOR=1
VERSION_MINOR=6
VERSION_PATCH=0
VERSION_BUILD=1
# Calculated
Current VERSION_MAJOR: 1
Current VERSION_MINOR: 6
Current VERSION_PATCH: 0
Current VERSION_BUILD: 1
Used versionCode: 1060001
Used versionName: 1.6.0-RC1
```

Version 2, update 22, on it's 14th hotfix  :dizzy_face: would look like this:
```bash
# In properties
VERSION_MAJOR=2
VERSION_MINOR=22
VERSION_PATCH=14
VERSION_BUILD=1
# Calculated
Current VERSION_MAJOR: 2
Current VERSION_MINOR: 22
Current VERSION_PATCH: 14
Current VERSION_BUILD: 1
Used versionCode: 2221401
Used versionName: 2.22.14-RC1
```