### PR TITLE
Fix incorrect TRL data being applied to submitted TEKs (EXPOSUREAPP-4260)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/TransmissionRiskVectorDeterminator.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/TransmissionRiskVectorDeterminator.kt
@@ -49,15 +49,12 @@ class TransmissionRiskVectorDeterminator @Inject constructor(
                 is StartOf.NoInformation -> intArrayOf(5, 6, 8, 8, 8, 7, 5, 3, 2, 1, 1, 1, 1, 1, 1)
                 is StartOf.OneToTwoWeeksAgo -> intArrayOf(1, 1, 1, 1, 2, 3, 4, 5, 6, 6, 7, 7, 6, 6, 4)
                 else -> {
-                    try {
-                        throw IllegalStateException("Positive indication without startDate is not allowed: $symptoms")
-                    } catch (e: IllegalStateException) {
-                        e.reportProblem(
+                   IllegalStateException("Positive indication without startDate is not allowed: $symptoms")
+                   .reportProblem(
                             tag = "TransmissionRiskVectorDeterminator",
                             info = "Symptoms has an invalid state."
                         )
                         intArrayOf(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1)
-                    }
                 }
             }
             Indication.NEGATIVE -> intArrayOf(4, 4, 3, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/TransmissionRiskVectorDeterminator.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/TransmissionRiskVectorDeterminator.kt
@@ -49,12 +49,12 @@ class TransmissionRiskVectorDeterminator @Inject constructor(
                 is StartOf.NoInformation -> intArrayOf(5, 6, 8, 8, 8, 7, 5, 3, 2, 1, 1, 1, 1, 1, 1)
                 is StartOf.OneToTwoWeeksAgo -> intArrayOf(1, 1, 1, 1, 2, 3, 4, 5, 6, 6, 7, 7, 6, 6, 4)
                 else -> {
-                   IllegalStateException("Positive indication without startDate is not allowed: $symptoms")
-                   .reportProblem(
+                    IllegalStateException("Positive indication without startDate is not allowed: $symptoms")
+                        .reportProblem(
                             tag = "TransmissionRiskVectorDeterminator",
                             info = "Symptoms has an invalid state."
                         )
-                        intArrayOf(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1)
+                    intArrayOf(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1)
                 }
             }
             Indication.NEGATIVE -> intArrayOf(4, 4, 3, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/TransmissionRiskVectorDeterminator.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/TransmissionRiskVectorDeterminator.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.submission
 
 import dagger.Reusable
+import de.rki.coronawarnapp.bugreporting.reportProblem
 import de.rki.coronawarnapp.submission.Symptoms.Indication
 import de.rki.coronawarnapp.submission.Symptoms.StartOf
 import de.rki.coronawarnapp.util.TimeAndDateExtensions.ageInDays
@@ -47,9 +48,20 @@ class TransmissionRiskVectorDeterminator @Inject constructor(
                 is StartOf.MoreThanTwoWeeks -> intArrayOf(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 3, 4, 5)
                 is StartOf.NoInformation -> intArrayOf(5, 6, 8, 8, 8, 7, 5, 3, 2, 1, 1, 1, 1, 1, 1)
                 is StartOf.OneToTwoWeeksAgo -> intArrayOf(1, 1, 1, 1, 2, 3, 4, 5, 6, 6, 7, 7, 6, 6, 4)
-                else -> intArrayOf(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1)
+                else -> {
+                    try {
+                        throw IllegalStateException("Positive indication without startDate is not allowed: $symptoms")
+                    } catch (e: IllegalStateException) {
+                        e.reportProblem(
+                            tag = "TransmissionRiskVectorDeterminator",
+                            info = "Symptoms has an invalid state."
+                        )
+                        intArrayOf(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1)
+                    }
+                }
             }
             Indication.NEGATIVE -> intArrayOf(4, 4, 3, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1)
             Indication.NO_INFORMATION -> intArrayOf(5, 6, 7, 7, 7, 6, 4, 3, 2, 1, 1, 1, 1, 1, 1)
-        })
+        }
+    )
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/symptoms/calendar/SubmissionSymptomCalendarFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/symptoms/calendar/SubmissionSymptomCalendarFragment.kt
@@ -4,13 +4,12 @@ import android.content.res.ColorStateList
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.navArgs
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.FragmentSubmissionSymptomCalendarBinding
 import de.rki.coronawarnapp.submission.Symptoms
 import de.rki.coronawarnapp.ui.submission.SubmissionBlockingDialog
 import de.rki.coronawarnapp.ui.submission.SubmissionCancelDialog
-import de.rki.coronawarnapp.ui.submission.viewmodel.SubmissionNavigationEvents.NavigateToMainActivity
-import de.rki.coronawarnapp.ui.submission.viewmodel.SubmissionNavigationEvents.NavigateToResultPositiveOtherWarning
 import de.rki.coronawarnapp.util.di.AutoInject
 import de.rki.coronawarnapp.util.formatter.formatCalendarBackgroundButtonStyleByState
 import de.rki.coronawarnapp.util.formatter.formatCalendarButtonStyleByState
@@ -24,12 +23,14 @@ import javax.inject.Inject
 class SubmissionSymptomCalendarFragment : Fragment(R.layout.fragment_submission_symptom_calendar),
     AutoInject {
 
+    private val navArgs by navArgs<SubmissionSymptomCalendarFragmentArgs>()
+
     @Inject lateinit var viewModelFactory: CWAViewModelFactoryProvider.Factory
     private val viewModel: SubmissionSymptomCalendarViewModel by cwaViewModelsAssisted(
         factoryProducer = { viewModelFactory },
         constructorCall = { factory, _ ->
             factory as SubmissionSymptomCalendarViewModel.Factory
-            factory.create()
+            factory.create(navArgs.symptomIndication)
         }
     )
 
@@ -54,15 +55,7 @@ class SubmissionSymptomCalendarFragment : Fragment(R.layout.fragment_submission_
         }
 
         viewModel.routeToScreen.observe2(this) {
-            when (it) {
-                is NavigateToResultPositiveOtherWarning -> doNavigate(
-                    SubmissionSymptomCalendarFragmentDirections
-                        .actionSubmissionSymptomCalendarFragmentToSubmissionResultPositiveOtherWarningFragment()
-                )
-                is NavigateToMainActivity -> doNavigate(
-                    SubmissionSymptomCalendarFragmentDirections.actionSubmissionSymptomCalendarFragmentToMainFragment()
-                )
-            }
+            doNavigate(it)
         }
 
         viewModel.symptomStart.observe2(this) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/symptoms/calendar/SubmissionSymptomCalendarViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/symptoms/calendar/SubmissionSymptomCalendarViewModel.kt
@@ -59,12 +59,9 @@ class SubmissionSymptomCalendarViewModel @AssistedInject constructor(
 
     fun onDone() {
         if (symptomStartInternal.value == null) {
-            try {
-                throw IllegalStateException("Can't finish symptom indication without symptomStart value.")
-            } catch (e: IllegalStateException) {
-                e.reportProblem(tag = TAG, "UI should not allow symptom submission without start date.")
+           IllegalStateException("Can't finish symptom indication without symptomStart value.")
+           .reportProblem(tag = TAG, "UI should not allow symptom submission without start date.")
                 return
-            }
         }
         Timber.tag(TAG).d("onDone() clicked on calender screen.")
         submissionRepository.currentSymptoms.update {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/symptoms/calendar/SubmissionSymptomCalendarViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/symptoms/calendar/SubmissionSymptomCalendarViewModel.kt
@@ -59,9 +59,9 @@ class SubmissionSymptomCalendarViewModel @AssistedInject constructor(
 
     fun onDone() {
         if (symptomStartInternal.value == null) {
-           IllegalStateException("Can't finish symptom indication without symptomStart value.")
-           .reportProblem(tag = TAG, "UI should not allow symptom submission without start date.")
-                return
+            IllegalStateException("Can't finish symptom indication without symptomStart value.")
+                .reportProblem(tag = TAG, "UI should not allow symptom submission without start date.")
+            return
         }
         Timber.tag(TAG).d("onDone() clicked on calender screen.")
         submissionRepository.currentSymptoms.update {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/symptoms/calendar/SubmissionSymptomCalendarViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/symptoms/calendar/SubmissionSymptomCalendarViewModel.kt
@@ -1,28 +1,30 @@
 package de.rki.coronawarnapp.ui.submission.symptoms.calendar
 
 import androidx.lifecycle.asLiveData
+import androidx.navigation.NavDirections
+import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
+import de.rki.coronawarnapp.bugreporting.reportProblem
 import de.rki.coronawarnapp.storage.SubmissionRepository
 import de.rki.coronawarnapp.submission.Symptoms
-import de.rki.coronawarnapp.ui.submission.viewmodel.SubmissionNavigationEvents
 import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
 import de.rki.coronawarnapp.util.ui.SingleLiveEvent
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactory
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.joda.time.LocalDate
 import timber.log.Timber
 
 class SubmissionSymptomCalendarViewModel @AssistedInject constructor(
+    @Assisted val symptomIndication: Symptoms.Indication,
     dispatcherProvider: DispatcherProvider,
     private val submissionRepository: SubmissionRepository
 ) : CWAViewModel(dispatcherProvider = dispatcherProvider) {
 
-    val symptomStart = submissionRepository.currentSymptoms.flow
-        .map { it?.startOfSymptoms }
-        .asLiveData(context = dispatcherProvider.Default)
+    private val symptomStartInternal = MutableStateFlow<Symptoms.StartOf?>(null)
+    val symptomStart = symptomStartInternal.asLiveData(context = dispatcherProvider.Default)
 
-    val routeToScreen: SingleLiveEvent<SubmissionNavigationEvents> = SingleLiveEvent()
+    val routeToScreen = SingleLiveEvent<NavDirections>()
     val showCancelDialog = SingleLiveEvent<Unit>()
     val showUploadDialog = submissionRepository.isSubmissionRunning
         .asLiveData(context = dispatcherProvider.Default)
@@ -48,9 +50,7 @@ class SubmissionSymptomCalendarViewModel @AssistedInject constructor(
     }
 
     private fun updateSymptomStart(startOf: Symptoms.StartOf?) {
-        submissionRepository.currentSymptoms.update {
-            (it ?: Symptoms.NO_INFO_GIVEN).copy(startOfSymptoms = startOf)
-        }
+        symptomStartInternal.value = startOf
     }
 
     fun onCalendarPreviousClicked() {
@@ -58,7 +58,21 @@ class SubmissionSymptomCalendarViewModel @AssistedInject constructor(
     }
 
     fun onDone() {
-        Timber.d("onDone() clicked on calender screen.")
+        if (symptomStartInternal.value == null) {
+            try {
+                throw IllegalStateException("Can't finish symptom indication without symptomStart value.")
+            } catch (e: IllegalStateException) {
+                e.reportProblem(tag = TAG, "UI should not allow symptom submission without start date.")
+                return
+            }
+        }
+        Timber.tag(TAG).d("onDone() clicked on calender screen.")
+        submissionRepository.currentSymptoms.update {
+            Symptoms(
+                symptomIndication = symptomIndication,
+                startOfSymptoms = symptomStartInternal.value
+            ).also { Timber.tag(TAG).v("Symptoms updated to %s", it) }
+        }
         performSubmission()
     }
 
@@ -72,9 +86,11 @@ class SubmissionSymptomCalendarViewModel @AssistedInject constructor(
             try {
                 submissionRepository.startSubmission()
             } catch (e: Exception) {
-                Timber.e(e, "performSubmission() failed.")
+                Timber.tag(TAG).e(e, "performSubmission() failed.")
             } finally {
-                routeToScreen.postValue(SubmissionNavigationEvents.NavigateToMainActivity)
+                routeToScreen.postValue(
+                    SubmissionSymptomCalendarFragmentDirections.actionSubmissionSymptomCalendarFragmentToMainFragment()
+                )
             }
         }
     }
@@ -82,6 +98,10 @@ class SubmissionSymptomCalendarViewModel @AssistedInject constructor(
     @AssistedInject.Factory
     interface Factory : CWAViewModelFactory<SubmissionSymptomCalendarViewModel> {
 
-        fun create(): SubmissionSymptomCalendarViewModel
+        fun create(symptomIndication: Symptoms.Indication): SubmissionSymptomCalendarViewModel
+    }
+
+    companion object {
+        private const val TAG = "SymptomsCalenderVM"
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/symptoms/introduction/SubmissionSymptomIntroductionFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/symptoms/introduction/SubmissionSymptomIntroductionFragment.kt
@@ -9,7 +9,6 @@ import de.rki.coronawarnapp.databinding.FragmentSubmissionSymptomIntroBinding
 import de.rki.coronawarnapp.submission.Symptoms
 import de.rki.coronawarnapp.ui.submission.SubmissionBlockingDialog
 import de.rki.coronawarnapp.ui.submission.SubmissionCancelDialog
-import de.rki.coronawarnapp.ui.submission.viewmodel.SubmissionNavigationEvents
 import de.rki.coronawarnapp.util.di.AutoInject
 import de.rki.coronawarnapp.util.formatter.formatBackgroundButtonStyleByState
 import de.rki.coronawarnapp.util.formatter.formatButtonStyleByState
@@ -37,17 +36,8 @@ class SubmissionSymptomIntroductionFragment : Fragment(R.layout.fragment_submiss
         super.onViewCreated(view, savedInstanceState)
         uploadDialog = SubmissionBlockingDialog(requireContext())
 
-        viewModel.routeToScreen.observe2(this) {
-            when (it) {
-                is SubmissionNavigationEvents.NavigateToSymptomCalendar -> doNavigate(
-                    SubmissionSymptomIntroductionFragmentDirections
-                        .actionSubmissionSymptomIntroductionFragmentToSubmissionSymptomCalendarFragment()
-                )
-                is SubmissionNavigationEvents.NavigateToMainActivity -> doNavigate(
-                    SubmissionSymptomIntroductionFragmentDirections
-                        .actionSubmissionSymptomIntroductionFragmentToMainFragment()
-                )
-            }
+        viewModel.navigation.observe2(this) {
+            doNavigate(it)
         }
 
         viewModel.showCancelDialog.observe2(this) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/viewmodel/SubmissionNavigationEvents.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/viewmodel/SubmissionNavigationEvents.kt
@@ -3,23 +3,11 @@ package de.rki.coronawarnapp.ui.submission.viewmodel
 sealed class SubmissionNavigationEvents {
     object NavigateToContact : SubmissionNavigationEvents()
     object NavigateToDispatcher : SubmissionNavigationEvents()
-    object NavigateToSubmissionDone : SubmissionNavigationEvents()
-    object NavigateToSubmissionIntro : SubmissionNavigationEvents()
     object NavigateToQRCodeScan : SubmissionNavigationEvents()
     object NavigateToDataPrivacy : SubmissionNavigationEvents()
 
-    object NavigateToResultPositiveOtherWarning : SubmissionNavigationEvents()
-
-    object NavigateToResultPositiveOtherWarningNoConsent : SubmissionNavigationEvents()
-
-    object NavigateToSymptomSubmission : SubmissionNavigationEvents()
-    object NavigateToSymptomCalendar : SubmissionNavigationEvents()
-
     object NavigateToSymptomIntroduction : SubmissionNavigationEvents()
     object NavigateToTAN : SubmissionNavigationEvents()
-    object NavigateToTestResult : SubmissionNavigationEvents()
     object NavigateToConsent : SubmissionNavigationEvents()
-    object NavigateToYourConsent : SubmissionNavigationEvents()
     object NavigateToMainActivity : SubmissionNavigationEvents()
-    object ShowCancelDialog : SubmissionNavigationEvents()
 }

--- a/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
+++ b/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
@@ -374,6 +374,9 @@
         android:id="@+id/submissionSymptomCalendarFragment"
         android:name="de.rki.coronawarnapp.ui.submission.symptoms.calendar.SubmissionSymptomCalendarFragment"
         android:label="SubmissionSymptomCalendarFragment">
+        <argument
+            android:name="symptomIndication"
+            app:argType="de.rki.coronawarnapp.submission.Symptoms$Indication" />
         <action
             android:id="@+id/action_submissionCalendarFragment_to_submissionSymptomIntroductionFragment"
             app:destination="@id/submissionSymptomIntroductionFragment" />

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/symptoms/calendar/SubmissionSymptomCalendarViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/symptoms/calendar/SubmissionSymptomCalendarViewModelTest.kt
@@ -1,0 +1,114 @@
+package de.rki.coronawarnapp.ui.submission.symptoms.calendar
+
+import de.rki.coronawarnapp.storage.SubmissionRepository
+import de.rki.coronawarnapp.submission.Symptoms
+import de.rki.coronawarnapp.util.preferences.FlowPreference
+import io.kotest.matchers.shouldBe
+import io.mockk.MockKAnnotations
+import io.mockk.Runs
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerifySequence
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.just
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import org.joda.time.LocalDate
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import testhelpers.BaseTest
+import testhelpers.TestDispatcherProvider
+import testhelpers.extensions.InstantExecutorExtension
+import testhelpers.preferences.mockFlowPreference
+
+@ExtendWith(InstantExecutorExtension::class)
+class SubmissionSymptomCalendarViewModelTest : BaseTest() {
+
+    @MockK lateinit var submissionRepository: SubmissionRepository
+    private lateinit var currentSymptoms: FlowPreference<Symptoms?>
+
+    @BeforeEach
+    fun setUp() {
+        MockKAnnotations.init(this, relaxed = true)
+
+        currentSymptoms = mockFlowPreference(null)
+
+        every { submissionRepository.isSubmissionRunning } returns flowOf(false)
+        coEvery { submissionRepository.startSubmission() } just Runs
+        every { submissionRepository.currentSymptoms } returns currentSymptoms
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    private fun createViewModel(indication: Symptoms.Indication = Symptoms.Indication.POSITIVE) =
+        SubmissionSymptomCalendarViewModel(
+            symptomIndication = indication,
+            dispatcherProvider = TestDispatcherProvider,
+            submissionRepository = submissionRepository
+        )
+
+    @Test
+    fun `symptom indication is not written to settings`() {
+        createViewModel().apply {
+            onLastSevenDaysStart()
+            onOneToTwoWeeksAgoStart()
+            onMoreThanTwoWeeksStart()
+            onNoInformationStart()
+            onDateSelected(LocalDate.now())
+        }
+
+        verify(exactly = 0) { submissionRepository.currentSymptoms }
+    }
+
+    @Test
+    fun `submission by symptom completion updates symptom data`() {
+        createViewModel().apply {
+            onLastSevenDaysStart()
+            onDone()
+        }
+
+        coVerifySequence {
+            submissionRepository.isSubmissionRunning
+            submissionRepository.currentSymptoms
+            submissionRepository.startSubmission()
+        }
+
+        currentSymptoms.value shouldBe Symptoms(
+            startOfSymptoms = Symptoms.StartOf.LastSevenDays,
+            symptomIndication = Symptoms.Indication.POSITIVE
+        )
+    }
+
+    @Test
+    fun `submission by abort does not write any symptom data`() {
+        createViewModel().onCancelConfirmed()
+
+        coVerifySequence {
+            submissionRepository.isSubmissionRunning
+            submissionRepository.startSubmission()
+        }
+    }
+
+    @Test
+    fun `submission shows upload dialog`() {
+        val uploadStatus = MutableStateFlow(false)
+        every { submissionRepository.isSubmissionRunning } returns uploadStatus
+        createViewModel().apply {
+            showUploadDialog.observeForever { }
+            showUploadDialog.value shouldBe false
+
+            uploadStatus.value = true
+            showUploadDialog.value shouldBe true
+
+            uploadStatus.value = false
+            showUploadDialog.value shouldBe false
+        }
+    }
+}

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/symptoms/introduction/SubmissionSymptomIntroductionViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/symptoms/introduction/SubmissionSymptomIntroductionViewModelTest.kt
@@ -1,0 +1,124 @@
+package de.rki.coronawarnapp.ui.submission.symptoms.introduction
+
+import de.rki.coronawarnapp.storage.SubmissionRepository
+import de.rki.coronawarnapp.submission.Symptoms
+import io.kotest.matchers.shouldBe
+import io.mockk.MockKAnnotations
+import io.mockk.Runs
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifySequence
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.just
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import testhelpers.BaseTest
+import testhelpers.TestDispatcherProvider
+import testhelpers.extensions.InstantExecutorExtension
+
+@ExtendWith(InstantExecutorExtension::class)
+class SubmissionSymptomIntroductionViewModelTest : BaseTest() {
+
+    @MockK lateinit var submissionRepository: SubmissionRepository
+
+    @BeforeEach
+    fun setUp() {
+        MockKAnnotations.init(this, relaxed = true)
+
+        every { submissionRepository.isSubmissionRunning } returns flowOf(false)
+        coEvery { submissionRepository.startSubmission() } just Runs
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    private fun createViewModel() = SubmissionSymptomIntroductionViewModel(
+        dispatcherProvider = TestDispatcherProvider,
+        submissionRepository = submissionRepository
+    )
+
+    @Test
+    fun `symptom indication is not written to settings`() {
+        createViewModel().apply {
+            onPositiveSymptomIndication()
+            onNegativeSymptomIndication()
+            onNoInformationSymptomIndication()
+            onNextClicked()
+        }
+
+        verify(exactly = 0) { submissionRepository.currentSymptoms }
+    }
+
+    @Test
+    fun `positive symptom indication is forwarded using navigation arguments`() {
+        createViewModel().apply {
+            onPositiveSymptomIndication()
+            onNextClicked()
+            navigation.value shouldBe SubmissionSymptomIntroductionFragmentDirections
+                .actionSubmissionSymptomIntroductionFragmentToSubmissionSymptomCalendarFragment(
+                    symptomIndication = Symptoms.Indication.POSITIVE
+                )
+        }
+
+        verify(exactly = 0) { submissionRepository.currentSymptoms }
+    }
+
+    @Test
+    fun `negative symptom indication leads to submission`() {
+        createViewModel().apply {
+            onNegativeSymptomIndication()
+            onNextClicked()
+            navigation.value shouldBe SubmissionSymptomIntroductionFragmentDirections
+                .actionSubmissionSymptomIntroductionFragmentToMainFragment()
+        }
+
+        coVerify { submissionRepository.startSubmission() }
+    }
+
+    @Test
+    fun `no information symptom indication leads to cancel dialog`() {
+        createViewModel().apply {
+            onNoInformationSymptomIndication()
+            onNextClicked()
+            navigation.value shouldBe null
+            showCancelDialog.value shouldBe Unit
+        }
+
+        verify(exactly = 0) { submissionRepository.currentSymptoms }
+    }
+
+    @Test
+    fun `submission by abort does not write any symptom data`() {
+        createViewModel().onCancelConfirmed()
+
+        coVerifySequence {
+            submissionRepository.isSubmissionRunning
+            submissionRepository.startSubmission()
+        }
+    }
+
+    @Test
+    fun `submission shows upload dialog`() {
+        val uploadStatus = MutableStateFlow(false)
+        every { submissionRepository.isSubmissionRunning } returns uploadStatus
+        createViewModel().apply {
+            showUploadDialog.observeForever { }
+            showUploadDialog.value shouldBe false
+
+            uploadStatus.value = true
+            showUploadDialog.value shouldBe true
+
+            uploadStatus.value = false
+            showUploadDialog.value shouldBe false
+        }
+    }
+}


### PR DESCRIPTION
Because we stored the information "we have so far" on each symptom step, aborting early could lead to the constellation of `Symptoms(startOf=null,indication=POSITIVE)`. The new submission flow behavior was missunderstood.

This PR fixes the behavior by switching to the `1.8.x` style of symptom indication:
* Pass the indication from the indication fragment to the calendar fragment using navigation arguments
* Only when the symptom data is completed on the calendar fragment, is the internal `SubmissionSettings.currentSymptoms` value updated.


## Test
* The original issue can be reproduced by performing a positive submission, and on the symptom indication screen, select "yes", but then abort symptom indication via the `X` in the toolbar.