### PR TITLE
Make version naming flavored (EXPOSUREAPP-2772)

### DIFF
--- a/Corona-Warn-App/build.gradle
+++ b/Corona-Warn-App/build.gradle
@@ -45,15 +45,15 @@ android {
         minSdkVersion 23
         targetSdkVersion 29
 
-        versionCode (
+        versionCode(
                 VERSION_MAJOR.toInteger() * 1000000
-                + VERSION_MINOR.toInteger() * 10000
-                + VERSION_PATCH.toInteger() * 100
-                + VERSION_BUILD.toInteger()
+                        + VERSION_MINOR.toInteger() * 10000
+                        + VERSION_PATCH.toInteger() * 100
+                        + VERSION_BUILD.toInteger()
         )
         println("Used versionCode: $versionCode")
 
-        versionName "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}-RC${VERSION_BUILD}"
+        versionName "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}"
         println("Used versionName: $versionName")
 
         testInstrumentationRunner "testhelpers.TestApplicationUIRunner"
@@ -130,6 +130,14 @@ android {
         def flavor = variant.productFlavors[0]
         def typeName = variant.buildType.name // debug/release
         variant.buildConfigField "String", "ENVIRONMENT_TYPE_DEFAULT", "\"${flavor.envTypeDefault[typeName]}\""
+
+        if (flavor.name == "deviceForTesters") {
+            def adjustedVersionName = "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}-RC${VERSION_BUILD}"
+            variant.outputs.each { output ->
+                output.versionNameOverride = adjustedVersionName
+            }
+            println("deviceForTesters adjusted versionName: $adjustedVersionName")
+        }
     }
 
     buildFeatures {


### PR DESCRIPTION
Version name now depends on build flavor, testers get `RC`, others don't.

![Screenshot from 2020-10-13 16-43-35](https://user-images.githubusercontent.com/1439229/95876506-6d3c4a80-0d73-11eb-9a8d-c22743105268.png)
