### PR TITLE
Autostart logfile for testers (DEV)

### DIFF
--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/api/ui/LoggerState.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/api/ui/LoggerState.kt
@@ -3,11 +3,13 @@ package de.rki.coronawarnapp.test.api.ui
 import de.rki.coronawarnapp.util.CWADebug
 
 data class LoggerState(
-    val isLogging: Boolean
+    val isLogging: Boolean,
+    val logsize: Long
 ) {
     companion object {
         internal fun CWADebug.toLoggerState() = LoggerState(
-            isLogging = fileLogger?.isLogging ?: false
+            isLogging = fileLogger?.isLogging ?: false,
+            logsize = fileLogger?.logFile?.length() ?: 0L
         )
     }
 }

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragment.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragment.kt
@@ -2,6 +2,7 @@ package de.rki.coronawarnapp.test.debugoptions.ui
 
 import android.annotation.SuppressLint
 import android.os.Bundle
+import android.text.format.Formatter
 import android.view.View
 import android.widget.RadioButton
 import android.widget.RadioGroup
@@ -49,6 +50,8 @@ class DebugOptionsFragment : Fragment(R.layout.fragment_test_debugoptions), Auto
         vm.loggerState.observe2(this) { state ->
             binding.apply {
                 testLogfileToggle.isChecked = state.isLogging
+                val logSize = Formatter.formatShortFileSize(requireContext(), state.logsize)
+                testLogfileToggle.text = "Logfile enabled ($logSize)"
                 testLogfileShare.setGone(!state.isLogging)
             }
         }

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragmentViewModel.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragmentViewModel.kt
@@ -5,11 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.squareup.inject.assisted.AssistedInject
 import de.rki.coronawarnapp.environment.EnvironmentSetup
 import de.rki.coronawarnapp.environment.EnvironmentSetup.Type.Companion.toEnvironmentType
-import de.rki.coronawarnapp.risk.RiskLevelTask
 import de.rki.coronawarnapp.storage.LocalData
-import de.rki.coronawarnapp.storage.TestSettings
-import de.rki.coronawarnapp.task.TaskController
-import de.rki.coronawarnapp.task.common.DefaultTaskRequest
 import de.rki.coronawarnapp.test.api.ui.EnvironmentState.Companion.toEnvironmentState
 import de.rki.coronawarnapp.test.api.ui.LoggerState.Companion.toLoggerState
 import de.rki.coronawarnapp.util.CWADebug
@@ -26,8 +22,6 @@ import java.io.File
 class DebugOptionsFragmentViewModel @AssistedInject constructor(
     @AppContext private val context: Context,
     private val envSetup: EnvironmentSetup,
-    private val testSettings: TestSettings,
-    private val taskController: TaskController,
     dispatcherProvider: DispatcherProvider
 ) : CWAViewModel(dispatcherProvider = dispatcherProvider) {
 
@@ -69,10 +63,6 @@ class DebugOptionsFragmentViewModel @AssistedInject constructor(
             if (enable) it.start() else it.stop()
         }
         loggerState.update { CWADebug.toLoggerState() }
-    }
-
-    fun calculateRiskLevelClicked() {
-        taskController.submit(DefaultTaskRequest(RiskLevelTask::class))
     }
 
     val logShareEvent = SingleLiveEvent<File?>()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CWADebug.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CWADebug.kt
@@ -14,7 +14,7 @@ object CWADebug {
         if (BuildConfig.DEBUG) {
             Timber.plant(Timber.DebugTree())
         }
-        if ((buildFlavor == BuildFlavor.DEVICE_FOR_TESTERS || BuildConfig.DEBUG)) {
+        if (isDeviceForTestersBuild) {
             fileLogger = FileLogger(application)
         }
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/debug/FileLogger.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/debug/FileLogger.kt
@@ -1,39 +1,45 @@
 package de.rki.coronawarnapp.util.debug
 
 import android.content.Context
+import de.rki.coronawarnapp.util.CWADebug
 import timber.log.Timber
 import java.io.File
 
-class FileLogger constructor(private val context: Context) {
+class FileLogger constructor(context: Context) {
 
     val logFile = File(context.cacheDir, "FileLoggerTree.log")
-    val triggerFile = File(context.filesDir, "FileLoggerTree.trigger")
+
+    private val blockerFile = File(context.filesDir, "FileLoggerTree.blocker")
     private var loggerTree: FileLoggerTree? = null
 
     val isLogging: Boolean
         get() = loggerTree != null
 
     init {
-        if (triggerFile.exists()) {
+        if (!blockerFile.exists()) {
             start()
         }
     }
 
     fun start() {
+        if (!CWADebug.isDeviceForTestersBuild) return
+
         if (loggerTree != null) return
 
         loggerTree = FileLoggerTree(logFile).also {
             Timber.plant(it)
             it.start()
-            triggerFile.createNewFile()
+            blockerFile.delete()
         }
     }
 
     fun stop() {
+        if (!CWADebug.isDeviceForTestersBuild) return
+
         loggerTree?.let {
             it.stop()
             logFile.delete()
-            triggerFile.delete()
+            blockerFile.createNewFile()
             loggerTree = null
         }
     }

--- a/Corona-Warn-App/src/testDeviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragmentViewModelTest.kt
+++ b/Corona-Warn-App/src/testDeviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragmentViewModelTest.kt
@@ -3,8 +3,6 @@ package de.rki.coronawarnapp.test.debugoptions.ui
 import android.content.Context
 import androidx.lifecycle.Observer
 import de.rki.coronawarnapp.environment.EnvironmentSetup
-import de.rki.coronawarnapp.storage.TestSettings
-import de.rki.coronawarnapp.task.TaskController
 import de.rki.coronawarnapp.test.api.ui.EnvironmentState
 import io.kotest.matchers.shouldBe
 import io.mockk.MockKAnnotations
@@ -30,8 +28,6 @@ class DebugOptionsFragmentViewModelTest : BaseTest() {
 
     @MockK private lateinit var environmentSetup: EnvironmentSetup
     @MockK private lateinit var context: Context
-    @MockK private lateinit var testSettings: TestSettings
-    @MockK lateinit var taskController: TaskController
 
     private var currentEnvironment = EnvironmentSetup.Type.DEV
 
@@ -61,9 +57,7 @@ class DebugOptionsFragmentViewModelTest : BaseTest() {
 
     private fun createViewModel(): DebugOptionsFragmentViewModel = DebugOptionsFragmentViewModel(
         context = context,
-        taskController = taskController,
         envSetup = environmentSetup,
-        testSettings = testSettings,
         dispatcherProvider = TestDispatcherProvider
     )
 


### PR DESCRIPTION
Enable logfile by default, unless disabled.

Discussion with testers showed that the logfile is enabled almost always and automating this saves time time on each test cycle.

### Testing
* Do a fresh install, check logfile
* Disable logging, restart the app, check log file
* Re-enable logging, check logfile