### PR TITLE
Don't show last risk contact on "tracing disabled" card (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/tracing/card/TracingCardState.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/tracing/card/TracingCardState.kt
@@ -135,11 +135,13 @@ data class TracingCardState(
      * only in the special case of increased risk as a positive contact is a
      * prerequisite for increased risk
      */
-    fun getRiskContactLast(c: Context): String = if (riskState == INCREASED_RISK) {
-        val formattedDate = lastEncounterAt?.toLocalDate()?.toString(DateTimeFormat.mediumDate())
-        c.getString(R.string.risk_card_high_risk_most_recent_body, formattedDate)
-    } else {
-        ""
+    fun getRiskContactLast(c: Context): String = when {
+        isTracingOff() -> ""
+        riskState == INCREASED_RISK -> {
+            val formattedDate = lastEncounterAt?.toLocalDate()?.toString(DateTimeFormat.mediumDate())
+            c.getString(R.string.risk_card_high_risk_most_recent_body, formattedDate)
+        }
+        else -> ""
     }
 
     /**

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/tracing/card/TracingCardStateTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/tracing/card/TracingCardStateTest.kt
@@ -211,6 +211,14 @@ class TracingCardStateTest : BaseTest() {
             }
         }
 
+        createInstance(
+            riskState = INCREASED_RISK,
+            lastEncounterAt = Instant.EPOCH,
+            tracingStatus = Status.TRACING_INACTIVE
+        ).apply {
+            getRiskContactLast(context) shouldBe ""
+        }
+
         createInstance(riskState = LOW_RISK).apply {
             getRiskContactLast(context) shouldBe ""
         }


### PR DESCRIPTION
Mock ups show that we shouldn't show the "last contact" on the "tracing disabled" card.

## Test
* Generate green card
* Disable tracing