### PR TITLE
Fix automatic data reset on for users affected by encryption issues (EXPOSUREAPP-3313, EXPOSUREAPP-3335)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainFragment.kt
@@ -66,7 +66,7 @@ class MainFragment : Fragment(R.layout.fragment_main) {
         if (errorResetTool.isResetNoticeToBeShown) {
             RecoveryByResetDialogFactory(this).showDialog(
                 detailsLink = R.string.errors_generic_text_catastrophic_error_encryption_failure,
-                onDismiss = {
+                onPositive = {
                     errorResetTool.isResetNoticeToBeShown = false
                 }
             )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/errors/RecoveryByResetDialogFactory.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/errors/RecoveryByResetDialogFactory.kt
@@ -14,17 +14,20 @@ class RecoveryByResetDialogFactory(private val fragment: Fragment) {
 
     fun showDialog(
         @StringRes detailsLink: Int,
-        onDismiss: () -> Unit
+        onPositive: () -> Unit
     ) {
-        AlertDialog.Builder(context)
+        val dialog = AlertDialog.Builder(context)
             .setTitle(R.string.errors_generic_headline)
             .setMessage(R.string.errors_generic_text_catastrophic_error_recovery_via_reset)
             .setCancelable(false)
-            .setOnDismissListener { onDismiss() }
-            .setNeutralButton(R.string.errors_generic_button_negative) { _, _ ->
-                ExternalActionHelper.openUrl(fragment, context.getString(detailsLink))
+            .setNeutralButton(R.string.errors_generic_button_negative, null)
+            .setPositiveButton(R.string.errors_generic_button_positive) { _, _ ->
+                onPositive()
             }
-            .setPositiveButton(R.string.errors_generic_button_positive) { _, _ -> }
-            .show()
+            .create()
+        dialog.show()
+        dialog.getButton(AlertDialog.BUTTON_NEUTRAL)?.setOnClickListener {
+            ExternalActionHelper.openUrl(fragment, context.getString(detailsLink))
+        }
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/security/EncryptionErrorResetTool.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/security/EncryptionErrorResetTool.kt
@@ -71,8 +71,8 @@ class EncryptionErrorResetTool @Inject constructor(
         }
         isResetWindowConsumed = true
 
-        val keyException = error.causes().singleOrNull { it is GeneralSecurityException }
-        if (keyException == null) {
+        val keyException = error.causes().lastOrNull()
+        if (keyException == null || keyException !is GeneralSecurityException) {
             Timber.v("Error has no GeneralSecurityException as cause -> no reset.")
             return false
         }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/security/EncryptionResetToolTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/security/EncryptionResetToolTest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test
 import testhelpers.BaseIOTest
 import testhelpers.preferences.MockSharedPreferences
 import java.io.File
+import java.io.IOException
 import java.security.GeneralSecurityException
 import java.security.KeyException
 import java.security.KeyStoreException
@@ -171,8 +172,32 @@ class EncryptionResetToolTest : BaseIOTest() {
     }
 
     @Test
-    fun `nested exception may have the same base exception type, GeneralSecurityException`() {
+    fun `nested exception may have the same base exception type, ie GeneralSecurityException`() {
         // https://github.com/corona-warn-app/cwa-app-android/issues/642#issuecomment-712188157
+        createMockFiles()
+
+        createInstance().tryResetIfNecessary(
+            KeyException( // subclass of GeneralSecurityException
+                "Permantly failed to instantiate encrypted preferences",
+                SecurityException(
+                    "Could not decrypt key. decryption failed",
+                    GeneralSecurityException("decryption failed")
+                )
+            )
+        ) shouldBe true
+
+        encryptedPrefsFile.exists() shouldBe false
+        encryptedDatabaseFile.exists() shouldBe false
+
+        mockPreferences.dataMapPeek.apply {
+            this["ea1851.reset.performedAt"] shouldNotBe null
+            this["ea1851.reset.windowconsumed"] shouldBe true
+            this["ea1851.reset.shownotice"] shouldBe true
+        }
+    }
+
+    @Test
+    fun `exception check does not care about the first exception type`() {
         createMockFiles()
 
         createInstance().tryResetIfNecessary(
@@ -194,6 +219,35 @@ class EncryptionResetToolTest : BaseIOTest() {
             this["ea1851.reset.performedAt"] shouldNotBe null
             this["ea1851.reset.windowconsumed"] shouldBe true
             this["ea1851.reset.shownotice"] shouldBe true
+        }
+    }
+
+    @Test
+    fun `exception check DOES care about the most nested exception`() {
+        createMockFiles()
+
+        createInstance().tryResetIfNecessary(
+            CwaSecurityException(
+                KeyException( // subclass of GeneralSecurityException
+                    "Permantly failed to instantiate encrypted preferences",
+                    SecurityException(
+                        "Could not decrypt key. decryption failed",
+                        GeneralSecurityException(
+                            "decryption failed",
+                            IOException("I am unexpeted")
+                        )
+                    )
+                )
+            )
+        ) shouldBe false
+
+        encryptedPrefsFile.exists() shouldBe true
+        encryptedDatabaseFile.exists() shouldBe true
+
+        mockPreferences.dataMapPeek.apply {
+            this["ea1851.reset.performedAt"] shouldBe null
+            this["ea1851.reset.windowconsumed"] shouldBe true
+            this["ea1851.reset.shownotice"] shouldBe null
         }
     }
 


### PR DESCRIPTION
The automatic data reset for users affected by #642 does unfortunately not match :frowning_face:.
We overlooked that `KeyException` is a subclass of `GeneralSecurityException`.
This causes us to abort early and continue with `KeyException` which then fails the error message matching test.
As the underlying Tink code throws the GeneralSecurityException first and should have no further causes, I've changed the code to not iterate, but directly pick the last exception in the list of causes.

## Test
This can't be easily tested on device.
Understand the original exception flow in the [stracktrace provided by a user](https://github.com/corona-warn-app/cwa-app-android/issues/642#issuecomment-712188157) and confirm that this is now fixed and the unit test correctly covers this case.

```
time: 1603116265174
msg: java.security.GeneralSecurityException: decryption failed
stacktrace: java.lang.RuntimeException: Unable to create application de.rki.coronawarnapp.CoronaWarnApplication: de.rki.coronawarnapp.exception.CwaSecurityException: something went wrong during a critical part of the application ensuring security, please referto the details for more information
	at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6465)
	at android.app.ActivityThread.access$1300(ActivityThread.java:219)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1859)
	at android.os.Handler.dispatchMessage(Handler.java:107)
	at android.os.Looper.loop(Looper.java:214)
	at android.app.ActivityThread.main(ActivityThread.java:7356)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:491)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:925)
Caused by: de.rki.coronawarnapp.exception.CwaSecurityException: something went wrong during a critical part of the application ensuring security, please referto the details for more information
	at de.rki.coronawarnapp.util.security.SecurityHelper$encryptedPreferencesProvider$1.invoke(SecurityHelper.kt:9)
	at de.rki.coronawarnapp.util.security.SecurityHelper$globalEncryptedSharedPreferencesInstance$2.invoke(SecurityHelper.kt:3)
	at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:6)
	at de.rki.coronawarnapp.util.security.SecurityHelper.getGlobalEncryptedSharedPreferencesInstance(Unknown Source:2)
	at de.rki.coronawarnapp.storage.LocalData.getSharedPreferenceInstance(LocalData.kt:1)
	at de.rki.coronawarnapp.CoronaWarnApplication.onCreate(CoronaWarnApplication.kt:42)
	at android.app.Instrumentation.callApplicationOnCreate(Instrumentation.java:1190)
	at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6460)
	... 8 more
Caused by: java.security.KeyException: Permantly failed to instantiate encrypted preferences
	at de.rki.coronawarnapp.util.security.EncryptedPreferencesFactory.create(EncryptedPreferencesFactory.kt:2)
	at de.rki.coronawarnapp.util.security.SecurityHelper$encryptedPreferencesProvider$1$1.invoke(SecurityHelper.kt:1)
	at de.rki.coronawarnapp.util.security.SecurityHelper$encryptedPreferencesProvider$1.invoke(SecurityHelper.kt:7)
	... 15 more
Caused by: java.lang.SecurityException: Could not decrypt key. decryption failed
	at androidx.security.crypto.EncryptedSharedPreferences.getAll(EncryptedSharedPreferences.java:13)
	at de.rki.coronawarnapp.util.security.EncryptedPreferencesFactory$create$1.invoke(EncryptedPreferencesFactory.kt:29)
	at de.rki.coronawarnapp.util.RetryMechanism.retryWithBackOff$default(RetryMechanism.kt:7)
	at de.rki.coronawarnapp.util.security.EncryptedPreferencesFactory.create(EncryptedPreferencesFactory.kt:1)
	... 17 more
Caused by: java.security.GeneralSecurityException: decryption failed
	at com.google.crypto.tink.daead.DeterministicAeadWrapper$WrappedDeterministicAead.decryptDeterministically(DeterministicAeadWrapper.java:16)
	at androidx.security.crypto.EncryptedSharedPreferences.getAll(EncryptedSharedPreferences.java:8)
	... 20 more
```