### PR TITLE
Fix google api token being overwritten despite aborted exposure detection (EXPOSUREAPP-3869)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/DownloadDiagnosisKeysTask.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/DownloadDiagnosisKeysTask.kt
@@ -61,10 +61,6 @@ class DownloadDiagnosisKeysTask @Inject constructor(
             val currentDate = Date(timeStamper.nowUTC.millis)
             Timber.tag(TAG).d("Using $currentDate as current date in task.")
 
-            /****************************************************
-             * RETRIEVE TOKEN
-             ****************************************************/
-            val token = retrieveToken(rollbackItems)
             throwIfCancelled()
 
             // RETRIEVE RISK SCORE PARAMETERS
@@ -105,7 +101,9 @@ class DownloadDiagnosisKeysTask @Inject constructor(
                 )
             )
 
-            Timber.tag(TAG).d("Attempting submission to ENF")
+            val token = retrieveToken(rollbackItems)
+            Timber.tag(TAG).d("Attempting submission to ENF with token $token")
+
             val isSubmissionSuccessful = enfClient.provideDiagnosisKeys(
                 keyFiles = availableKeyFiles,
                 configuration = exposureConfig.exposureDetectionConfiguration,
@@ -180,6 +178,7 @@ class DownloadDiagnosisKeysTask @Inject constructor(
             LocalData.googleApiToken(googleAPITokenForRollback)
         }
         return UUID.randomUUID().toString().also {
+            Timber.tag(TAG).d("Generating and storing new token: $it")
             LocalData.googleApiToken(it)
         }
     }


### PR DESCRIPTION
We generated a new exposure detection token for every DownloadTask execution, even if we only download files and do not submit to the ENF, as we abort gracefully and do not throw, there is no rollback that sets the original token again.

This leads to RiskLevelTasks being executed that use empty ExposureSummary's turning red cards into green cards.