### PR TITLE
Adjust Diagnosis key file provider to prevent deprecation (EXPOSUREAPP-3896)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/diagnosiskeyprovider/DefaultDiagnosisKeyProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/diagnosiskeyprovider/DefaultDiagnosisKeyProvider.kt
@@ -9,6 +9,7 @@ import timber.log.Timber
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
 
@@ -48,6 +49,7 @@ class DefaultDiagnosisKeyProvider @Inject constructor(
         return suspendCoroutine { cont ->
             Timber.d("Performing key submission.")
             provideDiagnosisKeysTask
+                .addOnSuccessListener { cont.resume(true) }
                 .addOnFailureListener {
                     val wrappedException =
                         when (it is ApiException &&

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/version/DefaultENFVersion.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/version/DefaultENFVersion.kt
@@ -9,6 +9,7 @@ import javax.inject.Singleton
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
+import kotlin.math.abs
 
 @Singleton
 class DefaultENFVersion @Inject constructor(
@@ -39,9 +40,27 @@ class DefaultENFVersion @Inject constructor(
         }
     }
 
+    override suspend fun isAtLeast(compareVersion: Long): Boolean {
+        if (!compareVersion.isCorrectVersionLength) throw IllegalArgumentException("given version has incorrect length")
+        return try {
+            internalGetENFClientVersion() >= compareVersion
+        } catch (e: Exception) {
+            Timber.e(e)
+            false
+        }
+    }
+
     private suspend fun internalGetENFClientVersion(): Long = suspendCoroutine { cont ->
         client.version
             .addOnSuccessListener { cont.resume(it) }
             .addOnFailureListener { cont.resumeWithException(it) }
+    }
+
+    // check if a raw long has the correct length to be considered an API version
+    private val Long.isCorrectVersionLength
+        get(): Boolean = abs(this).toString().length == GOOGLE_API_VERSION_FIELD_LENGTH
+
+    companion object {
+        private const val GOOGLE_API_VERSION_FIELD_LENGTH = 8
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/version/DefaultENFVersion.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/version/DefaultENFVersion.kt
@@ -42,12 +42,13 @@ class DefaultENFVersion @Inject constructor(
 
     override suspend fun isAtLeast(compareVersion: Long): Boolean {
         if (!compareVersion.isCorrectVersionLength) throw IllegalArgumentException("given version has incorrect length")
-        return try {
-            internalGetENFClientVersion() >= compareVersion
-        } catch (e: Exception) {
-            Timber.e(e)
-            false
+
+        getENFClientVersion()?.let { currentENFClientVersion ->
+            Timber.i("Comparing current ENF client version $currentENFClientVersion with $compareVersion")
+            return currentENFClientVersion >= compareVersion
         }
+
+        return false
     }
 
     private suspend fun internalGetENFClientVersion(): Long = suspendCoroutine { cont ->

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/version/ENFVersion.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/version/ENFVersion.kt
@@ -12,7 +12,15 @@ interface ENFVersion {
      */
     suspend fun requireMinimumVersion(required: Long)
 
+    /**
+     * Indicates if the client runs above a certain version
+     *
+     * @return isAboveVersion, if connected to an old unsupported version, return false
+     */
+    suspend fun isAtLeast(compareVersion: Long): Boolean
+
     companion object {
         const val V1_6 = 16000000L
+        const val V1_7 = 17000000L
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/nearby/modules/version/DefaultENFVersionTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/nearby/modules/version/DefaultENFVersionTest.kt
@@ -109,4 +109,54 @@ internal class DefaultENFVersionTest {
             }
         }
     }
+
+    @Test
+    fun `isAtLeast is true for newer version`() {
+        every { client.version } returns MockGMSTask.forValue(ENFVersion.V1_7)
+
+        runBlockingTest {
+            createInstance().isAtLeast(ENFVersion.V1_6) shouldBe true
+        }
+    }
+
+    @Test
+    fun `isAtLeast is true for equal version`() {
+        every { client.version } returns MockGMSTask.forValue(ENFVersion.V1_6)
+
+        runBlockingTest {
+            createInstance().isAtLeast(ENFVersion.V1_6) shouldBe true
+        }
+    }
+
+    @Test
+    fun `isAtLeast is false for older version`() {
+        every { client.version } returns MockGMSTask.forValue(ENFVersion.V1_6)
+
+        runBlockingTest {
+            createInstance().isAtLeast(ENFVersion.V1_7) shouldBe false
+        }
+    }
+
+    @Test
+    fun `invalid input for isAtLeast throws IllegalArgumentException`() {
+        runBlockingTest {
+            shouldThrow<IllegalArgumentException> {
+                createInstance().isAtLeast(16)
+            }
+        }
+    }
+
+    @Test
+    fun `isAtLeast returns false when client not connected`() {
+        every { client.version } returns MockGMSTask.forError(ApiException(Status(API_NOT_CONNECTED)))
+
+        runBlockingTest {
+            createInstance().apply {
+                shouldNotThrowAny {
+                    isAtLeast(ENFVersion.V1_6) shouldBe false
+                    isAtLeast(ENFVersion.V1_7) shouldBe false
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Adjusted DiagnosisKeyFileProvider to prevent deprecation for new Window Mode.

Note:
Reported Deprecation is not visible in Android Studio by current 1.7.2 eap.
But mentioned in Google Docs. 
Missmatch of information was reported to Max.

Missing:
Test-Adjustment (will follow asap) - tests have been adjusted/added

