### PR TITLE
Don't rename the APK on `device` flavor builds. (DEV)

### DIFF
--- a/Corona-Warn-App/build.gradle
+++ b/Corona-Warn-App/build.gradle
@@ -163,11 +163,12 @@ android {
             }
             println("deviceForTesters adjusted versionName: $adjustedVersionName")
         }
-
-        variant.outputs.each { output ->
-            def apkName = "Corona-Warn-App-${output.versionNameOverride}-${flavor.name}-${variant.buildType.name}.apk"
-            println("APK Name: $apkName")
-            output.outputFileName = apkName
+        if (flavor.name != "device") {
+            variant.outputs.each { output ->
+                def apkName = "Corona-Warn-App-${output.versionNameOverride}-${flavor.name}-${variant.buildType.name}.apk"
+                println("APK Name: $apkName")
+                output.outputFileName = apkName
+            }
         }
     }
 

--- a/Corona-Warn-App/build.gradle
+++ b/Corona-Warn-App/build.gradle
@@ -166,7 +166,7 @@ android {
         if (flavor.name != "device") {
             variant.outputs.each { output ->
                 def apkName = "Corona-Warn-App-${output.versionNameOverride}-${flavor.name}-${variant.buildType.name}.apk"
-                println("APK Name: $apkName")
+                println("Override APK Name: $apkName")
                 output.outputFileName = apkName
             }
         }


### PR DESCRIPTION
It breaks internal pipelines.

New
```bash
> Configure project :Corona-Warn-App
Current VERSION_MAJOR: 1
Current VERSION_MINOR: 7
Current VERSION_PATCH: 0
Current VERSION_BUILD: 2
Used versionCode: 1070002
Used versionName: 1.7.0
deviceForTesters adjusted versionName: 1.7.0-RC2
APK Name: Corona-Warn-App-1.7.0-RC2-deviceForTesters-debug.apk
deviceForTesters adjusted versionName: 1.7.0-RC2
APK Name: Corona-Warn-App-1.7.0-RC2-deviceForTesters-release.apk
```

Old
```bash
> Configure project :Corona-Warn-App
Current VERSION_MAJOR: 1
Current VERSION_MINOR: 7
Current VERSION_PATCH: 0
Current VERSION_BUILD: 2
Used versionCode: 1070002
Used versionName: 1.7.0
deviceForTesters adjusted versionName: 1.7.0-RC2
APK Name: Corona-Warn-App-1.7.0-RC2-deviceForTesters-debug.apk
APK Name: Corona-Warn-App-1.7.0-device-debug.apk
deviceForTesters adjusted versionName: 1.7.0-RC2
APK Name: Corona-Warn-App-1.7.0-RC2-deviceForTesters-release.apk
APK Name: Corona-Warn-App-1.7.0-device-release.apk
```
