### PR TITLE
[DRAFT] Change risk_card_body_saved_days_full text to prevent misunderstanding

### DIFF
--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -151,7 +151,7 @@
     <!-- XTXT: risk card - tracing active for x out of 14 days -->
     <string name="risk_card_body_saved_days">"Risiko-Ermittlung war für %1$s der letzten 14 Tage aktiv"</string>
     <!-- XTXT: risk card- tracing active for 14 out of 14 days -->
-    <string name="risk_card_body_saved_days_full">"Risiko-Ermittlung dauerhaft aktiv"</string>
+    <string name="risk_card_body_saved_days_full">"Risiko-Ermittlung bereit, wenn GPS an ist"</string>
     <!-- XTXT; risk card - no update done yet -->
     <string name="risk_card_body_not_yet_fetched">"Begegnungen wurden noch nicht überprüft."</string>
     <!-- XTXT: risk card - last successful update -->


### PR DESCRIPTION
### Description

The text "Risiko-Ermittlung dauerhaft aktiv" is mesleading. It sounds like the app is up and running and scans for other users, but in fact it is only active, if GPS is enabled. which is not clearly displayed. (only hidden behind the explanation `settings_tracing_status_location_body`, whichnot everyone would look at, if everything is green and the message displays "dauerhaft aktiv")

### about this DRAFT

Wenn wir eine gute deutsche Formulierung finden, die nicht mehr irreführend ist, dann kann den PR updaten und in allen translation files die Übersetzung einfügen. 

### Note
This is not a translation issue, it is more an issue about the wording in all languages