### PR TITLE
Adjust LongMethod LINT check (DEV)

### DIFF
--- a/Corona-Warn-App/config/detekt.yml
+++ b/Corona-Warn-App/config/detekt.yml
@@ -77,7 +77,7 @@ complexity:
     threshold: 600
   LongMethod:
     active: true
-    threshold: 60
+    threshold: 120
   LongParameterList:
     active: true
     functionThreshold: 6

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/risklevel/ui/TestRiskLevelCalculationFragment.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/risklevel/ui/TestRiskLevelCalculationFragment.kt
@@ -25,7 +25,6 @@ import timber.log.Timber
 import java.io.File
 import javax.inject.Inject
 
-@Suppress("LongMethod")
 class TestRiskLevelCalculationFragment : Fragment(R.layout.fragment_test_risk_level_calculation),
     AutoInject {
     private val navArgs by navArgs<TestRiskLevelCalculationFragmentArgs>()

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/tasks/ui/TestTaskControllerFragment.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/tasks/ui/TestTaskControllerFragment.kt
@@ -16,7 +16,6 @@ import de.rki.coronawarnapp.util.viewmodel.cwaViewModels
 import javax.inject.Inject
 
 @SuppressLint("SetTextI18n")
-@Suppress("LongMethod")
 class TestTaskControllerFragment : Fragment(R.layout.fragment_test_task_controller), AutoInject {
 
     @Inject lateinit var viewModelFactory: CWAViewModelFactoryProvider.Factory

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/DownloadDiagnosisKeysTask.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/DownloadDiagnosisKeysTask.kt
@@ -39,7 +39,6 @@ class DownloadDiagnosisKeysTask @Inject constructor(
 
     private var isCanceled = false
 
-    @Suppress("LongMethod")
     override suspend fun run(arguments: Task.Arguments): Task.Result {
         val rollbackItems = mutableListOf<RollbackItem>()
         try {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/exception/reporting/ErrorReportReceiver.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/exception/reporting/ErrorReportReceiver.kt
@@ -13,7 +13,6 @@ import java.util.Locale
 
 class ErrorReportReceiver(private val activity: Activity) : BroadcastReceiver() {
 
-    @Suppress("LongMethod")
     override fun onReceive(context: Context, intent: Intent) {
         val category = ExceptionCategory
             .valueOf(intent.getStringExtra(ReportingConstants.ERROR_REPORT_CATEGORY_EXTRA) ?: "")

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelTask.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelTask.kt
@@ -48,7 +48,6 @@ class RiskLevelTask @Inject constructor(
 
     private var isCanceled = false
 
-    @Suppress("LongMethod")
     override suspend fun run(arguments: Task.Arguments): RiskLevelTaskResult = try {
         Timber.d("Running with arguments=%s", arguments)
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragment.kt
@@ -47,7 +47,6 @@ class HomeFragment : Fragment(R.layout.home_fragment_layout), AutoInject {
 
     private val homeAdapter = HomeAdapter()
 
-    @Suppress("LongMethod")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 


### PR DESCRIPTION
Long methods are not generally bad and should be decided on a case by case basis in PR reviews.
`60` was evidently too short when we look at how often we used `Suppress`.

I think it decreases readability if code is just split to satisfy that LINT check, especially in `onViewCreated`.