### PR TITLE
Add Build.FINGERPRINT to debug log make debugging efforts quicker (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CWADebug.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CWADebug.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.util
 
 import android.app.Application
+import android.os.Build
 import de.rki.coronawarnapp.BuildConfig
 import de.rki.coronawarnapp.util.debug.FileLogger
 import timber.log.Timber
@@ -20,6 +21,7 @@ object CWADebug {
 
         Timber.i("CWA version: %s (%s)", BuildConfig.VERSION_CODE, BuildConfig.GIT_COMMIT_SHORT_HASH)
         Timber.i("CWA flavor: %s (%s)", BuildConfig.FLAVOR, BuildConfig.BUILD_TYPE)
+        Timber.i("Build.FINGERPRINT: %s", Build.FINGERPRINT)
     }
 
     val isDebugBuildOrMode: Boolean


### PR DESCRIPTION
Small quality of life change. When handling debug logs from testers, it helps us distinguish them.