### PR TITLE
Fix LocalData - isInteroperabilityShownAtLeastOnce - set(value) to commit=true

### DIFF
--- a/Corona-Warn-App/build.gradle
+++ b/Corona-Warn-App/build.gradle
@@ -40,8 +40,8 @@ android {
         applicationId 'de.rki.coronawarnapp'
         minSdkVersion 23
         targetSdkVersion 29
-        versionCode 47
-        versionName "1.5.0"
+        versionCode 48
+        versionName "1.5.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/TimeVariables.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/TimeVariables.kt
@@ -33,8 +33,10 @@ object TimeVariables {
     /**
      * The maximal runtime of a transaction
      * In milliseconds
+     * Stay below 10min with this timeout!
+     * We only 10min background execution time via WorkManager.
      */
-    private const val TRANSACTION_TIMEOUT = 180000L
+    private const val TRANSACTION_TIMEOUT = 8 * 60 * 1000L
 
     /**
      * Getter function for [TRANSACTION_TIMEOUT]

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/LocalData.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/LocalData.kt
@@ -726,7 +726,7 @@ object LocalData {
             )
         }
         set(value) {
-            getSharedPreferenceInstance().edit {
+            getSharedPreferenceInstance().edit(true) {
                 putBoolean(PREFERENCE_INTEROPERABILITY_IS_USED_AT_LEAST_ONCE, value)
             }
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainFragment.kt
@@ -66,7 +66,7 @@ class MainFragment : Fragment(R.layout.fragment_main) {
         if (errorResetTool.isResetNoticeToBeShown) {
             RecoveryByResetDialogFactory(this).showDialog(
                 detailsLink = R.string.errors_generic_text_catastrophic_error_encryption_failure,
-                onDismiss = {
+                onPositive = {
                     errorResetTool.isResetNoticeToBeShown = false
                 }
             )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/errors/RecoveryByResetDialogFactory.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/errors/RecoveryByResetDialogFactory.kt
@@ -14,17 +14,20 @@ class RecoveryByResetDialogFactory(private val fragment: Fragment) {
 
     fun showDialog(
         @StringRes detailsLink: Int,
-        onDismiss: () -> Unit
+        onPositive: () -> Unit
     ) {
-        AlertDialog.Builder(context)
+        val dialog = AlertDialog.Builder(context)
             .setTitle(R.string.errors_generic_headline)
             .setMessage(R.string.errors_generic_text_catastrophic_error_recovery_via_reset)
             .setCancelable(false)
-            .setOnDismissListener { onDismiss() }
-            .setNeutralButton(R.string.errors_generic_button_negative) { _, _ ->
-                ExternalActionHelper.openUrl(fragment, context.getString(detailsLink))
+            .setNeutralButton(R.string.errors_generic_button_negative, null)
+            .setPositiveButton(R.string.errors_generic_button_positive) { _, _ ->
+                onPositive()
             }
-            .setPositiveButton(R.string.errors_generic_button_positive) { _, _ -> }
-            .show()
+            .create()
+        dialog.show()
+        dialog.getButton(AlertDialog.BUTTON_NEUTRAL)?.setOnClickListener {
+            ExternalActionHelper.openUrl(fragment, context.getString(detailsLink))
+        }
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/security/EncryptionErrorResetTool.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/security/EncryptionErrorResetTool.kt
@@ -71,8 +71,8 @@ class EncryptionErrorResetTool @Inject constructor(
         }
         isResetWindowConsumed = true
 
-        val keyException = error.causes().singleOrNull { it is GeneralSecurityException }
-        if (keyException == null) {
+        val keyException = error.causes().lastOrNull()
+        if (keyException == null || keyException !is GeneralSecurityException) {
             Timber.v("Error has no GeneralSecurityException as cause -> no reset.")
             return false
         }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/TimeVariablesTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/TimeVariablesTest.kt
@@ -16,7 +16,7 @@ class TimeVariablesTest {
 
     @Test
     fun getTransactionTimeout() {
-        Assert.assertEquals(TimeVariables.getTransactionTimeout(), 180000L)
+        Assert.assertEquals(TimeVariables.getTransactionTimeout(), 480000L)
     }
 
     @Test


### PR DESCRIPTION
Related: https://github.com/corona-warn-app/cwa-app-android/issues/1421#issuecomment-713234063 and https://github.com/corona-warn-app/cwa-app-android/issues/1421#issuecomment-713664317


### Description
While discussing persistence using LocalData with @kolyaopahle , we found a small flaw in LocalData 
https://github.com/corona-warn-app/cwa-app-android/blob/0f12f4ddbd814ac368901858363f7835bb30b9a8/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/LocalData.kt#L717-L733

For `isInteroperabilityShownAtLeastOnce` the `getSharedPreferenceInstance().edit` lacks `the commit=true`. Would be nice to fix it for consistency of the code.

@kolyaopahle kindly invited me to create a PR for this minor fix, but I must admit, I'd be proud like Oscar if it was to be merged.

### Steps to reproduce
Investigate the code.
