### PR TITLE
Remove material styling from dialog buttons in contact diary activity (EXPOSUREAPP-4327)

### DIFF
--- a/Corona-Warn-App/src/main/res/values/styles.xml
+++ b/Corona-Warn-App/src/main/res/values/styles.xml
@@ -16,12 +16,13 @@
         <item name="colorPrimary">@color/colorBrandSecondary</item>
         <item name="colorPrimaryDark">@color/colorStableDark</item>
         <item name="android:windowBackground">@color/colorBackground</item>
-        <item name="alertDialogTheme">@style/dialog</item>
+        <item name="alertDialogTheme">@style/diaryDialog</item>
     </style>
 
     <style name="MaterialAppTheme.NoActionBar" parent="MaterialAppTheme">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
+        <item name="dialogTheme">@style/diaryDialog</item>
     </style>
 
     <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
@@ -58,6 +59,15 @@
     <style name="dialog" parent="ThemeOverlay.AppCompat.Dialog.Alert">
         <item name="buttonBarPositiveButtonStyle">@style/dialogPositiveButtonStyle</item>
         <item name="buttonBarNegativeButtonStyle">@style/dialogNegativeButtonStyle</item>
+    </style>
+
+    <style name="diaryButtonPositive" parent="Widget.MaterialComponents.Button.TextButton" />
+    <style name="diaryButtonNegative" parent="Widget.MaterialComponents.Button.TextButton" />
+
+    <!--    Contact Diary Dialog-->
+    <style name="diaryDialog" parent="Theme.MaterialComponents.DayNight.Dialog.Alert">
+        <item name="buttonBarPositiveButtonStyle">@style/diaryButtonPositive</item>
+        <item name="buttonBarNegativeButtonStyle">@style/diaryButtonNegative</item>
     </style>
 
     <style name="dialogPositiveButtonStyle" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">

--- a/Corona-Warn-App/src/main/res/values/styles.xml
+++ b/Corona-Warn-App/src/main/res/values/styles.xml
@@ -61,13 +61,15 @@
         <item name="buttonBarNegativeButtonStyle">@style/dialogNegativeButtonStyle</item>
     </style>
 
-    <style name="diaryButtonPositive" parent="Widget.MaterialComponents.Button.TextButton" />
+    <style name="diaryDialogButton" parent="Widget.MaterialComponents.Button.TextButton">
+        <item name="android:textColor">@color/colorAccentTintButton</item>
+    </style>
     <style name="diaryButtonNegative" parent="Widget.MaterialComponents.Button.TextButton" />
 
     <!--    Contact Diary Dialog-->
     <style name="diaryDialog" parent="Theme.MaterialComponents.DayNight.Dialog.Alert">
-        <item name="buttonBarPositiveButtonStyle">@style/diaryButtonPositive</item>
-        <item name="buttonBarNegativeButtonStyle">@style/diaryButtonNegative</item>
+        <item name="buttonBarPositiveButtonStyle">@style/diaryDialogButton</item>
+        <item name="buttonBarNegativeButtonStyle">@style/diaryDialogButton</item>
     </style>
 
     <style name="dialogPositiveButtonStyle" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">


### PR DESCRIPTION
This PR keeps the styling of the dialog buttons consistent with the rest of the app. 
Issue: using MaterialComponents theme for the diary activity added material-style buttons to the dialogs  opened by the diary activity so I added a custom styling for the dialog buttons.

To test the new styling, you need to add a dummy dialog in one of the fragments of the contact diary activity as there currently aren't any dialogs included. 