### PR TITLE
ENFClient v2 - ExposureDetectionTracker without identifier (EXPOSUREAPP-3540)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/ENFClient.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/ENFClient.kt
@@ -40,7 +40,7 @@ class ENFClient @Inject constructor(
         configuration: ExposureConfiguration?,
         token: String
     ): Boolean {
-        //NO-OP
+        // NO-OP
         return false
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/ENFClient.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/ENFClient.kt
@@ -39,30 +39,17 @@ class ENFClient @Inject constructor(
         keyFiles: Collection<File>,
         configuration: ExposureConfiguration?,
         token: String
-    ): Boolean = submitDiagnosisKeys(keyFiles, configuration, token)
-
-    override suspend fun provideDiagnosisKeys(keyFiles: Collection<File>): Boolean = submitDiagnosisKeys(keyFiles)
-
-    private suspend fun submitDiagnosisKeys(
-        keyFiles: Collection<File>,
-        configuration: ExposureConfiguration? = null,
-        token: String? = null
     ): Boolean {
-        Timber.d(
-            "asyncProvideDiagnosisKeys(keyFiles=%s, configuration=%s, token=%s)",
-            keyFiles, configuration, token
-        )
+        //NO-OP
+        return false
+    }
 
-        if (keyFiles.isEmpty()) {
+    override suspend fun provideDiagnosisKeys(keyFiles: Collection<File>): Boolean {
+        Timber.d("asyncProvideDiagnosisKeys(keyFiles=$keyFiles)")
+
+        return if (keyFiles.isEmpty()) {
             Timber.d("No key files submitted, returning early.")
-            return true
-        }
-
-        Timber.d("Forwarding %d key files to our DiagnosisKeyProvider.", keyFiles.size)
-
-        return if (token != null) {
-            exposureDetectionTracker.trackNewExposureDetection(token)
-            diagnosisKeyProvider.provideDiagnosisKeys(keyFiles, configuration, token)
+            true
         } else {
             Timber.d("Forwarding %d key files to our DiagnosisKeyProvider.", keyFiles.size)
             exposureDetectionTracker.trackNewExposureDetection(UUID.randomUUID().toString())

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/ENFClient.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/ENFClient.kt
@@ -41,7 +41,7 @@ class ENFClient @Inject constructor(
         configuration: ExposureConfiguration?,
         token: String
     ): Boolean {
-        //NO-OP
+        // NO-OP
         throw UnsupportedOperationException("Use provideDiagnosisKeys without token and configuration!")
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/ENFClient.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/ENFClient.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.map
 import org.joda.time.Instant
 import timber.log.Timber
 import java.io.File
+import java.lang.UnsupportedOperationException
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -40,8 +41,8 @@ class ENFClient @Inject constructor(
         configuration: ExposureConfiguration?,
         token: String
     ): Boolean {
-        // NO-OP
-        return false
+        //NO-OP
+        throw UnsupportedOperationException("Use provideDiagnosisKeys without token and configuration!")
     }
 
     override suspend fun provideDiagnosisKeys(keyFiles: Collection<File>): Boolean {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/ENFClient.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/ENFClient.kt
@@ -40,9 +40,8 @@ class ENFClient @Inject constructor(
         configuration: ExposureConfiguration?,
         token: String
     ): Boolean {
-        return false
-        // TODO uncomment Exception later, after every subtask has joined
-        // throw UnsupportedOperationException("Use provideDiagnosisKeys without token and configuration!")
+        // TODO uncomment Exception later, after every subtask has joined (fun will probably be removed)
+        throw UnsupportedOperationException("Use provideDiagnosisKeys without token and configuration!")
     }
 
     override suspend fun provideDiagnosisKeys(keyFiles: Collection<File>): Boolean {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/ENFClient.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/ENFClient.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.flow.map
 import org.joda.time.Instant
 import timber.log.Timber
 import java.io.File
-import java.lang.UnsupportedOperationException
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -41,8 +40,9 @@ class ENFClient @Inject constructor(
         configuration: ExposureConfiguration?,
         token: String
     ): Boolean {
-        // NO-OP
-        throw UnsupportedOperationException("Use provideDiagnosisKeys without token and configuration!")
+        return false
+        // TODO uncomment Exception later, after every subtask has joined
+        // throw UnsupportedOperationException("Use provideDiagnosisKeys without token and configuration!")
     }
 
     override suspend fun provideDiagnosisKeys(keyFiles: Collection<File>): Boolean {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/detectiontracker/DefaultExposureDetectionTracker.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/detectiontracker/DefaultExposureDetectionTracker.kt
@@ -64,7 +64,7 @@ class DefaultExposureDetectionTracker @Inject constructor(
                         }
                     }
 
-                    delay(TIMEOUT_CHECK_INTERVALL.millis)
+                    delay(TIMEOUT_CHECK_INTERVAL.millis)
                 }
             }.launchIn(scope + dispatcherProvider.Default)
         }
@@ -164,6 +164,6 @@ class DefaultExposureDetectionTracker @Inject constructor(
     companion object {
         private const val TAG = "DefaultExposureDetectionTracker"
         private const val MAX_ENTRY_SIZE = 5
-        private val TIMEOUT_CHECK_INTERVALL = Duration.standardMinutes(3)
+        private val TIMEOUT_CHECK_INTERVAL = Duration.standardMinutes(3)
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/detectiontracker/DefaultExposureDetectionTracker.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/detectiontracker/DefaultExposureDetectionTracker.kt
@@ -121,7 +121,10 @@ class DefaultExposureDetectionTracker @Inject constructor(
         map: MutableMap<String, TrackedExposureDetection>,
         result: Result
     ) {
-        Timber.d("finishExposureDetectionWithoutIdentifier(): Get identifier of newest unfinished detection or create new identifier")
+        Timber.d(
+            "finishExposureDetectionWithoutIdentifier(): " +
+                "Get identifier of newest unfinished detection or create new identifier"
+        )
         val identifier = map
             .map { it.value }
             .filter { it.finishedAt == null }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/detectiontracker/ExposureDetectionTracker.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/detectiontracker/ExposureDetectionTracker.kt
@@ -7,5 +7,5 @@ interface ExposureDetectionTracker {
 
     fun trackNewExposureDetection(identifier: String)
 
-    fun finishExposureDetection(identifier: String, result: TrackedExposureDetection.Result)
+    fun finishExposureDetection(identifier: String? = null, result: TrackedExposureDetection.Result)
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/receiver/ExposureStateUpdateReceiver.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/receiver/ExposureStateUpdateReceiver.kt
@@ -11,7 +11,6 @@ import com.google.android.gms.nearby.exposurenotification.ExposureNotificationCl
 import com.google.android.gms.nearby.exposurenotification.ExposureNotificationClient.EXTRA_TOKEN
 import dagger.android.AndroidInjection
 import de.rki.coronawarnapp.exception.ExceptionCategory.INTERNAL
-import de.rki.coronawarnapp.exception.NoTokenException
 import de.rki.coronawarnapp.exception.UnknownBroadcastException
 import de.rki.coronawarnapp.exception.reporting.report
 import de.rki.coronawarnapp.nearby.ExposureStateUpdateWorker
@@ -75,7 +74,7 @@ class ExposureStateUpdateReceiver : BroadcastReceiver() {
 
         val workManager = WorkManager.getInstance(context)
 
-        //TODO("Remove token from ExposureStateUpdateWorker")
+        // TODO("Remove token from ExposureStateUpdateWorker")
         val data = Data
             .Builder()
             .putString(EXTRA_TOKEN, token)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/receiver/ExposureStateUpdateReceiver.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/receiver/ExposureStateUpdateReceiver.kt
@@ -55,9 +55,10 @@ class ExposureStateUpdateReceiver : BroadcastReceiver() {
         val async = goAsync()
         scope.launch(context = dispatcherProvider.Default) {
             try {
+                val token = intent.getStringExtra(EXTRA_TOKEN)
                 when (action) {
-                    ACTION_EXPOSURE_STATE_UPDATED -> processStateUpdates(intent)
-                    ACTION_EXPOSURE_NOT_FOUND -> processNotFound(intent)
+                    ACTION_EXPOSURE_STATE_UPDATED -> processStateUpdates(token)
+                    ACTION_EXPOSURE_NOT_FOUND -> processNotFound(token)
                     else -> throw UnknownBroadcastException(action)
                 }
             } catch (e: Exception) {
@@ -69,13 +70,12 @@ class ExposureStateUpdateReceiver : BroadcastReceiver() {
         }
     }
 
-    private fun processStateUpdates(intent: Intent) {
+    private fun processStateUpdates(token: String?) {
         Timber.tag(TAG).i("Processing ACTION_EXPOSURE_STATE_UPDATED")
 
         val workManager = WorkManager.getInstance(context)
 
-        val token = intent.requireToken()
-
+        //TODO("Remove token from ExposureStateUpdateWorker")
         val data = Data
             .Builder()
             .putString(EXTRA_TOKEN, token)
@@ -93,20 +93,14 @@ class ExposureStateUpdateReceiver : BroadcastReceiver() {
         )
     }
 
-    private fun processNotFound(intent: Intent) {
+    private fun processNotFound(token: String?) {
         Timber.tag(TAG).i("Processing ACTION_EXPOSURE_NOT_FOUND")
-
-        val token = intent.requireToken()
 
         exposureDetectionTracker.finishExposureDetection(
             token,
             TrackedExposureDetection.Result.NO_MATCHES
         )
     }
-
-    private fun Intent.requireToken(): String = getStringExtra(EXTRA_TOKEN).also {
-        Timber.tag(TAG).v("Extracted token: %s", it)
-    } ?: throw NoTokenException(IllegalArgumentException("no token was found in the intent"))
 
     companion object {
         private val TAG: String? = ExposureStateUpdateReceiver::class.simpleName

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/nearby/ENFClientTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/nearby/ENFClientTest.kt
@@ -77,21 +77,19 @@ class ENFClientTest : BaseTest() {
         val configuration = mockk<ExposureConfiguration>()
         val token = "123"
 
-        coEvery { diagnosisKeyProvider.provideDiagnosisKeys(any(), any(), any()) } returns true
+        coEvery { diagnosisKeyProvider.provideDiagnosisKeys(any()) } returns true
         runBlocking {
-            client.provideDiagnosisKeys(keyFiles, configuration, token) shouldBe true
+            client.provideDiagnosisKeys(keyFiles) shouldBe true
         }
 
-        coEvery { diagnosisKeyProvider.provideDiagnosisKeys(any(), any(), any()) } returns false
+        coEvery { diagnosisKeyProvider.provideDiagnosisKeys(any()) } returns false
         runBlocking {
-            client.provideDiagnosisKeys(keyFiles, configuration, token) shouldBe false
+            client.provideDiagnosisKeys(keyFiles) shouldBe false
         }
 
         coVerify(exactly = 2) {
             diagnosisKeyProvider.provideDiagnosisKeys(
-                keyFiles,
-                configuration,
-                token
+                keyFiles
             )
         }
     }
@@ -103,13 +101,13 @@ class ENFClientTest : BaseTest() {
         val configuration = mockk<ExposureConfiguration>()
         val token = "123"
 
-        coEvery { diagnosisKeyProvider.provideDiagnosisKeys(any(), any(), any()) } returns true
+        coEvery { diagnosisKeyProvider.provideDiagnosisKeys(any()) } returns true
         runBlocking {
-            client.provideDiagnosisKeys(keyFiles, configuration, token) shouldBe true
+            client.provideDiagnosisKeys(keyFiles) shouldBe true
         }
 
         coVerify(exactly = 0) {
-            diagnosisKeyProvider.provideDiagnosisKeys(any(), any(), any())
+            diagnosisKeyProvider.provideDiagnosisKeys(any())
         }
     }
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/nearby/windows/ExposureWindowsCalculationTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/nearby/windows/ExposureWindowsCalculationTest.kt
@@ -297,7 +297,8 @@ class ExposureWindowsCalculationTest : BaseTest() {
             serverTime = Instant.now(),
             localOffset = Duration.ZERO,
             mappedConfig = configData,
-            isFallback = false
+            identifier = "soup",
+            configType = ConfigData.Type.FROM_SERVER
         )
 
         val attenuationFilters = mutableListOf<RiskCalculationParametersOuterClass.MinutesAtAttenuationFilter>()


### PR DESCRIPTION
This PR implements one additional part of the new ExposureWindowMode (#1584 ).

We don't have a token anymore and can't provide one to the ExposureDetectionTracker.
This PR implements the opportunity to use ExposureDetectionTracker with & without identifier.
Note: ExposureDetectionTracker was CalculationTracker some days ago (just to prevent confusion).
 