### PR TITLE
Fix passive config requests triggering a refresh (EXPOSUREAPP-3774)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/appconfig/AppConfigProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/appconfig/AppConfigProvider.kt
@@ -22,7 +22,7 @@ class AppConfigProvider @Inject constructor(
         loggingTag = "AppConfigProvider",
         scope = scope,
         coroutineContext = dispatcherProvider.IO,
-        sharingBehavior = SharingStarted.WhileSubscribed(replayExpirationMillis = 0)
+        sharingBehavior = SharingStarted.Lazily
     ) {
         source.retrieveConfig()
     }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/appconfig/AppConfigProviderTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/appconfig/AppConfigProviderTest.kt
@@ -98,7 +98,7 @@ class AppConfigProviderTest : BaseIOTest() {
     }
 
     @Test
-    fun `appConfig uses WHILE_SUBSCRIBED mode`() = runBlockingTest2(ignoreActive = true) {
+    fun `appConfig uses LAZILY mode`() = runBlockingTest2(ignoreActive = true) {
         val instance = createInstance(this)
 
         val testCollector1 = instance.currentConfig.test(startOnScope = this)
@@ -123,7 +123,7 @@ class AppConfigProviderTest : BaseIOTest() {
         advanceUntilIdle()
         testCollector4.cancel()
 
-        coVerify(exactly = 2) { source.retrieveConfig() }
+        coVerify(exactly = 1) { source.retrieveConfig() }
     }
 
     @Test


### PR DESCRIPTION
Make config sharing behavior `SharingStarted.Lazily`. (start once, never release)

Otherwise classes that are just interested in the current config, if there is no other subscriber active,
would launch the `startValueProvider` and pull a config each time.

The ExposureDetectionTracker is such a candidate that would like to use the latest config every ~3min.

While this already no longer happens since "Track config changes" (4d1ecb5),
because there is now a class that is permanently subscribed to `currentConfig`, we should not rely on side-effects,
so let's make the sharing behavior explicit.