### PR TITLE
Fix long loading times for legal texts

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/fragment_information_privacy.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_information_privacy.xml
@@ -10,62 +10,39 @@
 
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <LinearLayout
         android:id="@+id/information_privacy_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:orientation="vertical"
         android:focusable="true"
         android:contentDescription="@string/information_privacy_title">
 
         <include
             android:id="@+id/information_privacy_header"
             layout="@layout/include_header"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:icon="@{@drawable/ic_back}"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
             app:title="@{@string/information_privacy_title}" />
 
         <ScrollView
-            android:layout_width="@dimen/match_constraint"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:fillViewport="true"
-            app:layout_constraintBottom_toBottomOf="@+id/guideline_bottom"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/information_privacy_header">
+            android:paddingBottom="@dimen/guideline_bottom">
 
-            <androidx.constraintlayout.widget.ConstraintLayout
+            <include
+                android:id="@+id/information_privacy_header_details"
+                layout="@layout/include_information_details"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content">
-
-                <include
-                    android:id="@+id/information_privacy_header_details"
-                    layout="@layout/include_information_details"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    app:illustration="@{@drawable/ic_illustration_privacy}"
-                    app:illustrationDescription="@{@string/information_privacy_illustration_description}"
-                    app:body="@{FormatterHelper.formatStringAsHTMLFromLocal(@string/information_privacy_html_path)}"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
-
-                <include layout="@layout/merge_guidelines_side" />
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
+                android:layout_height="wrap_content"
+                app:illustration="@{@drawable/ic_illustration_privacy}"
+                app:illustrationDescription="@{@string/information_privacy_illustration_description}"
+                app:body="@{FormatterHelper.formatStringAsHTMLFromLocal(@string/information_privacy_html_path)}" />
 
         </ScrollView>
 
-        <androidx.constraintlayout.widget.Guideline
-            android:id="@+id/guideline_bottom"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            app:layout_constraintGuide_end="@dimen/guideline_bottom" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </LinearLayout>
 
 </layout>

--- a/Corona-Warn-App/src/main/res/layout/fragment_information_technical.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_information_technical.xml
@@ -10,62 +10,39 @@
 
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <LinearLayout
         android:id="@+id/information_technical_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:orientation="vertical"
         android:focusable="true"
         android:contentDescription="@string/information_technical_title">
 
         <include
             android:id="@+id/information_technical_header"
             layout="@layout/include_header"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:icon="@{@drawable/ic_back}"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
             app:title="@{@string/information_technical_title}" />
 
         <ScrollView
-            android:layout_width="@dimen/match_constraint"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:fillViewport="true"
-            app:layout_constraintBottom_toBottomOf="@+id/guideline_bottom"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/information_technical_header">
+            android:paddingBottom="@dimen/guideline_bottom">
 
-            <androidx.constraintlayout.widget.ConstraintLayout
+            <include
+                android:id="@+id/information_technical_header_details"
+                layout="@layout/include_information_details"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent">
-
-                <include
-                    android:id="@+id/information_technical_header_details"
-                    layout="@layout/include_information_details"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    app:body="@{FormatterHelper.formatStringAsHTMLFromLocal(@string/information_technical_html_path)}"
-                    app:illustration="@{@drawable/ic_information_illustration_technical}"
-                    app:illustrationDescription="@{@string/information_technical_illustration_description}"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
-
-                <include layout="@layout/merge_guidelines_side" />
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
+                android:layout_height="wrap_content"
+                app:body="@{FormatterHelper.formatStringAsHTMLFromLocal(@string/information_technical_html_path)}"
+                app:illustration="@{@drawable/ic_information_illustration_technical}"
+                app:illustrationDescription="@{@string/information_technical_illustration_description}"/>
 
         </ScrollView>
 
-        <androidx.constraintlayout.widget.Guideline
-            android:id="@+id/guideline_bottom"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            app:layout_constraintGuide_end="@dimen/guideline_bottom" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </LinearLayout>
 
 </layout>

--- a/Corona-Warn-App/src/main/res/layout/include_information_details.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_information_details.xml
@@ -25,47 +25,44 @@
             type="CharSequence" />
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
         <ImageView
             android:id="@+id/information_details_header_illustration"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             bind:cwaContentDescription="@{illustrationDescription}"
             android:focusable="true"
             android:src="@{illustration}"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
             tools:src="@drawable/ic_illustration_tracing_on"
             tools:ignore="ContentDescription" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintTop_toBottomOf="@+id/information_details_header_illustration">
+            android:orientation="vertical"
+            android:paddingStart="@dimen/guideline_start"
+            android:paddingEnd="@dimen/guideline_end">
 
             <TextView
                 android:id="@+id/information_details_header_headline"
                 style="@style/headline5"
-                android:layout_width="0dp"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_small"
                 android:accessibilityHeading="true"
                 android:focusable="true"
                 android:text="@{headline}"
                 android:visibility="@{FormatterHelper.formatVisibilityText(headline)}"
-                app:layout_constraintEnd_toEndOf="@id/guideline_end"
-                app:layout_constraintStart_toStartOf="@id/guideline_start"
-                app:layout_constraintTop_toTopOf="parent"
                 tools:text="@string/settings_title" />
 
             <TextView
                 android:id="@+id/information_details_header_body"
                 style="@style/subtitle"
-                android:layout_width="0dp"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_medium"
                 android:focusable="true"
@@ -73,26 +70,10 @@
                 android:visibility="@{FormatterHelper.formatVisibilityText(body)}"
                 android:autoLink="all"
                 android:textColorLink="@color/colorTextTint"
-                app:layout_constraintEnd_toEndOf="@id/guideline_end"
-                app:layout_constraintStart_toStartOf="@id/guideline_start"
-                app:layout_constraintTop_toBottomOf="@+id/information_details_header_headline"
                 tools:text="@string/settings_title" />
 
-            <androidx.constraintlayout.widget.Guideline
-                android:id="@+id/guideline_start"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                app:layout_constraintGuide_begin="@dimen/guideline_start" />
+        </LinearLayout>
 
-            <androidx.constraintlayout.widget.Guideline
-                android:id="@+id/guideline_end"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                app:layout_constraintGuide_end="@dimen/guideline_end" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </LinearLayout>
 
 </layout>


### PR DESCRIPTION
For myself and others I've asked, long texts like the privacy policy and the licenses take long to load for no good reason. The application "hangs" for a few seconds because some action (namely, rendering the layout – the `Html.fromHtml` call itself is a lot quicker) is performed on the main thread.

I used the profiler to determine that most of the time gets wasted for measuring layouts, which is an action that the `ConstraintsLayout` performs. I don't see a reason to use `ConstraintsLayout` in this location, as it is a quite simple layout which is able to render a lot faster when using `LinearLayout`.

Therefore, I propose to use `LinearLayout` in this location. It should also improve the loading times for other screens, but it is most noticeable with the long legal texts.