### PR TITLE
Handle failure to persist GSON serialized JSON data  (EXPOSUREAPP-3777)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/calculationtracker/CalculationTrackerStorage.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/calculationtracker/CalculationTrackerStorage.kt
@@ -36,11 +36,13 @@ class CalculationTrackerStorage @Inject constructor(
             if (!storageFile.exists()) return@withLock emptyMap()
 
             gson.fromJson<Map<String, Calculation>>(storageFile).also {
+                require(it.size >= 0)
                 Timber.v("Loaded calculation data: %s", it)
                 lastCalcuationData = it
             }
         } catch (e: Exception) {
             Timber.e(e, "Failed to load tracked calculations.")
+            if (storageFile.delete()) Timber.w("Storage file was deleted.")
             emptyMap()
         }
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/calculationtracker/CalculationTrackerStorage.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/calculationtracker/CalculationTrackerStorage.kt
@@ -2,6 +2,8 @@ package de.rki.coronawarnapp.nearby.modules.calculationtracker
 
 import android.content.Context
 import com.google.gson.Gson
+import de.rki.coronawarnapp.exception.ExceptionCategory
+import de.rki.coronawarnapp.exception.reporting.report
 import de.rki.coronawarnapp.util.di.AppContext
 import de.rki.coronawarnapp.util.gson.fromJson
 import de.rki.coronawarnapp.util.gson.toJson
@@ -57,6 +59,7 @@ class CalculationTrackerStorage @Inject constructor(
             gson.toJson(data, storageFile)
         } catch (e: Exception) {
             Timber.e(e, "Failed to save tracked calculations.")
+            e.report(ExceptionCategory.INTERNAL)
         }
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/gson/GsonExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/gson/GsonExtensions.kt
@@ -15,4 +15,5 @@ inline fun <reified T> Gson.fromJson(file: File): T = file.reader().use {
 
 inline fun <reified T> Gson.toJson(data: T, file: File) = file.writer().use { writer ->
     toJson(data, writer)
+    writer.flush()
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/gson/GsonExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/gson/GsonExtensions.kt
@@ -9,11 +9,11 @@ inline fun <reified T> Gson.fromJson(json: String): T = fromJson(
     object : TypeToken<T>() {}.type
 )
 
-inline fun <reified T> Gson.fromJson(file: File): T = file.reader().use {
+inline fun <reified T> Gson.fromJson(file: File): T = file.bufferedReader().use {
     fromJson(it, object : TypeToken<T>() {}.type)
 }
 
-inline fun <reified T> Gson.toJson(data: T, file: File) = file.writer().use { writer ->
+inline fun <reified T> Gson.toJson(data: T, file: File) = file.bufferedWriter().use { writer ->
     toJson(data, writer)
     writer.flush()
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/nearby/modules/calculationtracker/CalculationTrackerStorageTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/nearby/modules/calculationtracker/CalculationTrackerStorageTest.kt
@@ -130,4 +130,20 @@ class CalculationTrackerStorageTest : BaseIOTest() {
         storedData.getValue("b2b98400-058d-43e6-b952-529a5255248b").isCalculating shouldBe true
         storedData.getValue("aeb15509-fb34-42ce-8795-7a9ae0c2f389").isCalculating shouldBe false
     }
+
+    @Test
+    fun `we catch empty json data and prevent unsafely initialized maps`() = runBlockingTest {
+        storageDir.mkdirs()
+        storageFile.writeText("")
+
+        storageFile.exists() shouldBe true
+
+        createStorage().apply {
+            val value = load()
+            value.size shouldBe 0
+            value shouldBe emptyMap()
+
+            storageFile.exists() shouldBe false
+        }
+    }
 }


### PR DESCRIPTION
@ralfgehrer and me found the crash issue.

The file that should contain the json is empty.

When GSON reads it and deserializes it, it doesn't care that the file is empty, it will just create a new object that looks non-null, but is actually null. You only find out about that though when you try to access it.

In this case it was triggered by the mutate call [here](https://github.com/corona-warn-app/cwa-app-android/blob/main/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/calculationtracker/DefaultCalculationTracker.kt#L50) and the `mutate` extension function would call `toMutableMap()` where Kotlin would then notice that the object is actually `null`.

The symptoms for affected users are fixed by forcing an evaluation via `require(it.size >= 0)` and this triggers an exception, and we delete the corrupt data file.

We are not 100% certain what leads to the empty file though, suspicions:
* While the documentation states that `close()` calls `flush()` implicitly, the underlying implementation does not?
* GSON Serialization fails, but at that point the file writer already created a new empty file. Why does it fail random though? A wrong serialization config would fail every time.
* Process death at a really unlucky point in time, but this seems very unlikely, the timing would really have to been just right. Currently we didn't use the buffered version of the writer, so I'd expect the file to contain garbage, not just be empty, but the stacktraces show that the file must have been empty.
* A storage/IO/Permission issue that allowed file creation, but not writing. We thought about low storage space, but the block size on Android is 4KB, and the json data is much smaller than that. So why would we be able to create a 4KB block on the file system but then not be able to write to it...


```kotlin
java.lang.NullPointerException:
  at de.rki.coronawarnapp.nearby.modules.calculationtracker.DefaultCalculationTracker$calculationStates$2$setupTimeoutEnforcer$1$1$1.invokeSuspend (DefaultCalculationTracker.kt:5)
  at de.rki.coronawarnapp.nearby.modules.calculationtracker.DefaultCalculationTracker$calculationStates$2$setupTimeoutEnforcer$1$1$1.invoke (DefaultCalculationTracker.kt:2)
  at de.rki.coronawarnapp.util.flow.HotDataFlow$internalFlow$1$invokeSuspend$$inlined$collect$1.emit (Collect.kt:6)
  at kotlinx.coroutines.flow.SharedFlowImpl.collect (SharedFlow.kt:12)
  at de.rki.coronawarnapp.util.flow.HotDataFlow$internalFlow$1.invokeSuspend (HotDataFlow.kt:15)
  at de.rki.coronawarnapp.util.flow.HotDataFlow$internalFlow$1.invoke (HotDataFlow.kt:2)
  at kotlinx.coroutines.flow.ChannelFlowBuilder.collectTo (Builders.kt:1)
  at kotlinx.coroutines.flow.internal.ChannelFlow$collectToFun$1.invokeSuspend (ChannelFlow.kt:2)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:3)
  at kotlinx.coroutines.DispatchedTask.run (DispatchedTask.kt:15)
  at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely (CoroutineScheduler.kt:1)
  at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run (CoroutineScheduler.kt:13)

  java.lang.NullPointerException:
  at kotlin.collections.ArraysKt___ArraysKt.toMutableMap (_Arrays.kt)
  at de.rki.coronawarnapp.nearby.modules.calculationtracker.DefaultCalculationTracker$trackNewCalaculation$1.invoke (DefaultCalculationTracker.kt:6)
  at de.rki.coronawarnapp.util.flow.HotDataFlow$internalFlow$1$invokeSuspend$$inlined$collect$1.emit (Collect.kt:6)
  at kotlinx.coroutines.flow.SharedFlowImpl.collect (SharedFlow.kt:12)
  at de.rki.coronawarnapp.util.flow.HotDataFlow$internalFlow$1.invokeSuspend (HotDataFlow.kt:15)
  at de.rki.coronawarnapp.util.flow.HotDataFlow$internalFlow$1.invoke (HotDataFlow.kt:2)
  at kotlinx.coroutines.flow.ChannelFlowBuilder.collectTo (Builders.kt:1)
  at kotlinx.coroutines.flow.internal.ChannelFlow$collectToFun$1.invokeSuspend (ChannelFlow.kt:2)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:3)
  at kotlinx.coroutines.DispatchedTask.run (DispatchedTask.kt:15)
  at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely (CoroutineScheduler.kt:1)
  at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run (CoroutineScheduler.kt:13)

  java.lang.NullPointerException:
  at kotlin.collections.ArraysKt___ArraysKt.toMutableMap (Unknown Source:2)
  at de.rki.coronawarnapp.nearby.modules.calculationtracker.DefaultCalculationTracker$finishCalculation$1.invokeSuspend (DefaultCalculationTracker.kt:2)
  at de.rki.coronawarnapp.nearby.modules.calculationtracker.DefaultCalculationTracker$finishCalculation$1.invoke (DefaultCalculationTracker.kt:2)
  at de.rki.coronawarnapp.util.flow.HotDataFlow$internalFlow$1$invokeSuspend$$inlined$collect$1.emit (Collect.kt:6)
  at kotlinx.coroutines.flow.SharedFlowImpl.collect (SharedFlow.kt:12)
  at de.rki.coronawarnapp.util.flow.HotDataFlow$internalFlow$1.invokeSuspend (HotDataFlow.kt:15)
  at de.rki.coronawarnapp.util.flow.HotDataFlow$internalFlow$1.invoke (HotDataFlow.kt:2)
  at kotlinx.coroutines.flow.ChannelFlowBuilder.collectTo (Builders.kt:1)
  at kotlinx.coroutines.flow.internal.ChannelFlow$collectToFun$1.invokeSuspend (ChannelFlow.kt:2)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:3)
  at kotlinx.coroutines.DispatchedTask.run (DispatchedTask.kt:15)
  at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely (CoroutineScheduler.kt:1)
  at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run (CoroutineScheduler.kt:13)

  
  java.lang.NullPointerException:
  at kotlin.collections.ArraysKt___ArraysKt.toMutableMap (Unknown Source:2)
  at de.rki.coronawarnapp.nearby.modules.calculationtracker.DefaultCalculationTracker$trackNewCalaculation$1.invoke (DefaultCalculationTracker.kt:6)
  at de.rki.coronawarnapp.util.flow.HotDataFlow$internalFlow$1$invokeSuspend$$inlined$collect$1.emit (Collect.kt:6)
  at kotlinx.coroutines.flow.SharedFlowImpl.collect (SharedFlow.kt:12)
  at kotlinx.coroutines.flow.SharedFlowImpl$collect$1.invokeSuspend (Unknown Source:12)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:3)
  at kotlinx.coroutines.DispatchedTask.run (DispatchedTask.kt:15)
  at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely (CoroutineScheduler.kt:1)
  at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run (CoroutineScheduler.kt:13)
```

