### PR TITLE
Thank you screen and card image adjustment (EXPOSUREAPP-4231)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/include_submission_done.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_submission_done.xml
@@ -18,7 +18,7 @@
                 android:layout_width="@dimen/match_constraint"
                 android:layout_height="wrap_content"
                 android:focusable="true"
-                android:src="@drawable/ic_submission_illustration_thanks"
+                android:src="@drawable/ic_illustration_together"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"

--- a/Corona-Warn-App/src/main/res/layout/include_submission_status_card_done.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_submission_status_card_done.xml
@@ -30,7 +30,7 @@
             android:layout_marginTop="@dimen/spacing_tiny"
             android:contentDescription="@string/submission_done_illustration_description"
             android:importantForAccessibility="no"
-            android:src="@drawable/ic_submission_illustration_thanks"
+            android:src="@drawable/ic_illustration_together"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/submission_done_card_title" />


### PR DESCRIPTION
### Description
There were some discrepancy observed in the designs. Designs were rectified and in response to that the App is updated as well

### Steps to reproduce
Submission Flow without consent. Please check the attached gif. 
Note: After thank yous creen there's a slight pause but you should see thank you card on the main screen. just see the gif through

### Screenshot
![thank you new image](https://user-images.githubusercontent.com/54317407/101911125-db588e80-3bb7-11eb-9677-6bdbcad92cfd.gif)

