### PR TITLE
Generate nicer APK names (DEV)

### DIFF
--- a/Corona-Warn-App/build.gradle
+++ b/Corona-Warn-App/build.gradle
@@ -91,7 +91,7 @@ android {
         signingProps.load(new FileInputStream(signingPropFile))
         signingConfigs {
             deviceRelease {
-                if(signingProps['deviceRelease.storePath'] != null) {
+                if (signingProps['deviceRelease.storePath'] != null) {
                     storeFile file(signingProps['deviceRelease.storePath'])
                     keyAlias signingProps['deviceRelease.keyAlias']
                     storePassword signingProps['deviceRelease.storePassword']
@@ -99,7 +99,7 @@ android {
                 }
             }
             deviceForTestersRelease {
-                if(signingProps['deviceForTestersRelease.storePath'] != null) {
+                if (signingProps['deviceForTestersRelease.storePath'] != null) {
                     storeFile file(signingProps['deviceForTestersRelease.storePath'])
                     keyAlias signingProps['deviceForTestersRelease.keyAlias']
                     storePassword signingProps['deviceForTestersRelease.storePassword']
@@ -162,6 +162,12 @@ android {
                 output.versionNameOverride = adjustedVersionName
             }
             println("deviceForTesters adjusted versionName: $adjustedVersionName")
+        }
+
+        variant.outputs.each { output ->
+            def apkName = "Corona-Warn-App-${output.versionNameOverride}-${flavor.name}-${variant.buildType.name}.apk"
+            println("APK Name: $apkName")
+            output.outputFileName = apkName
         }
     }
 


### PR DESCRIPTION
Prevents APKs being accidentally confused if they have to be renamed manually.

```bash
APK Name: Corona-Warn-App-1.7.0-RC1-deviceForTesters-debug.apk
APK Name: Corona-Warn-App-1.7.0-device-debug.apk
APK Name: Corona-Warn-App-1.7.0-RC1-deviceForTesters-release.apk
APK Name: Corona-Warn-App-1.7.0-device-release.apk

apk/deviceForTesters
apk/deviceForTesters/debug
apk/deviceForTesters/debug/Corona-Warn-App-1.7.0-RC1-deviceForTesters-debug.apk
apk/deviceForTesters/debug/output.json
apk/deviceForTesters/release
apk/deviceForTesters/release/Corona-Warn-App-1.7.0-RC1-deviceForTesters-release.apk
apk/deviceForTesters/release/output.json