### PR TITLE
adapt gradle wrapper actionto main branch (DEV)

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -3,10 +3,10 @@ name: "Validate Gradle Wrapper"
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   validation:


### PR DESCRIPTION
Adapt GitHub Action "validate gradle wrapper", to be exeuted on renamed branch "main"