### PR TITLE
Export of Exposure Windows ambiguous (EXPOSUREAPP-4022)

### DIFF
--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/risklevel/ui/TestRiskLevelCalculationFragmentCWAViewModel.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/risklevel/ui/TestRiskLevelCalculationFragmentCWAViewModel.kt
@@ -29,6 +29,7 @@ import de.rki.coronawarnapp.test.risklevel.entities.toExposureWindowJson
 import de.rki.coronawarnapp.ui.tracing.card.TracingCardStateProvider
 import de.rki.coronawarnapp.ui.tracing.common.tryLatestResultsWithDefaults
 import de.rki.coronawarnapp.util.NetworkRequestWrapper.Companion.withSuccess
+import de.rki.coronawarnapp.util.TimeStamper
 import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
 import de.rki.coronawarnapp.util.di.AppContext
 import de.rki.coronawarnapp.util.security.SecurityHelper
@@ -57,7 +58,8 @@ class TestRiskLevelCalculationFragmentCWAViewModel @AssistedInject constructor(
     private val appConfigProvider: AppConfigProvider,
     tracingCardStateProvider: TracingCardStateProvider,
     private val riskLevelStorage: RiskLevelStorage,
-    private val testSettings: TestSettings
+    private val testSettings: TestSettings,
+    private val timeStamper: TimeStamper
 ) : CWAViewModel(
     dispatcherProvider = dispatcherProvider
 ) {
@@ -230,7 +232,7 @@ class TestRiskLevelCalculationFragmentCWAViewModel @AssistedInject constructor(
             val path = File(context.cacheDir, "share/")
             path.mkdirs()
 
-            val file = File(path, "exposureWindows.txt")
+            val file = File(path, "exposureWindows-${timeStamper.nowUTC}.txt")
             file.bufferedWriter()
                 .use { writer ->
                     if (exposureWindows.isNullOrEmpty()) {

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/risklevel/ui/TestRiskLevelCalculationFragmentCWAViewModel.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/risklevel/ui/TestRiskLevelCalculationFragmentCWAViewModel.kt
@@ -43,6 +43,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.sample
 import kotlinx.coroutines.withContext
 import org.joda.time.Instant
+import org.joda.time.format.DateTimeFormat
 import timber.log.Timber
 import java.io.File
 import java.util.Date
@@ -228,11 +229,14 @@ class TestRiskLevelCalculationFragmentCWAViewModel @AssistedInject constructor(
         Timber.d("Creating text file for Exposure Windows")
         launch(dispatcherProvider.IO) {
             val exposureWindows = riskLevelStorage.exposureWindows.firstOrNull()
+            val fileNameCompatibleTimestamp = timeStamper.nowUTC.toString(
+                DateTimeFormat.forPattern("yyyy-MM-DD-HH-mm-ss")
+            )
 
             val path = File(context.cacheDir, "share/")
             path.mkdirs()
 
-            val file = File(path, "exposureWindows-${timeStamper.nowUTC}.txt")
+            val file = File(path, "exposureWindows-${fileNameCompatibleTimestamp}.txt")
             file.bufferedWriter()
                 .use { writer ->
                     if (exposureWindows.isNullOrEmpty()) {

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/risklevel/ui/TestRiskLevelCalculationFragmentCWAViewModel.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/risklevel/ui/TestRiskLevelCalculationFragmentCWAViewModel.kt
@@ -25,6 +25,7 @@ import de.rki.coronawarnapp.storage.TestSettings
 import de.rki.coronawarnapp.task.TaskController
 import de.rki.coronawarnapp.task.common.DefaultTaskRequest
 import de.rki.coronawarnapp.task.submitBlocking
+import de.rki.coronawarnapp.test.risklevel.entities.toExposureWindowJson
 import de.rki.coronawarnapp.ui.tracing.card.TracingCardStateProvider
 import de.rki.coronawarnapp.ui.tracing.common.tryLatestResultsWithDefaults
 import de.rki.coronawarnapp.util.NetworkRequestWrapper.Companion.withSuccess
@@ -231,11 +232,11 @@ class TestRiskLevelCalculationFragmentCWAViewModel @AssistedInject constructor(
 
             val file = File(path, "exposureWindows.txt")
             file.bufferedWriter()
-                .use {
+                .use { writer ->
                     if (exposureWindows.isNullOrEmpty()) {
-                        it.appendLine("Exposure windows list was empty")
+                        writer.appendLine("Exposure windows list was empty")
                     } else {
-                        it.appendLine(gson.toJson(exposureWindows))
+                        writer.appendLine(gson.toJson(exposureWindows.map { it.toExposureWindowJson() }))
                     }
                 }
             shareFileEvent.postValue(file)

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/risklevel/ui/TestRiskLevelCalculationFragmentCWAViewModel.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/risklevel/ui/TestRiskLevelCalculationFragmentCWAViewModel.kt
@@ -236,7 +236,7 @@ class TestRiskLevelCalculationFragmentCWAViewModel @AssistedInject constructor(
             val path = File(context.cacheDir, "share/")
             path.mkdirs()
 
-            val file = File(path, "exposureWindows-${fileNameCompatibleTimestamp}.txt")
+            val file = File(path, "exposureWindows-$fileNameCompatibleTimestamp.txt")
             file.bufferedWriter()
                 .use { writer ->
                     if (exposureWindows.isNullOrEmpty()) {

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/risklevel/ui/TestRiskLevelCalculationFragmentCWAViewModel.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/risklevel/ui/TestRiskLevelCalculationFragmentCWAViewModel.kt
@@ -236,7 +236,7 @@ class TestRiskLevelCalculationFragmentCWAViewModel @AssistedInject constructor(
             val path = File(context.cacheDir, "share/")
             path.mkdirs()
 
-            val file = File(path, "exposureWindows-$fileNameCompatibleTimestamp.txt")
+            val file = File(path, "exposureWindows-$fileNameCompatibleTimestamp.json")
             file.bufferedWriter()
                 .use { writer ->
                     if (exposureWindows.isNullOrEmpty()) {


### PR DESCRIPTION
### Description
This PR adds a conversion from enf based exposure windows to a data class based version that contains the field names needed for json eports

### Steps to reproduce
1. Have exposure windows in the app
2. export them using the test menu
3. check the json fields for their naming