### PR TITLE
Skeletons for showing statistics in the home screen feed (EXPOSUREAPP-3674)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/StatsItem.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/StatsItem.kt
@@ -1,0 +1,30 @@
+package de.rki.coronawarnapp.statistics
+
+import de.rki.coronawarnapp.server.protocols.internal.stats.KeyFigureCardOuterClass
+import org.joda.time.Instant
+
+data class StatisticsData(
+    val items: List<StatsItem>
+) {
+    val isDataAvailable: Boolean = items.isNotEmpty()
+}
+
+sealed class StatsItem(val cardId: Int) {
+    abstract val updatedAt: Instant
+    abstract val keyFigures: List<KeyFigureCardOuterClass.KeyFigure>
+}
+
+data class InfectionStats(
+    override val updatedAt: Instant,
+    override val keyFigures: List<KeyFigureCardOuterClass.KeyFigure>
+) : StatsItem(cardId = 1)
+
+data class IncidenceStats(
+    override val updatedAt: Instant,
+    override val keyFigures: List<KeyFigureCardOuterClass.KeyFigure>
+) : StatsItem(cardId = 2)
+
+data class KeySubmissionsStats(
+    override val updatedAt: Instant,
+    override val keyFigures: List<KeyFigureCardOuterClass.KeyFigure>
+) : StatsItem(cardId = 3)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/source/StatisticsProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/source/StatisticsProvider.kt
@@ -1,0 +1,102 @@
+package de.rki.coronawarnapp.statistics.source
+
+import de.rki.coronawarnapp.server.protocols.internal.stats.KeyFigureCardOuterClass
+import de.rki.coronawarnapp.statistics.IncidenceStats
+import de.rki.coronawarnapp.statistics.InfectionStats
+import de.rki.coronawarnapp.statistics.KeySubmissionsStats
+import de.rki.coronawarnapp.statistics.StatisticsData
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.launch
+import org.joda.time.Instant
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class StatisticsProvider @Inject constructor() {
+
+    private val currentInternal = MutableStateFlow(StatisticsData(items = emptyList()))
+    val current: Flow<StatisticsData> = currentInternal.filterNotNull()
+
+    init {
+        // Mock data
+        GlobalScope.launch(context = Dispatchers.IO) {
+            val statisticsData = StatisticsData(
+                items = listOf(
+                    InfectionStats(
+                        updatedAt = Instant.ofEpochMilli(1604839761),
+                        keyFigures = listOf(
+                            KeyFigureCardOuterClass.KeyFigure.newBuilder().apply {
+                                rank = KeyFigureCardOuterClass.KeyFigure.Rank.PRIMARY
+                                value = 14714.0
+                                decimals = 0
+                                trend = KeyFigureCardOuterClass.KeyFigure.Trend.UNSPECIFIED_TREND
+                                trendSemantic =
+                                    KeyFigureCardOuterClass.KeyFigure.TrendSemantic.UNSPECIFIED_TREND_SEMANTIC
+                            }.build(),
+                            KeyFigureCardOuterClass.KeyFigure.newBuilder().apply {
+                                rank = KeyFigureCardOuterClass.KeyFigure.Rank.SECONDARY
+                                value = 11981.0
+                                decimals = 0
+                                trend = KeyFigureCardOuterClass.KeyFigure.Trend.INCREASING
+                                trendSemantic = KeyFigureCardOuterClass.KeyFigure.TrendSemantic.NEGATIVE
+                            }.build(), KeyFigureCardOuterClass.KeyFigure.newBuilder().apply {
+                                rank = KeyFigureCardOuterClass.KeyFigure.Rank.TERTIARY
+                                value = 429181.0
+                                decimals = 0
+                                trend = KeyFigureCardOuterClass.KeyFigure.Trend.UNSPECIFIED_TREND
+                                trendSemantic =
+                                    KeyFigureCardOuterClass.KeyFigure.TrendSemantic.UNSPECIFIED_TREND_SEMANTIC
+                            }.build()
+                        )
+                    ),
+                    IncidenceStats(
+                        updatedAt = Instant.ofEpochMilli(1604839761),
+                        keyFigures = listOf(
+                            KeyFigureCardOuterClass.KeyFigure.newBuilder().apply {
+                                rank = KeyFigureCardOuterClass.KeyFigure.Rank.PRIMARY
+                                value = 98.9
+                                decimals = 1
+                                trend = KeyFigureCardOuterClass.KeyFigure.Trend.UNSPECIFIED_TREND
+                                trendSemantic =
+                                    KeyFigureCardOuterClass.KeyFigure.TrendSemantic.UNSPECIFIED_TREND_SEMANTIC
+                            }.build()
+                        )
+                    ),
+                    KeySubmissionsStats(
+                        updatedAt = Instant.ofEpochMilli(1604839761),
+                        keyFigures = listOf(
+                            KeyFigureCardOuterClass.KeyFigure.newBuilder().apply {
+                                rank = KeyFigureCardOuterClass.KeyFigure.Rank.PRIMARY
+                                value = 1514.0
+                                decimals = 0
+                                trend = KeyFigureCardOuterClass.KeyFigure.Trend.UNSPECIFIED_TREND
+                                trendSemantic =
+                                    KeyFigureCardOuterClass.KeyFigure.TrendSemantic.UNSPECIFIED_TREND_SEMANTIC
+                            }.build(),
+                            KeyFigureCardOuterClass.KeyFigure.newBuilder().apply {
+                                rank = KeyFigureCardOuterClass.KeyFigure.Rank.SECONDARY
+                                value = 1812.0
+                                decimals = 0
+                                trend = KeyFigureCardOuterClass.KeyFigure.Trend.DECREASING
+                                trendSemantic = KeyFigureCardOuterClass.KeyFigure.TrendSemantic.NEGATIVE
+                            }.build(),
+                            KeyFigureCardOuterClass.KeyFigure.newBuilder().apply {
+                                rank = KeyFigureCardOuterClass.KeyFigure.Rank.TERTIARY
+                                value = 20922.0
+                                decimals = 0
+                                trend = KeyFigureCardOuterClass.KeyFigure.Trend.UNSPECIFIED_TREND
+                                trendSemantic =
+                                    KeyFigureCardOuterClass.KeyFigure.TrendSemantic.UNSPECIFIED_TREND_SEMANTIC
+                            }.build()
+                        )
+                    )
+                )
+            )
+            currentInternal.emit(statisticsData)
+        }
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/StatisticsCardAdapter.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/StatisticsCardAdapter.kt
@@ -1,0 +1,43 @@
+package de.rki.coronawarnapp.statistics.ui.homecards
+
+import android.view.ViewGroup
+import androidx.annotation.LayoutRes
+import androidx.viewbinding.ViewBinding
+import de.rki.coronawarnapp.statistics.IncidenceStats
+import de.rki.coronawarnapp.statistics.InfectionStats
+import de.rki.coronawarnapp.statistics.KeySubmissionsStats
+import de.rki.coronawarnapp.statistics.ui.homecards.StatisticsCardAdapter.ItemVH
+import de.rki.coronawarnapp.statistics.ui.homecards.cards.IncidenceCard
+import de.rki.coronawarnapp.statistics.ui.homecards.cards.InfectionsCard
+import de.rki.coronawarnapp.statistics.ui.homecards.cards.KeySubmissionsCard
+import de.rki.coronawarnapp.statistics.ui.homecards.cards.StatisticsCardItem
+import de.rki.coronawarnapp.util.lists.BindableVH
+import de.rki.coronawarnapp.util.lists.diffutil.AsyncDiffUtilAdapter
+import de.rki.coronawarnapp.util.lists.diffutil.AsyncDiffer
+import de.rki.coronawarnapp.util.lists.modular.ModularAdapter
+import de.rki.coronawarnapp.util.lists.modular.mods.DataBinderMod
+import de.rki.coronawarnapp.util.lists.modular.mods.StableIdMod
+import de.rki.coronawarnapp.util.lists.modular.mods.TypedVHCreatorMod
+
+class StatisticsCardAdapter : ModularAdapter<ItemVH<StatisticsCardItem, ViewBinding>>(),
+    AsyncDiffUtilAdapter<StatisticsCardItem> {
+
+    override val asyncDiffer: AsyncDiffer<StatisticsCardItem> = AsyncDiffer(adapter = this)
+
+    init {
+        listOf(
+            StableIdMod(data),
+            DataBinderMod<StatisticsCardItem, ItemVH<StatisticsCardItem, ViewBinding>>(data),
+            TypedVHCreatorMod({ data[it].stats is InfectionStats }) { InfectionsCard(it) },
+            TypedVHCreatorMod({ data[it].stats is IncidenceStats }) { IncidenceCard(it) },
+            TypedVHCreatorMod({ data[it].stats is KeySubmissionsStats }) { KeySubmissionsCard(it) }
+        ).let { modules.addAll(it) }
+    }
+
+    override fun getItemCount(): Int = data.size
+
+    abstract class ItemVH<Item, VB : ViewBinding>(
+        @LayoutRes layoutRes: Int,
+        parent: ViewGroup
+    ) : ModularAdapter.VH(layoutRes, parent), BindableVH<Item, VB>
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/StatisticsCardPaddingDecorator.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/StatisticsCardPaddingDecorator.kt
@@ -1,0 +1,38 @@
+package de.rki.coronawarnapp.statistics.ui.homecards
+
+import android.graphics.Rect
+import android.view.View
+import androidx.annotation.DimenRes
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.ItemDecoration
+
+class StatisticsCardPaddingDecorator(
+    @DimenRes val startPadding: Int,
+    @DimenRes val endPadding: Int = startPadding,
+    @DimenRes val cardDistance: Int = startPadding
+) : ItemDecoration() {
+
+    override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {
+        super.getItemOffsets(outRect, view, parent, state)
+
+        val itemPosition = parent.getChildAdapterPosition(view)
+
+        if (itemPosition == RecyclerView.NO_POSITION) return
+
+        val resources = parent.context.resources
+
+        if (itemPosition == 0) {
+            outRect.left = resources.getDimensionPixelSize(startPadding)
+        } else {
+            parent.adapter?.let {
+                if (itemPosition == it.itemCount - 1) {
+                    outRect.right = resources.getDimensionPixelSize(endPadding)
+                } else {
+                    val distance = resources.getDimensionPixelSize(cardDistance)
+                    outRect.left = distance / 2
+                    outRect.right = distance / 2
+                }
+            }
+        }
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/StatisticsCardPaddingDecorator.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/StatisticsCardPaddingDecorator.kt
@@ -21,17 +21,18 @@ class StatisticsCardPaddingDecorator(
 
         val resources = parent.context.resources
 
-        if (itemPosition == 0) {
-            outRect.left = resources.getDimensionPixelSize(startPadding)
-        } else {
-            parent.adapter?.let {
-                if (itemPosition == it.itemCount - 1) {
-                    outRect.right = resources.getDimensionPixelSize(endPadding)
-                } else {
-                    val distance = resources.getDimensionPixelSize(cardDistance)
-                    outRect.left = distance / 2
-                    outRect.right = distance / 2
-                }
+        val adapter = parent.adapter
+        when (itemPosition) {
+            0 -> {
+                outRect.left = resources.getDimensionPixelSize(startPadding)
+            }
+            (adapter?.itemCount ?: Int.MAX_VALUE) - 1 -> {
+                outRect.right = resources.getDimensionPixelSize(endPadding)
+            }
+            else -> {
+                val distance = resources.getDimensionPixelSize(cardDistance)
+                outRect.left = distance / 2
+                outRect.right = distance / 2
             }
         }
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/StatisticsHomeCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/StatisticsHomeCard.kt
@@ -1,0 +1,49 @@
+package de.rki.coronawarnapp.statistics.ui.homecards
+
+import android.view.ViewGroup
+import androidx.annotation.LayoutRes
+import androidx.recyclerview.widget.DefaultItemAnimator
+import androidx.recyclerview.widget.LinearLayoutManager
+import de.rki.coronawarnapp.R
+import de.rki.coronawarnapp.databinding.HomeStatisticsScrollcontainerBinding
+import de.rki.coronawarnapp.statistics.StatisticsData
+import de.rki.coronawarnapp.statistics.StatsItem
+import de.rki.coronawarnapp.statistics.ui.homecards.cards.StatisticsCardItem
+import de.rki.coronawarnapp.ui.main.home.HomeAdapter
+import de.rki.coronawarnapp.ui.main.home.items.HomeItem
+import de.rki.coronawarnapp.util.lists.diffutil.update
+
+class StatisticsHomeCard(
+    parent: ViewGroup,
+    @LayoutRes containerLayout: Int = R.layout.home_statistics_scrollcontainer
+) : HomeAdapter.HomeItemVH<StatisticsHomeCard.Item, HomeStatisticsScrollcontainerBinding>(containerLayout, parent) {
+
+    private val statsAdapter by lazy { StatisticsCardAdapter() }
+
+    override val viewBinding = lazy {
+        HomeStatisticsScrollcontainerBinding.bind(itemView).apply {
+            statisticsRecyclerview.apply {
+                layoutManager = LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
+                adapter = statsAdapter
+                itemAnimator = DefaultItemAnimator()
+                addItemDecoration(StatisticsCardPaddingDecorator(startPadding = R.dimen.spacing_small))
+            }
+        }
+    }
+
+    override val onBindData: HomeStatisticsScrollcontainerBinding.(
+        item: Item,
+        payloads: List<Any>
+    ) -> Unit = { item, _ ->
+        item.data.items.map {
+            StatisticsCardItem(it, item.onHelpAction)
+        }.let { statsAdapter.update(it) }
+    }
+
+    data class Item(
+        val data: StatisticsData,
+        val onHelpAction: (StatsItem) -> Unit
+    ) : HomeItem {
+        override val stableId: Long = Item::class.java.name.hashCode().toLong()
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/IncidenceCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/IncidenceCard.kt
@@ -1,0 +1,28 @@
+package de.rki.coronawarnapp.statistics.ui.homecards.cards
+
+import android.view.ViewGroup
+import de.rki.coronawarnapp.R
+import de.rki.coronawarnapp.databinding.HomeStatisticsCardsIncidenceLayoutBinding
+import de.rki.coronawarnapp.statistics.IncidenceStats
+import de.rki.coronawarnapp.statistics.ui.homecards.StatisticsCardAdapter
+
+class IncidenceCard(parent: ViewGroup) :
+    StatisticsCardAdapter.ItemVH<StatisticsCardItem, HomeStatisticsCardsIncidenceLayoutBinding>(
+        R.layout.home_statistics_cards_basecard_layout, parent
+    ) {
+
+    override val viewBinding = lazy {
+        HomeStatisticsCardsIncidenceLayoutBinding.inflate(
+            layoutInflater,
+            itemView.findViewById(R.id.card_container),
+            true
+        )
+    }
+
+    override val onBindData: HomeStatisticsCardsIncidenceLayoutBinding.(
+        item: StatisticsCardItem,
+        payloads: List<Any>
+    ) -> Unit = { item, payloads ->
+        item.stats as IncidenceStats
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/InfectionsCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/InfectionsCard.kt
@@ -1,0 +1,28 @@
+package de.rki.coronawarnapp.statistics.ui.homecards.cards
+
+import android.view.ViewGroup
+import de.rki.coronawarnapp.R
+import de.rki.coronawarnapp.databinding.HomeStatisticsCardsInfectionsLayoutBinding
+import de.rki.coronawarnapp.statistics.InfectionStats
+import de.rki.coronawarnapp.statistics.ui.homecards.StatisticsCardAdapter
+
+class InfectionsCard(parent: ViewGroup) :
+    StatisticsCardAdapter.ItemVH<StatisticsCardItem, HomeStatisticsCardsInfectionsLayoutBinding>(
+        R.layout.home_statistics_cards_basecard_layout, parent
+    ) {
+
+    override val viewBinding = lazy {
+        HomeStatisticsCardsInfectionsLayoutBinding.inflate(
+            layoutInflater,
+            itemView.findViewById(R.id.card_container),
+            true
+        )
+    }
+
+    override val onBindData: HomeStatisticsCardsInfectionsLayoutBinding.(
+        item: StatisticsCardItem,
+        payloads: List<Any>
+    ) -> Unit = { item, payloads ->
+        item.stats as InfectionStats
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/KeySubmissionsCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/KeySubmissionsCard.kt
@@ -1,0 +1,28 @@
+package de.rki.coronawarnapp.statistics.ui.homecards.cards
+
+import android.view.ViewGroup
+import de.rki.coronawarnapp.R
+import de.rki.coronawarnapp.databinding.HomeStatisticsCardsKeysubmissionsLayoutBinding
+import de.rki.coronawarnapp.statistics.KeySubmissionsStats
+import de.rki.coronawarnapp.statistics.ui.homecards.StatisticsCardAdapter
+
+class KeySubmissionsCard(parent: ViewGroup) :
+    StatisticsCardAdapter.ItemVH<StatisticsCardItem, HomeStatisticsCardsKeysubmissionsLayoutBinding>(
+        R.layout.home_statistics_cards_basecard_layout, parent
+    ) {
+
+    override val viewBinding = lazy {
+        HomeStatisticsCardsKeysubmissionsLayoutBinding.inflate(
+            layoutInflater,
+            itemView.findViewById(R.id.card_container),
+            true
+        )
+    }
+
+    override val onBindData: HomeStatisticsCardsKeysubmissionsLayoutBinding.(
+        item: StatisticsCardItem,
+        payloads: List<Any>
+    ) -> Unit = { item, payloads ->
+        item.stats as KeySubmissionsStats
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/StatisticsCardItem.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/StatisticsCardItem.kt
@@ -1,0 +1,12 @@
+package de.rki.coronawarnapp.statistics.ui.homecards.cards
+
+import de.rki.coronawarnapp.statistics.StatsItem
+import de.rki.coronawarnapp.util.lists.HasStableId
+
+data class StatisticsCardItem(
+    val stats: StatsItem,
+    val onHelpAction: (StatsItem) -> Unit
+) : HasStableId {
+
+    override val stableId: Long = stats.cardId.toLong()
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeAdapter.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeAdapter.kt
@@ -3,6 +3,7 @@ package de.rki.coronawarnapp.ui.main.home
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
 import androidx.viewbinding.ViewBinding
+import de.rki.coronawarnapp.statistics.ui.homecards.StatisticsHomeCard
 import de.rki.coronawarnapp.submission.ui.homecards.TestErrorCard
 import de.rki.coronawarnapp.submission.ui.homecards.TestFetchingCard
 import de.rki.coronawarnapp.submission.ui.homecards.TestInvalidCard
@@ -52,7 +53,8 @@ class HomeAdapter : ModularAdapter<HomeAdapter.HomeItemVH<HomeItem, ViewBinding>
             TypedVHCreatorMod({ data[it] is TestReadyCard.Item }) { TestReadyCard(it) },
             TypedVHCreatorMod({ data[it] is TestPendingCard.Item }) { TestPendingCard(it) },
             TypedVHCreatorMod({ data[it] is TestUnregisteredCard.Item }) { TestUnregisteredCard(it) },
-            TypedVHCreatorMod({ data[it] is DiaryCard.Item }) { DiaryCard(it) }
+            TypedVHCreatorMod({ data[it] is DiaryCard.Item }) { DiaryCard(it) },
+            TypedVHCreatorMod({ data[it] is StatisticsHomeCard.Item }) { StatisticsHomeCard(it) }
         ))
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragmentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragmentViewModel.kt
@@ -8,6 +8,8 @@ import de.rki.coronawarnapp.appconfig.AppConfigProvider
 import de.rki.coronawarnapp.main.CWASettings
 import de.rki.coronawarnapp.notification.TestResultNotificationService
 import de.rki.coronawarnapp.risk.TimeVariables
+import de.rki.coronawarnapp.statistics.source.StatisticsProvider
+import de.rki.coronawarnapp.statistics.ui.homecards.StatisticsHomeCard
 import de.rki.coronawarnapp.storage.LocalData
 import de.rki.coronawarnapp.storage.TracingRepository
 import de.rki.coronawarnapp.submission.SubmissionRepository
@@ -74,7 +76,8 @@ class HomeFragmentViewModel @AssistedInject constructor(
     private val testResultNotificationService: TestResultNotificationService,
     private val submissionRepository: SubmissionRepository,
     private val cwaSettings: CWASettings,
-    appConfigProvider: AppConfigProvider
+    appConfigProvider: AppConfigProvider,
+    statisticsProvider: StatisticsProvider
 ) : CWAViewModel(dispatcherProvider = dispatcherProvider) {
 
     private val tracingStateProvider by lazy { tracingStateProviderFactory.create(isDetailsMode = false) }
@@ -209,8 +212,9 @@ class HomeFragmentViewModel @AssistedInject constructor(
     val homeItems: LiveData<List<HomeItem>> = combine(
         tracingCardItems,
         submissionCardItems,
-        submissionStateProvider.state
-    ) { tracingItem, submissionItem, submissionState ->
+        submissionStateProvider.state,
+        statisticsProvider.current
+    ) { tracingItem, submissionItem, submissionState, statsData ->
         mutableListOf<HomeItem>().apply {
             when (submissionState) {
                 TestPositive,
@@ -218,6 +222,10 @@ class HomeFragmentViewModel @AssistedInject constructor(
                     // Don't show risk card
                 }
                 else -> add(tracingItem)
+            }
+
+            if (statsData.isDataAvailable) {
+                add(StatisticsHomeCard.Item(data = statsData, onHelpAction = { TODO("Nav to help page") }))
             }
 
             add(submissionItem)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragmentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragmentViewModel.kt
@@ -225,7 +225,7 @@ class HomeFragmentViewModel @AssistedInject constructor(
             }
 
             if (statsData.isDataAvailable) {
-                add(StatisticsHomeCard.Item(data = statsData, onHelpAction = { TODO("Nav to help page") }))
+                add(StatisticsHomeCard.Item(data = statsData, onHelpAction = { }))
             }
 
             add(submissionItem)

--- a/Corona-Warn-App/src/main/res/layout/home_statistics_cards_basecard_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_statistics_cards_basecard_layout.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/card_container"
+    android:layout_width="328dp"
+    android:layout_height="300dp"
+    android:backgroundTint="@color/colorSurface1"
+    android:focusable="true"
+    android:foreground="?selectableItemBackground"
+    app:cardCornerRadius="@dimen/radius_card"
+    app:cardElevation="@dimen/elevation_strong" />

--- a/Corona-Warn-App/src/main/res/layout/home_statistics_cards_incidence_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_statistics_cards_incidence_layout.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:showIn="@layout/home_statistics_cards_basecard_layout">
+
+        <TextView
+            android:id="@+id/title"
+            style="@style/headline5"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="24dp"
+            android:layout_marginTop="24dp"
+            android:focusable="false"
+            android:text="Incidence"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/Corona-Warn-App/src/main/res/layout/home_statistics_cards_infections_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_statistics_cards_infections_layout.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:showIn="@layout/home_statistics_cards_basecard_layout">
+
+        <TextView
+            android:id="@+id/title"
+            style="@style/headline5"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:focusable="false"
+            android:layout_marginStart="24dp"
+            android:layout_marginTop="24dp"
+            android:text="Infections"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/Corona-Warn-App/src/main/res/layout/home_statistics_cards_keysubmissions_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_statistics_cards_keysubmissions_layout.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:showIn="@layout/home_statistics_cards_basecard_layout">
+
+        <TextView
+            android:id="@+id/title"
+            style="@style/headline5"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="24dp"
+            android:layout_marginTop="24dp"
+            android:focusable="false"
+            android:text="Key Submissions"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/Corona-Warn-App/src/main/res/layout/home_statistics_scrollcontainer.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_statistics_scrollcontainer.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/statistics_recyclerview"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/spacing_tiny"
+    android:layout_marginBottom="@dimen/spacing_tiny" />

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/main/home/HomeFragmentViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/main/home/HomeFragmentViewModelTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import de.rki.coronawarnapp.appconfig.AppConfigProvider
 import de.rki.coronawarnapp.main.CWASettings
 import de.rki.coronawarnapp.notification.TestResultNotificationService
+import de.rki.coronawarnapp.statistics.source.StatisticsProvider
 import de.rki.coronawarnapp.storage.TracingRepository
 import de.rki.coronawarnapp.submission.SubmissionRepository
 import de.rki.coronawarnapp.submission.ui.homecards.SubmissionDone
@@ -55,6 +56,7 @@ class HomeFragmentViewModelTest : BaseTest() {
     @MockK lateinit var submissionRepository: SubmissionRepository
     @MockK lateinit var cwaSettings: CWASettings
     @MockK lateinit var appConfigProvider: AppConfigProvider
+    @MockK lateinit var statisticsProvider: StatisticsProvider
 
     @BeforeEach
     fun setup() {
@@ -70,6 +72,7 @@ class HomeFragmentViewModelTest : BaseTest() {
         every { submissionRepository.hasViewedTestResult } returns flowOf(true)
 
         coEvery { appConfigProvider.currentConfig } returns emptyFlow()
+        coEvery { statisticsProvider.current } returns emptyFlow()
     }
 
     @AfterEach
@@ -87,7 +90,8 @@ class HomeFragmentViewModelTest : BaseTest() {
         submissionStateProvider = submissionStateProvider,
         tracingStateProviderFactory = tracingStateProviderFactory,
         cwaSettings = cwaSettings,
-        appConfigProvider = appConfigProvider
+        appConfigProvider = appConfigProvider,
+        statisticsProvider = statisticsProvider
     )
 
     @Test


### PR DESCRIPTION
Introduce base for showing statistics in the home screen feed to enable parallel work on each screen.
Adds a nested horizontally scrolling RecyclerView that supports dynamic content updates.

### Testing
* It should not crash
* The code should not have any broad flaws that will be a problem later on