### PR TITLE
Fix KotlinNPE within error dialog (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/exception/reporting/ErrorReportReceiver.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/exception/reporting/ErrorReportReceiver.kt
@@ -47,7 +47,7 @@ class ErrorReportReceiver(private val activity: Activity) : BroadcastReceiver() 
             message += "#$apiStatusCode"
         }
 
-        val dialogTitle = if (intent.hasExtra(ReportingConstants.ERROR_REPORT_TITLE_EXTRA)) {
+        val dialogTitle = if (intent.getStringExtra(ReportingConstants.ERROR_REPORT_TITLE_EXTRA) != null) {
             intent.getStringExtra(ReportingConstants.ERROR_REPORT_TITLE_EXTRA)
         } else {
             val errorTitle = context.resources.getString(R.string.errors_generic_details_headline)


### PR DESCRIPTION
The title was set to `null` in the intent.
This wasn't caught by Kotlin's null checking as it couldn't resolve the nullability of `getStringExtra`.

We now explicitly check the value within the if check in the receiver, and in the reporter we also explicitly check whether there is a title.