### PR TITLE
Fix crash when accessing TEK history without tracing enabled (EXPOSUREAPP-4284)

### DIFF
--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/submission/ui/SubmissionTestFragment.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/submission/ui/SubmissionTestFragment.kt
@@ -9,6 +9,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.FragmentTestSubmissionBinding
 import de.rki.coronawarnapp.test.menu.ui.TestMenuItem
+import de.rki.coronawarnapp.tracing.ui.TracingConsentDialog
 import de.rki.coronawarnapp.util.di.AutoInject
 import de.rki.coronawarnapp.util.lists.diffutil.update
 import de.rki.coronawarnapp.util.ui.observe2
@@ -56,9 +57,18 @@ class SubmissionTestFragment : Fragment(R.layout.fragment_test_submission), Auto
         }
 
         binding.apply {
-            tekStorageUpdate.setOnClickListener { vm.updateStorage(requireActivity()) }
+            tekStorageUpdate.setOnClickListener { vm.updateStorage() }
             tekStorageClear.setOnClickListener { vm.clearStorage() }
             tekStorageEmail.setOnClickListener { vm.emailTEKs() }
+        }
+        vm.permissionRequestEvent.observe2(this) { permissionRequest ->
+            permissionRequest.invoke(requireActivity())
+        }
+        vm.showTracingConsentDialog.observe2(this) { consentResult ->
+            TracingConsentDialog(requireContext()).show(
+                onConsentGiven = { consentResult(true) },
+                onConsentDeclined = { consentResult(false) }
+            )
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/TracingPermissionHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/TracingPermissionHelper.kt
@@ -70,7 +70,9 @@ class TracingPermissionHelper @AssistedInject constructor(
     }
 
     private fun isConsentGiven(): Boolean {
-        return LocalData.initialTracingActivationTimestamp() != null
+        val firstTracingActivationAt = LocalData.initialTracingActivationTimestamp()
+        Timber.tag(TAG).v("isConsentGiven(): First tracing activationat: %d", firstTracingActivationAt)
+        return firstTracingActivationAt != null
     }
 
     interface Callback {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/TracingPermissionHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/TracingPermissionHelper.kt
@@ -2,6 +2,7 @@ package de.rki.coronawarnapp.nearby
 
 import android.app.Activity
 import android.content.Intent
+import androidx.annotation.VisibleForTesting
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
 import de.rki.coronawarnapp.storage.LocalData
@@ -84,7 +85,9 @@ class TracingPermissionHelper @AssistedInject constructor(
 
     companion object {
         private const val TAG = "TracingPermissionHelper"
-        const val TRACING_PERMISSION_REQUESTCODE = 3010
+
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        internal const val TRACING_PERMISSION_REQUESTCODE = 3010
     }
 
     @AssistedInject.Factory

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/data/tekhistory/TEKHistoryUpdater.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/data/tekhistory/TEKHistoryUpdater.kt
@@ -3,72 +3,84 @@ package de.rki.coronawarnapp.submission.data.tekhistory
 import android.app.Activity
 import android.content.Intent
 import com.google.android.gms.nearby.exposurenotification.TemporaryExposureKey
+import com.squareup.inject.assisted.Assisted
+import com.squareup.inject.assisted.AssistedInject
 import de.rki.coronawarnapp.exception.ExceptionCategory
 import de.rki.coronawarnapp.exception.reporting.report
 import de.rki.coronawarnapp.nearby.ENFClient
+import de.rki.coronawarnapp.nearby.TracingPermissionHelper
 import de.rki.coronawarnapp.util.TimeStamper
 import de.rki.coronawarnapp.util.coroutine.AppScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.UUID
-import javax.inject.Inject
 
-class TEKHistoryUpdater @Inject constructor(
+class TEKHistoryUpdater @AssistedInject constructor(
+    @Assisted val callback: Callback,
     private val tekHistoryStorage: TEKHistoryStorage,
     private val timeStamper: TimeStamper,
     private val enfClient: ENFClient,
+    private val tracingPermissionHelperFactory: TracingPermissionHelper.Factory,
     @AppScope private val scope: CoroutineScope
 ) {
 
-    var callback: Callback? = null
-
-    fun updateTEKHistoryOrRequestPermission(
-        onUserPermissionRequired: (permissionRequest: (Activity) -> Unit) -> Unit
-    ) {
-        scope.launch {
-            enfClient.getTEKHistoryOrRequestPermission(
-                onTEKHistoryAvailable = {
-                    updateHistoryAndTriggerCallback(it)
-                },
-                onPermissionRequired = { status ->
-                    val permissionRequestTrigger: (Activity) -> Unit = {
-                        status.startResolutionForResult(it, TEK_PERMISSION_REQUESTCODE)
-                    }
-                    onUserPermissionRequired(permissionRequestTrigger)
+    private val tracingPermissionHelper by lazy {
+        tracingPermissionHelperFactory.create(object : TracingPermissionHelper.Callback {
+            override fun onUpdateTracingStatus(isTracingEnabled: Boolean) {
+                if (isTracingEnabled) {
+                    updateTEKHistoryOrRequestPermission()
+                } else {
+                    Timber.tag(TAG).w("Can't start TEK update, tracing permission was declined.")
                 }
-            )
+            }
+
+            override fun onTracingConsentRequired(onConsentResult: (given: Boolean) -> Unit) =
+                callback.onTracingConsentRequired(onConsentResult)
+
+            override fun onPermissionRequired(permissionRequest: (Activity) -> Unit) =
+                callback.onPermissionRequired(permissionRequest)
+
+            override fun onError(error: Throwable) = callback.onError(error)
+        })
+    }
+
+    fun updateTEKHistoryOrRequestPermission() {
+        scope.launch {
+            if (!enfClient.isTracingEnabled.first()) {
+                Timber.tag(TAG).w("Tracing is disabled, enabling...")
+                tracingPermissionHelper.startTracing()
+            } else {
+                updateTEKHistoryInternal()
+            }
         }
     }
 
-    suspend fun updateHistoryOrThrow(): List<TemporaryExposureKey> {
-        return updateTEKHistory()
-    }
-
-    fun handleActivityResult(requestCode: Int, resultCode: Int, data: Intent?): UpdateResult {
-        if (requestCode != TEK_PERMISSION_REQUESTCODE) {
-            Timber.tag(TAG).w("Not our request code ($requestCode): %s", data)
-            return UpdateResult.UNKNOWN_RESULT
-        }
-        return if (resultCode == Activity.RESULT_OK) {
-            Timber.tag(TAG).d("Permission granted (== RESULT_OK): %s", data)
-            updateHistoryAndTriggerCallback()
-            UpdateResult.PERMISSION_AVAILABLE
-        } else {
-            Timber.tag(TAG).i("Permission declined (!= RESULT_OK): %s", data)
-            callback?.onPermissionDeclined()
-            UpdateResult.PERMISSION_UNAVAILABLE
-        }
+    private suspend fun updateTEKHistoryInternal() {
+        enfClient.getTEKHistoryOrRequestPermission(
+            onTEKHistoryAvailable = {
+                Timber.tag(TAG).d("TEKS were directly available.")
+                updateHistoryAndTriggerCallback(it)
+            },
+            onPermissionRequired = { status ->
+                Timber.tag(TAG).d("TEK request requires user resolution.")
+                val permissionRequestTrigger: (Activity) -> Unit = {
+                    status.startResolutionForResult(it, TEK_PERMISSION_REQUEST)
+                }
+                callback.onPermissionRequired(permissionRequestTrigger)
+            }
+        )
     }
 
     private fun updateHistoryAndTriggerCallback(availableTEKs: List<TemporaryExposureKey>? = null) {
         scope.launch {
             try {
                 val result = updateTEKHistory(availableTEKs)
-                callback?.onTEKAvailable(result)
+                callback.onTEKAvailable(result)
             } catch (e: Exception) {
-                callback?.onError(e)
+                callback.onError(e)
             }
         }
     }
@@ -80,15 +92,15 @@ class TEKHistoryUpdater @Inject constructor(
             val teks = availableTEKs ?: enfClient.getTEKHistory()
             Timber.i("Permission are available, storing TEK history.")
 
-            tekHistoryStorage.storeTEKData(
-                TEKHistoryStorage.TEKBatch(
-                    batchId = UUID.randomUUID().toString(),
-                    obtainedAt = timeStamper.nowUTC,
-                    keys = teks
+            teks.also {
+                tekHistoryStorage.storeTEKData(
+                    TEKHistoryStorage.TEKBatch(
+                        batchId = UUID.randomUUID().toString(),
+                        obtainedAt = timeStamper.nowUTC,
+                        keys = teks
+                    )
                 )
-            )
-
-            teks
+            }
         }
         return try {
             deferred.await()
@@ -99,20 +111,43 @@ class TEKHistoryUpdater @Inject constructor(
         }
     }
 
-    enum class UpdateResult {
-        PERMISSION_AVAILABLE,
-        PERMISSION_UNAVAILABLE,
-        UNKNOWN_RESULT
-    }
+    fun handleActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
+        val isTracingPermissionRequest = tracingPermissionHelper.handleActivityResult(requestCode, resultCode, data)
+        if (isTracingPermissionRequest) {
+            Timber.tag(TAG).d("Was tracing permission request, will try TEK update if tracing is now enabled.")
+            return true
+        }
 
-    companion object {
-        private const val TAG = "TEKHistoryUpdater"
-        const val TEK_PERMISSION_REQUESTCODE = 3011
+        if (requestCode != TEK_PERMISSION_REQUEST) {
+            Timber.tag(TAG).w("Not our request code ($requestCode): %s", data)
+            return false
+        }
+
+        if (resultCode == Activity.RESULT_OK) {
+            Timber.tag(TAG).d("We got TEK permission, now updating history.")
+            updateHistoryAndTriggerCallback()
+        } else {
+            Timber.tag(TAG).i("Permission declined (!= RESULT_OK): %s", data)
+            callback.onTEKPermissionDeclined()
+        }
+        return true
     }
 
     interface Callback {
         fun onTEKAvailable(teks: List<TemporaryExposureKey>)
-        fun onPermissionDeclined()
+        fun onTEKPermissionDeclined()
+        fun onTracingConsentRequired(onConsentResult: (given: Boolean) -> Unit)
+        fun onPermissionRequired(permissionRequest: (Activity) -> Unit)
         fun onError(error: Throwable)
+    }
+
+    @AssistedInject.Factory
+    interface Factory {
+        fun create(callback: Callback): TEKHistoryUpdater
+    }
+
+    companion object {
+        private const val TAG = "TEKHistoryUpdater"
+        private const val TEK_PERMISSION_REQUEST = 3011
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/data/tekhistory/TEKHistoryUpdater.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/data/tekhistory/TEKHistoryUpdater.kt
@@ -2,6 +2,7 @@ package de.rki.coronawarnapp.submission.data.tekhistory
 
 import android.app.Activity
 import android.content.Intent
+import androidx.annotation.VisibleForTesting
 import com.google.android.gms.nearby.exposurenotification.TemporaryExposureKey
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
@@ -148,6 +149,8 @@ class TEKHistoryUpdater @AssistedInject constructor(
 
     companion object {
         private const val TAG = "TEKHistoryUpdater"
-        private const val TEK_PERMISSION_REQUEST = 3011
+
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        internal const val TEK_PERMISSION_REQUEST = 3011
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/TracingConsentDialog.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/TracingConsentDialog.kt
@@ -1,0 +1,25 @@
+package de.rki.coronawarnapp.tracing.ui
+
+import android.content.Context
+import de.rki.coronawarnapp.R
+import de.rki.coronawarnapp.util.DialogHelper
+
+class TracingConsentDialog(private val context: Context) {
+
+    fun show(
+        onConsentGiven: () -> Unit,
+        onConsentDeclined: () -> Unit
+    ) {
+        val dialog = DialogHelper.DialogInstance(
+            context = context,
+            title = R.string.onboarding_tracing_headline_consent,
+            message = R.string.onboarding_tracing_body_consent,
+            positiveButton = R.string.onboarding_button_enable,
+            negativeButton = R.string.onboarding_button_cancel,
+            cancelable = true,
+            positiveButtonFunction = { onConsentGiven() },
+            negativeButtonFunction = { onConsentDeclined() }
+        )
+        DialogHelper.showDialog(dialog)
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingTracingFragmentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingTracingFragmentViewModel.kt
@@ -18,7 +18,7 @@ import timber.log.Timber
 
 class OnboardingTracingFragmentViewModel @AssistedInject constructor(
     private val interoperabilityRepository: InteroperabilityRepository,
-    private val tracingPermissionHelper: TracingPermissionHelper,
+    tracingPermissionHelperFactory: TracingPermissionHelper.Factory,
     dispatcherProvider: DispatcherProvider
 ) : CWAViewModel(dispatcherProvider = dispatcherProvider) {
 
@@ -27,19 +27,27 @@ class OnboardingTracingFragmentViewModel @AssistedInject constructor(
     val routeToScreen: SingleLiveEvent<OnboardingNavigationEvents> = SingleLiveEvent()
     val permissionRequestEvent = SingleLiveEvent<(Activity) -> Unit>()
 
-    init {
-        tracingPermissionHelper.callback = object : TracingPermissionHelper.Callback {
+    private val tracingPermissionHelper =
+        tracingPermissionHelperFactory.create(object : TracingPermissionHelper.Callback {
             override fun onUpdateTracingStatus(isTracingEnabled: Boolean) {
                 if (isTracingEnabled) {
                     routeToScreen.postValue(OnboardingNavigationEvents.NavigateToOnboardingTest)
                 }
             }
 
+            override fun onTracingConsentRequired(onConsentResult: (given: Boolean) -> Unit) {
+                // Tracing consent is given implicitly on this screen.
+                onConsentResult(true)
+            }
+
+            override fun onPermissionRequired(permissionRequest: (Activity) -> Unit) {
+                permissionRequestEvent.postValue(permissionRequest)
+            }
+
             override fun onError(error: Throwable) {
                 Timber.e(error, "Failed to activate tracing during onboarding.")
             }
-        }
-    }
+        })
 
     fun saveInteroperabilityUsed() {
         interoperabilityRepository.saveInteroperabilityUsed()
@@ -65,9 +73,7 @@ class OnboardingTracingFragmentViewModel @AssistedInject constructor(
     }
 
     fun onActivateTracingClicked() {
-        tracingPermissionHelper.startTracing { permissionRequest ->
-            permissionRequestEvent.postValue(permissionRequest)
-        }
+        tracingPermissionHelper.startTracing()
     }
 
     fun showCancelDialog() {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/resultavailable/SubmissionTestResultAvailableFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/resultavailable/SubmissionTestResultAvailableFragment.kt
@@ -8,6 +8,7 @@ import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.Fragment
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.FragmentSubmissionTestResultAvailableBinding
+import de.rki.coronawarnapp.tracing.ui.TracingConsentDialog
 import de.rki.coronawarnapp.util.DialogHelper
 import de.rki.coronawarnapp.util.di.AutoInject
 import de.rki.coronawarnapp.util.ui.doNavigate
@@ -64,6 +65,12 @@ class SubmissionTestResultAvailableFragment : Fragment(R.layout.fragment_submiss
 
         vm.showPermissionRequest.observe2(this) { permissionRequest ->
             permissionRequest.invoke(requireActivity())
+        }
+        vm.showTracingConsentDialog.observe2(this) { onConsentResult ->
+            TracingConsentDialog(requireContext()).show(
+                onConsentGiven = { onConsentResult(true) },
+                onConsentDeclined = { onConsentResult(false) }
+            )
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/resultavailable/SubmissionTestResultAvailableViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/resultavailable/SubmissionTestResultAvailableViewModel.kt
@@ -19,8 +19,8 @@ import timber.log.Timber
 
 class SubmissionTestResultAvailableViewModel @AssistedInject constructor(
     dispatcherProvider: DispatcherProvider,
-    private val tekHistoryUpdater: TEKHistoryUpdater,
-    private val submissionRepository: SubmissionRepository
+    tekHistoryUpdaterFactory: TEKHistoryUpdater.Factory,
+    submissionRepository: SubmissionRepository
 ) : CWAViewModel(dispatcherProvider = dispatcherProvider) {
 
     val routeToScreen = SingleLiveEvent<NavDirections>()
@@ -29,33 +29,42 @@ class SubmissionTestResultAvailableViewModel @AssistedInject constructor(
     val consent = consentFlow.asLiveData(dispatcherProvider.Default)
     val showPermissionRequest = SingleLiveEvent<(Activity) -> Unit>()
     val showCloseDialog = SingleLiveEvent<Unit>()
+    val showTracingConsentDialog = SingleLiveEvent<(Boolean) -> Unit>()
+
+    private val tekHistoryUpdater = tekHistoryUpdaterFactory.create(object : TEKHistoryUpdater.Callback {
+        override fun onTEKAvailable(teks: List<TemporaryExposureKey>) {
+            routeToScreen.postValue(
+                SubmissionTestResultAvailableFragmentDirections
+                    .actionSubmissionTestResultAvailableFragmentToSubmissionTestResultConsentGivenFragment()
+            )
+        }
+
+        override fun onTEKPermissionDeclined() {
+            routeToScreen.postValue(
+                SubmissionTestResultAvailableFragmentDirections
+                    .actionSubmissionTestResultAvailableFragmentToSubmissionTestResultNoConsentFragment()
+            )
+        }
+
+        override fun onTracingConsentRequired(onConsentResult: (given: Boolean) -> Unit) {
+            showTracingConsentDialog.postValue(onConsentResult)
+        }
+
+        override fun onPermissionRequired(permissionRequest: (Activity) -> Unit) {
+            showPermissionRequest.postValue(permissionRequest)
+        }
+
+        override fun onError(error: Throwable) {
+            Timber.e(error, "Failed to update TEKs.")
+            error.report(
+                exceptionCategory = ExceptionCategory.EXPOSURENOTIFICATION,
+                prefix = "SubmissionTestResultAvailableViewModel"
+            )
+        }
+    })
 
     init {
         submissionRepository.refreshDeviceUIState(refreshTestResult = false)
-
-        tekHistoryUpdater.callback = object : TEKHistoryUpdater.Callback {
-            override fun onTEKAvailable(teks: List<TemporaryExposureKey>) {
-                routeToScreen.postValue(
-                    SubmissionTestResultAvailableFragmentDirections
-                        .actionSubmissionTestResultAvailableFragmentToSubmissionTestResultConsentGivenFragment()
-                )
-            }
-
-            override fun onPermissionDeclined() {
-                routeToScreen.postValue(
-                    SubmissionTestResultAvailableFragmentDirections
-                        .actionSubmissionTestResultAvailableFragmentToSubmissionTestResultNoConsentFragment()
-                )
-            }
-
-            override fun onError(error: Throwable) {
-                Timber.e(error, "Failed to update TEKs.")
-                error.report(
-                    exceptionCategory = ExceptionCategory.EXPOSURENOTIFICATION,
-                    prefix = "SubmissionTestResultAvailableViewModel"
-                )
-            }
-        }
     }
 
     fun goBack() {
@@ -81,9 +90,7 @@ class SubmissionTestResultAvailableViewModel @AssistedInject constructor(
     fun proceed() {
         launch {
             if (consentFlow.first()) {
-                tekHistoryUpdater.updateTEKHistoryOrRequestPermission { permissionRequest ->
-                    showPermissionRequest.postValue(permissionRequest)
-                }
+                tekHistoryUpdater.updateTEKHistoryOrRequestPermission()
             } else {
                 routeToScreen.postValue(
                     SubmissionTestResultAvailableFragmentDirections

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/warnothers/SubmissionResultPositiveOtherWarningNoConsentFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/warnothers/SubmissionResultPositiveOtherWarningNoConsentFragment.kt
@@ -7,6 +7,7 @@ import android.view.accessibility.AccessibilityEvent
 import androidx.fragment.app.Fragment
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.FragmentSubmissionNoConsentPositiveOtherWarningBinding
+import de.rki.coronawarnapp.tracing.ui.TracingConsentDialog
 import de.rki.coronawarnapp.util.DialogHelper
 import de.rki.coronawarnapp.util.di.AutoInject
 import de.rki.coronawarnapp.util.ui.doNavigate
@@ -68,6 +69,13 @@ class SubmissionResultPositiveOtherWarningNoConsentFragment :
 
         viewModel.countryList.observe2(this) {
             binding.countryList.countries = it
+        }
+
+        viewModel.showTracingConsentDialog.observe2(this) { onConsentResult ->
+            TracingConsentDialog(requireContext()).show(
+                onConsentGiven = { onConsentResult(true) },
+                onConsentDeclined = { onConsentResult(false) }
+            )
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/tracing/settings/SettingsTracingFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/tracing/settings/SettingsTracingFragment.kt
@@ -8,6 +8,7 @@ import androidx.fragment.app.Fragment
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.FragmentSettingsTracingBinding
 import de.rki.coronawarnapp.nearby.InternalExposureNotificationClient
+import de.rki.coronawarnapp.tracing.ui.TracingConsentDialog
 import de.rki.coronawarnapp.ui.main.MainActivity
 import de.rki.coronawarnapp.ui.tracing.settings.SettingsTracingFragmentViewModel.Event
 import de.rki.coronawarnapp.ui.viewmodel.SettingsViewModel
@@ -26,7 +27,6 @@ import javax.inject.Inject
  *
  * @see SettingsViewModel
  * @see InternalExposureNotificationClient
- * @see InternalExposureNotificationPermissionHelper
  */
 class SettingsTracingFragment : Fragment(R.layout.fragment_settings_tracing), AutoInject {
 
@@ -62,8 +62,13 @@ class SettingsTracingFragment : Fragment(R.layout.fragment_settings_tracing), Au
         vm.events.observe2(this) {
             when (it) {
                 is Event.RequestPermissions -> it.permissionRequest.invoke(requireActivity())
-                Event.ShowConsentDialog -> showConsentDialog()
                 Event.ManualCheckingDialog -> showManualCheckingRequiredDialog()
+                is Event.TracingConsentDialog -> {
+                    TracingConsentDialog(requireContext()).show(
+                        onConsentGiven = { it.onConsentResult(true) },
+                        onConsentDeclined = { it.onConsentResult(false) }
+                    )
+                }
             }
         }
 
@@ -132,24 +137,6 @@ class SettingsTracingFragment : Fragment(R.layout.fragment_settings_tracing), Au
             null,
             false, {
                 // close dialog
-            }
-        )
-        DialogHelper.showDialog(dialog)
-    }
-
-    private fun showConsentDialog() {
-        val dialog = DialogHelper.DialogInstance(
-            context = requireActivity(),
-            title = R.string.onboarding_tracing_headline_consent,
-            message = R.string.onboarding_tracing_body_consent,
-            positiveButton = R.string.onboarding_button_enable,
-            negativeButton = R.string.onboarding_button_cancel,
-            cancelable = true,
-            positiveButtonFunction = {
-                vm.requestTracingTurnedOn()
-            },
-            negativeButtonFunction = {
-                vm.onTracingTurnedOff()
             }
         )
         DialogHelper.showDialog(dialog)

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/nearby/TracingPermissionHelperTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/nearby/TracingPermissionHelperTest.kt
@@ -1,6 +1,5 @@
 package de.rki.coronawarnapp.nearby
 
-import android.app.Activity
 import io.mockk.MockKAnnotations
 import io.mockk.Runs
 import io.mockk.coEvery
@@ -26,7 +25,8 @@ class TracingPermissionHelperTest : BaseTest() {
         coEvery { enfClient.isTracingEnabled } returns flowOf(false)
     }
 
-    fun createInstance(scope: CoroutineScope) = TracingPermissionHelper(
+    fun createInstance(scope: CoroutineScope, callback: TracingPermissionHelper.Callback) = TracingPermissionHelper(
+        callback = callback,
         scope = scope,
         enfClient = enfClient
     )
@@ -43,12 +43,9 @@ class TracingPermissionHelperTest : BaseTest() {
         val callback = mockk<TracingPermissionHelper.Callback>()
         every { callback.onUpdateTracingStatus(any()) } just Runs
 
-        val instance = createInstance(scope = this)
-        instance.callback = callback
+        val instance = createInstance(scope = this, callback = callback)
 
-        val permissionRequestListener = mockk<(permissionRequest: (Activity) -> Unit) -> Unit>()
-
-        instance.startTracing(permissionRequestListener)
+        instance.startTracing()
 
         advanceUntilIdle()
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/nearby/TracingPermissionHelperTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/nearby/TracingPermissionHelperTest.kt
@@ -1,13 +1,16 @@
 package de.rki.coronawarnapp.nearby
 
+import de.rki.coronawarnapp.storage.LocalData
 import io.mockk.MockKAnnotations
 import io.mockk.Runs
 import io.mockk.coEvery
+import io.mockk.coVerifySequence
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.just
 import io.mockk.mockk
-import io.mockk.verify
+import io.mockk.mockkObject
+import io.mockk.slot
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runBlockingTest
@@ -23,6 +26,10 @@ class TracingPermissionHelperTest : BaseTest() {
         MockKAnnotations.init(this)
 
         coEvery { enfClient.isTracingEnabled } returns flowOf(false)
+        coEvery { enfClient.setTracing(any(), any(), any(), any()) } just Runs
+
+        mockkObject(LocalData)
+        every { LocalData.initialTracingActivationTimestamp() } returns 123L
     }
 
     fun createInstance(scope: CoroutineScope, callback: TracingPermissionHelper.Callback) = TracingPermissionHelper(
@@ -32,23 +39,78 @@ class TracingPermissionHelperTest : BaseTest() {
     )
 
     @Test
-    fun `request is forwarded if tracing is disabled`() = runBlockingTest {
-//        TODO()
-    }
-
-    @Test
     fun `request is not forwarded if tracing is enabled`() = runBlockingTest {
         coEvery { enfClient.isTracingEnabled } returns flowOf(true)
 
-        val callback = mockk<TracingPermissionHelper.Callback>()
-        every { callback.onUpdateTracingStatus(any()) } just Runs
-
+        val callback = mockk<TracingPermissionHelper.Callback>(relaxUnitFun = true)
         val instance = createInstance(scope = this, callback = callback)
 
         instance.startTracing()
 
         advanceUntilIdle()
 
-        verify { callback.onUpdateTracingStatus(true) }
+        coVerifySequence {
+            callback.onUpdateTracingStatus(true)
+        }
+    }
+
+    @Test
+    fun `if consent is missing then we continue after it was given`() = runBlockingTest {
+        every { LocalData.initialTracingActivationTimestamp() } returns null
+
+        val callback = mockk<TracingPermissionHelper.Callback>(relaxUnitFun = true)
+        val consentCallbackSlot = slot<(Boolean) -> Unit>()
+        every { callback.onTracingConsentRequired(capture(consentCallbackSlot)) } just Runs
+        val instance = createInstance(scope = this, callback = callback)
+
+        instance.startTracing()
+
+        consentCallbackSlot.captured(true)
+
+        coVerifySequence {
+            enfClient.isTracingEnabled
+            enfClient.setTracing(
+                enable = true,
+                onSuccess = any(),
+                onError = any(),
+                onPermissionRequired = any()
+            )
+        }
+    }
+
+    @Test
+    fun `if consent was declined then we do nothing`() = runBlockingTest {
+        every { LocalData.initialTracingActivationTimestamp() } returns null
+
+        val callback = mockk<TracingPermissionHelper.Callback>(relaxUnitFun = true)
+        val consentCallbackSlot = slot<(Boolean) -> Unit>()
+        every { callback.onTracingConsentRequired(capture(consentCallbackSlot)) } just Runs
+        val instance = createInstance(scope = this, callback = callback)
+
+        instance.startTracing()
+
+        consentCallbackSlot.captured(false)
+
+        coVerifySequence {
+            enfClient.isTracingEnabled
+        }
+    }
+
+    @Test
+    fun `request is forwarded if tracing is disabled`() = runBlockingTest {
+        val callback = mockk<TracingPermissionHelper.Callback>(relaxUnitFun = true)
+        val instance = createInstance(scope = this, callback = callback)
+
+        instance.startTracing()
+
+        coVerifySequence {
+            enfClient.isTracingEnabled
+            enfClient.setTracing(
+                enable = true,
+                onSuccess = any(),
+                onError = any(),
+                onPermissionRequired = any()
+            )
+        }
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/submission/data/tekhistory/TEKHistoryUpdaterTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/submission/data/tekhistory/TEKHistoryUpdaterTest.kt
@@ -87,8 +87,6 @@ class TEKHistoryUpdaterTest : BaseTest() {
 
         instance.updateTEKHistoryOrRequestPermission()
 
-
-
         verify {
             tracingPermissionHelper.startTracing()
         }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/submission/data/tekhistory/TEKHistoryUpdaterTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/submission/data/tekhistory/TEKHistoryUpdaterTest.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.submission.data.tekhistory
 
 import de.rki.coronawarnapp.nearby.ENFClient
+import de.rki.coronawarnapp.nearby.TracingPermissionHelper
 import de.rki.coronawarnapp.util.TimeStamper
 import io.mockk.MockKAnnotations
 import io.mockk.Runs
@@ -8,7 +9,9 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.impl.annotations.MockK
 import io.mockk.just
+import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -16,6 +19,7 @@ import testhelpers.BaseTest
 
 class TEKHistoryUpdaterTest : BaseTest() {
     @MockK lateinit var tekHistoryStorage: TEKHistoryStorage
+    @MockK lateinit var tracingPermissionHelper: TracingPermissionHelper.Factory
     @MockK lateinit var timeStamper: TimeStamper
     @MockK lateinit var enfClient: ENFClient
 
@@ -24,10 +28,13 @@ class TEKHistoryUpdaterTest : BaseTest() {
         MockKAnnotations.init(this)
 
         coEvery { enfClient.getTEKHistoryOrRequestPermission(any(), any()) } just Runs
+        coEvery { enfClient.isTracingEnabled } returns flowOf(true)
     }
 
-    fun createInstance(scope: CoroutineScope) = TEKHistoryUpdater(
+    fun createInstance(scope: CoroutineScope, callback: TEKHistoryUpdater.Callback) = TEKHistoryUpdater(
+        callback = callback,
         scope = scope,
+        tracingPermissionHelperFactory = tracingPermissionHelper,
         tekHistoryStorage = tekHistoryStorage,
         timeStamper = timeStamper,
         enfClient = enfClient
@@ -35,8 +42,10 @@ class TEKHistoryUpdaterTest : BaseTest() {
 
     @Test
     fun `request is forwaded to enf client`() = runBlockingTest {
-        val instance = createInstance(scope = this)
-        instance.updateTEKHistoryOrRequestPermission { }
+        val callback = mockk<TEKHistoryUpdater.Callback>()
+        val instance = createInstance(scope = this, callback = callback)
+
+        instance.updateTEKHistoryOrRequestPermission()
         coVerify {
             enfClient.getTEKHistoryOrRequestPermission(
                 any(),

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/submission/data/tekhistory/TEKHistoryUpdaterTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/submission/data/tekhistory/TEKHistoryUpdaterTest.kt
@@ -1,40 +1,60 @@
 package de.rki.coronawarnapp.submission.data.tekhistory
 
+import android.app.Activity
+import android.content.Intent
+import com.google.android.gms.nearby.exposurenotification.TemporaryExposureKey
 import de.rki.coronawarnapp.nearby.ENFClient
 import de.rki.coronawarnapp.nearby.TracingPermissionHelper
 import de.rki.coronawarnapp.util.TimeStamper
+import io.kotest.matchers.shouldBe
 import io.mockk.MockKAnnotations
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifySequence
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runBlockingTest
+import org.joda.time.Instant
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 
 class TEKHistoryUpdaterTest : BaseTest() {
     @MockK lateinit var tekHistoryStorage: TEKHistoryStorage
-    @MockK lateinit var tracingPermissionHelper: TracingPermissionHelper.Factory
+    @MockK lateinit var tracingPermissionHelper: TracingPermissionHelper
+    @MockK lateinit var tracingPermissionHelperFactory: TracingPermissionHelper.Factory
     @MockK lateinit var timeStamper: TimeStamper
     @MockK lateinit var enfClient: ENFClient
+
+    val availableTEKs: List<TemporaryExposureKey> = listOf(mockk())
 
     @BeforeEach
     fun setup() {
         MockKAnnotations.init(this)
 
+        every { timeStamper.nowUTC } returns Instant.EPOCH
+
         coEvery { enfClient.getTEKHistoryOrRequestPermission(any(), any()) } just Runs
         coEvery { enfClient.isTracingEnabled } returns flowOf(true)
+        coEvery { enfClient.getTEKHistory() } returns availableTEKs
+
+        coEvery { tekHistoryStorage.storeTEKData(any()) } just Runs
+
+        every { tracingPermissionHelperFactory.create(any()) } returns tracingPermissionHelper
+        coEvery { tracingPermissionHelper.startTracing() } just Runs
+        every { tracingPermissionHelper.handleActivityResult(any(), any(), any()) } returns false
     }
 
     fun createInstance(scope: CoroutineScope, callback: TEKHistoryUpdater.Callback) = TEKHistoryUpdater(
         callback = callback,
         scope = scope,
-        tracingPermissionHelperFactory = tracingPermissionHelper,
+        tracingPermissionHelperFactory = tracingPermissionHelperFactory,
         tekHistoryStorage = tekHistoryStorage,
         timeStamper = timeStamper,
         enfClient = enfClient
@@ -51,6 +71,110 @@ class TEKHistoryUpdaterTest : BaseTest() {
                 any(),
                 any()
             )
+        }
+    }
+
+    @Test
+    fun `if tracing is disabled then start tracing`() = runBlockingTest {
+        coEvery { enfClient.isTracingEnabled } returns flowOf(false)
+
+        val callback = mockk<TEKHistoryUpdater.Callback>()
+        val instance = createInstance(scope = this, callback = callback)
+
+        instance.updateTEKHistoryOrRequestPermission()
+
+        verify {
+            tracingPermissionHelper.startTracing()
+        }
+    }
+
+    @Test
+    fun `tracing permission results are forwarded to the tracing permissionhelper`() = runBlockingTest {
+        every { tracingPermissionHelper.handleActivityResult(any(), any(), any()) } returns true
+        val callback = mockk<TEKHistoryUpdater.Callback>(relaxUnitFun = true)
+        val instance = createInstance(scope = this, callback = callback)
+
+        val testIntent = mockk<Intent>()
+        instance.handleActivityResult(
+            requestCode = TracingPermissionHelper.TRACING_PERMISSION_REQUESTCODE,
+            resultCode = Activity.RESULT_OK,
+            data = testIntent
+        )
+
+        verify {
+            tracingPermissionHelper.handleActivityResult(
+                requestCode = TracingPermissionHelper.TRACING_PERMISSION_REQUESTCODE,
+                resultCode = Activity.RESULT_OK,
+                data = testIntent
+            )
+        }
+    }
+
+    @Test
+    fun `TEK activity results processed if not consumed by the tracing permissionhelper`() = runBlockingTest {
+        every { tracingPermissionHelper.handleActivityResult(any(), any(), any()) } returns false
+        val callback = mockk<TEKHistoryUpdater.Callback>(relaxUnitFun = true)
+        val instance = createInstance(scope = this, callback = callback)
+
+        val testIntent = mockk<Intent>()
+        instance.handleActivityResult(
+            requestCode = TEKHistoryUpdater.TEK_PERMISSION_REQUEST,
+            resultCode = Activity.RESULT_CANCELED,
+            data = testIntent
+        ) shouldBe true
+
+        verifySequence {
+            tracingPermissionHelper.handleActivityResult(
+                requestCode = TEKHistoryUpdater.TEK_PERMISSION_REQUEST,
+                resultCode = Activity.RESULT_CANCELED,
+                data = testIntent
+            )
+            callback.onTEKPermissionDeclined()
+        }
+    }
+
+    @Test
+    fun `unknown resultcodes are not consumed`() = runBlockingTest {
+        every { tracingPermissionHelper.handleActivityResult(any(), any(), any()) } returns false
+        val callback = mockk<TEKHistoryUpdater.Callback>(relaxUnitFun = true)
+        val instance = createInstance(scope = this, callback = callback)
+
+        val testIntent = mockk<Intent>()
+        instance.handleActivityResult(
+            requestCode = 123,
+            resultCode = Activity.RESULT_OK,
+            data = testIntent
+        ) shouldBe false
+
+        verify {
+            tracingPermissionHelper.handleActivityResult(
+                requestCode = 123,
+                resultCode = Activity.RESULT_OK,
+                data = testIntent
+            )
+        }
+    }
+
+    @Test
+    fun `positive TEK activity results trigger new update attempt`() = runBlockingTest {
+        every { tracingPermissionHelper.handleActivityResult(any(), any(), any()) } returns false
+        val callback = mockk<TEKHistoryUpdater.Callback>(relaxUnitFun = true)
+        val instance = createInstance(scope = this, callback = callback)
+
+        val testIntent = mockk<Intent>()
+        instance.handleActivityResult(
+            requestCode = TEKHistoryUpdater.TEK_PERMISSION_REQUEST,
+            resultCode = Activity.RESULT_OK,
+            data = testIntent
+        ) shouldBe true
+
+        verifySequence {
+            tracingPermissionHelper.handleActivityResult(
+                requestCode = TEKHistoryUpdater.TEK_PERMISSION_REQUEST,
+                resultCode = Activity.RESULT_OK,
+                data = testIntent
+            )
+            callback.onTEKAvailable(availableTEKs)
         }
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/testavailable/SubmissionTestResultAvailableViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/testavailable/SubmissionTestResultAvailableViewModelTest.kt
@@ -28,13 +28,15 @@ class SubmissionTestResultAvailableViewModelTest : BaseTest() {
 
     @MockK lateinit var submissionRepository: SubmissionRepository
     @MockK lateinit var tekHistoryUpdater: TEKHistoryUpdater
+    @MockK lateinit var tekHistoryUpdaterFactory: TEKHistoryUpdater.Factory
 
     @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this)
         every { submissionRepository.hasGivenConsentToSubmission } returns flowOf(true)
-        every { tekHistoryUpdater.callback = any() } just Runs
-        every { tekHistoryUpdater.updateTEKHistoryOrRequestPermission(any()) } just Runs
+
+        every { tekHistoryUpdaterFactory.create(any()) } returns tekHistoryUpdater
+        every { tekHistoryUpdater.updateTEKHistoryOrRequestPermission() } just Runs
 
         // TODO Check specific behavior
         every { submissionRepository.refreshDeviceUIState(any()) } just Runs
@@ -43,7 +45,7 @@ class SubmissionTestResultAvailableViewModelTest : BaseTest() {
     private fun createViewModel(): SubmissionTestResultAvailableViewModel = SubmissionTestResultAvailableViewModel(
         submissionRepository = submissionRepository,
         dispatcherProvider = TestDispatcherProvider,
-        tekHistoryUpdater = tekHistoryUpdater
+        tekHistoryUpdaterFactory = tekHistoryUpdaterFactory
     )
 
     @AfterEach
@@ -89,7 +91,7 @@ class SubmissionTestResultAvailableViewModelTest : BaseTest() {
 
         viewModel.proceed()
         verify {
-            tekHistoryUpdater.updateTEKHistoryOrRequestPermission(any())
+            tekHistoryUpdater.updateTEKHistoryOrRequestPermission()
         }
     }
 


### PR DESCRIPTION
We crashed when tracing was disabled and tried to update the TEK history during submission.

This PR:
* Refactors the tracing permission helper to offer more reusability
* The `TEKHistoryUpdater` will now use the `TracingPermissionHelper` to request tracing permission to be enabled when we want to update the TEK history
* Besides fixing the crash it has the added benefit that the user no longer has to leave the submission flow if they have had tracing disabled.

## Testing
* Enable / disable tracing where ever possible
* Perform submission with tracing enabled and disabled
* If the user never gave consent during onboarding, the tracing consent dialog needs to be shown every time we want to enable tracing on any screen until consent was given once, and tracing has been enabled