### PR TITLE
Fix fake window data for low risk card with encounters (DEV)

### DIFF
--- a/Corona-Warn-App/src/deviceForTesters/assets/exposure-windows-lowrisk-random.json
+++ b/Corona-Warn-App/src/deviceForTesters/assets/exposure-windows-lowrisk-random.json
@@ -2,7 +2,7 @@
   {
     "ageInDays": 1,
     "reportType": 2,
-    "infectiousness": 2,
+    "infectiousness": 1,
     "calibrationConfidence": 0,
     "scanInstances": [
       {
@@ -14,24 +14,11 @@
         "minAttenuation": 30,
         "typicalAttenuation": 25,
         "secondsSinceLastScan": 300
-      }
-    ]
-  },
-  {
-    "ageInDays": 4,
-    "calibrationConfidence": 0,
-    "infectiousness": 2,
-    "reportType": 1,
-    "scanInstances": [
-      {
-        "minAttenuation": 30,
-        "secondsSinceLastScan": 300,
-        "typicalAttenuation": 25
       },
       {
         "minAttenuation": 30,
-        "secondsSinceLastScan": 300,
-        "typicalAttenuation": 25
+        "typicalAttenuation": 25,
+        "secondsSinceLastScan": 299
       }
     ]
   }


### PR DESCRIPTION
Server side change caused our fake data to show a low risk card with an encounter, to show as high risk.