### PR TITLE
Merge 1.9.x into 1.10.x (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/assets/technical.html
+++ b/Corona-Warn-App/src/main/assets/technical.html
@@ -76,7 +76,7 @@
     License: Apache 2.0
 <p>Component: Lottie<br/>
     Licensor: Airbnb, Inc.<br/>
-    Website: http://airbnb.io/lottie<br/>
+    Website: https://github.com/airbnb/lottie-android<br/>
     License: Apache 2.0
 <hr/>
 <p>Copyright (c) 2008-2020 Zetetic LLC

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,4 +20,4 @@ org.gradle.dependency.verification.console=verbose
 VERSION_MAJOR=1
 VERSION_MINOR=9
 VERSION_PATCH=1
-VERSION_BUILD=1
+VERSION_BUILD=2


### PR DESCRIPTION
Merge 1.9.x into 1.10.x (DEV)
conflict was
- versionbump 
- one gradleimport (github.com/airbnb/lottie-android)