### PR TITLE
Fix display of last successful risk level when tracing is disabled (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/tracing/card/TracingCardState.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/tracing/card/TracingCardState.kt
@@ -63,29 +63,19 @@ data class TracingCardState(
      * the persisted risk level is of importance
      */
     fun getSavedRiskBody(c: Context): String {
-        // Don't display last risk when tracing is disabled
-        if (isTracingOff()) {
-            val arg = c.getString(R.string.risk_card_no_calculation_possible_headline)
-            return c.getString(R.string.risk_card_no_calculation_possible_body_saved_risk).format(arg)
+        val stateToDisplay = when {
+            riskState == CALCULATION_FAILED -> lastSuccessfulRiskState
+            isTracingOff() -> riskState
+            else -> null
         }
-
-        // Don't have any old risk state to display
-        if (lastSuccessfulRiskState == CALCULATION_FAILED) {
-            return ""
-        }
-
-        // If we failed this time, we want to display the old risk
-        if (riskState == CALCULATION_FAILED) {
-            val arg = when (lastSuccessfulRiskState) {
-                INCREASED_RISK -> R.string.risk_card_increased_risk_headline
-                LOW_RISK -> R.string.risk_card_low_risk_headline
-                else -> null
-            }?.let { c.getString(it) } ?: ""
-            return c.getString(R.string.risk_card_no_calculation_possible_body_saved_risk).format(arg)
-        }
-
-        // We are not in an error state
-        return ""
+        return when (stateToDisplay) {
+            INCREASED_RISK -> R.string.risk_card_increased_risk_headline
+            LOW_RISK -> R.string.risk_card_low_risk_headline
+            else -> null
+        }?.let {
+            val argumentValue = c.getString(it)
+            c.getString(R.string.risk_card_no_calculation_possible_body_saved_risk).format(argumentValue)
+        } ?: ""
     }
 
     /**

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/tracing/card/TracingCardStateTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/tracing/card/TracingCardStateTest.kt
@@ -170,6 +170,48 @@ class TracingCardStateTest : BaseTest() {
     }
 
     @Test
+    fun `saved risk body when tracing is disabled`() {
+        createInstance(
+            riskState = CALCULATION_FAILED,
+            lastSuccessfulRiskState = LOW_RISK,
+            tracingStatus = Status.TRACING_INACTIVE
+        ).apply {
+            getSavedRiskBody(context)
+            verify {
+                context
+                    .getString(R.string.risk_card_no_calculation_possible_body_saved_risk)
+                    .format(context.getString(R.string.risk_card_low_risk_headline))
+            }
+        }
+
+        createInstance(
+            riskState = CALCULATION_FAILED,
+            lastSuccessfulRiskState = INCREASED_RISK,
+            tracingStatus = Status.TRACING_INACTIVE
+        ).apply {
+            getSavedRiskBody(context)
+            verify {
+                context
+                    .getString(R.string.risk_card_no_calculation_possible_body_saved_risk)
+                    .format(context.getString(R.string.risk_card_increased_risk_headline))
+            }
+        }
+
+        createInstance(
+            riskState = CALCULATION_FAILED,
+            lastSuccessfulRiskState = LOW_RISK,
+            tracingStatus = Status.TRACING_INACTIVE
+        ).apply {
+            getSavedRiskBody(context)
+            verify {
+                context
+                    .getString(R.string.risk_card_no_calculation_possible_body_saved_risk)
+                    .format(context.getString(R.string.risk_card_low_risk_headline))
+            }
+        }
+    }
+
+    @Test
     fun `risk contact body is affected by risklevel`() {
         createInstance(riskState = CALCULATION_FAILED, daysWithEncounters = 0).apply {
             getRiskContactBody(context) shouldBe ""


### PR DESCRIPTION
Card did not show the correct last state:

[Screenshot showing the bug](https://user-images.githubusercontent.com/1439229/100782808-3e566280-340d-11eb-9cec-a942358f27d9.png)
