### PR TITLE
Increase transaction timeout (EXPOSUREAPP-3238, EXPOSUREAPP-3335) (#1406)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/TimeVariables.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/TimeVariables.kt
@@ -33,8 +33,10 @@ object TimeVariables {
     /**
      * The maximal runtime of a transaction
      * In milliseconds
+     * Stay below 10min with this timeout!
+     * We only 10min background execution time via WorkManager.
      */
-    private const val TRANSACTION_TIMEOUT = 180000L
+    private const val TRANSACTION_TIMEOUT = 8 * 60 * 1000L
 
     /**
      * Getter function for [TRANSACTION_TIMEOUT]

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/TimeVariablesTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/TimeVariablesTest.kt
@@ -16,7 +16,7 @@ class TimeVariablesTest {
 
     @Test
     fun getTransactionTimeout() {
-        Assert.assertEquals(TimeVariables.getTransactionTimeout(), 180000L)
+        Assert.assertEquals(TimeVariables.getTransactionTimeout(), 480000L)
     }
 
     @Test


### PR DESCRIPTION
Cherry pick to backport the timeout increase from #1406 into 1.5.x for a potential hotfix.