### PR TITLE
Your consent switch status text fix (EXPOSUREAPP-4214)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/yourconsent/SubmissionYourConsentFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/yourconsent/SubmissionYourConsentFragment.kt
@@ -32,7 +32,7 @@ class SubmissionYourConsentFragment : Fragment(R.layout.fragment_submission_your
 
         vm.consent.observe2(this) {
             binding.submissionYourConsentSwitch.status = it
-            binding.submissionYourConsentSwitch.settingsSwitchRowHeaderBody.setText(
+            binding.submissionYourConsentSwitch.statusText = getString(
                 if (it) {
                     R.string.submission_your_consent_switch_status_on
                 } else {


### PR DESCRIPTION
Fix for your consent switch status text: when fragment "Your Consent" is opened by default switch had no text.

**How to test**

1. Open Your Consent fragment
2. Do not press on switch
3. Check if switch has status text (Active/Stopped)

**How to open Your Consent fragment**

1. Reset the app
2. Scan Pending QR code
3. Press on Consent "Warn others" granted button (on the bottom of Test Results fragment)