### PR TITLE
Fix missing timestamp on TracingFailed card (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/states/TracingState.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/states/TracingState.kt
@@ -131,13 +131,13 @@ data class TracingFailed(
 
     val showRestartButton: Boolean = !isInDetailsMode
 
-    fun getTimeFetched(c: Context): String = if (lastExposureDetectionTime != null) {
-        c.getString(
+    fun getTimeFetched(context: Context): String = if (lastExposureDetectionTime != null) {
+        context.getString(
             R.string.risk_card_body_time_fetched,
-            formatRelativeDateTimeString(c, lastExposureDetectionTime)
+            formatRelativeDateTimeString(context, lastExposureDetectionTime)
         )
     } else {
-        c.getString(R.string.risk_card_body_not_yet_fetched)
+        context.getString(R.string.risk_card_body_not_yet_fetched)
     }
 
     fun getLastRiskState(c: Context): String {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/states/TracingState.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/states/TracingState.kt
@@ -131,18 +131,13 @@ data class TracingFailed(
 
     val showRestartButton: Boolean = !isInDetailsMode
 
-    fun getTimeFetched(c: Context): String = when (riskState) {
-        RiskState.LOW_RISK, RiskState.INCREASED_RISK -> {
-            if (lastExposureDetectionTime != null) {
-                c.getString(
-                    R.string.risk_card_body_time_fetched,
-                    formatRelativeDateTimeString(c, lastExposureDetectionTime)
-                )
-            } else {
-                c.getString(R.string.risk_card_body_not_yet_fetched)
-            }
-        }
-        else -> ""
+    fun getTimeFetched(c: Context): String = if (lastExposureDetectionTime != null) {
+        c.getString(
+            R.string.risk_card_body_time_fetched,
+            formatRelativeDateTimeString(c, lastExposureDetectionTime)
+        )
+    } else {
+        c.getString(R.string.risk_card_body_not_yet_fetched)
     }
 
     fun getLastRiskState(c: Context): String {


### PR DESCRIPTION
Just noticed while working on something else.

The card looked like this:
![Screenshot from 2021-01-07 11-50-06](https://user-images.githubusercontent.com/1439229/103885221-f5ff2400-50df-11eb-9b46-e3200a3ea711.png)

I see no reason to not display the timestamp here. Seems to be an oversight from refactoring.
The TracingDisabled card also did not have this restriction to LOW/INCREASED risk levels.