### PR TITLE
Prevent premature task abortions, Store timestamp first (EXPOSUREAPP-3878)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/DownloadDiagnosisKeysTask.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/DownloadDiagnosisKeysTask.kt
@@ -82,14 +82,16 @@ class DownloadDiagnosisKeysTask @Inject constructor(
                 return object : Task.Result {}
             }
 
+            // EXPOSUREAPP-3878 just to be sure that risk level calculation can take place
             if (TimeVariables.getLastTimeDiagnosisKeysFromServerFetch() != null) {
                 if (wasLastDetectionPerformedRecently(now, exposureConfig, trackedExposureDetections)) {
                     // At most one detection every 6h
+                    Timber.tag(TAG).i("task aborted, because detection was performed recently")
                     return object : Task.Result {}
                 }
 
                 if (hasRecentDetectionAndNoNewFiles(now, keySyncResult, trackedExposureDetections)) {
-                    //  Last check was within 24h, and there are no new files.
+                    Timber.tag(TAG).i("task aborted, last check was within 24h, and there are no new files")
                     return object : Task.Result {}
                 }
             }
@@ -114,6 +116,8 @@ class DownloadDiagnosisKeysTask @Inject constructor(
             )
             Timber.tag(TAG).d("Diagnosis Keys provided (success=%s, token=%s)", isSubmissionSuccessful, token)
 
+            // EXPOSUREAPP-3878 write timestamp immediately after submission,
+            // so that progress observers can rely on a clean app state
             if (isSubmissionSuccessful) {
                 saveTimestamp(currentDate, rollbackItems)
             }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/DownloadDiagnosisKeysTask.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/DownloadDiagnosisKeysTask.kt
@@ -8,7 +8,6 @@ import de.rki.coronawarnapp.nearby.ENFClient
 import de.rki.coronawarnapp.nearby.InternalExposureNotificationClient
 import de.rki.coronawarnapp.nearby.modules.detectiontracker.TrackedExposureDetection
 import de.rki.coronawarnapp.risk.RollbackItem
-import de.rki.coronawarnapp.risk.TimeVariables
 import de.rki.coronawarnapp.storage.LocalData
 import de.rki.coronawarnapp.task.Task
 import de.rki.coronawarnapp.task.TaskCancellationException
@@ -82,18 +81,15 @@ class DownloadDiagnosisKeysTask @Inject constructor(
                 return object : Task.Result {}
             }
 
-            // EXPOSUREAPP-3878 just to be sure that risk level calculation can take place
-            if (TimeVariables.getLastTimeDiagnosisKeysFromServerFetch() != null) {
-                if (wasLastDetectionPerformedRecently(now, exposureConfig, trackedExposureDetections)) {
-                    // At most one detection every 6h
-                    Timber.tag(TAG).i("task aborted, because detection was performed recently")
-                    return object : Task.Result {}
-                }
+            if (wasLastDetectionPerformedRecently(now, exposureConfig, trackedExposureDetections)) {
+                // At most one detection every 6h
+                Timber.tag(TAG).i("task aborted, because detection was performed recently")
+                return object : Task.Result {}
+            }
 
-                if (hasRecentDetectionAndNoNewFiles(now, keySyncResult, trackedExposureDetections)) {
-                    Timber.tag(TAG).i("task aborted, last check was within 24h, and there are no new files")
-                    return object : Task.Result {}
-                }
+            if (hasRecentDetectionAndNoNewFiles(now, keySyncResult, trackedExposureDetections)) {
+                Timber.tag(TAG).i("task aborted, last check was within 24h, and there are no new files")
+                return object : Task.Result {}
             }
 
             val availableKeyFiles = keySyncResult.availableKeys.map { it.path }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/KeyPackageSyncSettings.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/KeyPackageSyncSettings.kt
@@ -1,9 +1,11 @@
 package de.rki.coronawarnapp.diagnosiskeys.download
 
+import android.annotation.SuppressLint
 import android.content.Context
 import com.google.gson.Gson
 import de.rki.coronawarnapp.util.di.AppContext
 import de.rki.coronawarnapp.util.preferences.FlowPreference
+import de.rki.coronawarnapp.util.preferences.clearAndNotify
 import de.rki.coronawarnapp.util.serialization.BaseGson
 import org.joda.time.Instant
 import javax.inject.Inject
@@ -31,6 +33,11 @@ class KeyPackageSyncSettings @Inject constructor(
         reader = FlowPreference.gsonReader<LastDownload?>(gson, null),
         writer = FlowPreference.gsonWriter(gson)
     )
+
+    @SuppressLint("ApplySharedPref")
+    fun clear() {
+        prefs.clearAndNotify()
+    }
 
     data class LastDownload(
         val startedAt: Instant,

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/detectiontracker/DefaultExposureDetectionTracker.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/detectiontracker/DefaultExposureDetectionTracker.kt
@@ -134,6 +134,13 @@ class DefaultExposureDetectionTracker @Inject constructor(
         }
     }
 
+    override fun clear() {
+        Timber.i("clear()")
+        detectionStates.updateSafely {
+            emptyMap()
+        }
+    }
+
     companion object {
         private const val TAG = "DefaultExposureDetectionTracker"
         private const val MAX_ENTRY_SIZE = 5

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/detectiontracker/ExposureDetectionTracker.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/detectiontracker/ExposureDetectionTracker.kt
@@ -8,4 +8,6 @@ interface ExposureDetectionTracker {
     fun trackNewExposureDetection(identifier: String)
 
     fun finishExposureDetection(identifier: String, result: TrackedExposureDetection.Result)
+
+    fun clear()
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/LocalData.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/LocalData.kt
@@ -726,4 +726,8 @@ object LocalData {
                 putBoolean(PREFERENCE_INTEROPERABILITY_IS_USED_AT_LEAST_ONCE, value)
             }
         }
+
+    fun clear() {
+        lastTimeDiagnosisKeysFetchedFlowPref.update { 0L }
+    }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/DataReset.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/DataReset.kt
@@ -22,6 +22,7 @@ package de.rki.coronawarnapp.util
 import android.annotation.SuppressLint
 import android.content.Context
 import de.rki.coronawarnapp.appconfig.AppConfigProvider
+import de.rki.coronawarnapp.diagnosiskeys.download.KeyPackageSyncSettings
 import de.rki.coronawarnapp.diagnosiskeys.storage.KeyCacheRepository
 import de.rki.coronawarnapp.nearby.modules.detectiontracker.ExposureDetectionTracker
 import de.rki.coronawarnapp.storage.AppDatabase
@@ -45,7 +46,8 @@ class DataReset @Inject constructor(
     private val keyCacheRepository: KeyCacheRepository,
     private val appConfigProvider: AppConfigProvider,
     private val interoperabilityRepository: InteroperabilityRepository,
-    private val exposureDetectionTracker: ExposureDetectionTracker
+    private val exposureDetectionTracker: ExposureDetectionTracker,
+    private val keyPackageSyncSettings: KeyPackageSyncSettings
 ) {
 
     private val mutex = Mutex()
@@ -68,6 +70,7 @@ class DataReset @Inject constructor(
         appConfigProvider.clear()
         interoperabilityRepository.clear()
         exposureDetectionTracker.clear()
+        keyPackageSyncSettings.clear()
         Timber.w("CWA LOCAL DATA DELETION COMPLETED.")
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/DataReset.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/DataReset.kt
@@ -26,6 +26,7 @@ import de.rki.coronawarnapp.diagnosiskeys.download.KeyPackageSyncSettings
 import de.rki.coronawarnapp.diagnosiskeys.storage.KeyCacheRepository
 import de.rki.coronawarnapp.nearby.modules.detectiontracker.ExposureDetectionTracker
 import de.rki.coronawarnapp.storage.AppDatabase
+import de.rki.coronawarnapp.storage.LocalData
 import de.rki.coronawarnapp.storage.RiskLevelRepository
 import de.rki.coronawarnapp.storage.SubmissionRepository
 import de.rki.coronawarnapp.storage.interoperability.InteroperabilityRepository
@@ -60,6 +61,8 @@ class DataReset @Inject constructor(
         Timber.w("CWA LOCAL DATA DELETION INITIATED.")
         // Database Reset
         AppDatabase.reset(context)
+        // Because LocalData does not behave like a normal shared preference
+        LocalData.clear()
         // Shared Preferences Reset
         SecurityHelper.resetSharedPrefs()
         // Reset the current risk level stored in LiveData

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/DataReset.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/DataReset.kt
@@ -23,6 +23,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import de.rki.coronawarnapp.appconfig.AppConfigProvider
 import de.rki.coronawarnapp.diagnosiskeys.storage.KeyCacheRepository
+import de.rki.coronawarnapp.nearby.modules.detectiontracker.ExposureDetectionTracker
 import de.rki.coronawarnapp.storage.AppDatabase
 import de.rki.coronawarnapp.storage.RiskLevelRepository
 import de.rki.coronawarnapp.storage.SubmissionRepository
@@ -43,7 +44,8 @@ class DataReset @Inject constructor(
     @AppContext private val context: Context,
     private val keyCacheRepository: KeyCacheRepository,
     private val appConfigProvider: AppConfigProvider,
-    private val interoperabilityRepository: InteroperabilityRepository
+    private val interoperabilityRepository: InteroperabilityRepository,
+    private val exposureDetectionTracker: ExposureDetectionTracker
 ) {
 
     private val mutex = Mutex()
@@ -65,6 +67,7 @@ class DataReset @Inject constructor(
         keyCacheRepository.clear()
         appConfigProvider.clear()
         interoperabilityRepository.clear()
+        exposureDetectionTracker.clear()
         Timber.w("CWA LOCAL DATA DELETION COMPLETED.")
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/preferences/SharedPreferenceExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/preferences/SharedPreferenceExtensions.kt
@@ -1,0 +1,17 @@
+package de.rki.coronawarnapp.util.preferences
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import timber.log.Timber
+
+fun SharedPreferences.clearAndNotify() {
+    val currentKeys = this.all.keys.toSet()
+    Timber.v("%s clearAndNotify(): %s", this, currentKeys)
+    edit {
+        currentKeys.forEach { remove(it) }
+    }
+    // Clear does not notify anyone using registerOnSharedPreferenceChangeListener
+    edit(commit = true) {
+        clear()
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/security/SecurityHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/security/SecurityHelper.kt
@@ -27,6 +27,7 @@ import androidx.annotation.VisibleForTesting
 import de.rki.coronawarnapp.exception.CwaSecurityException
 import de.rki.coronawarnapp.util.di.AppInjector
 import de.rki.coronawarnapp.util.di.ApplicationComponent
+import de.rki.coronawarnapp.util.preferences.clearAndNotify
 import de.rki.coronawarnapp.util.security.SecurityConstants.CWA_APP_SQLITE_DB_PW
 import de.rki.coronawarnapp.util.security.SecurityConstants.DB_PASSWORD_MAX_LENGTH
 import de.rki.coronawarnapp.util.security.SecurityConstants.DB_PASSWORD_MIN_LENGTH
@@ -80,7 +81,7 @@ object SecurityHelper {
 
     @SuppressLint("ApplySharedPref")
     fun resetSharedPrefs() {
-        globalEncryptedSharedPreferencesInstance.edit().clear().commit()
+        globalEncryptedSharedPreferencesInstance.clearAndNotify()
     }
 
     private fun getStoredDbPassword(): ByteArray? =

--- a/Corona-Warn-App/src/test/java/testhelpers/preferences/MockFlowPreference.kt
+++ b/Corona-Warn-App/src/test/java/testhelpers/preferences/MockFlowPreference.kt
@@ -16,5 +16,6 @@ fun <T> mockFlowPreference(
         val updateCall = arg<(T) -> T>(0)
         flow.value = updateCall(flow.value)
     }
+
     return instance
 }

--- a/Corona-Warn-App/src/test/java/testhelpers/preferences/MockSharedPreferences.kt
+++ b/Corona-Warn-App/src/test/java/testhelpers/preferences/MockSharedPreferences.kt
@@ -3,6 +3,7 @@ package testhelpers.preferences
 import android.content.SharedPreferences
 
 class MockSharedPreferences : SharedPreferences {
+    private val listeners = mutableListOf<SharedPreferences.OnSharedPreferenceChangeListener>()
     private val dataMap = mutableMapOf<String, Any>()
     val dataMapPeek: Map<String, Any>
         get() = dataMap.toMap()
@@ -36,12 +37,12 @@ class MockSharedPreferences : SharedPreferences {
         dataMap.putAll(newData)
     }
 
-    override fun registerOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {
-        throw NotImplementedError()
+    override fun registerOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener) {
+        listeners.add(listener)
     }
 
-    override fun unregisterOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener?) {
-        throw NotImplementedError()
+    override fun unregisterOnSharedPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener) {
+        listeners.remove(listener)
     }
 
     private fun createEditor(


### PR DESCRIPTION
### Steps:

1. time travel to t-2
2. open app
3. complete onboarding
4. wait for files to download
5. risk card is gray (initial)
6. kill app
7. time travel to t-1 at 23:00
8. open app
9. wait for files to download
10. risk card is gray (initial)
11. kill app
12. time travel to t-0 at 5:00
13. open app
14. wait for files to download
15. risk card is gray (initial)

### Expected result:
steps 10 and 15 should not be gray but green or red

not reproducable on clean install - only when app is reseted from menu