### PR TITLE
Fix sporadic worker crash on older android versions (EXPOSUREAPP-3987)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/worker/CWAWorkerFactory.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/worker/CWAWorkerFactory.kt
@@ -25,13 +25,29 @@ class CWAWorkerFactory @Inject constructor(
         workerClassName: String,
         workerParameters: WorkerParameters
     ): ListenableWorker? {
-        Timber.v("Looking up worker for %s", workerClassName)
-        val factory = factories.entries.find {
+        Timber.v("Checking in known worker factories for %s", workerClassName)
+        val ourWorkerFactories = factories.entries.find {
             Class.forName(workerClassName).isAssignableFrom(it.key)
         }?.value
 
-        requireNotNull(factory) { "Unknown worker: $workerClassName" }
-        Timber.v("Creating worker for %s with %s", workerClassName, workerParameters)
-        return factory.get().create(appContext, workerParameters)
+        return if (ourWorkerFactories != null) {
+            Timber.v("It's one of ours, creating worker for %s with %s", workerClassName, workerParameters)
+            ourWorkerFactories.get().create(appContext, workerParameters).also {
+                Timber.i("Our worker was created: %s", it)
+            }
+        } else {
+            Timber.w("Unknown worker class, trying direct instantiation on %s", workerClassName)
+            workerClassName.toNewWorkerInstance(appContext, workerParameters).also {
+                Timber.i("Unknown worker was created: %s", it)
+            }
+        }
+    }
+
+    private fun String.toNewWorkerInstance(context: Context, workerParameters: WorkerParameters): ListenableWorker {
+        val workerClass = Class.forName(this).asSubclass(ListenableWorker::class.java)
+        Timber.v("Worker class created: %s", workerClass)
+        val workerConstructor = workerClass.getDeclaredConstructor(Context::class.java, WorkerParameters::class.java)
+        Timber.v("Worker constructor created: %s", workerConstructor)
+        return workerConstructor.newInstance(context, workerParameters)
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/worker/CWAWorkerFactoryTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/worker/CWAWorkerFactoryTest.kt
@@ -1,0 +1,65 @@
+package de.rki.coronawarnapp.util.worker
+
+import android.content.Context
+import androidx.work.ListenableWorker
+import androidx.work.WorkerParameters
+import androidx.work.impl.workers.DiagnosticsWorker
+import de.rki.coronawarnapp.worker.DiagnosisKeyRetrievalOneTimeWorker
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import javax.inject.Provider
+
+class CWAWorkerFactoryTest : BaseTest() {
+
+    private val workerFactories =
+        mutableMapOf<Class<out ListenableWorker>, Provider<InjectedWorkerFactory<out ListenableWorker>>>()
+
+    @MockK lateinit var context: Context
+    @MockK lateinit var workerParameters: WorkerParameters
+    @MockK lateinit var ourWorker: DiagnosisKeyRetrievalOneTimeWorker
+    @MockK lateinit var ourFactory: DiagnosisKeyRetrievalOneTimeWorker.Factory
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this)
+
+        every { ourFactory.create(context, workerParameters) } returns ourWorker
+        workerFactories[DiagnosisKeyRetrievalOneTimeWorker::class.java] = Provider { ourFactory }
+    }
+
+    @AfterEach
+    fun teardown() {
+        clearAllMocks()
+    }
+
+    fun createInstance() = CWAWorkerFactory(
+        workerFactories
+    )
+
+    @Test
+    fun `instantiate one of our workers`() {
+        val instance = createInstance()
+        instance.createWorker(
+            context, DiagnosisKeyRetrievalOneTimeWorker::class.qualifiedName!!, workerParameters
+        ) shouldBe ourWorker
+    }
+
+    @Test
+    fun `instantiate an unknown worker`() {
+        val instance = createInstance()
+        val worker1 = instance.createWorker(context, DiagnosticsWorker::class.qualifiedName!!, workerParameters)
+        worker1 shouldNotBe null
+        val worker2 = instance.createWorker(context, DiagnosticsWorker::class.qualifiedName!!, workerParameters)
+        worker1 shouldNotBe worker2
+    }
+}
+
+


### PR DESCRIPTION
What happens is that our WorkManager tries to instantiate a worker that is unknown to us and we crash due to that.
During development we overlooked that we may be asked to instantiate other worker classes than our own, for which we have no known factory.

The stack trace is of the crash is 
```kotlin
2020-12-19 21:37:45.049 25231-25267/? E/AndroidRuntime: FATAL EXCEPTION: pool-2-thread-2
    Process: de.rki.coronawarnapp.test, PID: 25231
    java.lang.IllegalArgumentException: Unknown worker: androidx.work.impl.workers.ConstraintTrackingWorker
        at de.rki.coronawarnapp.util.worker.CWAWorkerFactory.createWorker(CWAWorkerFactory.kt:33)
        at androidx.work.WorkerFactory.createWorkerWithDefaultFallback(WorkerFactory.java:83)
        at androidx.work.impl.WorkerWrapper.runWorker(WorkerWrapper.java:242)
        at androidx.work.impl.WorkerWrapper.run(WorkerWrapper.java:136)
        at androidx.work.impl.utils.SerialExecutor$Task.run(SerialExecutor.java:91)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1133)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:607)
        at java.lang.Thread.run(Thread.java:761)
```
the `androidx.work.impl.workers.ConstraintTrackingWorker` was what caused the crash in my case, but for affected users the actual class may be a different one.

The crash specifically happens on older Android versions where different worker implementations are used to work around API level issues. I couldn't get it to crash outright on a 7.0 device that was among the devices for which this stack trace was reported, but I could force the the same type of stacktrace by adding these constraints to one of our worker request's constraints:
```kotlin
.setRequiresBatteryNotLow(true)
.setRequiresStorageNotLow(true)
```

It's likely some kind of extra restraint that get's set by the devices themselves (e.g. battery saver options).

The fix is to first look in our map of known factories, if none is found, to try direct instantiation on the worker class name, which will succeed if it's one of the systems known "workaround" workers.

### How to test
* Add the above mentioned constraints, then launch our app on Android 7.0, monitor the log. Without the fix, as soon as the worker with these cosntraints is started it should crash, and with this fix it shouldn't.

```kotlin
2020-12-19 21:39:19.587 25683-25702/de.rki.coronawarnapp.test V/CWAWorkerFactory: Looking up worker for androidx.work.impl.workers.ConstraintTrackingWorker
2020-12-19 21:39:19.589 25683-25702/de.rki.coronawarnapp.test W/CWAWorkerFactory: Unknown worker class, trying direct instantiation on androidx.work.impl.workers.ConstraintTrackingWorker
2020-12-19 21:39:19.593 25683-25702/de.rki.coronawarnapp.test V/CWAWorkerFactory: Worker class created: class androidx.work.impl.workers.ConstraintTrackingWorker
2020-12-19 21:39:19.597 25683-25702/de.rki.coronawarnapp.test V/CWAWorkerFactory: Worker constructor created: public androidx.work.impl.workers.ConstraintTrackingWorker(android.content.Context,androidx.work.WorkerParameters)
2020-12-19 21:39:19.599 25683-25702/de.rki.coronawarnapp.test V/CWAWorkerFactory: Unknown worker was created: androidx.work.impl.workers.ConstraintTrackingWorker@c6be51a
```