### PR TITLE
Log uncaught exceptions (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CWADebug.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CWADebug.kt
@@ -2,9 +2,11 @@ package de.rki.coronawarnapp.util
 
 import android.app.Application
 import android.os.Build
+import androidx.annotation.VisibleForTesting
 import de.rki.coronawarnapp.BuildConfig
 import de.rki.coronawarnapp.bugreporting.debuglog.DebugLogger
 import de.rki.coronawarnapp.util.debug.FileLogger
+import de.rki.coronawarnapp.util.debug.UncaughtExceptionLogger
 import de.rki.coronawarnapp.util.di.ApplicationComponent
 import timber.log.Timber
 
@@ -20,6 +22,8 @@ object CWADebug {
         if (isDeviceForTestersBuild) {
             fileLogger = FileLogger(application)
         }
+
+        setupExceptionHandler()
 
         DebugLogger.init(application)
 
@@ -56,5 +60,13 @@ object CWADebug {
         Timber.i("CWA version: %s (%s)", BuildConfig.VERSION_CODE, BuildConfig.GIT_COMMIT_SHORT_HASH)
         Timber.i("CWA flavor: %s (%s)", BuildConfig.FLAVOR, BuildConfig.BUILD_TYPE)
         Timber.i("Build.FINGERPRINT: %s", Build.FINGERPRINT)
+    }
+
+    /**
+     * Allow internal logging via `DebugLogger` to log stacktraces for uncaught exceptions.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun setupExceptionHandler() {
+        UncaughtExceptionLogger.wrapCurrentHandler()
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/debug/UncaughtExceptionLogger.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/debug/UncaughtExceptionLogger.kt
@@ -1,0 +1,23 @@
+package de.rki.coronawarnapp.util.debug
+
+import timber.log.Timber
+
+class UncaughtExceptionLogger(
+    private val wrappedHandler: Thread.UncaughtExceptionHandler?
+) : Thread.UncaughtExceptionHandler {
+
+    init {
+        Timber.v("Wrapping exception handler: %s", wrappedHandler)
+    }
+
+    override fun uncaughtException(thread: Thread, error: Throwable) {
+        Timber.tag(thread.name).e(error, "Uncaught exception!")
+        wrappedHandler?.uncaughtException(thread, error)
+    }
+
+    companion object {
+        fun wrapCurrentHandler() = UncaughtExceptionLogger(Thread.getDefaultUncaughtExceptionHandler()).also {
+            Thread.setDefaultUncaughtExceptionHandler(it)
+        }
+    }
+}

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/debug/UncaughtExceptionLoggerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/debug/UncaughtExceptionLoggerTest.kt
@@ -1,0 +1,63 @@
+package de.rki.coronawarnapp.util.debug
+
+import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class UncaughtExceptionLoggerTest : BaseTest() {
+
+    var originalHandler: Thread.UncaughtExceptionHandler? = null
+
+    @BeforeEach
+    fun setup() {
+        originalHandler = Thread.getDefaultUncaughtExceptionHandler()
+    }
+
+    @AfterEach
+    fun teardown() {
+        Thread.setDefaultUncaughtExceptionHandler(originalHandler)
+    }
+
+    @Test
+    fun `we wrap and call through to the original handler`() {
+        val wrappedHandler = mockk<Thread.UncaughtExceptionHandler>()
+        every { wrappedHandler.uncaughtException(any(), any()) } just Runs
+
+        val instance = UncaughtExceptionLogger(wrappedHandler)
+        val testException = NotImplementedError()
+        instance.uncaughtException(Thread.currentThread(), testException)
+
+        verify { wrappedHandler.uncaughtException(Thread.currentThread(), testException) }
+    }
+
+    @Test
+    fun `auto setup replaces the current handler`() {
+        val wrappedHandler = mockk<Thread.UncaughtExceptionHandler>()
+        every { wrappedHandler.uncaughtException(any(), any()) } just Runs
+
+        Thread.setDefaultUncaughtExceptionHandler(wrappedHandler)
+        Thread.getDefaultUncaughtExceptionHandler() shouldBe wrappedHandler
+
+        val ourHandler = UncaughtExceptionLogger.wrapCurrentHandler()
+        Thread.getDefaultUncaughtExceptionHandler() shouldBe ourHandler
+    }
+
+    @Test
+    fun `null handlers would be okay`() {
+        Thread.setDefaultUncaughtExceptionHandler(null)
+        Thread.getDefaultUncaughtExceptionHandler() shouldBe null
+
+        val ourHandler = UncaughtExceptionLogger.wrapCurrentHandler()
+        Thread.getDefaultUncaughtExceptionHandler() shouldBe ourHandler
+
+        val instance = UncaughtExceptionLogger(null)
+        instance.uncaughtException(Thread.currentThread(), NotImplementedError())
+    }
+}


### PR DESCRIPTION
Catch uncaught exceptions and log them before forwarding and crashing.
This allows our logging to capture those errors that crash the app, too.

### Testing
* Make the app crash and check that the stacktrace that took it down is present in the logfile when sharing it afterwards.