### PR TITLE
Fix refresh check and improve test menu (EXPOSUREAPP-4049)

### DIFF
--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/risklevel/ui/TestRiskLevelCalculationFragment.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/risklevel/ui/TestRiskLevelCalculationFragment.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.View
 import android.widget.RadioButton
 import android.widget.RadioGroup
-import android.widget.Toast
 import androidx.core.app.ShareCompat
 import androidx.core.content.FileProvider
 import androidx.core.view.ViewCompat
@@ -13,6 +12,7 @@ import androidx.core.view.children
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.navArgs
+import com.google.android.material.snackbar.Snackbar
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.FragmentTestRiskLevelCalculationBinding
 import de.rki.coronawarnapp.storage.TestSettings
@@ -59,12 +59,9 @@ class TestRiskLevelCalculationFragment : Fragment(R.layout.fragment_test_risk_le
         binding.buttonClearDiagnosisKeyCache.setOnClickListener { vm.clearKeyCache() }
         binding.buttonResetRiskLevel.setOnClickListener { vm.resetRiskLevel() }
         binding.buttonExposureWindowsShare.setOnClickListener { vm.shareExposureWindows() }
-        vm.riskLevelResetEvent.observe2(this) {
-            Toast.makeText(
-                requireContext(), "Reset done, please fetch diagnosis keys from server again",
-                Toast.LENGTH_SHORT
-            ).show()
-        }
+
+        vm.dataResetEvent.observe2(this) { Snackbar.make(requireView(), it, Snackbar.LENGTH_SHORT).show() }
+
         vm.additionalRiskCalcInfo.observe2(this) {
             binding.labelRiskAdditionalInfo.text = it
         }

--- a/Corona-Warn-App/src/deviceForTesters/res/layout/fragment_test_risk_level_calculation.xml
+++ b/Corona-Warn-App/src/deviceForTesters/res/layout/fragment_test_risk_level_calculation.xml
@@ -34,13 +34,13 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical">
-            
+
             <LinearLayout
                 android:id="@+id/environment_container"
                 style="@style/card"
                 android:layout_width="match_parent"
-                android:orientation="vertical"
-                android:layout_height="wrap_content">
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
 
                 <TextView
                     android:id="@+id/fake_windows_title"
@@ -50,11 +50,11 @@
                     android:text="Fake exposure windows" />
 
                 <TextView
-                    android:layout_width="match_parent"
                     style="@style/TextAppearance.AppCompat.Caption"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_tiny"
-                    android:text="Takes effect the next time `ExposureNotificationClient.exposureWindows` is called, i.e. on risk level calculation."
-                    android:layout_height="wrap_content" />
+                    android:text="Takes effect the next time `ExposureNotificationClient.exposureWindows` is called, i.e. on risk level calculation." />
 
                 <RadioGroup
                     android:id="@+id/fake_windows_toggle_group"
@@ -83,20 +83,18 @@
             </FrameLayout>
 
             <Button
-                android:id="@+id/button_retrieve_diagnosis_keys"
-                style="@style/buttonPrimary"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/spacing_normal"
-                android:text="Retrieve Diagnosis Keys" />
-
-            <Button
                 android:id="@+id/button_calculate_risk_level"
                 style="@style/buttonPrimary"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_normal"
                 android:text="Calculate Risk Level" />
+            <TextView
+                style="@style/TextAppearance.AppCompat.Caption"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacing_tiny"
+                android:text="Start the task that gets the latest exposure windows and calculates a current risk state." />
 
             <Button
                 android:id="@+id/button_reset_risk_level"
@@ -106,13 +104,41 @@
                 android:layout_marginTop="@dimen/spacing_normal"
                 android:text="Reset Risk Level" />
 
+            <TextView
+                style="@style/TextAppearance.AppCompat.Caption"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacing_tiny"
+                android:text="Delete the all stored calculated risk level results." />
+
+            <Button
+                android:id="@+id/button_retrieve_diagnosis_keys"
+                style="@style/buttonPrimary"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacing_normal"
+                android:text="Download Diagnosis Keys" />
+
+            <TextView
+                style="@style/TextAppearance.AppCompat.Caption"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacing_tiny"
+                android:text="Start the task syncs the local diagnosis key cache with the server and submits them to the exposure notification framework for detection (if constraints allow). " />
+
             <Button
                 android:id="@+id/button_clear_diagnosis_key_cache"
                 style="@style/buttonPrimary"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_normal"
-                android:text="Clear Diagnosis-Key cache" />
+                android:text="Reset Diagnosis-Keys" />
+            <TextView
+                style="@style/TextAppearance.AppCompat.Caption"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacing_tiny"
+                android:text="Restore download task conditions to initial state. Remove cached keys, delete last download logs, reset tracked exposure detections. " />
 
             <TextView
                 android:id="@+id/label_aggregated_risk_result_title"

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/detectiontracker/ExposureDetectionTrackerExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/detectiontracker/ExposureDetectionTrackerExtensions.kt
@@ -5,10 +5,10 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 
 suspend fun ExposureDetectionTracker.lastSubmission(
-    onlySuccessful: Boolean = true
+    onlyFinished: Boolean = true
 ): TrackedExposureDetection? = calculations
     .first().values
-    .filter { it.isSuccessful || !onlySuccessful }
+    .filter { it.isSuccessful || !onlyFinished }
     .maxByOrNull { it.startedAt }
 
 fun ExposureDetectionTracker.latestSubmission(
@@ -20,4 +20,3 @@ fun ExposureDetectionTracker.latestSubmission(
     .map { detections ->
         detections.maxByOrNull { it.startedAt }
     }
-

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/detectiontracker/ExposureDetectionTrackerExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/detectiontracker/ExposureDetectionTrackerExtensions.kt
@@ -1,0 +1,23 @@
+package de.rki.coronawarnapp.nearby.modules.detectiontracker
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+suspend fun ExposureDetectionTracker.lastSubmission(
+    onlySuccessful: Boolean = true
+): TrackedExposureDetection? = calculations
+    .first().values
+    .filter { it.isSuccessful || !onlySuccessful }
+    .maxByOrNull { it.startedAt }
+
+fun ExposureDetectionTracker.latestSubmission(
+    onlySuccessful: Boolean = true
+): Flow<TrackedExposureDetection?> = calculations
+    .map { entries ->
+        entries.values.filter { it.isSuccessful || !onlySuccessful }
+    }
+    .map { detections ->
+        detections.maxByOrNull { it.startedAt }
+    }
+

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/LocalData.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/LocalData.kt
@@ -4,12 +4,10 @@ import android.content.SharedPreferences
 import androidx.core.content.edit
 import de.rki.coronawarnapp.CoronaWarnApplication
 import de.rki.coronawarnapp.R
-import de.rki.coronawarnapp.util.preferences.createFlowPreference
 import de.rki.coronawarnapp.util.security.SecurityHelper.globalEncryptedSharedPreferencesInstance
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.map
-import java.util.Date
+import timber.log.Timber
 
 /**
  * LocalData is responsible for all access to the shared preferences. Each preference is accessible
@@ -307,28 +305,6 @@ object LocalData {
             .also { isUserToBeNotifiedOfLoweredRiskLevelFlowInternal.value = value }
 
     /****************************************************
-     * SERVER FETCH DATA
-     ****************************************************/
-
-    private val dateMapperForFetchTime: (Long) -> Date? = {
-        if (it != 0L) Date(it) else null
-    }
-
-    private val lastTimeDiagnosisKeysFetchedFlowPref by lazy {
-        getSharedPreferenceInstance()
-            .createFlowPreference<Long>(key = "preference_timestamp_diagnosis_keys_fetch", 0L)
-    }
-
-    fun lastTimeDiagnosisKeysFromServerFetchFlow() = lastTimeDiagnosisKeysFetchedFlowPref.flow
-        .map { dateMapperForFetchTime(it) }
-
-    fun lastTimeDiagnosisKeysFromServerFetch() =
-        dateMapperForFetchTime(lastTimeDiagnosisKeysFetchedFlowPref.value)
-
-    fun lastTimeDiagnosisKeysFromServerFetch(value: Date?) =
-        lastTimeDiagnosisKeysFetchedFlowPref.update { value?.time ?: 0L }
-
-    /****************************************************
      * SETTINGS DATA
      ****************************************************/
 
@@ -583,6 +559,6 @@ object LocalData {
         }
 
     fun clear() {
-        lastTimeDiagnosisKeysFetchedFlowPref.update { 0L }
+        Timber.w("LocalData.clear()")
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/TracingRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/TracingRepository.kt
@@ -128,7 +128,7 @@ class TracingRepository @Inject constructor(
 
         if (isNetworkEnabled && isBackgroundJobEnabled) {
             scope.launch {
-                val lastSubmission = exposureDetectionTracker.lastSubmission(onlySuccessful = false)
+                val lastSubmission = exposureDetectionTracker.lastSubmission(onlyFinished = false)
                 Timber.tag(TAG).v("Last submission was %s", lastSubmission)
 
                 if (lastSubmission == null || downloadDiagnosisKeysTaskDidNotRunRecently()) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/tracing/card/TracingCardState.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/tracing/card/TracingCardState.kt
@@ -16,7 +16,6 @@ import de.rki.coronawarnapp.ui.tracing.common.BaseTracingState
 import de.rki.coronawarnapp.util.TimeAndDateExtensions.toLocalDate
 import org.joda.time.Instant
 import org.joda.time.format.DateTimeFormat
-import java.util.Date
 
 @Suppress("TooManyFunctions")
 data class TracingCardState(
@@ -27,7 +26,7 @@ data class TracingCardState(
     val daysWithEncounters: Int,
     val lastEncounterAt: Instant?,
     val activeTracingDays: Long,
-    val lastTimeDiagnosisKeysFetched: Date?,
+    val lastTimeDiagnosisKeysFetched: Instant?,
     override val isManualKeyRetrievalEnabled: Boolean,
     override val showDetails: Boolean = false
 ) : BaseTracingState() {
@@ -164,10 +163,10 @@ data class TracingCardState(
         else -> ""
     }
 
-    private fun formatRelativeDateTimeString(c: Context, date: Date): CharSequence? =
+    private fun formatRelativeDateTimeString(c: Context, date: Instant): CharSequence? =
         DateUtils.getRelativeDateTimeString(
             c,
-            date.time,
+            date.millis,
             DateUtils.DAY_IN_MILLIS,
             DateUtils.DAY_IN_MILLIS * 2,
             0

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/tracing/card/TracingCardState.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/tracing/card/TracingCardState.kt
@@ -26,7 +26,7 @@ data class TracingCardState(
     val daysWithEncounters: Int,
     val lastEncounterAt: Instant?,
     val activeTracingDays: Long,
-    val lastTimeDiagnosisKeysFetched: Instant?,
+    val lastExposureDetectionTime: Instant?,
     override val isManualKeyRetrievalEnabled: Boolean,
     override val showDetails: Boolean = false
 ) : BaseTracingState() {
@@ -180,10 +180,10 @@ data class TracingCardState(
      */
     fun getTimeFetched(c: Context): String {
         if (isTracingOff()) {
-            return if (lastTimeDiagnosisKeysFetched != null) {
+            return if (lastExposureDetectionTime != null) {
                 c.getString(
                     R.string.risk_card_body_time_fetched,
-                    formatRelativeDateTimeString(c, lastTimeDiagnosisKeysFetched)
+                    formatRelativeDateTimeString(c, lastExposureDetectionTime)
                 )
             } else {
                 c.getString(R.string.risk_card_body_not_yet_fetched)
@@ -191,10 +191,10 @@ data class TracingCardState(
         }
         return when (riskState) {
             LOW_RISK, INCREASED_RISK -> {
-                if (lastTimeDiagnosisKeysFetched != null) {
+                if (lastExposureDetectionTime != null) {
                     c.getString(
                         R.string.risk_card_body_time_fetched,
-                        formatRelativeDateTimeString(c, lastTimeDiagnosisKeysFetched)
+                        formatRelativeDateTimeString(c, lastExposureDetectionTime)
                     )
                 } else {
                     c.getString(R.string.risk_card_body_not_yet_fetched)
@@ -203,10 +203,10 @@ data class TracingCardState(
             CALCULATION_FAILED -> {
                 when (lastSuccessfulRiskState) {
                     LOW_RISK, INCREASED_RISK -> {
-                        if (lastTimeDiagnosisKeysFetched != null) {
+                        if (lastExposureDetectionTime != null) {
                             c.getString(
                                 R.string.risk_card_body_time_fetched,
-                                formatRelativeDateTimeString(c, lastTimeDiagnosisKeysFetched)
+                                formatRelativeDateTimeString(c, lastExposureDetectionTime)
                             )
                         } else {
                             c.getString(R.string.risk_card_body_not_yet_fetched)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/tracing/card/TracingCardStateProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/tracing/card/TracingCardStateProvider.kt
@@ -1,6 +1,8 @@
 package de.rki.coronawarnapp.ui.tracing.card
 
 import dagger.Reusable
+import de.rki.coronawarnapp.nearby.modules.detectiontracker.ExposureDetectionTracker
+import de.rki.coronawarnapp.nearby.modules.detectiontracker.latestSubmission
 import de.rki.coronawarnapp.risk.RiskState
 import de.rki.coronawarnapp.risk.storage.RiskLevelStorage
 import de.rki.coronawarnapp.storage.TracingRepository
@@ -20,7 +22,8 @@ class TracingCardStateProvider @Inject constructor(
     tracingStatus: GeneralTracingStatus,
     backgroundModeStatus: BackgroundModeStatus,
     tracingRepository: TracingRepository,
-    riskLevelStorage: RiskLevelStorage
+    riskLevelStorage: RiskLevelStorage,
+    exposureDetectionTracker: ExposureDetectionTracker
 ) {
 
     val state: Flow<TracingCardState> = combine(
@@ -36,8 +39,8 @@ class TracingCardStateProvider @Inject constructor(
         tracingRepository.activeTracingDaysInRetentionPeriod.onEach {
             Timber.v("activeTracingDaysInRetentionPeriod: $it")
         },
-        tracingRepository.lastTimeDiagnosisKeysFetched.onEach {
-            Timber.v("lastTimeDiagnosisKeysFetched: $it")
+        exposureDetectionTracker.latestSubmission().onEach {
+            Timber.v("latestSubmission: $it")
         },
         backgroundModeStatus.isAutoModeEnabled.onEach {
             Timber.v("isAutoModeEnabled: $it")
@@ -46,7 +49,7 @@ class TracingCardStateProvider @Inject constructor(
         tracingProgress,
         riskLevelResults,
         activeTracingDaysInRetentionPeriod,
-        lastTimeDiagnosisKeysFetched,
+        latestSubmission,
         isBackgroundJobEnabled ->
 
         val (
@@ -61,7 +64,7 @@ class TracingCardStateProvider @Inject constructor(
             riskState = latestCalc.riskState,
             tracingProgress = tracingProgress,
             lastSuccessfulRiskState = latestSuccessfulCalc.riskState,
-            lastTimeDiagnosisKeysFetched = lastTimeDiagnosisKeysFetched,
+            lastTimeDiagnosisKeysFetched = latestSubmission?.startedAt,
             daysWithEncounters = latestCalc.daysWithEncounters,
             lastEncounterAt = latestCalc.lastRiskEncounterAt,
             activeTracingDays = activeTracingDaysInRetentionPeriod,

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/tracing/card/TracingCardStateProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/tracing/card/TracingCardStateProvider.kt
@@ -64,7 +64,7 @@ class TracingCardStateProvider @Inject constructor(
             riskState = latestCalc.riskState,
             tracingProgress = tracingProgress,
             lastSuccessfulRiskState = latestSuccessfulCalc.riskState,
-            lastTimeDiagnosisKeysFetched = latestSubmission?.startedAt,
+            lastExposureDetectionTime = latestSubmission?.startedAt,
             daysWithEncounters = latestCalc.daysWithEncounters,
             lastEncounterAt = latestCalc.lastRiskEncounterAt,
             activeTracingDays = activeTracingDaysInRetentionPeriod,

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/nearby/modules/detectiontracker/ExposureDetectionTrackerExtensionsTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/nearby/modules/detectiontracker/ExposureDetectionTrackerExtensionsTest.kt
@@ -1,0 +1,94 @@
+package de.rki.coronawarnapp.nearby.modules.detectiontracker
+
+import io.kotest.matchers.shouldBe
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runBlockingTest
+import org.joda.time.Instant
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.util.UUID
+
+class ExposureDetectionTrackerExtensionsTest : BaseTest() {
+
+    @MockK lateinit var tracker: ExposureDetectionTracker
+
+    private val fakeCalculations: MutableStateFlow<Map<String, TrackedExposureDetection>> = MutableStateFlow(emptyMap())
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this)
+        every { tracker.calculations } returns fakeCalculations
+    }
+
+    @AfterEach
+    fun teardown() {
+    }
+
+    private fun createFakeCalculation(
+        startedAt: Instant,
+        result: TrackedExposureDetection.Result? = TrackedExposureDetection.Result.NO_MATCHES
+    ) = TrackedExposureDetection(
+        identifier = UUID.randomUUID().toString(),
+        startedAt = startedAt,
+        finishedAt = if (result != null) startedAt.plus(100) else null,
+        result = result
+    )
+
+    @Test
+    fun `last submission`() {
+        val tr1 = createFakeCalculation(startedAt = Instant.EPOCH)
+        val tr2 = createFakeCalculation(startedAt = Instant.EPOCH.plus(1))
+        val tr3 = createFakeCalculation(startedAt = Instant.EPOCH.plus(2), result = null)
+        fakeCalculations.value = mapOf(
+            tr1.identifier to tr1,
+            tr2.identifier to tr2,
+            tr3.identifier to tr3,
+        )
+        runBlockingTest {
+            tracker.lastSubmission(onlyFinished = false) shouldBe tr3
+            tracker.lastSubmission(onlyFinished = true) shouldBe tr2
+        }
+    }
+
+    @Test
+    fun `last submission on empty data`() {
+        runBlockingTest {
+            tracker.lastSubmission(onlyFinished = false) shouldBe null
+            tracker.lastSubmission(onlyFinished = true) shouldBe null
+        }
+    }
+
+    @Test
+    fun `latest submission`() {
+        val tr1 = createFakeCalculation(startedAt = Instant.EPOCH)
+        val tr2 = createFakeCalculation(startedAt = Instant.EPOCH.plus(1))
+        val tr3 = createFakeCalculation(startedAt = Instant.EPOCH.plus(2), result = null)
+        fakeCalculations.value = mapOf(
+            tr1.identifier to tr1,
+            tr2.identifier to tr2,
+            tr3.identifier to tr3,
+        )
+        runBlockingTest {
+            tracker.latestSubmission(onlySuccessful = false).first() shouldBe tr3
+            tracker.latestSubmission(onlySuccessful = true).first() shouldBe tr2
+        }
+    }
+
+    @Test
+    fun `latest submission on empty data`() = runBlockingTest {
+        tracker.latestSubmission(onlySuccessful = false).first() shouldBe null
+        tracker.latestSubmission(onlySuccessful = true).first() shouldBe null
+
+        val tr1 = createFakeCalculation(startedAt = Instant.EPOCH)
+        fakeCalculations.value = mapOf(tr1.identifier to tr1)
+
+        tracker.latestSubmission(onlySuccessful = false).first() shouldBe tr1
+        tracker.latestSubmission(onlySuccessful = true).first() shouldBe tr1
+    }
+}

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/tracing/card/TracingCardStateTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/tracing/card/TracingCardStateTest.kt
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
-import java.util.Date
 
 class TracingCardStateTest : BaseTest() {
 
@@ -46,7 +45,7 @@ class TracingCardStateTest : BaseTest() {
         daysWithEncounters: Int = 0,
         lastEncounterAt: Instant? = null,
         activeTracingDaysInRetentionPeriod: Long = 0,
-        lastTimeDiagnosisKeysFetched: Date? = mockk(),
+        lastExposureDetectionTime: Instant? = mockk(),
         isBackgroundJobEnabled: Boolean = false
     ) = TracingCardState(
         tracingStatus = tracingStatus,
@@ -56,7 +55,7 @@ class TracingCardStateTest : BaseTest() {
         daysWithEncounters = daysWithEncounters,
         lastEncounterAt = lastEncounterAt,
         activeTracingDays = activeTracingDaysInRetentionPeriod,
-        lastTimeDiagnosisKeysFetched = lastTimeDiagnosisKeysFetched,
+        lastExposureDetectionTime = lastExposureDetectionTime,
         isManualKeyRetrievalEnabled = !isBackgroundJobEnabled
     )
 
@@ -243,11 +242,11 @@ class TracingCardStateTest : BaseTest() {
 
     @Test
     fun `text for last time diagnosis keys were fetched`() {
-        val date = Date()
+        val date = Instant()
         createInstance(
             riskState = INCREASED_RISK,
             lastSuccessfulRiskState = LOW_RISK,
-            lastTimeDiagnosisKeysFetched = date
+            lastExposureDetectionTime = date
         ).apply {
             getTimeFetched(context)
             verify { context.getString(eq(R.string.risk_card_body_time_fetched), any()) }
@@ -256,7 +255,7 @@ class TracingCardStateTest : BaseTest() {
         createInstance(
             riskState = CALCULATION_FAILED,
             lastSuccessfulRiskState = LOW_RISK,
-            lastTimeDiagnosisKeysFetched = date
+            lastExposureDetectionTime = date
         ).apply {
             getTimeFetched(context)
             verify { context.getString(eq(R.string.risk_card_body_time_fetched), any()) }
@@ -265,7 +264,7 @@ class TracingCardStateTest : BaseTest() {
         createInstance(
             riskState = CALCULATION_FAILED,
             lastSuccessfulRiskState = LOW_RISK,
-            lastTimeDiagnosisKeysFetched = date
+            lastExposureDetectionTime = date
         ).apply {
             getTimeFetched(context)
             verify { context.getString(eq(R.string.risk_card_body_time_fetched), any()) }
@@ -274,36 +273,36 @@ class TracingCardStateTest : BaseTest() {
         createInstance(
             riskState = LOW_RISK,
             lastSuccessfulRiskState = LOW_RISK,
-            lastTimeDiagnosisKeysFetched = date
+            lastExposureDetectionTime = date
         ).apply {
             getTimeFetched(context)
             verify { context.getString(eq(R.string.risk_card_body_time_fetched), any()) }
         }
 
-        createInstance(riskState = INCREASED_RISK, lastTimeDiagnosisKeysFetched = date).apply {
+        createInstance(riskState = INCREASED_RISK, lastExposureDetectionTime = date).apply {
             getTimeFetched(context)
             verify { context.getString(eq(R.string.risk_card_body_time_fetched), any()) }
         }
 
-        createInstance(riskState = CALCULATION_FAILED, lastTimeDiagnosisKeysFetched = date).apply {
+        createInstance(riskState = CALCULATION_FAILED, lastExposureDetectionTime = date).apply {
             getTimeFetched(context) shouldBe ""
         }
 
-        createInstance(riskState = LOW_RISK, lastTimeDiagnosisKeysFetched = date).apply {
+        createInstance(riskState = LOW_RISK, lastExposureDetectionTime = date).apply {
             getTimeFetched(context)
             verify { context.getString(eq(R.string.risk_card_body_time_fetched), any()) }
         }
 
-        createInstance(riskState = INCREASED_RISK, lastTimeDiagnosisKeysFetched = null).apply {
+        createInstance(riskState = INCREASED_RISK, lastExposureDetectionTime = null).apply {
             getTimeFetched(context)
             verify { context.getString(R.string.risk_card_body_not_yet_fetched) }
         }
 
-        createInstance(riskState = CALCULATION_FAILED, lastTimeDiagnosisKeysFetched = null).apply {
+        createInstance(riskState = CALCULATION_FAILED, lastExposureDetectionTime = null).apply {
             getTimeFetched(context) shouldBe ""
         }
 
-        createInstance(riskState = LOW_RISK, lastTimeDiagnosisKeysFetched = null).apply {
+        createInstance(riskState = LOW_RISK, lastExposureDetectionTime = null).apply {
             getTimeFetched(context)
             verify { context.getString(R.string.risk_card_body_not_yet_fetched) }
         }


### PR DESCRIPTION
Remove "lastTimeDiagnosisKeysFromServerFetch" and replace it with less missleading data.

While it was called "lastTimeDiagnosisKeysFromServerFetch" it was actually "last time we submitted keys for exposure detection". Which was also missleading because it does not directly relate to what the risk card is displaying. It's neither the last download (because it only get's set on submission) and it get's set on start of submission so it likely does not represent the latest risk level until the second risk level calculation has been executed.

* To decide whether to refresh in "onResume", we now use "has there been any submission to the ENF?" (exposure detection `startedAt`).
* To display a timestamp on the risk card, we take the last successful submission (`finishedAt`) to the ENF as the risk card displays the calculation results, which in turn are based on the latest submission. While we could use the last calculated risk level result timestamp, we currently also trigger risk calculations if there are no new submissions to the ENF, which would mean the timestamp is updated even though the result is not based on new data.
    * When we deem it no longer necessary to launch the risk level task in `onResume` we should consider displaying the last risk level result timestamp on the card. This is only viable though when the risk level task only get's launched as reaction to finished exposure detections.

I've also fixed the test fragment button behavior and added descriptions, the "Reset risk level" button surfaced the initial issue because it behaved like a "do a 75% data reset" button. 

@harambasicluka the bug you described [here](https://github.com/corona-warn-app/cwa-app-android/pull/1751#issuecomment-735906177) was likely caused by the incorrectly working test menu button "Reset risklevel", did more than just reset the risk level, it reset `LocalData`. This lead to downloaded diagnosis keys existing such that no new download was deemed necessary. As no new downloaded happened the "lastTimeDiagnosisKeysFromServerFetch" used for detecting new installs was never set again despite being reset by "Reset risk level", this meant that `val wasNotYetFetched = LocalData.lastTimeDiagnosisKeysFromServerFetch() == null` always returned true and let the risk level calculation be launched.