### PR TITLE
Transnational country list names not changing when language is changed (EXPOSUREAPP-4416)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/Country.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/Country.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import de.rki.coronawarnapp.R
-import de.rki.coronawarnapp.util.ui.CachedString
 
 enum class Country(
     val code: String,
@@ -47,5 +46,4 @@ enum class Country(
     fun getLabel(context: Context): String {
         return context.getString(labelRes)
     }
-
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/Country.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/Country.kt
@@ -1,5 +1,6 @@
 package de.rki.coronawarnapp.ui
 
+import android.content.Context
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import de.rki.coronawarnapp.R
@@ -43,5 +44,8 @@ enum class Country(
     SI("si", R.string.country_name_si, R.drawable.ic_country_si),
     SK("sk", R.string.country_name_sk, R.drawable.ic_country_sk);
 
-    val label = CachedString { it.getString(labelRes) }
+    fun getLabel(context: Context): String {
+        return context.getString(labelRes)
+    }
+
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/view/CountryListView.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/view/CountryListView.kt
@@ -25,10 +25,10 @@ class CountryListView(context: Context, attrs: AttributeSet) : LinearLayout(cont
         set(value) {
             field = value.sortedWith { a, b ->
                 // Sort country list alphabetically
-                Collator.getInstance().compare(a.label.get(context), b.label.get(context))
+                Collator.getInstance().compare(a.getLabel(context), b.getLabel(context))
             }.also { countries ->
                 adapterCountryFlags.countryList = countries
-                countryNames.text = countries.joinToString(", ") { context.getString(it.labelRes) }
+                countryNames.text = countries.joinToString(", ") { it.getLabel(context) }
             }
         }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/view/CountryListView.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/view/CountryListView.kt
@@ -28,7 +28,7 @@ class CountryListView(context: Context, attrs: AttributeSet) : LinearLayout(cont
                 Collator.getInstance().compare(a.label.get(context), b.label.get(context))
             }.also { countries ->
                 adapterCountryFlags.countryList = countries
-                countryNames.text = countries.joinToString(", ") { it.label.get(context) }
+                countryNames.text = countries.joinToString(", ") { context.getString(it.labelRes) }
             }
         }
 


### PR DESCRIPTION
This PR fixes an issue where the country names in the transnational country list are not changed when changing the system language.
This only occurred when this particular screen is currently opened or was opened before. This behaviour was traced back to the usage of CachedStrings for the country names.

While testing the changes, no performance issue was identified.