### PR TITLE
Fix date format on overview page (EXPOSUREAPP-4404)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/overview/adapter/ContactDiaryOverviewAdapter.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/overview/adapter/ContactDiaryOverviewAdapter.kt
@@ -47,7 +47,7 @@ class ContactDiaryOverviewAdapter(private val onItemSelectionListener: (ListItem
             onElementSelectionListener: (ListItem) -> Unit
         ) {
             viewDataBinding.contactDiaryOverviewElementName.text =
-                item.date.toString("EEEE, dd.MM.yyyy", Locale.getDefault())
+                item.date.toString("EEEE, dd.MM.yy", Locale.getDefault())
 
             viewDataBinding.contactDiaryOverviewElementBody.setOnClickListener { onElementSelectionListener(item) }
 


### PR DESCRIPTION
<img width="391" alt="Screenshot 2020-12-18 at 13 46 49" src="https://user-images.githubusercontent.com/56824/102616213-7bbe2e00-4137-11eb-9eea-db690bd954f6.png">

two digit year instead of four digits.