### PR TITLE
Accept invalidly handed out qr-codes (COMMUNITY)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/service/submission/QRScanResult.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/service/submission/QRScanResult.kt
@@ -22,7 +22,7 @@ data class QRScanResult(val rawResult: String) {
     companion object {
         // regex pattern for scanned QR code URL
         val QR_CODE_REGEX: Pattern = Pattern.compile(
-            "^((^https:\\/{2}localhost)(\\/\\?)[A-Fa-f0-9]{6}" +
+            "^((^https:\\/{2}localhost)(\\/)?(\\/\\?)[A-Fa-f0-9]{6}" +
                     "[-][A-Fa-f0-9]{8}[-][A-Fa-f0-9]{4}[-][A-Fa-f0-9]{4}[-][A-Fa-f0-9]{4}[-][A-Fa-f0-9]{12})\$"
         )
         const val GUID_SEPARATOR = '?'

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/service/submission/ScanResultTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/service/submission/ScanResultTest.kt
@@ -27,6 +27,10 @@ class ScanResultTest {
         scanResult = QRScanResult("https://localhost/?$guid")
         scanResult.isValid shouldBe true
 
+        // valid test for incorrectly handed out qr codes
+        scanResult = QRScanResult("https://localhost//?$guid")
+        scanResult.isValid shouldBe true
+
         // more invalid tests checks
         scanResult = QRScanResult("http://localhost/?$guid")
         scanResult.isValid shouldBe false


### PR DESCRIPTION
Incorrectly generated QR-Codes have been handed out apparently, these contain an extra `/` before the GUID, e.g. `https://localhost//?GUID`. This fix will allow people with such QR-Codes to also use the CWA to register their test.