### PR TITLE
Polish information fragments (DEV/Community)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/formatter/FormatterHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/formatter/FormatterHelper.kt
@@ -6,9 +6,9 @@ import android.content.Context
 import android.graphics.drawable.Drawable
 import android.text.Spanned
 import android.view.View
-import androidx.core.text.HtmlCompat
 import de.rki.coronawarnapp.CoronaWarnApplication
 import de.rki.coronawarnapp.R
+import de.rki.coronawarnapp.util.html.HtmlParser
 
 /*Style*/
 /**
@@ -129,13 +129,8 @@ fun formatColorIcon(color: Int?): Int {
     return color ?: appContext.getColor(R.color.colorAccentTintIcon)
 }
 
-fun formatStringAsHTMLFromLocal(path: String): Spanned {
-    val appContext = CoronaWarnApplication.getAppContext()
-    val content = appContext.assets.open(path).bufferedReader().use { it.readText() }
-    return HtmlCompat.fromHtml(
-        content,
-        HtmlCompat.FROM_HTML_MODE_LEGACY
-    )
+fun parseHtmlFromAssets(context: Context, path: String): Spanned {
+    return HtmlParser(context.assets).parseByASsetPath(path)
 }
 
 /**

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/formatter/FormatterHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/formatter/FormatterHelper.kt
@@ -130,7 +130,7 @@ fun formatColorIcon(color: Int?): Int {
 }
 
 fun parseHtmlFromAssets(context: Context, path: String): Spanned {
-    return HtmlParser(context.assets).parseByASsetPath(path)
+    return HtmlParser(context.assets).parseByAssetPath(path)
 }
 
 /**

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/html/HtmlParser.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/html/HtmlParser.kt
@@ -13,8 +13,8 @@ class HtmlParser @Inject constructor(
     private val assets: AssetManager
 ) {
 
-    fun parseByASsetPath(path: String): Spanned = assets.open(path).bufferedReader().use {
-        Timber.v("parseByPath($path)")
+    fun parseByAssetPath(path: String): Spanned = assets.open(path).bufferedReader().use {
+        Timber.v("parseByAssetPath($path)")
         parse(it.readText())
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/html/HtmlParser.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/html/HtmlParser.kt
@@ -1,0 +1,28 @@
+package de.rki.coronawarnapp.util.html
+
+import android.content.res.AssetManager
+import android.text.Spanned
+import androidx.core.text.HtmlCompat
+import dagger.Reusable
+import de.rki.coronawarnapp.util.debug.measureTimeMillisWithResult
+import timber.log.Timber
+import javax.inject.Inject
+
+@Reusable
+class HtmlParser @Inject constructor(
+    private val assets: AssetManager
+) {
+
+    fun parseByASsetPath(path: String): Spanned = assets.open(path).bufferedReader().use {
+        Timber.v("parseByPath($path)")
+        parse(it.readText())
+    }
+
+    fun parse(html: String): Spanned {
+        val (result, time) = measureTimeMillisWithResult {
+            HtmlCompat.fromHtml(html, HtmlCompat.FROM_HTML_MODE_LEGACY)
+        }
+        Timber.v("parse(html.length=${html.length}) took ${time}ms")
+        return result
+    }
+}

--- a/Corona-Warn-App/src/main/res/layout/fragment_information_legal.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_information_legal.xml
@@ -80,7 +80,7 @@
 
                 <TextView
                     android:id="@+id/information_legal_headline_contact"
-                    style="@style/headline5"
+                    style="@style/headline6"
                     android:accessibilityHeading="true"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
@@ -126,7 +126,7 @@
 
                 <TextView
                     android:id="@+id/information_legal_headline_taxid"
-                    style="@style/headline5"
+                    style="@style/headline6"
                     android:accessibilityHeading="true"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"

--- a/Corona-Warn-App/src/main/res/layout/fragment_information_privacy.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_information_privacy.xml
@@ -14,9 +14,9 @@
         android:id="@+id/information_privacy_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical"
+        android:contentDescription="@string/information_privacy_title"
         android:focusable="true"
-        android:contentDescription="@string/information_privacy_title">
+        android:orientation="vertical">
 
         <include
             android:id="@+id/information_privacy_header"
@@ -37,9 +37,9 @@
                 layout="@layout/include_information_details"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                app:body="@{FormatterHelper.parseHtmlFromAssets(context, @string/information_privacy_html_path)}"
                 app:illustration="@{@drawable/ic_illustration_privacy}"
-                app:illustrationDescription="@{@string/information_privacy_illustration_description}"
-                app:body="@{FormatterHelper.formatStringAsHTMLFromLocal(@string/information_privacy_html_path)}" />
+                app:illustrationDescription="@{@string/information_privacy_illustration_description}" />
 
         </ScrollView>
 

--- a/Corona-Warn-App/src/main/res/layout/fragment_information_privacy.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_information_privacy.xml
@@ -10,62 +10,39 @@
 
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <LinearLayout
         android:id="@+id/information_privacy_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:orientation="vertical"
         android:focusable="true"
         android:contentDescription="@string/information_privacy_title">
 
         <include
             android:id="@+id/information_privacy_header"
             layout="@layout/include_header"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:icon="@{@drawable/ic_back}"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
             app:title="@{@string/information_privacy_title}" />
 
         <ScrollView
-            android:layout_width="@dimen/match_constraint"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:fillViewport="true"
-            app:layout_constraintBottom_toBottomOf="@+id/guideline_bottom"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/information_privacy_header">
+            android:paddingBottom="@dimen/guideline_bottom">
 
-            <androidx.constraintlayout.widget.ConstraintLayout
+            <include
+                android:id="@+id/information_privacy_header_details"
+                layout="@layout/include_information_details"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content">
-
-                <include
-                    android:id="@+id/information_privacy_header_details"
-                    layout="@layout/include_information_details"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    app:illustration="@{@drawable/ic_illustration_privacy}"
-                    app:illustrationDescription="@{@string/information_privacy_illustration_description}"
-                    app:body="@{FormatterHelper.formatStringAsHTMLFromLocal(@string/information_privacy_html_path)}"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
-
-                <include layout="@layout/merge_guidelines_side" />
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
+                android:layout_height="wrap_content"
+                app:illustration="@{@drawable/ic_illustration_privacy}"
+                app:illustrationDescription="@{@string/information_privacy_illustration_description}"
+                app:body="@{FormatterHelper.formatStringAsHTMLFromLocal(@string/information_privacy_html_path)}" />
 
         </ScrollView>
 
-        <androidx.constraintlayout.widget.Guideline
-            android:id="@+id/guideline_bottom"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            app:layout_constraintGuide_end="@dimen/guideline_bottom" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </LinearLayout>
 
 </layout>

--- a/Corona-Warn-App/src/main/res/layout/fragment_information_technical.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_information_technical.xml
@@ -10,62 +10,39 @@
 
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <LinearLayout
         android:id="@+id/information_technical_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:orientation="vertical"
         android:focusable="true"
         android:contentDescription="@string/information_technical_title">
 
         <include
             android:id="@+id/information_technical_header"
             layout="@layout/include_header"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:icon="@{@drawable/ic_back}"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
             app:title="@{@string/information_technical_title}" />
 
         <ScrollView
-            android:layout_width="@dimen/match_constraint"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:fillViewport="true"
-            app:layout_constraintBottom_toBottomOf="@+id/guideline_bottom"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/information_technical_header">
+            android:paddingBottom="@dimen/guideline_bottom">
 
-            <androidx.constraintlayout.widget.ConstraintLayout
+            <include
+                android:id="@+id/information_technical_header_details"
+                layout="@layout/include_information_details"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent">
-
-                <include
-                    android:id="@+id/information_technical_header_details"
-                    layout="@layout/include_information_details"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    app:body="@{FormatterHelper.formatStringAsHTMLFromLocal(@string/information_technical_html_path)}"
-                    app:illustration="@{@drawable/ic_information_illustration_technical}"
-                    app:illustrationDescription="@{@string/information_technical_illustration_description}"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
-
-                <include layout="@layout/merge_guidelines_side" />
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
+                android:layout_height="wrap_content"
+                app:body="@{FormatterHelper.formatStringAsHTMLFromLocal(@string/information_technical_html_path)}"
+                app:illustration="@{@drawable/ic_information_illustration_technical}"
+                app:illustrationDescription="@{@string/information_technical_illustration_description}"/>
 
         </ScrollView>
 
-        <androidx.constraintlayout.widget.Guideline
-            android:id="@+id/guideline_bottom"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            app:layout_constraintGuide_end="@dimen/guideline_bottom" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </LinearLayout>
 
 </layout>

--- a/Corona-Warn-App/src/main/res/layout/fragment_information_technical.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_information_technical.xml
@@ -14,9 +14,9 @@
         android:id="@+id/information_technical_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical"
+        android:contentDescription="@string/information_technical_title"
         android:focusable="true"
-        android:contentDescription="@string/information_technical_title">
+        android:orientation="vertical">
 
         <include
             android:id="@+id/information_technical_header"
@@ -37,9 +37,9 @@
                 layout="@layout/include_information_details"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:body="@{FormatterHelper.formatStringAsHTMLFromLocal(@string/information_technical_html_path)}"
+                app:body="@{FormatterHelper.parseHtmlFromAssets(context, @string/information_technical_html_path)}"
                 app:illustration="@{@drawable/ic_information_illustration_technical}"
-                app:illustrationDescription="@{@string/information_technical_illustration_description}"/>
+                app:illustrationDescription="@{@string/information_technical_illustration_description}" />
 
         </ScrollView>
 

--- a/Corona-Warn-App/src/main/res/layout/fragment_information_terms.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_information_terms.xml
@@ -14,8 +14,8 @@
         android:id="@+id/information_terms_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:focusable="true"
-        android:contentDescription="@string/information_terms_title">
+        android:contentDescription="@string/information_terms_title"
+        android:focusable="true">
 
         <include
             android:id="@+id/information_terms_header"
@@ -46,7 +46,7 @@
                     layout="@layout/include_information_details"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    app:body="@{FormatterHelper.formatStringAsHTMLFromLocal(@string/information_terms_html_path)}"
+                    app:body="@{FormatterHelper.parseHtmlFromAssets(context, @string/information_terms_html_path)}"
                     app:headline="@{@string/information_terms_headline}"
                     app:illustration="@{@drawable/ic_information_illustration_terms}"
                     app:illustrationDescription="@{@string/information_terms_illustration_description}"

--- a/Corona-Warn-App/src/main/res/layout/fragment_information_terms.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_information_terms.xml
@@ -10,75 +10,37 @@
 
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <LinearLayout
         android:id="@+id/information_terms_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:contentDescription="@string/information_terms_title"
-        android:focusable="true">
+        android:focusable="true"
+        android:orientation="vertical">
 
         <include
             android:id="@+id/information_terms_header"
             layout="@layout/include_header"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:icon="@{@drawable/ic_back}"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
             app:title="@{@string/information_terms_title}" />
 
         <ScrollView
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:fillViewport="true"
-            app:layout_constraintBottom_toBottomOf="@+id/guideline_bottom"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/information_terms_header">
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:fillViewport="true">
 
-            <androidx.constraintlayout.widget.ConstraintLayout
+            <include
+                android:id="@+id/information_terms_header_details"
+                layout="@layout/include_information_details"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent">
-
-                <include
-                    android:id="@+id/information_terms_header_details"
-                    layout="@layout/include_information_details"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    app:body="@{FormatterHelper.parseHtmlFromAssets(context, @string/information_terms_html_path)}"
-                    app:headline="@{@string/information_terms_headline}"
-                    app:illustration="@{@drawable/ic_information_illustration_terms}"
-                    app:illustrationDescription="@{@string/information_terms_illustration_description}"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
-
-                <androidx.constraintlayout.widget.Guideline
-                    android:id="@+id/guideline_start"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    app:layout_constraintGuide_begin="@dimen/guideline_start" />
-
-                <androidx.constraintlayout.widget.Guideline
-                    android:id="@+id/guideline_end"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    app:layout_constraintGuide_end="@dimen/guideline_end" />
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
+                android:layout_height="wrap_content"
+                app:body="@{FormatterHelper.parseHtmlFromAssets(context, @string/information_terms_html_path)}"
+                app:headline="@{@string/information_terms_headline}"
+                app:illustration="@{@drawable/ic_information_illustration_terms}"
+                app:illustrationDescription="@{@string/information_terms_illustration_description}" />
 
         </ScrollView>
-
-        <androidx.constraintlayout.widget.Guideline
-            android:id="@+id/guideline_bottom"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            app:layout_constraintGuide_end="@dimen/guideline_bottom" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
+    </LinearLayout>
 </layout>

--- a/Corona-Warn-App/src/main/res/layout/fragment_onboarding_privacy.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_onboarding_privacy.xml
@@ -12,8 +12,8 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:contentDescription="@string/onboarding_privacy_accessibility_title"
-        android:focusable="true"
-        android:fillViewport="true">
+        android:fillViewport="true"
+        android:focusable="true">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/onboarding_header"
@@ -48,8 +48,8 @@
             android:layout_width="@dimen/match_constraint"
             android:layout_height="@dimen/match_constraint"
             android:layout_marginBottom="@dimen/spacing_small"
+            app:body="@{FormatterHelper.parseHtmlFromAssets(context, @string/information_privacy_html_path)}"
             app:headline="@{@string/onboarding_privacy_headline}"
-            app:body="@{FormatterHelper.formatStringAsHTMLFromLocal(@string/information_privacy_html_path)}"
             app:illustration="@{@drawable/ic_illustration_privacy}"
             app:illustrationDescription="@{@string/onboarding_privacy_illustration_description}"
             app:layout_constraintBottom_toTopOf="@+id/onboarding_button_next"

--- a/Corona-Warn-App/src/main/res/layout/include_information_details.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_information_details.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:bind="http://schemas.android.com/apk/res-auto"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
@@ -34,45 +33,40 @@
             android:id="@+id/information_details_header_illustration"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            bind:cwaContentDescription="@{illustrationDescription}"
             android:focusable="true"
             android:src="@{illustration}"
-            tools:src="@drawable/ic_illustration_tracing_on"
-            tools:ignore="ContentDescription" />
+            bind:cwaContentDescription="@{illustrationDescription}"
+            tools:ignore="ContentDescription"
+            tools:src="@drawable/ic_information_illustration_terms" />
 
-        <LinearLayout
+        <TextView
+            android:id="@+id/information_details_header_headline"
+            style="@style/headline5"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:paddingStart="@dimen/guideline_start"
-            android:paddingEnd="@dimen/guideline_end">
+            android:layout_marginStart="@dimen/spacing_normal"
+            android:layout_marginTop="@dimen/spacing_small"
+            android:layout_marginEnd="@dimen/spacing_normal"
+            android:accessibilityHeading="true"
+            android:focusable="true"
+            android:text="@{headline}"
+            android:visibility="@{FormatterHelper.formatVisibilityText(headline)}"
+            tools:text="@string/settings_title" />
 
-            <TextView
-                android:id="@+id/information_details_header_headline"
-                style="@style/headline5"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/spacing_small"
-                android:accessibilityHeading="true"
-                android:focusable="true"
-                android:text="@{headline}"
-                android:visibility="@{FormatterHelper.formatVisibilityText(headline)}"
-                tools:text="@string/settings_title" />
-
-            <TextView
-                android:id="@+id/information_details_header_body"
-                style="@style/subtitle"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/spacing_medium"
-                android:focusable="true"
-                android:text="@{body}"
-                android:visibility="@{FormatterHelper.formatVisibilityText(body)}"
-                android:autoLink="all"
-                android:textColorLink="@color/colorTextTint"
-                tools:text="@string/settings_title" />
-
-        </LinearLayout>
+        <TextView
+            android:id="@+id/information_details_header_body"
+            style="@style/subtitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/spacing_normal"
+            android:layout_marginTop="@dimen/spacing_medium"
+            android:layout_marginEnd="@dimen/spacing_normal"
+            android:autoLink="all"
+            android:focusable="true"
+            android:text="@{body}"
+            android:textColorLink="@color/colorTextTint"
+            android:visibility="@{FormatterHelper.formatVisibilityText(body)}"
+            tools:text="@string/settings_title" />
 
     </LinearLayout>
 

--- a/Corona-Warn-App/src/main/res/layout/include_information_details.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_information_details.xml
@@ -25,47 +25,44 @@
             type="CharSequence" />
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
         <ImageView
             android:id="@+id/information_details_header_illustration"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             bind:cwaContentDescription="@{illustrationDescription}"
             android:focusable="true"
             android:src="@{illustration}"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
             tools:src="@drawable/ic_illustration_tracing_on"
             tools:ignore="ContentDescription" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintTop_toBottomOf="@+id/information_details_header_illustration">
+            android:orientation="vertical"
+            android:paddingStart="@dimen/guideline_start"
+            android:paddingEnd="@dimen/guideline_end">
 
             <TextView
                 android:id="@+id/information_details_header_headline"
                 style="@style/headline5"
-                android:layout_width="0dp"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_small"
                 android:accessibilityHeading="true"
                 android:focusable="true"
                 android:text="@{headline}"
                 android:visibility="@{FormatterHelper.formatVisibilityText(headline)}"
-                app:layout_constraintEnd_toEndOf="@id/guideline_end"
-                app:layout_constraintStart_toStartOf="@id/guideline_start"
-                app:layout_constraintTop_toTopOf="parent"
                 tools:text="@string/settings_title" />
 
             <TextView
                 android:id="@+id/information_details_header_body"
                 style="@style/subtitle"
-                android:layout_width="0dp"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_medium"
                 android:focusable="true"
@@ -73,26 +70,10 @@
                 android:visibility="@{FormatterHelper.formatVisibilityText(body)}"
                 android:autoLink="all"
                 android:textColorLink="@color/colorTextTint"
-                app:layout_constraintEnd_toEndOf="@id/guideline_end"
-                app:layout_constraintStart_toStartOf="@id/guideline_start"
-                app:layout_constraintTop_toBottomOf="@+id/information_details_header_headline"
                 tools:text="@string/settings_title" />
 
-            <androidx.constraintlayout.widget.Guideline
-                android:id="@+id/guideline_start"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                app:layout_constraintGuide_begin="@dimen/guideline_start" />
+        </LinearLayout>
 
-            <androidx.constraintlayout.widget.Guideline
-                android:id="@+id/guideline_end"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                app:layout_constraintGuide_end="@dimen/guideline_end" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </LinearLayout>
 
 </layout>

--- a/Corona-Warn-App/src/main/res/layout/include_information_details.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_information_details.xml
@@ -44,11 +44,11 @@
 
         <TextView
             android:id="@+id/information_details_header_headline"
-            style="@style/headline5"
+            style="@style/headline6"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/spacing_normal"
             android:layout_marginTop="@dimen/spacing_small"
+            android:layout_marginStart="@dimen/spacing_normal"
             android:layout_marginEnd="@dimen/spacing_normal"
             android:accessibilityHeading="true"
             android:focusable="true"

--- a/Corona-Warn-App/src/main/res/layout/include_information_details.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_information_details.xml
@@ -34,10 +34,13 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:focusable="true"
+            android:scaleType="centerCrop"
+            android:paddingTop="@dimen/spacing_small"
+            android:paddingBottom="@dimen/spacing_small"
             android:src="@{illustration}"
             bind:cwaContentDescription="@{illustrationDescription}"
             tools:ignore="ContentDescription"
-            tools:src="@drawable/ic_information_illustration_terms" />
+            tools:src="@drawable/ic_submission_illustration_hotline" />
 
         <TextView
             android:id="@+id/information_details_header_headline"


### PR DESCRIPTION
This PR polishes the information fragments under `Menu > App Information`.

* Contains the cherry picked commits from @fynngodau that improve loading performance (see #1854) , especially of fragments that display `.html` files from assets. 
* Refactor the formatter helper to remove static context access and make the html parser reusable
* Flatten a few more layouts by 1-2 levels
* Align headline sizes
* Fix illustration display, previously there was white space at the start and end due to the illustrations dimensions, now they are touching the screen edge so they have the desired "effects" (i.e. hand reaching in).

![Screenshot from 2020-12-11 18-26-46](https://user-images.githubusercontent.com/1439229/101934845-72d0d800-3bde-11eb-84b7-55de042118e4.png)

Ref #1855