### PR TITLE
Update Kotlin/Coroutines (EXPOSUREAPP-3847)

### DIFF
--- a/Corona-Warn-App/build.gradle
+++ b/Corona-Warn-App/build.gradle
@@ -305,7 +305,7 @@ configurations.all {
 
 dependencies {
     // KOTLIN
-    def coroutineVersion = "1.4.0-M1"
+    def coroutineVersion = "1.4.1"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutineVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutineVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutineVersion"

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/tracing/GeneralTracingStatusTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/tracing/GeneralTracingStatusTest.kt
@@ -56,10 +56,12 @@ class GeneralTracingStatusTest : BaseTest() {
     @Test
     fun `flow updates work`() = runBlockingTest {
         val testCollector = createInstance().generalStatus.test(startOnScope = this)
+        advanceUntilIdle()
 
         isBluetoothEnabled.emit(false)
-        isBluetoothEnabled.emit(true)
+        advanceUntilIdle()
 
+        isBluetoothEnabled.emit(true)
         advanceUntilIdle()
 
         testCollector.latestValues shouldBe listOf(

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.4.10'
+    ext.kotlin_version = '1.4.20'
     ext.protobufVersion = '0.8.12'
     ext.navVersion = "2.2.2"
 


### PR DESCRIPTION
We don't directly need the newer versions but I have a shimmer of hope that it will have a positive effect on users affected by the local VM bug on MediaTek devices (#1609).