### PR TITLE
Test menu for registration token related interaction (EXPOSUREAPP-3772)

### DIFF
--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/menu/ui/TestMenuFragmentViewModel.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/menu/ui/TestMenuFragmentViewModel.kt
@@ -8,6 +8,7 @@ import de.rki.coronawarnapp.test.crash.ui.SettingsCrashReportFragment
 import de.rki.coronawarnapp.test.debugoptions.ui.DebugOptionsFragment
 import de.rki.coronawarnapp.test.keydownload.ui.KeyDownloadTestFragment
 import de.rki.coronawarnapp.test.risklevel.ui.TestRiskLevelCalculationFragment
+import de.rki.coronawarnapp.test.submission.ui.SubmissionTestFragment
 import de.rki.coronawarnapp.test.tasks.ui.TestTaskControllerFragment
 import de.rki.coronawarnapp.util.ui.SingleLiveEvent
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
@@ -23,6 +24,7 @@ class TestMenuFragmentViewModel @AssistedInject constructor() : CWAViewModel() {
             TestRiskLevelCalculationFragment.MENU_ITEM,
             KeyDownloadTestFragment.MENU_ITEM,
             TestTaskControllerFragment.MENU_ITEM,
+            SubmissionTestFragment.MENU_ITEM,
             SettingsCrashReportFragment.MENU_ITEM
         ).let { MutableLiveData(it) }
     }

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/submission/ui/SubmissionTestFragment.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/submission/ui/SubmissionTestFragment.kt
@@ -1,0 +1,45 @@
+package de.rki.coronawarnapp.test.submission.ui
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import de.rki.coronawarnapp.R
+import de.rki.coronawarnapp.databinding.FragmentTestSubmissionBinding
+import de.rki.coronawarnapp.test.menu.ui.TestMenuItem
+import de.rki.coronawarnapp.util.di.AutoInject
+import de.rki.coronawarnapp.util.ui.observe2
+import de.rki.coronawarnapp.util.ui.viewBindingLazy
+import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactoryProvider
+import de.rki.coronawarnapp.util.viewmodel.cwaViewModels
+import javax.inject.Inject
+
+@SuppressLint("SetTextI18n")
+class SubmissionTestFragment : Fragment(R.layout.fragment_test_submission), AutoInject {
+    @Inject lateinit var viewModelFactory: CWAViewModelFactoryProvider.Factory
+    private val vm: SubmissionTestFragmentViewModel by cwaViewModels { viewModelFactory }
+
+    private val binding: FragmentTestSubmissionBinding by viewBindingLazy()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        vm.currentTestId.observe2(this) {
+            binding.registrationTokenCurrent.text = "Current: '$it'"
+        }
+
+        binding.apply {
+            deleteTokenAction.setOnClickListener { vm.deleteRegistrationToken() }
+            scrambleTokenAction.setOnClickListener { vm.scrambleRegistrationToken() }
+        }
+    }
+
+    companion object {
+        val TAG: String = SubmissionTestFragment::class.simpleName!!
+        val MENU_ITEM = TestMenuItem(
+            title = "Submission Test Options",
+            description = "Submission related test options..",
+            targetId = R.id.test_submission_fragment
+        )
+    }
+}

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/submission/ui/SubmissionTestFragmentModule.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/submission/ui/SubmissionTestFragmentModule.kt
@@ -1,0 +1,18 @@
+package de.rki.coronawarnapp.test.submission.ui
+
+import dagger.Binds
+import dagger.Module
+import dagger.multibindings.IntoMap
+import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
+import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactory
+import de.rki.coronawarnapp.util.viewmodel.CWAViewModelKey
+
+@Module
+abstract class SubmissionTestFragmentModule {
+    @Binds
+    @IntoMap
+    @CWAViewModelKey(SubmissionTestFragmentViewModel::class)
+    abstract fun testKeyDownloadFragment(
+        factory: SubmissionTestFragmentViewModel.Factory
+    ): CWAViewModelFactory<out CWAViewModel>
+}

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/submission/ui/SubmissionTestFragmentViewModel.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/submission/ui/SubmissionTestFragmentViewModel.kt
@@ -1,0 +1,31 @@
+package de.rki.coronawarnapp.test.submission.ui
+
+import androidx.lifecycle.asLiveData
+import com.squareup.inject.assisted.AssistedInject
+import de.rki.coronawarnapp.storage.LocalData
+import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
+import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
+import de.rki.coronawarnapp.util.viewmodel.SimpleCWAViewModelFactory
+import kotlinx.coroutines.flow.MutableStateFlow
+import java.util.UUID
+
+class SubmissionTestFragmentViewModel @AssistedInject constructor(
+    dispatcherProvider: DispatcherProvider
+) : CWAViewModel(dispatcherProvider = dispatcherProvider) {
+
+    private val internalToken = MutableStateFlow(LocalData.registrationToken())
+    val currentTestId = internalToken.asLiveData()
+
+    fun scrambleRegistrationToken() {
+        LocalData.registrationToken(UUID.randomUUID().toString())
+        internalToken.value = LocalData.registrationToken()
+    }
+
+    fun deleteRegistrationToken() {
+        LocalData.registrationToken(null)
+        internalToken.value = LocalData.registrationToken()
+    }
+
+    @AssistedInject.Factory
+    interface Factory : SimpleCWAViewModelFactory<SubmissionTestFragmentViewModel>
+}

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/ui/main/MainActivityTestModule.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/ui/main/MainActivityTestModule.kt
@@ -14,6 +14,8 @@ import de.rki.coronawarnapp.test.menu.ui.TestMenuFragment
 import de.rki.coronawarnapp.test.menu.ui.TestMenuFragmentModule
 import de.rki.coronawarnapp.test.risklevel.ui.TestRiskLevelCalculationFragment
 import de.rki.coronawarnapp.test.risklevel.ui.TestRiskLevelCalculationFragmentModule
+import de.rki.coronawarnapp.test.submission.ui.SubmissionTestFragment
+import de.rki.coronawarnapp.test.submission.ui.SubmissionTestFragmentModule
 import de.rki.coronawarnapp.test.tasks.ui.TestTaskControllerFragment
 import de.rki.coronawarnapp.test.tasks.ui.TestTaskControllerFragmentModule
 
@@ -40,4 +42,7 @@ abstract class MainActivityTestModule {
 
     @ContributesAndroidInjector(modules = [KeyDownloadTestFragmentModule::class])
     abstract fun keyDownload(): KeyDownloadTestFragment
+
+    @ContributesAndroidInjector(modules = [SubmissionTestFragmentModule::class])
+    abstract fun submissionTest(): SubmissionTestFragment
 }

--- a/Corona-Warn-App/src/deviceForTesters/res/layout/fragment_test_submission.xml
+++ b/Corona-Warn-App/src/deviceForTesters/res/layout/fragment_test_submission.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:ignore="HardcodedText">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="8dp"
+        android:orientation="vertical"
+        android:paddingBottom="32dp">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            style="@style/card"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/spacing_tiny"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"
+            android:orientation="vertical">
+            <TextView
+                android:id="@+id/registration_token_title"
+                style="@style/body1"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Submission registration token "
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+            <TextView
+                android:id="@+id/registration_token_current"
+                style="@style/body2"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacing_tiny"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/registration_token_title"
+                tools:text="Current test ID: 1234567890" />
+            <Button
+                android:id="@+id/delete_token_action"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacing_tiny"
+                android:layout_weight="1"
+                android:text="Delete token"
+                app:layout_constraintEnd_toStartOf="@+id/scramble_token_action"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/registration_token_current" />
+            <Button
+                android:id="@+id/scramble_token_action"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacing_tiny"
+                android:layout_weight="1"
+                android:text="Random token"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/delete_token_action"
+                app:layout_constraintTop_toBottomOf="@+id/registration_token_current" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </LinearLayout>
+</androidx.core.widget.NestedScrollView>

--- a/Corona-Warn-App/src/deviceForTesters/res/navigation/test_nav_graph.xml
+++ b/Corona-Warn-App/src/deviceForTesters/res/navigation/test_nav_graph.xml
@@ -31,6 +31,9 @@
         <action
             android:id="@+id/action_test_menu_fragment_to_keyDownloadTestFragment"
             app:destination="@id/test_keydownload_fragment" />
+        <action
+            android:id="@+id/action_test_menu_fragment_to_submissionTestFragment"
+            app:destination="@id/test_submission_fragment" />
     </fragment>
 
     <fragment
@@ -86,5 +89,10 @@
         android:name="de.rki.coronawarnapp.test.keydownload.ui.KeyDownloadTestFragment"
         android:label="KeyDownloadTestFragment"
         tools:layout="@layout/fragment_test_keydownload" />
+    <fragment
+        android:id="@+id/test_submission_fragment"
+        android:name="de.rki.coronawarnapp.test.submission.ui.SubmissionTestFragment"
+        android:label="SubmissionTestFragment"
+        tools:layout="@layout/fragment_test_submission" />
 
 </navigation>


### PR DESCRIPTION
A new test menu for submission specific options:
* Clear current registration token
* Set a random registration token

## Testing
* Check that the code does what the ticket wants it to do
* Are we resetting the right data?