### PR TITLE
Grant one more encryption reset attempt for users on v1.6.0 (EXPOSUREAPP-3313)

### DIFF
--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/security/EncryptionResetToolTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/security/EncryptionResetToolTest.kt
@@ -1,13 +1,15 @@
 package de.rki.coronawarnapp.util.security
 
 import android.content.Context
+import androidx.core.content.edit
 import de.rki.coronawarnapp.exception.CwaSecurityException
+import de.rki.coronawarnapp.util.TimeStamper
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import io.mockk.MockKAnnotations
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import org.joda.time.Instant
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -19,8 +21,8 @@ import java.security.KeyStoreException
 
 class EncryptionResetToolTest : BaseIOTest() {
 
-    @MockK
-    lateinit var context: Context
+    @MockK lateinit var context: Context
+    @MockK lateinit var timeStamper: TimeStamper
     private lateinit var mockPreferences: MockSharedPreferences
 
     private val testDir = File(IO_TEST_BASEDIR, this::class.simpleName!!)
@@ -42,6 +44,8 @@ class EncryptionResetToolTest : BaseIOTest() {
                 Context.MODE_PRIVATE
             )
         } returns mockPreferences
+
+        every { timeStamper.nowUTC } returns Instant.ofEpochMilli(1234567890L)
     }
 
     @AfterEach
@@ -52,7 +56,8 @@ class EncryptionResetToolTest : BaseIOTest() {
     }
 
     private fun createInstance() = EncryptionErrorResetTool(
-        context = context
+        context = context,
+        timeStamper = timeStamper
     )
 
     private fun createMockFiles() {
@@ -144,8 +149,33 @@ class EncryptionResetToolTest : BaseIOTest() {
         encryptedDatabaseFile.exists() shouldBe false
 
         mockPreferences.dataMapPeek.apply {
-            this["ea1851.reset.performedAt"] shouldNotBe null
+            this["ea1851.reset.performedAt"] shouldBe 1234567890L
+            this["ea1851.reset.windowconsumed.160"] shouldBe true
+            this["ea1851.reset.shownotice"] shouldBe true
+        }
+    }
+
+    @Test
+    fun `the previous reset attempt from 1_5_0 is ignored`() {
+        mockPreferences.edit { putBoolean("ea1851.reset.windowconsumed", true) }
+
+        mockPreferences.dataMapPeek.apply {
+            this["ea1851.reset.performedAt"] shouldBe null
             this["ea1851.reset.windowconsumed"] shouldBe true
+            this["ea1851.reset.windowconsumed.160"] shouldBe null
+            this["ea1851.reset.shownotice"] shouldBe null
+        }
+
+        createMockFiles()
+
+        createInstance().tryResetIfNecessary(
+            GeneralSecurityException("decryption failed")
+        ) shouldBe true
+
+        mockPreferences.dataMapPeek.apply {
+            this["ea1851.reset.performedAt"] shouldBe 1234567890L
+            this["ea1851.reset.windowconsumed"] shouldBe true
+            this["ea1851.reset.windowconsumed.160"] shouldBe true
             this["ea1851.reset.shownotice"] shouldBe true
         }
     }
@@ -163,8 +193,8 @@ class EncryptionResetToolTest : BaseIOTest() {
         encryptedDatabaseFile.exists() shouldBe false
 
         mockPreferences.dataMapPeek.apply {
-            this["ea1851.reset.performedAt"] shouldNotBe null
-            this["ea1851.reset.windowconsumed"] shouldBe true
+            this["ea1851.reset.performedAt"] shouldBe 1234567890L
+            this["ea1851.reset.windowconsumed.160"] shouldBe true
             this["ea1851.reset.shownotice"] shouldBe true
         }
     }
@@ -182,7 +212,7 @@ class EncryptionResetToolTest : BaseIOTest() {
 
         mockPreferences.dataMapPeek.apply {
             this["ea1851.reset.performedAt"] shouldBe null
-            this["ea1851.reset.windowconsumed"] shouldBe true
+            this["ea1851.reset.windowconsumed.160"] shouldBe true
             this["ea1851.reset.shownotice"] shouldBe null
         }
     }
@@ -202,7 +232,7 @@ class EncryptionResetToolTest : BaseIOTest() {
 
         mockPreferences.dataMapPeek.apply {
             this["ea1851.reset.performedAt"] shouldBe null
-            this["ea1851.reset.windowconsumed"] shouldBe true
+            this["ea1851.reset.windowconsumed.160"] shouldBe true
             this["ea1851.reset.shownotice"] shouldBe null
         }
     }
@@ -220,7 +250,7 @@ class EncryptionResetToolTest : BaseIOTest() {
 
         mockPreferences.dataMapPeek.apply {
             this["ea1851.reset.performedAt"] shouldBe null
-            this["ea1851.reset.windowconsumed"] shouldBe true
+            this["ea1851.reset.windowconsumed.160"] shouldBe true
             this["ea1851.reset.shownotice"] shouldBe null
         }
     }
@@ -241,7 +271,7 @@ class EncryptionResetToolTest : BaseIOTest() {
 
         mockPreferences.dataMapPeek.apply {
             this["ea1851.reset.performedAt"] shouldBe null
-            this["ea1851.reset.windowconsumed"] shouldBe true
+            this["ea1851.reset.windowconsumed.160"] shouldBe true
             this["ea1851.reset.shownotice"] shouldBe null
         }
     }
@@ -262,7 +292,7 @@ class EncryptionResetToolTest : BaseIOTest() {
 
         mockPreferences.dataMapPeek.apply {
             this["ea1851.reset.performedAt"] shouldBe null
-            this["ea1851.reset.windowconsumed"] shouldBe true
+            this["ea1851.reset.windowconsumed.160"] shouldBe true
             this["ea1851.reset.shownotice"] shouldBe null
         }
     }


### PR DESCRIPTION
The mitigation for the encryption issue is already in place but we are still trying to help those users that are just updating the app in the background automatically hoping for a solution to their error when opening the app.

Either the mitigation works or it doesn't so resetting the data should only happens once.
If the mitigation does not work and the issue reappears we don't want to keep resetting the data.

@vaubaehn noticed that users who upgraded to 1.5.0 before 1.5.1 was available, and who were affected by the encryption issue, the data reset attempt was already consumed without helping those users, due to a bug in the previous implementation, and it should be retried.

This PR adds a new stored [boolean value](https://github.com/corona-warn-app/cwa-app-android/compare/release/1.6.x...fix/encryption-reset-per-version?expand=1#diff-069e5febb8fd6d0280bfacf45d686c5799dd786629f330fd8126e61532e6ba4bR138), ignoring the previous one, such that for everyone affected by the issue, the recovery through data reset will be attempted once again if the error case matches.

## Testing
Sadly this can't be easily tested again and manually editing the code to throw exceptions, and reviewing code + unit-tests is required.