### PR TITLE
Home screen only shows FAQ when leaving Consent (EXPOSUREAPP-4275)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/SubmissionCardState.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/SubmissionCardState.kt
@@ -61,7 +61,7 @@ data class SubmissionCardState(
     fun isPositiveSubmissionCardVisible(): Boolean =
         deviceUiState.withSuccess(false) {
             when (it) {
-                PAIRED_POSITIVE, PAIRED_POSITIVE_TELETAN -> !hasTestResultBeenSeen
+                PAIRED_POSITIVE, PAIRED_POSITIVE_TELETAN -> hasTestResultBeenSeen
                 else -> false
             }
         }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/main/home/SubmissionCardStateTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/main/home/SubmissionCardStateTest.kt
@@ -211,14 +211,14 @@ class SubmissionCardStateTest : BaseTest() {
         instance(
             deviceUiState = DeviceUIState.PAIRED_POSITIVE,
             uiStateState = ApiRequestState.SUCCESS,
-            hasResultBeenSeen = false
+            hasResultBeenSeen = true
         ).apply {
             isPositiveSubmissionCardVisible() shouldBe true
         }
         instance(
             deviceUiState = DeviceUIState.PAIRED_POSITIVE_TELETAN,
             uiStateState = ApiRequestState.SUCCESS,
-            hasResultBeenSeen = false
+            hasResultBeenSeen = true
         ).apply {
             isPositiveSubmissionCardVisible() shouldBe true
         }


### PR DESCRIPTION
### Description

Small condition change for the positive card to be shown. Short oversight on my part. Apologies. 

Positive test result _**should**_ be shown _**if test result has been seen**_. Adjusted the state function for this logic to be true. 

Adjusted tests to match. 

### Steps to reproduce
1.Scan positive QR code
4.Tap on "Continue" on the "Test Result is Available" screen
5.Tap on "Don't share" on the OS consent screen
6.Tap on "X" on the "Positive Test Result (no consent)" screen
8.Tap on "Don't warn" in the confirmation pop-up
9. _**Positive Test Result card should now be shown**_