### PR TITLE
"Invalid Tan" message is displayed when the TAN input screen is opened (EXPOSUREAPP-3646)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/tan/SubmissionTanFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/tan/SubmissionTanFragment.kt
@@ -40,7 +40,11 @@ class SubmissionTanFragment : Fragment(R.layout.fragment_submission_tan), AutoIn
             binding.uiState = it
 
             submission_tan_character_error.setGone(it.areCharactersCorrect)
-            submission_tan_error.setGone(it.isTanValid)
+            if (it.isCorrectLength) {
+                submission_tan_error.setGone(it.isTanValid)
+            } else {
+                submission_tan_error.setGone(true)
+            }
         }
 
         binding.submissionTanContent.submissionTanInput.listener = { tan ->

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/tan/SubmissionTanFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/tan/SubmissionTanFragment.kt
@@ -40,7 +40,7 @@ class SubmissionTanFragment : Fragment(R.layout.fragment_submission_tan), AutoIn
             binding.uiState = it
 
             submission_tan_character_error.setGone(it.areCharactersCorrect)
-            submission_tan_error.setGone(it.isTanValidFormat)
+            submission_tan_error.setGone(it.isTanValid)
         }
 
         binding.submissionTanContent.submissionTanInput.listener = { tan ->

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/tan/SubmissionTanViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/tan/SubmissionTanViewModel.kt
@@ -28,7 +28,8 @@ class SubmissionTanViewModel @AssistedInject constructor(
         UIState(
             isTanValid = currentTan.isTanValid,
             isTanValidFormat = currentTan.isTanValidFormat,
-            areCharactersCorrect = currentTan.areCharactersValid
+            areCharactersCorrect = currentTan.areCharactersValid,
+            isCorrectLength = currentTan.isCorrectLength
         )
     }.asLiveData(context = dispatcherProvider.Default)
 
@@ -73,7 +74,8 @@ class SubmissionTanViewModel @AssistedInject constructor(
     data class UIState(
         val isTanValid: Boolean = false,
         val areCharactersCorrect: Boolean = false,
-        val isTanValidFormat: Boolean = false
+        val isTanValidFormat: Boolean = false,
+        val isCorrectLength: Boolean = false
     )
 
     @AssistedInject.Factory

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/tan/Tan.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/tan/Tan.kt
@@ -10,7 +10,7 @@ data class Tan(
 
     val areCharactersValid = allCharactersValid(value)
     val isTanValidFormat = value.length == MAX_LENGTH && isChecksumValid(value)
-    val isTanValid = areCharactersValid && isTanValidFormat
+    val isTanValid = if (value.length != MAX_LENGTH) true else areCharactersValid && isTanValidFormat
 
     companion object {
         const val MAX_LENGTH = 10

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/tan/Tan.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/tan/Tan.kt
@@ -8,10 +8,10 @@ data class Tan(
     val value: String
 ) {
 
-    val areCharactersValid = allCharactersValid(value)
-    val isTanValidFormat = value.length == MAX_LENGTH && isChecksumValid(value)
-    val isTanValid = areCharactersValid && isTanValidFormat
     val isCorrectLength = value.length == MAX_LENGTH
+    val areCharactersValid = allCharactersValid(value)
+    val isTanValidFormat = isCorrectLength && isChecksumValid(value)
+    val isTanValid = areCharactersValid && isTanValidFormat
 
     companion object {
         const val MAX_LENGTH = 10

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/tan/Tan.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/tan/Tan.kt
@@ -10,7 +10,7 @@ data class Tan(
 
     val areCharactersValid = allCharactersValid(value)
     val isTanValidFormat = value.length == MAX_LENGTH && isChecksumValid(value)
-    val isTanValid = if (value.length != MAX_LENGTH) true else areCharactersValid && isTanValidFormat
+    val isTanValid = if (value.length < MAX_LENGTH) true else areCharactersValid && isTanValidFormat
 
     companion object {
         const val MAX_LENGTH = 10

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/tan/Tan.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/tan/Tan.kt
@@ -10,7 +10,8 @@ data class Tan(
 
     val areCharactersValid = allCharactersValid(value)
     val isTanValidFormat = value.length == MAX_LENGTH && isChecksumValid(value)
-    val isTanValid = if (value.length < MAX_LENGTH) true else areCharactersValid && isTanValidFormat
+    val isTanValid = areCharactersValid && isTanValidFormat
+    val isCorrectLength = value.length == MAX_LENGTH
 
     companion object {
         const val MAX_LENGTH = 10

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/tan/SubmissionTanViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/tan/SubmissionTanViewModelTest.kt
@@ -28,18 +28,20 @@ class SubmissionTanViewModelTest : BaseTest() {
 
         viewModel.onTanChanged("ZWFPC7NG47")
         viewModel.state.value!!.isTanValid shouldBe true
+        viewModel.state.value!!.isCorrectLength shouldBe true
 
         viewModel.onTanChanged("ABC")
-        viewModel.state.value!!.isTanValid shouldBe true
-
-        viewModel.onTanChanged("ABC")
-        viewModel.state.value!!.isTanValidFormat shouldBe false
+        viewModel.state.value!!.isTanValid shouldBe false
+        viewModel.state.value!!.isCorrectLength shouldBe false
 
         viewModel.onTanChanged("ZWFPC7NG48")
         viewModel.state.value!!.isTanValid shouldBe false
+        viewModel.state.value!!.isCorrectLength shouldBe true
 
         viewModel.onTanChanged("ZWFPC7NG4A")
         viewModel.state.value!!.isTanValid shouldBe false
+        viewModel.state.value!!.isCorrectLength shouldBe true
+
     }
 
     @Test

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/tan/SubmissionTanViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/tan/SubmissionTanViewModelTest.kt
@@ -30,7 +30,10 @@ class SubmissionTanViewModelTest : BaseTest() {
         viewModel.state.value!!.isTanValid shouldBe true
 
         viewModel.onTanChanged("ABC")
-        viewModel.state.value!!.isTanValid shouldBe false
+        viewModel.state.value!!.isTanValid shouldBe true
+
+        viewModel.onTanChanged("ABC")
+        viewModel.state.value!!.isTanValidFormat shouldBe false
 
         viewModel.onTanChanged("ZWFPC7NG48")
         viewModel.state.value!!.isTanValid shouldBe false

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/tan/SubmissionTanViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/tan/SubmissionTanViewModelTest.kt
@@ -41,7 +41,6 @@ class SubmissionTanViewModelTest : BaseTest() {
         viewModel.onTanChanged("ZWFPC7NG4A")
         viewModel.state.value!!.isTanValid shouldBe false
         viewModel.state.value!!.isCorrectLength shouldBe true
-
     }
 
     @Test

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/tan/TanTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/tan/TanTest.kt
@@ -47,6 +47,26 @@ class TanTest : BaseTest() {
     }
 
     @Test
+    fun isTanValid() {
+        val validTans = arrayOf(
+            "9A3B578UMG", "DEU7TKSV3H", "PTPHM35RP4", "V923D59AT8", "H9NC5CQ34E"
+        )
+        for (tan in validTans) {
+            Tan.allCharactersValid(tan)  shouldBe true
+            Tan.isChecksumValid(tan) shouldBe true
+            (tan.length == Tan.MAX_LENGTH) shouldBe true
+        }
+
+        // invalid tans due to length and/or invalid characters
+        val invalidTans = arrayOf(
+            "ABÖAA1", "-1234", "PTPHM15RP4", "aAASd A"
+        )
+        for (tan in invalidTans) {
+           Tan.allCharactersValid(tan) shouldBe false
+        }
+    }
+
+    @Test
     fun isChecksumValid() {
         // valid
         val validTans = arrayOf(


### PR DESCRIPTION
### Description

As soon as the user opens the screen for teletan input, a message appears stating that the TAN is invalid. This message remains until the complete TAN has been entered.

**Expected**: Only if the TAN is invalid the message should appear

**Fix**: Added check to only do valid tan check if the length of the TAN is at the max length. Changed unit tests to reflect this. 

### Steps to reproduce

Go to TAN input screen, enter an invalid TAN - the error will now only appear once the user has filled in all the spaces. 
