### PR TITLE
Never report CancellationException (closes #1588)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/exception/reporting/ExceptionReporter.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/exception/reporting/ExceptionReporter.kt
@@ -15,6 +15,7 @@ import de.rki.coronawarnapp.util.HasHumanReadableError
 import de.rki.coronawarnapp.util.tryHumanReadableError
 import java.io.PrintWriter
 import java.io.StringWriter
+import java.util.concurrent.CancellationException
 
 fun Throwable.report(exceptionCategory: ExceptionCategory) =
     this.report(exceptionCategory, null, null)
@@ -25,6 +26,10 @@ fun Throwable.report(
     suffix: String?
 ) {
     if (CWADebug.isAUnitTest) return
+
+    // CancellationException is a part of normal operation. It is used to cancel a running
+    // asynchronous operation. It is not a failure and should not be reported as such.
+    if (this is CancellationException) return
 
     reportProblem(tag = prefix, info = suffix)
     val context = CoronaWarnApplication.getAppContext()


### PR DESCRIPTION
There is a number of places in the app with the following code pattern:

```
try {
    // do some suspending operation
} catch(e: Exception) {
    e.report(ExceptionCategory.EXPOSURENOTIFICATION) // or similar
}
```

In all such places if the corresponding suspending gets cancelled for any reason, the resulting CancellationException will get reported as an application crash. This fix prevents it from happening, since a cancellation exception is a part of a normal operation, not a failure that should be reported.

Fixes #1588