### PR TITLE
ENFv2 -Cleanup deprecations and corresponding tests (EXPOSUREAPP-3456)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/ENFClient.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/ENFClient.kt
@@ -2,7 +2,6 @@
 
 package de.rki.coronawarnapp.nearby
 
-import com.google.android.gms.nearby.exposurenotification.ExposureConfiguration
 import com.google.android.gms.nearby.exposurenotification.ExposureNotificationClient
 import com.google.android.gms.nearby.exposurenotification.ExposureWindow
 import de.rki.coronawarnapp.nearby.modules.detectiontracker.ExposureDetectionTracker
@@ -34,15 +33,6 @@ class ENFClient @Inject constructor(
     // i.e. in **[InternalExposureNotificationClient]**
     internal val internalClient: ExposureNotificationClient
         get() = googleENFClient
-
-    override suspend fun provideDiagnosisKeys(
-        keyFiles: Collection<File>,
-        configuration: ExposureConfiguration?,
-        token: String
-    ): Boolean {
-        // TODO uncomment Exception later, after every subtask has joined (fun will probably be removed)
-        throw UnsupportedOperationException("Use provideDiagnosisKeys without token and configuration!")
-    }
 
     override suspend fun provideDiagnosisKeys(keyFiles: Collection<File>): Boolean {
         Timber.d("asyncProvideDiagnosisKeys(keyFiles=$keyFiles)")

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/diagnosiskeyprovider/DefaultDiagnosisKeyProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/diagnosiskeyprovider/DefaultDiagnosisKeyProvider.kt
@@ -1,9 +1,6 @@
-@file:Suppress("DEPRECATION")
-
 package de.rki.coronawarnapp.nearby.modules.diagnosiskeyprovider
 
 import com.google.android.gms.common.api.ApiException
-import com.google.android.gms.nearby.exposurenotification.ExposureConfiguration
 import com.google.android.gms.nearby.exposurenotification.ExposureNotificationClient
 import de.rki.coronawarnapp.exception.reporting.ReportingConstants
 import de.rki.coronawarnapp.util.GoogleAPIVersion
@@ -22,38 +19,6 @@ class DefaultDiagnosisKeyProvider @Inject constructor(
     private val enfClient: ExposureNotificationClient
 ) : DiagnosisKeyProvider {
 
-    override suspend fun provideDiagnosisKeys(
-        keyFiles: Collection<File>,
-        configuration: ExposureConfiguration?,
-        token: String
-    ): Boolean {
-        return try {
-            if (keyFiles.isEmpty()) {
-                Timber.d("No key files submitted, returning early.")
-                return true
-            }
-
-            val usedConfiguration = if (configuration == null) {
-                Timber.w("Passed configuration was NULL, creating fallback.")
-                ExposureConfiguration.ExposureConfigurationBuilder().build()
-            } else {
-                configuration
-            }
-
-            if (googleAPIVersion.isAtLeast(GoogleAPIVersion.V16)) {
-                provideKeys(keyFiles, usedConfiguration, token)
-            } else {
-                provideKeysLegacy(keyFiles, usedConfiguration, token)
-            }
-        } catch (e: Exception) {
-            Timber.e(
-                e, "Error during provideDiagnosisKeys(keyFiles=%s, configuration=%s, token=%s)",
-                keyFiles, configuration, token
-            )
-            throw e
-        }
-    }
-
     override suspend fun provideDiagnosisKeys(keyFiles: Collection<File>): Boolean {
         if (keyFiles.isEmpty()) {
             Timber.d("No key files submitted, returning early.")
@@ -68,6 +33,7 @@ class DefaultDiagnosisKeyProvider @Inject constructor(
 
         if (!submissionQuota.consumeQuota(1)) {
             Timber.w("No key files submitted because not enough quota available.")
+            return false
         }
 
         return suspendCoroutine { cont ->
@@ -75,67 +41,14 @@ class DefaultDiagnosisKeyProvider @Inject constructor(
             enfClient
                 .provideDiagnosisKeys(keyFiles.toList())
                 .addOnSuccessListener { cont.resume(true) }
-                .addOnFailureListener { cont.resumeWithException(it) }
-        }
-    }
-
-    private suspend fun provideKeys(
-        files: Collection<File>,
-        configuration: ExposureConfiguration,
-        token: String
-    ): Boolean {
-        Timber.d("Using non-legacy key provision.")
-
-        if (!submissionQuota.consumeQuota(1)) {
-            Timber.w("Not enough quota available.")
-            // TODO Currently only logging, we'll be more strict in a future release
-            // return false
-        }
-
-        performSubmission(files, configuration, token)
-        return true
-    }
-
-    /**
-     * We use Batch Size 1 and thus submit multiple times to the API.
-     * This means that instead of directly submitting all files at once, we have to split up
-     * our file list as this equals a different batch for Google every time.
-     */
-    private suspend fun provideKeysLegacy(
-        keyFiles: Collection<File>,
-        configuration: ExposureConfiguration,
-        token: String
-    ): Boolean {
-        Timber.d("Using LEGACY key provision.")
-
-        if (!submissionQuota.consumeQuota(keyFiles.size)) {
-            Timber.w("Not enough quota available.")
-            // TODO What about proceeding with partial submission?
-            // TODO Currently only logging, we'll be more strict in a future release
-            // return false
-        }
-
-        keyFiles.forEach { performSubmission(listOf(it), configuration, token) }
-        return true
-    }
-
-    private suspend fun performSubmission(
-        keyFiles: Collection<File>,
-        configuration: ExposureConfiguration,
-        token: String
-    ): Void = suspendCoroutine { cont ->
-        Timber.d("Performing key submission.")
-        enfClient
-            .provideDiagnosisKeys(keyFiles.toList(), configuration, token)
-            .addOnSuccessListener { cont.resume(it) }
-            .addOnFailureListener {
-                val wrappedException = when {
-                    it is ApiException && it.statusCode == ReportingConstants.STATUS_CODE_REACHED_REQUEST_LIMIT -> {
-                        QuotaExceededException(cause = it)
-                    }
-                    else -> it
+                .addOnFailureListener {
+                    val wrappedException =
+                        when (it is ApiException && it.statusCode == ReportingConstants.STATUS_CODE_REACHED_REQUEST_LIMIT) {
+                            true -> QuotaExceededException(cause = it)
+                            false -> it
+                        }
+                    cont.resumeWithException(wrappedException)
                 }
-                cont.resumeWithException(wrappedException)
-            }
+        }
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/diagnosiskeyprovider/DefaultDiagnosisKeyProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/diagnosiskeyprovider/DefaultDiagnosisKeyProvider.kt
@@ -43,7 +43,8 @@ class DefaultDiagnosisKeyProvider @Inject constructor(
                 .addOnSuccessListener { cont.resume(true) }
                 .addOnFailureListener {
                     val wrappedException =
-                        when (it is ApiException && it.statusCode == ReportingConstants.STATUS_CODE_REACHED_REQUEST_LIMIT) {
+                        when (it is ApiException &&
+                            it.statusCode == ReportingConstants.STATUS_CODE_REACHED_REQUEST_LIMIT) {
                             true -> QuotaExceededException(cause = it)
                             false -> it
                         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/diagnosiskeyprovider/DiagnosisKeyProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/diagnosiskeyprovider/DiagnosisKeyProvider.kt
@@ -1,28 +1,19 @@
 package de.rki.coronawarnapp.nearby.modules.diagnosiskeyprovider
 
-import com.google.android.gms.nearby.exposurenotification.ExposureConfiguration
 import java.io.File
 
 interface DiagnosisKeyProvider {
 
     /**
-     * Takes an ExposureConfiguration object. Inserts a list of files that contain key
-     * information into the on-device database. Provide the keys of confirmed cases retrieved
-     * from your internet-accessible server to the Google Play service once requested from the
-     * API. Information about the file format is in the Exposure Key Export File Format and
-     * Verification document that is linked from google.com/covid19/exposurenotifications.
+     * Inserts a list of files that contain key information into the on-device database.
+     * Provide the keys of confirmed cases retrieved from your internet-accessible server to
+     * the Google Play service once requested from the API. Information about the file format
+     * is in the Exposure Key Export File Format and Verification document that is linked
+     * from google.com/covid19/exposurenotifications.
      *
      * @param keyFiles
-     * @param configuration
-     * @param token
      * @return
      */
-    @Deprecated("Use provideDiagnosisKeys with only keyFiles as param to activate WindowExposure mode")
-    suspend fun provideDiagnosisKeys(
-        keyFiles: Collection<File>,
-        configuration: ExposureConfiguration?,
-        token: String
-    ): Boolean
 
     suspend fun provideDiagnosisKeys(keyFiles: Collection<File>): Boolean
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/nearby/ENFClientTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/nearby/ENFClientTest.kt
@@ -1,6 +1,5 @@
 package de.rki.coronawarnapp.nearby
 
-import com.google.android.gms.nearby.exposurenotification.ExposureConfiguration
 import com.google.android.gms.nearby.exposurenotification.ExposureNotificationClient
 import com.google.android.gms.nearby.exposurenotification.ExposureWindow
 import de.rki.coronawarnapp.nearby.modules.detectiontracker.ExposureDetectionTracker
@@ -18,7 +17,6 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.just
-import io.mockk.mockk
 import io.mockk.verifySequence
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
@@ -31,7 +29,6 @@ import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import java.io.File
 
-@Suppress("DEPRECATION")
 class ENFClientTest : BaseTest() {
 
     @MockK lateinit var googleENFClient: ExposureNotificationClient
@@ -45,7 +42,7 @@ class ENFClientTest : BaseTest() {
     @BeforeEach
     fun setup() {
         MockKAnnotations.init(this)
-        coEvery { diagnosisKeyProvider.provideDiagnosisKeys(any(), any(), any()) } returns true
+        coEvery { diagnosisKeyProvider.provideDiagnosisKeys(any()) } returns true
         every { exposureDetectionTracker.trackNewExposureDetection(any()) } just Runs
     }
 
@@ -74,8 +71,6 @@ class ENFClientTest : BaseTest() {
     fun `provide diagnosis key call is forwarded to the right module`() {
         val client = createClient()
         val keyFiles = listOf(File("test"))
-        val configuration = mockk<ExposureConfiguration>()
-        val token = "123"
 
         coEvery { diagnosisKeyProvider.provideDiagnosisKeys(any()) } returns true
         runBlocking {
@@ -98,8 +93,6 @@ class ENFClientTest : BaseTest() {
     fun `provide diagnosis key call is only forwarded if there are actually key files`() {
         val client = createClient()
         val keyFiles = emptyList<File>()
-        val configuration = mockk<ExposureConfiguration>()
-        val token = "123"
 
         coEvery { diagnosisKeyProvider.provideDiagnosisKeys(any()) } returns true
         runBlocking {

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/nearby/modules/diagnosiskeyprovider/DefaultDiagnosisKeyProviderTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/nearby/modules/diagnosiskeyprovider/DefaultDiagnosisKeyProviderTest.kt
@@ -1,10 +1,8 @@
-@file:Suppress("DEPRECATION")
-
 package de.rki.coronawarnapp.nearby.modules.diagnosiskeyprovider
 
-import com.google.android.gms.nearby.exposurenotification.ExposureConfiguration
 import com.google.android.gms.nearby.exposurenotification.ExposureNotificationClient
 import de.rki.coronawarnapp.util.GoogleAPIVersion
+import io.kotest.matchers.shouldBe
 import io.mockk.MockKAnnotations
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
@@ -28,10 +26,7 @@ class DefaultDiagnosisKeyProviderTest : BaseTest() {
     @MockK
     lateinit var submissionQuota: SubmissionQuota
 
-    @MockK
-    lateinit var exampleConfiguration: ExposureConfiguration
     private val exampleKeyFiles = listOf(File("file1"), File("file2"))
-    private val exampleToken = "123e4567-e89b-12d3-a456-426655440000"
 
     @BeforeEach
     fun setup() {
@@ -39,15 +34,9 @@ class DefaultDiagnosisKeyProviderTest : BaseTest() {
 
         coEvery { submissionQuota.consumeQuota(any()) } returns true
 
-        coEvery {
-            googleENFClient.provideDiagnosisKeys(
-                any(),
-                any(),
-                any()
-            )
-        } returns MockGMSTask.forValue(null)
+        coEvery { googleENFClient.provideDiagnosisKeys(any<List<File>>()) } returns MockGMSTask.forValue(null)
 
-        coEvery { googleAPIVersion.isAtLeast(GoogleAPIVersion.V16) } returns true
+        coEvery { googleAPIVersion.isAtLeast(GoogleAPIVersion.V15) } returns true
     }
 
     @AfterEach
@@ -62,135 +51,64 @@ class DefaultDiagnosisKeyProviderTest : BaseTest() {
     )
 
     @Test
-    fun `legacy key provision is used on older ENF versions`() {
-        coEvery { googleAPIVersion.isAtLeast(GoogleAPIVersion.V16) } returns false
+    fun `key provision is used on older ENF versions`() {
+        coEvery { googleAPIVersion.isAtLeast(GoogleAPIVersion.V15) } returns false
 
         val provider = createProvider()
 
-        runBlocking {
-            provider.provideDiagnosisKeys(exampleKeyFiles, exampleConfiguration, exampleToken)
-        }
+        runBlocking { provider.provideDiagnosisKeys(exampleKeyFiles) } shouldBe false
 
         coVerify(exactly = 0) {
-            googleENFClient.provideDiagnosisKeys(
-                exampleKeyFiles, exampleConfiguration, exampleToken
-            )
-        }
-
-        coVerify(exactly = 1) {
-            googleENFClient.provideDiagnosisKeys(
-                listOf(exampleKeyFiles[0]), exampleConfiguration, exampleToken
-            )
-            googleENFClient.provideDiagnosisKeys(
-                listOf(exampleKeyFiles[1]), exampleConfiguration, exampleToken
-            )
+            googleENFClient.provideDiagnosisKeys(exampleKeyFiles)
+            googleENFClient.provideDiagnosisKeys(listOf(exampleKeyFiles[0]))
+            googleENFClient.provideDiagnosisKeys(listOf(exampleKeyFiles[1]))
             submissionQuota.consumeQuota(2)
         }
     }
 
     @Test
-    fun `normal key provision is used on newer ENF versions`() {
-        coEvery { googleAPIVersion.isAtLeast(GoogleAPIVersion.V16) } returns true
+    fun `key provision is used on newer ENF versions`() {
+        coEvery { googleAPIVersion.isAtLeast(GoogleAPIVersion.V15) } returns true
 
         val provider = createProvider()
 
-        runBlocking {
-            provider.provideDiagnosisKeys(exampleKeyFiles, exampleConfiguration, exampleToken)
-        }
+        runBlocking { provider.provideDiagnosisKeys(exampleKeyFiles) } shouldBe true
 
         coVerify(exactly = 1) {
-            googleENFClient.provideDiagnosisKeys(any(), any(), any())
-            googleENFClient.provideDiagnosisKeys(
-                exampleKeyFiles, exampleConfiguration, exampleToken
-            )
+            googleENFClient.provideDiagnosisKeys(any<List<File>>())
+            googleENFClient.provideDiagnosisKeys(exampleKeyFiles)
             submissionQuota.consumeQuota(1)
         }
     }
 
     @Test
-    fun `passing an a null configuration leads to constructing a fallback from defaults`() {
-        coEvery { googleAPIVersion.isAtLeast(GoogleAPIVersion.V16) } returns true
-
-        val provider = createProvider()
-        val fallback = ExposureConfiguration.ExposureConfigurationBuilder().build()
-
-        runBlocking {
-            provider.provideDiagnosisKeys(exampleKeyFiles, null, exampleToken)
-        }
-
-        coVerify(exactly = 1) {
-            googleENFClient.provideDiagnosisKeys(any(), any(), any())
-            googleENFClient.provideDiagnosisKeys(exampleKeyFiles, fallback, exampleToken)
-        }
-    }
-
-    @Test
-    fun `passing an a null configuration leads to constructing a fallback from defaults, legacy`() {
-        coEvery { googleAPIVersion.isAtLeast(GoogleAPIVersion.V16) } returns false
-
-        val provider = createProvider()
-        val fallback = ExposureConfiguration.ExposureConfigurationBuilder().build()
-
-        runBlocking {
-            provider.provideDiagnosisKeys(exampleKeyFiles, null, exampleToken)
-        }
-
-        coVerify(exactly = 1) {
-            googleENFClient.provideDiagnosisKeys(
-                listOf(exampleKeyFiles[0]), fallback, exampleToken
-            )
-            googleENFClient.provideDiagnosisKeys(
-                listOf(exampleKeyFiles[1]), fallback, exampleToken
-            )
-            submissionQuota.consumeQuota(2)
-        }
-    }
-
-    @Test
-    fun `quota is consumed silenently`() {
-        coEvery { googleAPIVersion.isAtLeast(GoogleAPIVersion.V16) } returns true
+    fun `quota is consumed silently`() {
+        coEvery { googleAPIVersion.isAtLeast(GoogleAPIVersion.V15) } returns true
         coEvery { submissionQuota.consumeQuota(any()) } returns false
 
         val provider = createProvider()
 
-        runBlocking {
-            provider.provideDiagnosisKeys(exampleKeyFiles, exampleConfiguration, exampleToken)
-        }
-
-        coVerify(exactly = 1) {
-            googleENFClient.provideDiagnosisKeys(any(), any(), any())
-            googleENFClient.provideDiagnosisKeys(
-                exampleKeyFiles, exampleConfiguration, exampleToken
-            )
-            submissionQuota.consumeQuota(1)
-        }
-    }
-
-    @Test
-    fun `quota is consumed silently, legacy`() {
-        coEvery { googleAPIVersion.isAtLeast(GoogleAPIVersion.V16) } returns false
-        coEvery { submissionQuota.consumeQuota(any()) } returns false
-
-        val provider = createProvider()
-
-        runBlocking {
-            provider.provideDiagnosisKeys(exampleKeyFiles, exampleConfiguration, exampleToken)
-        }
+        runBlocking { provider.provideDiagnosisKeys(exampleKeyFiles) } shouldBe false
 
         coVerify(exactly = 0) {
-            googleENFClient.provideDiagnosisKeys(
-                exampleKeyFiles, exampleConfiguration, exampleToken
-            )
+            googleENFClient.provideDiagnosisKeys(any<List<File>>())
+            googleENFClient.provideDiagnosisKeys(exampleKeyFiles)
         }
 
-        coVerify(exactly = 1) {
-            googleENFClient.provideDiagnosisKeys(
-                listOf(exampleKeyFiles[0]), exampleConfiguration, exampleToken
-            )
-            googleENFClient.provideDiagnosisKeys(
-                listOf(exampleKeyFiles[1]), exampleConfiguration, exampleToken
-            )
-            submissionQuota.consumeQuota(2)
+        coVerify(exactly = 1) { submissionQuota.consumeQuota(1) }
+    }
+
+    @Test
+    fun `provide empty key list`() {
+        coEvery { googleAPIVersion.isAtLeast(GoogleAPIVersion.V15) } returns true
+
+        val provider = createProvider()
+
+        runBlocking { provider.provideDiagnosisKeys(emptyList()) } shouldBe true
+
+        coVerify(exactly = 0) {
+            googleENFClient.provideDiagnosisKeys(any<List<File>>())
+            googleENFClient.provideDiagnosisKeys(emptyList())
         }
     }
 }


### PR DESCRIPTION
This PR implements one neccessary part of the new ExposureWindowMode to proceed with further adjustments (EXPOSUREAPP-3456).

- Adjustend tests to work properly (DefaultDiagnosisKeyProviderTest, ENFClientTest)
- Removed deprecated methods (not needed anymore in ENFv2).

This PR does not address:
- Changes to RiskLevelTask (other subtask)