### PR TITLE
Increased Kontakt-Tagebuch text size (EXPOSUREAPP-4390)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/contact_diary_overview_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/contact_diary_overview_fragment.xml
@@ -21,7 +21,7 @@
 
         <TextView
             android:id="@+id/onboarding_headline"
-            style="@style/headline7"
+            style="@style/headline5Bold"
             android:layout_marginTop="@dimen/spacing_tiny"
             android:layout_width="@dimen/match_constraint"
             android:layout_height="wrap_content"

--- a/Corona-Warn-App/src/main/res/layout/contact_diary_overview_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/contact_diary_overview_fragment.xml
@@ -21,7 +21,7 @@
 
         <TextView
             android:id="@+id/onboarding_headline"
-            style="@style/headline6"
+            style="@style/headline7"
             android:layout_marginTop="@dimen/spacing_tiny"
             android:layout_width="@dimen/match_constraint"
             android:layout_height="wrap_content"

--- a/Corona-Warn-App/src/main/res/values/styles.xml
+++ b/Corona-Warn-App/src/main/res/values/styles.xml
@@ -223,6 +223,9 @@
     <style name="headline6" parent="@style/TextAppearance.MaterialComponents.Headline6">
         <item name="android:textColor">@color/colorTextPrimary1</item>
     </style>
+    <style name="headline7" parent="@style/TextAppearance.MaterialComponents.Headline5">
+        <item name="android:textStyle">bold</item>
+    </style>
 
     <style name="subtitle" parent="@style/TextAppearance.MaterialComponents.Subtitle1">
         <item name="android:textColor">@color/colorTextPrimary1</item>

--- a/Corona-Warn-App/src/main/res/values/styles.xml
+++ b/Corona-Warn-App/src/main/res/values/styles.xml
@@ -219,12 +219,12 @@
     <style name="headline5Tint" parent="@style/headline5">
         <item name="android:textColor">@color/colorTextTint</item>
     </style>
+    <style name="headline5Bold" parent="@style/TextAppearance.MaterialComponents.Headline5">
+        <item name="android:textStyle">bold</item>
+    </style>
 
     <style name="headline6" parent="@style/TextAppearance.MaterialComponents.Headline6">
         <item name="android:textColor">@color/colorTextPrimary1</item>
-    </style>
-    <style name="headline7" parent="@style/TextAppearance.MaterialComponents.Headline5">
-        <item name="android:textStyle">bold</item>
     </style>
 
     <style name="subtitle" parent="@style/TextAppearance.MaterialComponents.Subtitle1">


### PR DESCRIPTION
This PR increases the heading size of the Kontakt-Tagebuch overview screen from 20sp to 24sp.