### PR TITLE
Fixed legacy config (EXPOSUREAPP-4195)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/appconfig/internal/ConfigDataContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/appconfig/internal/ConfigDataContainer.kt
@@ -15,8 +15,10 @@ data class ConfigDataContainer(
 ) : ConfigData, ConfigMapping by mappedConfig {
     override val updatedAt: Instant = serverTime.plus(localOffset)
 
-    override fun isValid(nowUTC: Instant): Boolean {
+    override fun isValid(nowUTC: Instant): Boolean = if (cacheValidity == Duration.ZERO) {
+        false
+    } else {
         val expiresAt = updatedAt.plus(cacheValidity)
-        return nowUTC.isBefore(expiresAt)
+        nowUTC.isBefore(expiresAt)
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/appconfig/sources/local/AppConfigStorage.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/appconfig/sources/local/AppConfigStorage.kt
@@ -49,10 +49,10 @@ class AppConfigStorage @Inject constructor(
             return@withLock try {
                 InternalConfigData(
                     rawData = legacyConfigFile.readBytes(),
-                    serverTime = timeStamper.nowUTC,
+                    serverTime = Instant.ofEpochMilli(legacyConfigFile.lastModified()),
                     localOffset = Duration.ZERO,
                     etag = "legacy.migration",
-                    cacheValidity = Duration.standardMinutes(5)
+                    cacheValidity = Duration.standardSeconds(0)
                 )
             } catch (e: Exception) {
                 Timber.e(e, "Legacy config exits but couldn't be read.")
@@ -80,6 +80,12 @@ class AppConfigStorage @Inject constructor(
             Timber.v("Overwriting %d from %s", configFile.length(), configFile.lastModified())
         }
 
+        if (legacyConfigFile.exists()) {
+            if (legacyConfigFile.delete()) {
+                Timber.i("Legacy config file deleted, superseeded.")
+            }
+        }
+
         if (value == null) {
             if (configFile.delete()) Timber.d("Config file was deleted (value=null).")
             return
@@ -87,12 +93,6 @@ class AppConfigStorage @Inject constructor(
 
         try {
             gson.toJson(value, configFile)
-
-            if (legacyConfigFile.exists()) {
-                if (legacyConfigFile.delete()) {
-                    Timber.i("Legacy config file deleted, superseeded.")
-                }
-            }
         } catch (e: Exception) {
             // We'll not rethrow as we could still keep working just with the remote config,
             // but we will notify the user.

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/appconfig/internal/ConfigDataContainerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/appconfig/internal/ConfigDataContainerTest.kt
@@ -48,6 +48,10 @@ class ConfigDataContainerTest : BaseTest() {
         config.isValid(Instant.EPOCH.plus(Duration.standardHours(1))) shouldBe false
         config.isValid(Instant.EPOCH.plus(Duration.standardHours(24))) shouldBe false
         config.isValid(Instant.EPOCH.plus(Duration.standardDays(14))) shouldBe false
+
+        config.isValid(Instant.EPOCH.minus(Duration.standardHours(1))) shouldBe false
+        config.isValid(Instant.EPOCH.minus(Duration.standardHours(24))) shouldBe false
+        config.isValid(Instant.EPOCH.minus(Duration.standardDays(14))) shouldBe false
     }
 
     @Test

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/appconfig/internal/ConfigDataContainerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/appconfig/internal/ConfigDataContainerTest.kt
@@ -1,0 +1,65 @@
+package de.rki.coronawarnapp.appconfig.internal
+
+import de.rki.coronawarnapp.appconfig.ConfigData
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.joda.time.Duration
+import org.joda.time.Instant
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class ConfigDataContainerTest : BaseTest() {
+
+    @Test
+    fun `cache validity is evaluated`() {
+        val now = Instant.EPOCH
+        val config = ConfigDataContainer(
+            serverTime = now,
+            localOffset = Duration.standardHours(1),
+            mappedConfig = mockk(),
+            configType = ConfigData.Type.LAST_RETRIEVED,
+            identifier = "localetag",
+            cacheValidity = Duration.standardSeconds(300)
+        )
+        config.isValid(now) shouldBe true
+        config.isValid(now.plus(Duration.standardSeconds(300))) shouldBe true
+        config.isValid(now.minus(Duration.standardSeconds(300))) shouldBe true
+
+        val nowWithOffset = now.plus(config.localOffset)
+        config.isValid(nowWithOffset.plus(Duration.standardSeconds(299))) shouldBe true
+        config.isValid(nowWithOffset.minus(Duration.standardSeconds(299))) shouldBe true
+
+        config.isValid(nowWithOffset) shouldBe true
+        config.isValid(nowWithOffset.minus(Duration.standardSeconds(300))) shouldBe true
+        config.isValid(nowWithOffset.plus(Duration.standardSeconds(300))) shouldBe false
+    }
+
+    @Test
+    fun `cache validity can be set to 0`() {
+        val config = ConfigDataContainer(
+            serverTime = Instant.EPOCH,
+            localOffset = Duration.standardHours(1),
+            mappedConfig = mockk(),
+            configType = ConfigData.Type.LAST_RETRIEVED,
+            identifier = "localetag",
+            cacheValidity = Duration.standardSeconds(0)
+        )
+        config.isValid(Instant.EPOCH) shouldBe false
+        config.isValid(Instant.EPOCH.plus(Duration.standardHours(1))) shouldBe false
+        config.isValid(Instant.EPOCH.plus(Duration.standardHours(24))) shouldBe false
+        config.isValid(Instant.EPOCH.plus(Duration.standardDays(14))) shouldBe false
+    }
+
+    @Test
+    fun `updated at is based on servertime and offset`() {
+        val config = ConfigDataContainer(
+            serverTime = Instant.EPOCH,
+            localOffset = Duration.standardHours(1),
+            mappedConfig = mockk(),
+            configType = ConfigData.Type.LAST_RETRIEVED,
+            identifier = "localetag",
+            cacheValidity = Duration.standardSeconds(0)
+        )
+        config.updatedAt shouldBe Instant.EPOCH.plus(Duration.standardHours(1))
+    }
+}


### PR DESCRIPTION
The problem was that the legacy config had a wrong time stamp and therefor was sometimes not considered outdated.
This leads to some Apps being updated from <= 1.6 to >= 1.7 to not always download remote config.
Test:

1. install 1.6.x
2. update to 1.7.x
3. config should be downloaded on first access (for instance when displaying interop countries)