### PR TITLE
Fix appconfig display for testers (DEV)

### DIFF
--- a/Corona-Warn-App/proguard-rules.pro
+++ b/Corona-Warn-App/proguard-rules.pro
@@ -72,9 +72,6 @@
 -dontwarn sun.misc.**
 #-keep class com.google.gson.stream.** { *; }
 
-# Application classes that will be serialized/deserialized over Gson
--keep class com.google.gson.examples.android.model.** { <fields>; }
-
 # Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
 # JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)
 -keep class * extends com.google.gson.TypeAdapter
@@ -88,3 +85,5 @@
 }
 
 ##---------------End: proguard configuration for Gson  ----------
+
+-keep class de.rki.coronawarnapp.server.protocols.internal.** { *; }

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/appconfig/ui/AppConfigTestFragment.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/appconfig/ui/AppConfigTestFragment.kt
@@ -32,12 +32,9 @@ class AppConfigTestFragment : Fragment(R.layout.fragment_test_appconfig), AutoIn
         super.onViewCreated(view, savedInstanceState)
 
         vm.currentConfig.observe2(this) { data ->
-            binding.currentConfiguration.text =
-                data?.rawConfig?.toString() ?: "No config available."
-            binding.lastUpdate.text = data?.updatedAt?.let { timeFormatter.print(it) } ?: "n/a"
-            binding.timeOffset.text = data?.let {
-                "${it.localOffset.millis}ms (configType=${it.configType})"
-            } ?: "n/a"
+            binding.currentConfiguration.text = data.rawConfig.toString()
+            binding.lastUpdate.text = timeFormatter.print(data.updatedAt)
+            binding.timeOffset.text = "${data.localOffset.millis}ms (configType=${data.configType})"
         }
 
         vm.errorEvent.observe2(this) {


### PR DESCRIPTION
Testers are not able to read the app config in the test menu due to the `toString()` method requiring the config getters and the shrinker strips them. The little bit of extra space due to not shrinking the protobuf generated classes is well worth making it easier for testers to confirm correct behavior.

### How test
* Compare the app config test menu in debug and release mode with/without the change

Before in release mode:

<img src="https://user-images.githubusercontent.com/1439229/99317699-c31a7b80-2866-11eb-9d87-1a61e6d55bb3.png" width="400">

Now in release mode:

<img src="https://user-images.githubusercontent.com/1439229/99317661-b39b3280-2866-11eb-911b-1896471c9fa1.png" width="400">


