### PR TITLE
Ignore negative secondsSinceLastScan (EXPOSUREAPP-3897)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/DefaultRiskLevels.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/DefaultRiskLevels.kt
@@ -14,6 +14,7 @@ import org.joda.time.Instant
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.math.max
 
 @Singleton
 class DefaultRiskLevels @Inject constructor() : RiskLevels {
@@ -37,7 +38,7 @@ class DefaultRiskLevels @Inject constructor() : RiskLevels {
             // Get total seconds at attenuation in exposure window
             val secondsAtAttenuation: Double = scanInstances
                 .filter { attenuationFilter.attenuationRange.inRange(it.minAttenuationDb) }
-                .fold(.0) { acc, scanInstance -> acc + scanInstance.secondsSinceLastScan }
+                .fold(.0) { acc, scanInstance -> acc + max(scanInstance.secondsSinceLastScan, 0) }
 
             val minutesAtAttenuation = secondsAtAttenuation / 60
             return attenuationFilter.dropIfMinutesInRange.inRange(minutesAtAttenuation)
@@ -86,7 +87,7 @@ class DefaultRiskLevels @Inject constructor() : RiskLevels {
                     .filter { it.attenuationRange.inRange(scanInstance.minAttenuationDb) }
                     .map { it.weight }
                     .firstOrNull() ?: .0
-            seconds + scanInstance.secondsSinceLastScan * weight
+            seconds + max(scanInstance.secondsSinceLastScan, 0) * weight
         }
 
     private fun determineRiskLevel(

--- a/Corona-Warn-App/src/test/resources/exposure-windows-risk-calculation.json
+++ b/Corona-Warn-App/src/test/resources/exposure-windows-risk-calculation.json
@@ -1060,6 +1060,46 @@
       "expAgeOfMostRecentDateWithHighRisk": null,
       "expNumberOfDaysWithLowRisk": 1,
       "expNumberOfDaysWithHighRisk": 0
+    },
+    {
+      "description": "ignores negative secondsSinceLastScan (can happen when time-travelling, not officially supported)",
+      "exposureWindows": [
+        {
+          "ageInDays": 1,
+          "reportType": 3,
+          "infectiousness": 2,
+          "calibrationConfidence": 0,
+          "scanInstances": [
+            {
+              "minAttenuation": 25,
+              "typicalAttenuation": 25,
+              "secondsSinceLastScan": -86160
+            },
+            {
+              "minAttenuation": 25,
+              "typicalAttenuation": 25,
+              "secondsSinceLastScan": 300
+            },
+            {
+              "minAttenuation": 25,
+              "typicalAttenuation": 25,
+              "secondsSinceLastScan": 300
+            },
+            {
+              "minAttenuation": 25,
+              "typicalAttenuation": 25,
+              "secondsSinceLastScan": 300
+            }
+          ]
+        }
+      ],
+      "expTotalRiskLevel": 2,
+      "expTotalMinimumDistinctEncountersWithLowRisk": 0,
+      "expTotalMinimumDistinctEncountersWithHighRisk": 1,
+      "expAgeOfMostRecentDateWithLowRisk": null,
+      "expAgeOfMostRecentDateWithHighRisk": 1,
+      "expNumberOfDaysWithLowRisk": 0,
+      "expNumberOfDaysWithHighRisk": 1
     }
   ]
 }


### PR DESCRIPTION
The API can return a negative value for secondsSinceLastScan (seen on my device). Most likely, this is related to time travel and should not happen in production. Anyway, to avoid potential issues from this in the first place - regardless of whether it's PROD or testing - the client should handle this properly.