### PR TITLE
Fix notification issues by introducing IDs (EXPOSUREAPP-3971)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/notification/NotificationConstants.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/notification/NotificationConstants.kt
@@ -39,14 +39,4 @@ object NotificationConstants {
      * Notification channel description String.xml path
      */
     const val CHANNEL_DESCRIPTION = R.string.notification_description
-
-    /**
-     * Risk changed notification title String.xml path
-     */
-    const val NOTIFICATION_CONTENT_TITLE_RISK_CHANGED = R.string.notification_headline
-
-    /**
-     * Risk changed notification content text String.xml path
-     */
-    const val NOTIFICATION_CONTENT_TEXT_RISK_CHANGED = R.string.notification_body
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/notification/NotificationConstants.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/notification/NotificationConstants.kt
@@ -17,6 +17,9 @@ object NotificationConstants {
     val POSITIVE_RESULT_NOTIFICATION_INITIAL_OFFSET: Duration = Duration.standardHours(2)
     val POSITIVE_RESULT_NOTIFICATION_INTERVAL: Duration = Duration.standardHours(2)
 
+    const val NEW_MESSAGE_RISK_LEVEL_SCORE_NOTIFICATION_ID = 110
+    const val NEW_MESSAGE_TEST_RESULT_NOTIFICATION_ID = 120
+
     /**
      * Notification channel id String.xml path
      */

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/notification/NotificationHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/notification/NotificationHelper.kt
@@ -229,6 +229,8 @@ object NotificationHelper {
                 content,
                 notificationId,
                 true)
+        } else {
+            Timber.d("App is in foreground - not sending the notification with id: %s", notificationId)
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/notification/NotificationHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/notification/NotificationHelper.kt
@@ -94,6 +94,11 @@ object NotificationHelper {
         Timber.v("Canceled future notifications with id: %s", notificationId)
     }
 
+    fun cancelCurrentNotification(notificationId: Int) {
+        NotificationManagerCompat.from(CoronaWarnApplication.getAppContext()).cancel(notificationId)
+        Timber.v("Canceled notifications with id: %s", notificationId)
+    }
+
     fun scheduleRepeatingNotification(
         initialTime: Instant,
         interval: Duration,
@@ -201,7 +206,7 @@ object NotificationHelper {
         expandableLongText: Boolean = false,
         pendingIntent: PendingIntent = createPendingIntentToMainActivity()
     ) {
-        Timber.d("Sending nsotification with id: %s | title: %s | content: %s", notificationId, title, content)
+        Timber.d("Sending notification with id: %s | title: %s | content: %s", notificationId, title, content)
         val notification =
             buildNotification(title, content, PRIORITY_HIGH, expandableLongText, pendingIntent) ?: return
         with(NotificationManagerCompat.from(CoronaWarnApplication.getAppContext())) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/notification/NotificationHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/notification/NotificationHelper.kt
@@ -16,12 +16,12 @@ import androidx.core.app.NotificationCompat.PRIORITY_HIGH
 import androidx.core.app.NotificationManagerCompat
 import de.rki.coronawarnapp.BuildConfig
 import de.rki.coronawarnapp.CoronaWarnApplication
+import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.notification.NotificationConstants.NOTIFICATION_ID
 import de.rki.coronawarnapp.ui.main.MainActivity
 import org.joda.time.Duration
 import org.joda.time.Instant
 import timber.log.Timber
-import kotlin.random.Random
 
 /**
  * Singleton class for notification handling
@@ -189,7 +189,6 @@ object NotificationHelper {
      *
      * @param title: String
      * @param content: String
-     * @param visibility: Int
      * @param expandableLongText: Boolean
      * @param notificationId: NotificationId
      * @param pendingIntent: PendingIntent
@@ -198,10 +197,11 @@ object NotificationHelper {
     fun sendNotification(
         title: String,
         content: String,
+        notificationId: NotificationId,
         expandableLongText: Boolean = false,
-        notificationId: NotificationId = Random.nextInt(),
         pendingIntent: PendingIntent = createPendingIntentToMainActivity()
     ) {
+        Timber.d("Sending nsotification with id: %s | title: %s | content: %s", notificationId, title, content)
         val notification =
             buildNotification(title, content, PRIORITY_HIGH, expandableLongText, pendingIntent) ?: return
         with(NotificationManagerCompat.from(CoronaWarnApplication.getAppContext())) {
@@ -215,10 +215,15 @@ object NotificationHelper {
      * Notification is only sent if app is not in foreground.
      *
      * @param content: String
+     * @param notificationId: NotificationId
      */
-    fun sendNotification(content: String) {
+    fun sendNotificationIfAppIsNotInForeground(content: String, notificationId: NotificationId) {
         if (!CoronaWarnApplication.isAppInForeground) {
-            sendNotification("", content, true)
+            sendNotification(
+                CoronaWarnApplication.getAppContext().getString(R.string.notification_name),
+                content,
+                notificationId,
+                true)
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/DefaultRiskLevels.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/DefaultRiskLevels.kt
@@ -7,6 +7,7 @@ import de.rki.coronawarnapp.CoronaWarnApplication
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.appconfig.RiskCalculationConfig
 import de.rki.coronawarnapp.exception.RiskLevelCalculationException
+import de.rki.coronawarnapp.notification.NotificationConstants.NEW_MESSAGE_RISK_LEVEL_SCORE_NOTIFICATION_ID
 import de.rki.coronawarnapp.notification.NotificationHelper
 import de.rki.coronawarnapp.risk.RiskLevel.UNKNOWN_RISK_INITIAL
 import de.rki.coronawarnapp.risk.RiskLevel.UNKNOWN_RISK_OUTDATED_RESULTS
@@ -206,11 +207,12 @@ class DefaultRiskLevels @Inject constructor() : RiskLevels {
                 }"
             )
 
-            NotificationHelper.sendNotification(
-                CoronaWarnApplication.getAppContext().getString(R.string.notification_body)
+            NotificationHelper.sendNotificationIfAppIsNotInForeground(
+                CoronaWarnApplication.getAppContext().getString(R.string.notification_body),
+                NEW_MESSAGE_RISK_LEVEL_SCORE_NOTIFICATION_ID
             )
 
-            Timber.d("Risk level changed and notification sent. Current Risk level is ${riskLevel.raw}")
+            Timber.d("Risk level changed and notification issued. Current Risk level is ${riskLevel.raw}")
         }
         if (lastCalculatedScore.raw == RiskLevelConstants.INCREASED_RISK &&
             riskLevel.raw == RiskLevelConstants.LOW_LEVEL_RISK) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/worker/BackgroundWorkHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/worker/BackgroundWorkHelper.kt
@@ -69,6 +69,6 @@ object BackgroundWorkHelper {
     fun sendDebugNotification(title: String, content: String) {
         Timber.d("sendDebugNotification(title=%s, content=%s)", title, content)
         if (!LocalData.backgroundNotification()) return
-        NotificationHelper.sendNotification(title, content, true)
+        NotificationHelper.sendNotification(title, content, Random.nextInt(), true)
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/worker/DiagnosisTestResultRetrievalPeriodicWorker.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/worker/DiagnosisTestResultRetrievalPeriodicWorker.kt
@@ -7,6 +7,7 @@ import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 import de.rki.coronawarnapp.CoronaWarnApplication
 import de.rki.coronawarnapp.R
+import de.rki.coronawarnapp.notification.NotificationConstants.NEW_MESSAGE_RISK_LEVEL_SCORE_NOTIFICATION_ID
 import de.rki.coronawarnapp.notification.NotificationConstants.NEW_MESSAGE_TEST_RESULT_NOTIFICATION_ID
 import de.rki.coronawarnapp.notification.NotificationHelper
 import de.rki.coronawarnapp.service.submission.SubmissionService
@@ -27,10 +28,6 @@ class DiagnosisTestResultRetrievalPeriodicWorker @AssistedInject constructor(
     @Assisted workerParams: WorkerParameters
 ) : CoroutineWorker(context, workerParams) {
 
-    companion object {
-        private val TAG: String? = DiagnosisTestResultRetrievalPeriodicWorker::class.simpleName
-    }
-
     /**
      * Work execution
      *
@@ -43,7 +40,6 @@ class DiagnosisTestResultRetrievalPeriodicWorker @AssistedInject constructor(
      * @see LocalData.initialPollingForTestResultTimeStamp
      */
     override suspend fun doWork(): Result {
-
         Timber.d("$id: doWork() started. Run attempt: $runAttemptCount")
         BackgroundWorkHelper.sendDebugNotification(
             "TestResult Executing: Start", "TestResult started. Run attempt: $runAttemptCount "
@@ -111,7 +107,9 @@ class DiagnosisTestResultRetrievalPeriodicWorker @AssistedInject constructor(
                 CoronaWarnApplication.getAppContext().getString(R.string.notification_body),
                 NEW_MESSAGE_TEST_RESULT_NOTIFICATION_ID
             )
-            Timber.d("$id: Test Result available - notification issued (if app is not in foreground")
+            NotificationHelper.cancelCurrentNotification(NEW_MESSAGE_RISK_LEVEL_SCORE_NOTIFICATION_ID)
+
+            Timber.d("$id: Test Result available - notification issued & risk level notification canceled")
             LocalData.isTestResultNotificationSent(true)
             stopWorker()
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/worker/DiagnosisTestResultRetrievalPeriodicWorker.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/worker/DiagnosisTestResultRetrievalPeriodicWorker.kt
@@ -7,6 +7,7 @@ import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 import de.rki.coronawarnapp.CoronaWarnApplication
 import de.rki.coronawarnapp.R
+import de.rki.coronawarnapp.notification.NotificationConstants.NEW_MESSAGE_TEST_RESULT_NOTIFICATION_ID
 import de.rki.coronawarnapp.notification.NotificationHelper
 import de.rki.coronawarnapp.service.submission.SubmissionService
 import de.rki.coronawarnapp.storage.LocalData
@@ -106,15 +107,11 @@ class DiagnosisTestResultRetrievalPeriodicWorker @AssistedInject constructor(
         if (testResult == TestResult.NEGATIVE || testResult == TestResult.POSITIVE ||
             testResult == TestResult.INVALID
         ) {
-            if (!CoronaWarnApplication.isAppInForeground) {
-                NotificationHelper.sendNotification(
-                    CoronaWarnApplication.getAppContext()
-                        .getString(R.string.notification_name),
-                    CoronaWarnApplication.getAppContext()
-                        .getString(R.string.notification_body)
-                )
-                Timber.d("$id: Test Result available and notification is initiated")
-            }
+            NotificationHelper.sendNotificationIfAppIsNotInForeground(
+                CoronaWarnApplication.getAppContext().getString(R.string.notification_body),
+                NEW_MESSAGE_TEST_RESULT_NOTIFICATION_ID
+            )
+            Timber.d("$id: Test Result available - notification issued (if app is not in foreground")
             LocalData.isTestResultNotificationSent(true)
             stopWorker()
         }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/notification/NotificationConstantsTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/notification/NotificationConstantsTest.kt
@@ -12,10 +12,5 @@ class NotificationConstantsTest {
         Assert.assertEquals(NotificationConstants.NOTIFICATION_SMALL_ICON, R.drawable.ic_splash_logo)
         Assert.assertEquals(NotificationConstants.CHANNEL_NAME, R.string.notification_name)
         Assert.assertEquals(NotificationConstants.CHANNEL_DESCRIPTION, R.string.notification_description)
-        Assert.assertEquals(
-            NotificationConstants.NOTIFICATION_CONTENT_TITLE_RISK_CHANGED,
-            R.string.notification_headline
-        )
-        Assert.assertEquals(NotificationConstants.NOTIFICATION_CONTENT_TEXT_RISK_CHANGED, R.string.notification_body)
     }
 }


### PR DESCRIPTION
This PR fixes the notification part of EXPOSUREAPP-3971.

So far, every notification had its own random ID which is bad for two reasons:
- if triggered multiple times, notifications for the same event (type) pile up
- we cannot cancel notifications without knowing their id

This PR introduces two fixed notification types 
`NEW_MESSAGE_RISK_LEVEL_SCORE_NOTIFICATION_ID` and `NEW_MESSAGE_TEST_RESULT_NOTIFICATION_ID`

Moreover, if a new test result notification is scheduled, all risk level score notifications are canceled.
_EDIT_: Additional testing showed that the cancelation of notifications is not working reliably. Will be further investigated and addressed in an upcoming release.

**How to test:**
- put the app in a high-risk state --> a notification should show up (don't click on it  nor dismiss it - keep it in the notification drawer)
- scan a QR code with a positive test result 
Expected  result: the notification should be dismissed

More advanced:
- put the app in a high-risk state (see above)
- don't dismiss the notification
- generate a  QR Code that is pending
- Scan it with the app
- but the app in the background
- eventually, a notification should remind you that you received a new test  result 
Expected result: There is only one notification in the navigation drawer.