### PR TITLE
Fix/LocalData - isInteroperabilityShownAtLeastOnce - set(value) to commit=true

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/LocalData.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/LocalData.kt
@@ -707,7 +707,7 @@ object LocalData {
             )
         }
         set(value) {
-            getSharedPreferenceInstance().edit {
+            getSharedPreferenceInstance().edit(true) {
                 putBoolean(PREFERENCE_INTEROPERABILITY_IS_USED_AT_LEAST_ONCE, value)
             }
         }


### PR DESCRIPTION
Related: [#1421 (comment)](https://github.com/corona-warn-app/cwa-app-android/issues/1421#issuecomment-713234063) and [#1421 (comment)](https://github.com/corona-warn-app/cwa-app-android/issues/1421#issuecomment-713664317)

### Description
While discussing persistence using LocalData with @kolyaopahle , we found a small flaw in LocalData
https://github.com/corona-warn-app/cwa-app-android/blob/0f12f4ddbd814ac368901858363f7835bb30b9a8/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/LocalData.kt#L717-L733

For `isInteroperabilityShownAtLeastOnce` the `getSharedPreferenceInstance().edit` lacks `the commit=true`. Would be nice to fix it for consistency of the code.
 
@kolyaopahle kindly invited me to create a PR for this minor fix, but I must admit, I'd be proud like Oscar if it was to be merged.
### Steps to reproduce
Investigate the code.

