### PR TITLE
Change CODEOWNER for strings to UA team (DEV)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,4 +8,4 @@
 * @corona-warn-app/cwa-app-android-maintainers
 
 # Code Onwer of all german texts
-/Corona-Warn-App/src/main/res/values-de/ @janetback @SabineLoss
+/Corona-Warn-App/src/main/res/values-de/ @corona-warn-app/cwa-app-android-ua


### PR DESCRIPTION
This way only one person of the team has to approve and adding/removing UA team members doesn't require changes to the CODEOWNERS file.

Currently both UA team members are tagged individually and both need to review although one approval is sufficient.
