### PR TITLE
Adjust "abort warn others" dialog (EXPOSUREAPP-4253)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/testresult/positive/SubmissionTestResultNoConsentFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/testresult/positive/SubmissionTestResultNoConsentFragment.kt
@@ -65,8 +65,10 @@ class SubmissionTestResultNoConsentFragment : Fragment(R.layout.fragment_submiss
         AlertDialog.Builder(requireContext()).apply {
             setTitle(R.string.submission_test_result_positive_no_consent_dialog_title)
             setMessage(R.string.submission_test_result_positive_no_consent_dialog_message)
-            setPositiveButton(R.string.submission_test_result_positive_no_consent_dialog_positive_button) { _, _ -> }
-            setNegativeButton(R.string.submission_test_result_positive_no_consent_dialog_negative_button) { _, _ ->
+            setNegativeButton(R.string.submission_test_result_positive_no_consent_dialog_positive_button) { _, _ ->
+
+            }
+            setPositiveButton(R.string.submission_test_result_positive_no_consent_dialog_negative_button) { _, _ ->
                 navigateToHome()
             }
         }.show()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/testresult/positive/SubmissionTestResultNoConsentFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/testresult/positive/SubmissionTestResultNoConsentFragment.kt
@@ -65,9 +65,7 @@ class SubmissionTestResultNoConsentFragment : Fragment(R.layout.fragment_submiss
         AlertDialog.Builder(requireContext()).apply {
             setTitle(R.string.submission_test_result_positive_no_consent_dialog_title)
             setMessage(R.string.submission_test_result_positive_no_consent_dialog_message)
-            setPositiveButton(R.string.submission_test_result_positive_no_consent_dialog_positive_button) { _, _ ->
-                navigateToWarnOthers()
-            }
+            setPositiveButton(R.string.submission_test_result_positive_no_consent_dialog_positive_button) { _, _ -> }
             setNegativeButton(R.string.submission_test_result_positive_no_consent_dialog_negative_button) { _, _ ->
                 navigateToHome()
             }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/testresult/positive/SubmissionTestResultNoConsentFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/testresult/positive/SubmissionTestResultNoConsentFragment.kt
@@ -67,7 +67,6 @@ class SubmissionTestResultNoConsentFragment : Fragment(R.layout.fragment_submiss
             setTitle(R.string.submission_test_result_positive_no_consent_dialog_title)
             setMessage(R.string.submission_test_result_positive_no_consent_dialog_message)
             setNegativeButton(R.string.submission_test_result_positive_no_consent_dialog_positive_button) { _, _ ->
-
             }
             setPositiveButton(R.string.submission_test_result_positive_no_consent_dialog_negative_button) { _, _ ->
                 navigateToHome()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/testresult/positive/SubmissionTestResultNoConsentFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/testresult/positive/SubmissionTestResultNoConsentFragment.kt
@@ -44,15 +44,16 @@ class SubmissionTestResultNoConsentFragment : Fragment(R.layout.fragment_submiss
                 .setTestResultSection(it.deviceUiState, it.testResultReceivedDate)
         }
 
-        binding.submissionTestResultConsentGivenHeader.headerButtonBack.buttonIcon.setOnClickListener {
-            showCancelDialog()
-        }
-
-        binding.submissionTestResultPositiveNoConsentButtonAbort.setOnClickListener {
-            showCancelDialog()
-        }
-        binding.submissionTestResultPositiveNoConsentButtonWarnOthers.setOnClickListener {
-            navigateToWarnOthers()
+        binding.apply {
+            submissionTestResultConsentGivenHeader.headerButtonBack.buttonIcon.setOnClickListener {
+                showCancelDialog()
+            }
+            submissionTestResultPositiveNoConsentButtonAbort.setOnClickListener {
+                showCancelDialog()
+            }
+            submissionTestResultPositiveNoConsentButtonWarnOthers.setOnClickListener {
+                navigateToWarnOthers()
+            }
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/testresult/positive/SubmissionTestResultNoConsentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/testresult/positive/SubmissionTestResultNoConsentViewModel.kt
@@ -5,44 +5,24 @@ import androidx.lifecycle.asLiveData
 import com.squareup.inject.assisted.AssistedInject
 import de.rki.coronawarnapp.storage.SubmissionRepository
 import de.rki.coronawarnapp.ui.submission.testresult.TestResultUIState
-import de.rki.coronawarnapp.util.DeviceUIState
-import de.rki.coronawarnapp.util.NetworkRequestWrapper.Companion.withSuccess
-import de.rki.coronawarnapp.util.ui.SingleLiveEvent
+import de.rki.coronawarnapp.util.flow.combine
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
 import de.rki.coronawarnapp.util.viewmodel.SimpleCWAViewModelFactory
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.combineTransform
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 
 class SubmissionTestResultNoConsentViewModel @AssistedInject constructor(
     val submissionRepository: SubmissionRepository
 ) : CWAViewModel() {
 
-    private val showRedeemedTokenWarning = SingleLiveEvent<Unit>()
-    private var wasRedeemedTokenErrorShown = false
-    private val tokenErrorMutex = Mutex()
-
-    val uiState: LiveData<TestResultUIState> = combineTransform(
+    val uiState: LiveData<TestResultUIState> = combine(
         submissionRepository.deviceUIStateFlow,
         submissionRepository.testResultReceivedDateFlow
     ) { deviceUiState, resultDate ->
 
-        tokenErrorMutex.withLock {
-            if (!wasRedeemedTokenErrorShown) {
-                deviceUiState.withSuccess {
-                    if (it == DeviceUIState.PAIRED_REDEEMED) {
-                        wasRedeemedTokenErrorShown = true
-                        showRedeemedTokenWarning.postValue(Unit)
-                    }
-                }
-            }
-        }
-
         TestResultUIState(
             deviceUiState = deviceUiState,
             testResultReceivedDate = resultDate
-        ).let { emit(it) }
+        )
     }.asLiveData(context = Dispatchers.Default)
 
     fun onTestOpened() {

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/main/home/SubmissionCardStateTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/main/home/SubmissionCardStateTest.kt
@@ -10,7 +10,6 @@ import de.rki.coronawarnapp.util.NetworkRequestWrapper
 import io.kotest.matchers.shouldBe
 import io.mockk.MockKAnnotations
 import io.mockk.clearAllMocks
-import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import io.mockk.verify
@@ -42,7 +41,11 @@ class SubmissionCardStateTest : BaseTest() {
     ) =
         when (uiStateState) {
             ApiRequestState.SUCCESS ->
-                SubmissionCardState(NetworkRequestWrapper.RequestSuccessful(deviceUiState), isDeviceRegistered, hasResultBeenSeen)
+                SubmissionCardState(
+                    NetworkRequestWrapper.RequestSuccessful(deviceUiState),
+                    isDeviceRegistered,
+                    hasResultBeenSeen
+                )
             ApiRequestState.FAILED ->
                 SubmissionCardState(NetworkRequestWrapper.RequestFailed(mockk()), isDeviceRegistered, hasResultBeenSeen)
             ApiRequestState.STARTED ->

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/update/UpdateCheckerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/update/UpdateCheckerTest.kt
@@ -29,7 +29,6 @@ class UpdateCheckerTest : BaseTest() {
         MockKAnnotations.init(this)
         mockkObject(BuildConfigWrap)
 
-
         coEvery { appConfigProvider.getAppConfig() } returns configData
     }
 


### PR DESCRIPTION
We no longer leave the screen if we cancel the cancel dialog :smile:.

* Change dialog cancel behavior. Stay on screen.
* Switch dialog button. The "positive" action is always in reference to the dialog's question. So positive here means to not warn others, while "warn others" is the negative action that cancels the dialog.
* Also removed some unused codes and did a little code cleanup.

## Testing
* Basically what is described in Jira: Positive TAN, press cancel on the test result screen, cancel the dialog.