### PR TITLE
Remove @dimen/match_constraint as it is replaced by tooling (DEV)

### DIFF
--- a/Corona-Warn-App/src/deviceForTesters/res/layout/fragment_test_contact_diary.xml
+++ b/Corona-Warn-App/src/deviceForTesters/res/layout/fragment_test_contact_diary.xml
@@ -124,7 +124,7 @@
 
             <View
                 android:id="@+id/divider_top"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="@dimen/card_divider"
                 android:layout_marginTop="@dimen/spacing_small"
                 android:background="@color/colorHairline"
@@ -166,7 +166,7 @@
 
             <View
                 android:id="@+id/divider_bottom"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="@dimen/card_divider"
                 android:layout_marginTop="@dimen/spacing_small"
                 android:background="@color/colorHairline"

--- a/Corona-Warn-App/src/deviceForTesters/res/layout/view_crashreport_list_item.xml
+++ b/Corona-Warn-App/src/deviceForTesters/res/layout/view_crashreport_list_item.xml
@@ -45,7 +45,7 @@
             <TextView
                 android:id="@+id/textViewCrashReportDate"
                 style="@style/body1"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="4dp"
                 android:text="@{crashReportDateFormatted}"

--- a/Corona-Warn-App/src/main/res/layout/contact_diary_day_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/contact_diary_day_fragment.xml
@@ -11,7 +11,7 @@
 
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/contact_diary_day_header"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:background="@drawable/contact_diary_background"
             android:elevation="@dimen/elevation_weak"
@@ -23,7 +23,7 @@
 
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/contact_diary_day_tab_layout"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:background="@drawable/contact_diary_background"
             android:elevation="@dimen/elevation_weak"
@@ -35,8 +35,8 @@
 
         <androidx.viewpager2.widget.ViewPager2
             android:id="@+id/contact_diary_day_view_pager"
-            android:layout_width="@dimen/match_constraint"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/Corona-Warn-App/src/main/res/layout/contact_diary_edit_list_item.xml
+++ b/Corona-Warn-App/src/main/res/layout/contact_diary_edit_list_item.xml
@@ -12,7 +12,7 @@
     <TextView
         android:id="@+id/name"
         style="@style/subtitle"
-        android:layout_width="@dimen/match_constraint"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:ellipsize="end"
         android:maxLines="1"

--- a/Corona-Warn-App/src/main/res/layout/contact_diary_edit_locations_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/contact_diary_edit_locations_fragment.xml
@@ -9,7 +9,7 @@
 
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -40,7 +40,7 @@
         <TextView
             android:id="@+id/contact_diary_location_list_no_items_title"
             style="@style/subtitleMedium"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/spacing_huge"
             android:layout_marginTop="@dimen/spacing_normal"
@@ -53,8 +53,8 @@
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/locations_recycler_view"
-            android:layout_width="@dimen/match_constraint"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             android:layout_margin="@dimen/spacing_normal"
             android:importantForAccessibility="no"
             android:scrollbars="vertical"
@@ -67,7 +67,7 @@
         <android.widget.Button
             android:id="@+id/delete_button"
             style="@style/buttonReset"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_margin="@dimen/spacing_normal"
             android:text="@string/contact_diary_remove_all_button"

--- a/Corona-Warn-App/src/main/res/layout/contact_diary_edit_persons_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/contact_diary_edit_persons_fragment.xml
@@ -9,7 +9,7 @@
 
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             style="@style/CWAToolbar.Close"
             app:layout_constraintEnd_toEndOf="parent"
@@ -40,7 +40,7 @@
         <TextView
             android:id="@+id/contact_diary_person_list_no_items_title"
             style="@style/subtitleMedium"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/spacing_huge"
             android:layout_marginTop="@dimen/spacing_normal"
@@ -53,8 +53,8 @@
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/persons_recycler_view"
-            android:layout_width="@dimen/match_constraint"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             android:layout_margin="@dimen/spacing_normal"
             android:importantForAccessibility="no"
             android:scrollbars="vertical"
@@ -67,7 +67,7 @@
         <android.widget.Button
             android:id="@+id/delete_button"
             style="@style/buttonReset"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_margin="@dimen/spacing_normal"
             android:text="@string/contact_diary_remove_all_button"

--- a/Corona-Warn-App/src/main/res/layout/contact_diary_homescreen_card_include.xml
+++ b/Corona-Warn-App/src/main/res/layout/contact_diary_homescreen_card_include.xml
@@ -10,7 +10,7 @@
         <TextView
             android:id="@+id/contact_diary_card_homescreen_title"
             style="@style/headline5"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/card_padding"
             android:layout_marginTop="@dimen/card_padding"
@@ -23,7 +23,7 @@
         <TextView
             android:id="@+id/contact_diary_card_homescreen_body"
             style="@style/subtitleMedium"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/card_padding"
             android:layout_marginTop="@dimen/spacing_normal"
@@ -55,7 +55,7 @@
         <Button
             android:id="@+id/contact_diary_card_homescreen_button"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/card_padding"
             android:layout_marginTop="@dimen/spacing_normal"

--- a/Corona-Warn-App/src/main/res/layout/contact_diary_location_bottom_sheet_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/contact_diary_location_bottom_sheet_fragment.xml
@@ -44,7 +44,7 @@
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/contact_diary_location_bottom_sheet_text_input_layout"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/spacing_normal"
             android:layout_marginTop="@dimen/spacing_small"
@@ -67,7 +67,7 @@
         <android.widget.Button
             android:id="@+id/contact_diary_location_bottom_sheet_save_button"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/spacing_normal"
             android:layout_marginTop="@dimen/spacing_normal"

--- a/Corona-Warn-App/src/main/res/layout/contact_diary_location_list_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/contact_diary_location_list_fragment.xml
@@ -8,8 +8,8 @@
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/contact_diary_location_list_recycler_view"
-            android:layout_width="@dimen/match_constraint"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             android:layout_marginHorizontal="@dimen/spacing_small"
             android:layout_marginVertical="@dimen/spacing_normal"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
@@ -40,7 +40,7 @@
         <TextView
             android:id="@+id/contact_diary_location_list_no_items_title"
             style="@style/subtitle"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/spacing_huge"
             android:layout_marginTop="@dimen/spacing_normal"
@@ -54,7 +54,7 @@
         <TextView
             android:id="@+id/contact_diary_location_list_no_items_subtitle"
             style="@style/body2Medium"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/spacing_huge"
             android:layout_marginTop="@dimen/spacing_tiny"

--- a/Corona-Warn-App/src/main/res/layout/contact_diary_location_list_item.xml
+++ b/Corona-Warn-App/src/main/res/layout/contact_diary_location_list_item.xml
@@ -23,7 +23,7 @@
         <TextView
             android:id="@+id/contact_diary_location_list_item_name"
             style="@style/subtitle"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/spacing_small"
             android:layout_marginVertical="@dimen/spacing_small"

--- a/Corona-Warn-App/src/main/res/layout/contact_diary_onboarding_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/contact_diary_onboarding_fragment.xml
@@ -13,7 +13,7 @@
 
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             style="@style/CWAToolbar.Close"
             app:layout_constraintEnd_toEndOf="parent"
@@ -22,8 +22,8 @@
             app:title="@string/contact_diary_title" />
 
         <ScrollView
-            android:layout_width="@dimen/match_constraint"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             android:layout_marginBottom="@dimen/spacing_small"
             app:layout_constraintBottom_toTopOf="@id/contact_diary_onboarding_next_button"
             app:layout_constraintEnd_toEndOf="parent"
@@ -36,7 +36,7 @@
 
                 <ImageView
                     android:id="@+id/contact_diary_onboarding_illustration"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:contentDescription="@string/contact_diary_onboarding_image_content_description"
                     android:focusable="true"
@@ -49,7 +49,7 @@
                 <TextView
                     android:id="@+id/onboarding_headline"
                     style="@style/headline5"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     android:accessibilityHeading="true"
@@ -63,7 +63,7 @@
                 <TextView
                     android:id="@+id/contact_diary_onboarding_body"
                     style="@style/subtitleMedium"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     android:focusable="true"
@@ -76,7 +76,7 @@
                 <include
                     android:id="@+id/contact_diary_onboarding_first_section"
                     layout="@layout/contact_diary_onboarding_row"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     android:focusable="true"
@@ -89,7 +89,7 @@
                 <include
                     android:id="@+id/contact_diary_onboarding_second_section"
                     layout="@layout/contact_diary_onboarding_row"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     android:focusable="true"
@@ -102,7 +102,7 @@
                 <include
                     android:id="@+id/contact_diary_onboarding_third_section"
                     layout="@layout/contact_diary_onboarding_row"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     android:focusable="true"
@@ -115,7 +115,7 @@
                 <include
                     android:id="@+id/contact_diary_onboarding_fourth_section"
                     layout="@layout/contact_diary_onboarding_row"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     android:focusable="true"
@@ -128,7 +128,7 @@
                 <include
                     android:id="@+id/contact_diary_onboarding_fifth_section"
                     layout="@layout/contact_diary_onboarding_row"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     android:focusable="true"
@@ -141,7 +141,7 @@
                 <include
                     android:id="@+id/contact_diary_onboarding_privacy_card"
                     layout="@layout/contact_diary_privacy_card"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="@dimen/guideline_card"
                     android:layout_marginTop="@dimen/spacing_normal"
@@ -152,7 +152,7 @@
 
                 <View
                     android:id="@+id/contact_diary_onboarding_first_divider"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="@dimen/card_divider"
                     android:layout_marginTop="@dimen/spacing_small"
                     android:background="?android:attr/listDivider"
@@ -163,7 +163,7 @@
                 <TextView
                     android:id="@+id/contact_diary_onboarding_privacy_information"
                     style="@style/subtitle"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:background="?selectableItemBackground"
                     android:clickable="true"
@@ -177,7 +177,7 @@
 
                 <View
                     android:id="@+id/contact_diary_onboarding_second_divider"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="@dimen/card_divider"
                     android:background="?android:attr/listDivider"
                     app:layout_constraintBottom_toBottomOf="parent"
@@ -206,7 +206,7 @@
         <android.widget.Button
             android:id="@+id/contact_diary_onboarding_next_button"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/spacing_normal"
             android:layout_marginEnd="@dimen/spacing_normal"

--- a/Corona-Warn-App/src/main/res/layout/contact_diary_onboarding_row.xml
+++ b/Corona-Warn-App/src/main/res/layout/contact_diary_onboarding_row.xml
@@ -33,7 +33,7 @@
         <TextView
             android:id="@+id/contact_diary_row_body"
             style="@style/subtitle"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/spacing_small"
             android:text="@{body}"

--- a/Corona-Warn-App/src/main/res/layout/contact_diary_overview_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/contact_diary_overview_fragment.xml
@@ -11,7 +11,7 @@
 
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             style="@style/CWAToolbar.BackArrow"
             android:background="@color/colorBackground"
@@ -24,7 +24,7 @@
         <TextView
             android:id="@+id/onboarding_headline"
             style="@style/headline5Bold"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_tiny"
             android:focusable="true"
@@ -37,7 +37,7 @@
         <TextView
             android:id="@+id/contact_diary_overview_subtitle"
             style="@style/subtitleMedium"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_small"
             android:focusable="true"
@@ -49,8 +49,8 @@
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/contact_diary_overview_recyclerview"
-            android:layout_width="@dimen/match_constraint"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             android:layout_marginTop="@dimen/spacing_small"
             android:layout_marginBottom="@dimen/spacing_mega_tiny"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"

--- a/Corona-Warn-App/src/main/res/layout/contact_diary_overview_list_item.xml
+++ b/Corona-Warn-App/src/main/res/layout/contact_diary_overview_list_item.xml
@@ -23,7 +23,7 @@
             <TextView
                 android:id="@+id/contact_diary_overview_element_name"
                 style="@style/contactDiaryListItem"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/spacing_small"
                 android:focusable="true"
@@ -35,7 +35,7 @@
 
             <ImageView
                 android:id="@+id/contact_diary_overview_element_right_arrow"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginVertical="@dimen/spacing_tiny"
                 android:layout_marginEnd="@dimen/spacing_small"

--- a/Corona-Warn-App/src/main/res/layout/contact_diary_overview_nested_list_item.xml
+++ b/Corona-Warn-App/src/main/res/layout/contact_diary_overview_nested_list_item.xml
@@ -25,7 +25,7 @@
         <ImageView
             android:id="@+id/contact_diary_overview_element_image"
             android:layout_width="wrap_content"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_height="0dp"
             android:layout_marginStart="@dimen/spacing_small"
             android:importantForAccessibility="no"
             android:scaleType="centerInside"
@@ -37,7 +37,7 @@
         <TextView
             android:id="@+id/contact_diary_overview_element_name"
             style="@style/subtitle"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/spacing_small"
             android:layout_marginEnd="@dimen/spacing_small"

--- a/Corona-Warn-App/src/main/res/layout/contact_diary_person_bottom_sheet_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/contact_diary_person_bottom_sheet_fragment.xml
@@ -43,7 +43,7 @@
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/contact_diary_person_bottom_sheet_text_input_layout"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/spacing_normal"
             android:layout_marginTop="@dimen/spacing_small"
@@ -66,7 +66,7 @@
         <android.widget.Button
             android:id="@+id/contact_diary_person_bottom_sheet_save_button"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/spacing_normal"
             android:layout_marginTop="@dimen/spacing_normal"

--- a/Corona-Warn-App/src/main/res/layout/contact_diary_person_list_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/contact_diary_person_list_fragment.xml
@@ -8,8 +8,8 @@
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/contact_diary_person_list_recycler_view"
-            android:layout_width="@dimen/match_constraint"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             android:layout_marginHorizontal="@dimen/spacing_small"
             android:layout_marginVertical="@dimen/spacing_normal"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
@@ -40,7 +40,7 @@
         <TextView
             android:id="@+id/contact_diary_person_list_no_items_title"
             style="@style/subtitle"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/spacing_huge"
             android:layout_marginTop="@dimen/spacing_normal"
@@ -54,7 +54,7 @@
         <TextView
             android:id="@+id/contact_diary_person_list_no_items_subtitle"
             style="@style/body2Medium"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/spacing_huge"
             android:layout_marginTop="@dimen/spacing_tiny"

--- a/Corona-Warn-App/src/main/res/layout/contact_diary_person_list_item.xml
+++ b/Corona-Warn-App/src/main/res/layout/contact_diary_person_list_item.xml
@@ -23,7 +23,7 @@
         <TextView
             android:id="@+id/contact_diary_person_list_item_name"
             style="@style/subtitle"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/spacing_small"
             android:layout_marginVertical="@dimen/spacing_small"

--- a/Corona-Warn-App/src/main/res/layout/contact_diary_privacy_card.xml
+++ b/Corona-Warn-App/src/main/res/layout/contact_diary_privacy_card.xml
@@ -14,7 +14,7 @@
             android:id="@+id/contact_diary_privacy_card_title"
             style="@style/headline5"
             android:accessibilityHeading="true"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/contact_diary_onboarding_privacy_information_title"
             android:focusable="true"
@@ -26,7 +26,7 @@
             android:id="@+id/contact_diary_privacy_card_first_section_title"
             style="@style/subtitle"
             android:accessibilityHeading="true"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             android:text="@string/contact_diary_onboarding_privacy_information_first_section_title"
@@ -38,7 +38,7 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/contact_diary_privacy_card_first_section_body_container_one"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             app:layout_constraintEnd_toEndOf="parent"
@@ -56,7 +56,7 @@
             <TextView
                 android:id="@+id/contact_diary_privacy_card_first_section_body_one"
                 style="@style/subtitle"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/spacing_normal"
                 android:focusable="true"
@@ -70,7 +70,7 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/contact_diary_privacy_card_first_section_body_container_two"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             app:layout_constraintEnd_toEndOf="parent"
@@ -87,7 +87,7 @@
             <TextView
                 android:id="@+id/contact_diary_privacy_card_first_section_body_two"
                 style="@style/subtitle"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/spacing_normal"
                 android:focusable="true"
@@ -102,7 +102,7 @@
         <TextView
             android:id="@+id/contact_diary_privacy_card_second_section_title"
             style="@style/subtitle"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             android:accessibilityHeading="true"
@@ -114,7 +114,7 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/contact_diary_privacy_card_second_section_body_container_one"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             app:layout_constraintEnd_toEndOf="parent"
@@ -131,7 +131,7 @@
             <TextView
                 android:id="@+id/contact_diary_privacy_card_second_section_body_one"
                 style="@style/subtitle"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/spacing_normal"
                 android:focusable="true"
@@ -145,7 +145,7 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/contact_diary_privacy_card_second_section_body_container_two"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             app:layout_constraintEnd_toEndOf="parent"
@@ -162,7 +162,7 @@
             <TextView
                 android:id="@+id/contact_diary_privacy_card_second_section_body_two"
                 style="@style/subtitle"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/spacing_normal"
                 android:focusable="true"

--- a/Corona-Warn-App/src/main/res/layout/fragment_information_legal.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_information_legal.xml
@@ -20,7 +20,7 @@
         <include
             android:id="@+id/information_legal_header"
             layout="@layout/include_header"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:icon="@{@drawable/ic_back}"
             app:layout_constraintEnd_toEndOf="parent"
@@ -29,8 +29,8 @@
             app:title="@{@string/information_legal_title}" />
 
         <ScrollView
-            android:layout_width="@dimen/match_constraint"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             android:fillViewport="true"
             android:focusable="true"
             app:layout_constraintBottom_toBottomOf="@+id/guideline_bottom"
@@ -70,7 +70,7 @@
                 <include
                     android:id="@+id/information_legal_divider_contact"
                     layout="@layout/include_divider"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_medium"
                     android:focusable="true"
@@ -108,7 +108,7 @@
                 <include
                     android:id="@+id/information_legal_contact_form"
                     layout="@layout/include_contact_form"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     app:layout_constraintEnd_toStartOf="@+id/guideline_end"
                     app:layout_constraintStart_toEndOf="@+id/guideline_start"
@@ -117,7 +117,7 @@
                 <include
                     android:id="@+id/information_legal_divider_taxid"
                     layout="@layout/include_divider"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_medium"
                     app:layout_constraintEnd_toEndOf="@+id/guideline_end"

--- a/Corona-Warn-App/src/main/res/layout/fragment_interoperability_configuration.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_interoperability_configuration.xml
@@ -15,7 +15,7 @@
         <include
             android:id="@+id/interoperability_configuration_header"
             layout="@layout/include_header"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:title="@{@string/interoperability_title}"
             app:icon="@{@drawable/ic_back}"

--- a/Corona-Warn-App/src/main/res/layout/fragment_onboarding_privacy.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_onboarding_privacy.xml
@@ -45,8 +45,8 @@
 
         <include
             layout="@layout/include_onboarding"
-            android:layout_width="@dimen/match_constraint"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             android:layout_marginBottom="@dimen/spacing_small"
             app:body="@{FormatterHelper.parseHtmlFromAssets(context, @string/information_privacy_html_path)}"
             app:headline="@{@string/onboarding_privacy_headline}"

--- a/Corona-Warn-App/src/main/res/layout/fragment_settings.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_settings.xml
@@ -84,7 +84,7 @@
                 <include
                     android:id="@+id/settings_background_priority"
                     layout="@layout/include_setting_row"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     app:body="@{@string/settings_background_priority_body_description}"
                     app:color="@{backgroundState.getBackgroundPriorityIconColor(context)}"

--- a/Corona-Warn-App/src/main/res/layout/fragment_settings_background_priority.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_settings_background_priority.xml
@@ -18,7 +18,7 @@
         <include
             android:id="@+id/settings_background_priority_header"
             layout="@layout/include_header"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:icon="@{@drawable/ic_back}"
             app:layout_constraintEnd_toEndOf="parent"
@@ -27,8 +27,8 @@
             app:title="@{@string/settings_background_priority_title}" />
 
         <ScrollView
-            android:layout_width="@dimen/match_constraint"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             android:fillViewport="true"
             app:layout_constraintBottom_toBottomOf="@+id/guideline_bottom"
             app:layout_constraintEnd_toEndOf="parent"
@@ -42,7 +42,7 @@
                 <include
                     android:id="@+id/settings_background_priority_header_details"
                     layout="@layout/include_information_details"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     app:body="@{@string/settings_background_priority_body}"
                     app:headline="@{@string/settings_background_priority_headline}"
@@ -101,7 +101,7 @@
                 <include
                     android:id="@+id/settings_tracing_status_connection"
                     layout="@layout/include_tracing_status_card"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_small"
                     app:body="@{@string/settings_background_priority_card_body}"

--- a/Corona-Warn-App/src/main/res/layout/fragment_settings_notifications.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_settings_notifications.xml
@@ -88,7 +88,7 @@
                 <include
                     android:id="@+id/settings_notifications_card"
                     layout="@layout/include_tracing_status_card"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_small"
                     gone="@{state == null || state.isNotificationsEnabled}"

--- a/Corona-Warn-App/src/main/res/layout/fragment_settings_reset.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_settings_reset.xml
@@ -50,7 +50,7 @@
                 <include
                     android:id="@+id/settings_reset_keys"
                     layout="@layout/include_tracing_status_card"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_medium"
                     app:body="@{@string/settings_reset_body_keys}"

--- a/Corona-Warn-App/src/main/res/layout/fragment_settings_tracing.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_settings_tracing.xml
@@ -61,7 +61,7 @@
                 <include
                     android:id="@+id/settings_tracing_switch_row"
                     layout="@layout/include_settings_switch_row"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     app:enabled="@{settingsTracingState.isTracingSwitchEnabled()}"
@@ -75,7 +75,7 @@
                 <include
                     android:id="@+id/settings_interoperability_row"
                     layout="@layout/include_settings_plain_row"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
@@ -86,7 +86,7 @@
 
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:id="@+id/settings_tracing_status"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_small"
                     app:layout_constraintEnd_toEndOf="parent"
@@ -96,7 +96,7 @@
                     <include
                         android:id="@+id/settings_tracing_status_location"
                         layout="@layout/include_tracing_status_card_location"
-                        android:layout_width="@dimen/match_constraint"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         gone="@{!settingsTracingState.isLocationCardVisible()}"
                         app:buttonText="@{@string/settings_tracing_status_location_button}"
@@ -109,7 +109,7 @@
                     <include
                         android:id="@+id/settings_tracing_status_bluetooth"
                         layout="@layout/include_tracing_status_card"
-                        android:layout_width="@dimen/match_constraint"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         gone="@{!settingsTracingState.isBluetoothCardVisible()}"
                         app:body="@{@string/settings_tracing_status_bluetooth_body}"
@@ -151,7 +151,7 @@
                     <TextView
                         android:id="@+id/settings_tracing_body"
                         style="@style/body1"
-                        android:layout_width="@dimen/match_constraint"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:focusable="true"
                         android:text="@string/settings_tracing_body_text"

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_consent.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_consent.xml
@@ -21,7 +21,7 @@
         <include
             android:id="@+id/submission_consent_header"
             layout="@layout/include_header"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:icon="@{@drawable/ic_close}"
             app:layout_constraintEnd_toEndOf="parent"
@@ -30,21 +30,21 @@
             app:title="@{@string/submission_consent_main_headline}" />
 
         <ScrollView
-            android:layout_width="@dimen/match_constraint"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/submission_consent_header"
             app:layout_constraintBottom_toTopOf="@+id/guideline_action">
 
             <androidx.constraintlayout.widget.ConstraintLayout
-                 android:layout_width="match_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:paddingBottom="@dimen/spacing_normal">
 
                 <ImageView
                     android:id="@+id/submission_consent_illustration"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:src="@drawable/ic_submission_consent"
                     app:layout_constraintTop_toTopOf="parent"
@@ -54,7 +54,7 @@
 
                 <include layout="@layout/include_submission_consent_intro"
                     android:id="@+id/include_submission_consent_intro"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     app:layout_constraintStart_toStartOf="parent"
@@ -63,7 +63,7 @@
 
                 <de.rki.coronawarnapp.ui.view.CountryListView
                     android:id="@+id/countryList"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     android:layout_marginHorizontal="@dimen/spacing_normal"
@@ -74,7 +74,7 @@
 
                 <include layout="@layout/include_submission_consent_body"
                     android:id="@+id/include_submission_consent_body"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     android:layout_marginHorizontal="@dimen/guideline_card"
@@ -84,7 +84,7 @@
 
                 <FrameLayout
                     android:id="@+id/divider"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="@dimen/card_divider"
                     android:layout_marginTop="@dimen/spacing_tiny"
                     android:background="@color/colorHairline"
@@ -94,7 +94,7 @@
 
                 <TextView
                     android:id="@+id/submission_consent_main_bottom_body"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:paddingVertical="@dimen/spacing_tiny"
                     android:text="@string/submission_consent_main_bottom_body"
@@ -108,7 +108,7 @@
                     style="@style/subtitle"/>
 
                 <FrameLayout
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="@dimen/card_divider"
                     android:background="@color/colorHairline"
                     app:layout_constraintTop_toBottomOf="@id/submission_consent_main_bottom_body"
@@ -124,7 +124,7 @@
         <Button
             android:id="@+id/submission_consent_button"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/submission_accept_button"
             android:textAllCaps="true"

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_contact.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_contact.xml
@@ -14,7 +14,7 @@
         <include
             android:id="@+id/submission_contact_header"
             layout="@layout/include_header"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:icon="@{@drawable/ic_back}"
             app:layout_constraintEnd_toEndOf="parent"
@@ -25,8 +25,8 @@
         <include
             android:id="@+id/include_submission_contact"
             layout="@layout/include_submission_contact"
-            android:layout_width="@dimen/match_constraint"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             app:layout_constraintBottom_toTopOf="@id/guideline_bottom"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -35,7 +35,7 @@
         <Button
             android:id="@+id/submission_contact_button_call"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/submission_contact_button_call"
             android:textAllCaps="true"
@@ -47,7 +47,7 @@
         <Button
             android:id="@+id/submission_contact_button_enter"
             style="@style/buttonLight"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/submission_contact_button_enter"
             android:textAllCaps="true"

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_country_selection.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_country_selection.xml
@@ -26,7 +26,7 @@
             <include
                 android:id="@+id/submission_country_selection_header"
                 layout="@layout/include_header"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 app:icon="@{@drawable/ic_back}"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -37,7 +37,7 @@
             <TextView
                 android:id="@+id/submission_country_selection_headline"
                 style="@style/headline5"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_normal"
                 android:accessibilityHeading="true"
@@ -49,7 +49,7 @@
             <include
                 android:id="@+id/submission_country_selection_selector"
                 layout="@layout/include_submission_country_selector"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="@dimen/spacing_tiny"
                 android:layout_marginTop="@dimen/spacing_medium"
@@ -62,7 +62,7 @@
             <include
                 android:id="@+id/submission_country_selection_no_selection"
                 layout="@layout/include_submission_country_no_selection"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="@dimen/spacing_tiny"
                 android:layout_marginTop="@dimen/spacing_small"
@@ -74,7 +74,7 @@
             <TextView
                 android:id="@+id/submission_country_selection_data_faq"
                 style="@style/body1"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_normal"
                 android:accessibilityHeading="true"
@@ -86,7 +86,7 @@
             <Button
                 android:id="@+id/submission_country_selection_button"
                 style="@style/buttonPrimary"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginVertical="@dimen/spacing_normal"
                 android:enabled="@{submissionCountrySelectViewModel.nextActive}"

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_dispatcher.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_dispatcher.xml
@@ -14,7 +14,7 @@
         <include
             android:id="@+id/submission_dispatcher_header"
             layout="@layout/include_header"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:icon="@{@drawable/ic_close}"
             app:layout_constraintEnd_toEndOf="parent"
@@ -39,7 +39,7 @@
 
                 <ImageView
                     android:id="@+id/submission_dispatcher_illustration"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:src="@drawable/ic_illustration_test"
                     app:layout_constraintEnd_toEndOf="parent"
@@ -49,7 +49,7 @@
                 <TextView
                     android:id="@+id/submission_dispatcher_text"
                     style="@style/subtitle"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     android:text="@string/submission_dispatcher_subheadline"
@@ -61,7 +61,7 @@
                 <TextView
                     android:id="@+id/submission_dispatcher_needs_testing_text"
                     style="@style/headline6"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     android:text="@string/submission_dispatcher_needs_testing_subheadline"
@@ -73,7 +73,7 @@
                 <include
                     android:id="@+id/submission_dispatcher_qr"
                     layout="@layout/include_dispatcher_card"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     android:clickable="true"
@@ -89,7 +89,7 @@
                 <TextView
                     android:id="@+id/submission_dispatcher_already_positive_text"
                     style="@style/headline6"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     android:text="@string/submission_dispatcher_already_positive_subheadline"
@@ -101,7 +101,7 @@
                 <include
                     android:id="@+id/submission_dispatcher_tan_code"
                     layout="@layout/include_dispatcher_card"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_small"
                     android:clickable="true"
@@ -116,7 +116,7 @@
                 <include
                     android:id="@+id/submission_dispatcher_tan_tele"
                     layout="@layout/include_dispatcher_card"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     android:layout_marginBottom="@dimen/spacing_normal"

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_done.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_done.xml
@@ -14,7 +14,7 @@
         <include
             android:id="@+id/submission_done_header"
             layout="@layout/include_header"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:icon="@{@drawable/ic_close}"
             app:layout_constraintEnd_toEndOf="parent"
@@ -24,8 +24,8 @@
         <include
             android:id="@+id/submission_done_content"
             layout="@layout/include_submission_done"
-            android:layout_width="@dimen/match_constraint"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             app:layout_constraintBottom_toBottomOf="@id/guideline_action"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -34,7 +34,7 @@
         <Button
             android:id="@+id/submission_done_button_done"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginVertical="@dimen/spacing_normal"
             android:text="@string/submission_done_button_done"

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_no_consent_positive_other_warning.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_no_consent_positive_other_warning.xml
@@ -21,7 +21,7 @@
         <include
             android:id="@+id/submission_positive_other_warning_header"
             layout="@layout/include_header"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:icon="@{@drawable/ic_back}"
             app:layout_constraintEnd_toEndOf="parent"
@@ -48,7 +48,7 @@
                 <ImageView
                     android:id="@+id/submission_positive_other_warning_hero_illustration"
                     bind:cwaContentDescription="@{@string/submission_positive_other_illustration_description}"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:src="@drawable/ic_submission_illustration_other_warning"
                     app:layout_constraintEnd_toEndOf="parent"
@@ -59,7 +59,7 @@
                 <TextView
                     android:id="@+id/submission_positive_other_warning_headline"
                     style="@style/headline5"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     android:accessibilityHeading="true"
@@ -72,7 +72,7 @@
                 <TextView
                     android:id="@+id/submission_positive_other_warning_text_first_part"
                     style="@style/subtitle"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     android:focusable="true"
@@ -84,7 +84,7 @@
                 <TextView
                     android:id="@+id/submission_positive_other_warning_text_second_part"
                     style="@style/subtitle"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     android:focusable="true"
@@ -96,7 +96,7 @@
 
                 <de.rki.coronawarnapp.ui.view.CountryListView
                     android:id="@+id/countryList"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     app:layout_constraintEnd_toEndOf="@+id/guideline_end"
@@ -106,7 +106,7 @@
                 <include
                     android:id="@+id/submission_positive_other_privacy"
                     layout="@layout/include_privacy_card_no_consent"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     app:layout_constraintEnd_toStartOf="@+id/guideline_card_end"
@@ -116,7 +116,7 @@
                 <include
                     android:id="@+id/submission_no_consent_main_first_point"
                     layout="@layout/view_bullet_point_text"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     app:itemText="@{@string/submission_consent_main_first_point}"
@@ -127,7 +127,7 @@
                 <include
                     android:id="@+id/submission_no_consent_main_second_point"
                     layout="@layout/view_bullet_point_text"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_tiny"
                     app:itemText="@{@string/submission_consent_main_third_point}"
@@ -138,7 +138,7 @@
                 <include
                     android:id="@+id/submission_no_consent_main_third_point"
                     layout="@layout/view_bullet_point_text"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_tiny"
                     app:itemText="@{@string/submission_consent_main_fourth_point}"
@@ -148,7 +148,7 @@
 
                 <FrameLayout
                     android:id="@+id/divider"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="@dimen/card_divider"
                     android:layout_marginTop="@dimen/spacing_small"
                     android:background="@color/colorHairline"
@@ -159,7 +159,7 @@
                 <TextView
                     android:id="@+id/submission_consent_main_bottom_body"
                     style="@style/subtitle"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:background="?selectableItemBackground"
                     android:clickable="true"
@@ -171,7 +171,7 @@
                     app:layout_constraintTop_toBottomOf="@id/divider" />
 
                 <FrameLayout
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="@dimen/card_divider"
                     android:background="@color/colorHairline"
                     app:layout_constraintEnd_toEndOf="@id/guideline_end"
@@ -188,7 +188,7 @@
         <Button
             android:id="@+id/submission_positive_other_warning_no_consent_button_next"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/submission_accept_button"
             android:textAllCaps="true"

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_positive_other_warning.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_positive_other_warning.xml
@@ -21,7 +21,7 @@
         <include
             android:id="@+id/submission_positive_other_warning_header"
             layout="@layout/include_header"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:icon="@{@drawable/ic_back}"
             app:layout_constraintEnd_toEndOf="parent"
@@ -31,8 +31,8 @@
 
         <include
             layout="@layout/include_submission_positive_other_warning"
-            android:layout_width="@dimen/match_constraint"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             app:countryData="@{uiState.countryList}"
             app:layout_constraintBottom_toTopOf="@+id/guideline_action"
             app:layout_constraintEnd_toEndOf="parent"
@@ -44,7 +44,7 @@
         <Button
             android:id="@+id/submission_positive_other_warning_button_next"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:enabled="@{uiState != null &amp;&amp; uiState.isSubmitButtonEnabled()}"
             android:text="@string/submission_accept_button"
@@ -57,7 +57,7 @@
         <ProgressBar
             android:id="@+id/submission_positive_other_warning_spinner"
             style="?android:attr/progressBarStyleHorizontal"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_large"
             android:indeterminate="true"

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_qr_code_scan.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_qr_code_scan.xml
@@ -12,8 +12,8 @@
 
         <com.journeyapps.barcodescanner.BarcodeView
             android:id="@+id/submission_qr_code_scan_preview"
-            android:layout_width="@dimen/match_constraint"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -25,8 +25,8 @@
 
         <com.journeyapps.barcodescanner.ViewfinderView
             android:id="@+id/submission_qr_code_scan_viewfinder_view"
-            android:layout_width="@dimen/match_constraint"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_result_ready.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_result_ready.xml
@@ -15,7 +15,7 @@
         <include
             android:id="@+id/submission_done_no_consent_header"
             layout="@layout/include_header"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:icon="@{@drawable/ic_close}"
             app:layout_constraintEnd_toEndOf="parent"
@@ -25,8 +25,8 @@
 
         <ScrollView
             android:id="@+id/content_scrollcontainer"
-            android:layout_width="@dimen/match_constraint"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             android:fillViewport="true"
             app:layout_constraintBottom_toTopOf="@+id/submission_done_button_continue_with_symptom_recording"
             app:layout_constraintEnd_toEndOf="parent"
@@ -42,7 +42,7 @@
 
                 <ImageView
                     android:id="@+id/submission_done_hero_illustration"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:focusable="true"
                     android:src="@drawable/ic_illustration_together"
@@ -54,7 +54,7 @@
                 <TextView
                     android:id="@+id/submission_done_text"
                     style="@style/headline6"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="@dimen/spacing_normal"
                     android:layout_marginEnd="@dimen/spacing_normal"
@@ -67,7 +67,7 @@
                 <TextView
                     android:id="@+id/submission_done_subtitle"
                     style="@style/headline6"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     android:accessibilityHeading="true"
@@ -80,7 +80,7 @@
                 <TextView
                     android:id="@+id/submission_done_no_consent_body"
                     style="@style/subtitle"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     android:accessibilityHeading="true"
@@ -109,7 +109,7 @@
         <Button
             android:id="@+id/submission_done_contact_button_finish_flow"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/spacing_small"
             android:text="@string/submission_done_no_consent_break_flow"

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_tan.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_tan.xml
@@ -21,7 +21,7 @@
         <include
             android:id="@+id/submission_tan_header"
             layout="@layout/include_header"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:focusable="false"
             app:icon="@{@drawable/ic_close}"
@@ -33,8 +33,8 @@
         <include
             android:id="@+id/submission_tan_content"
             layout="@layout/include_submission_tan"
-            android:layout_width="@dimen/match_constraint"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             app:layout_constraintBottom_toTopOf="@id/guideline_action"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -54,7 +54,7 @@
         <Button
             android:id="@+id/submission_tan_button_enter"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:enabled="@{uiState.tanValid}"
             android:text="@string/submission_tan_button_text"

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_test_result_available.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_test_result_available.xml
@@ -15,7 +15,7 @@
         <include
             android:id="@+id/submission_test_result_available_header"
             layout="@layout/include_header"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:icon="@{@drawable/ic_close}"
             app:title="@{@string/submission_test_result_available_title}"
@@ -24,8 +24,8 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <ScrollView
-            android:layout_width="@dimen/match_constraint"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             app:layout_constraintBottom_toBottomOf="@id/guideline_action"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="1.0"
@@ -40,7 +40,7 @@
 
                 <ImageView
                     android:id="@+id/submission_test_result_illustration_result_available"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:focusable="true"
                     android:src="@drawable/ic_test_result_illustration_result_available"
@@ -52,7 +52,7 @@
 
                 <de.rki.coronawarnapp.ui.submission.consentstatus.ConsentStatusView
                     android:id="@+id/submission_test_result_available_consent_status"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_medium"
                     android:focusable="true"
@@ -63,7 +63,7 @@
                 <TextView
                     android:id="@+id/submission_test_result_available_text"
                     style="@style/subtitle"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     android:layout_marginStart="@dimen/spacing_normal"
@@ -83,7 +83,7 @@
         <Button
             android:id="@+id/submission_test_result_available_proceed_button"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginVertical="@dimen/spacing_normal"
             android:text="@string/submission_intro_button_next"

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_test_result_consent_given.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_test_result_consent_given.xml
@@ -21,7 +21,7 @@
         <include
             android:id="@+id/submission_test_result_consent_given_header"
             layout="@layout/include_header"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:icon="@{@drawable/ic_close}"
             app:layout_constraintEnd_toEndOf="parent"
@@ -30,8 +30,8 @@
             app:title="@{@string/submission_test_result_consent_given_heading}" />
 
         <ScrollView
-            android:layout_width="@dimen/match_constraint"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             app:layout_constraintEnd_toEndOf="@+id/guideline_end"
             app:layout_constraintStart_toStartOf="@+id/guideline_start"
             android:fillViewport="true"
@@ -46,7 +46,7 @@
 
                 <de.rki.coronawarnapp.ui.view.TestResultSectionView
                     android:id="@+id/submission_test_result_section"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_small"
                     android:focusable="true"
@@ -58,7 +58,7 @@
                 <TextView
                     android:id="@+id/submission_test_result_consent_given_subtitle"
                     style="@style/headline6"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_medium"
                     android:accessibilityHeading="true"
@@ -70,7 +70,7 @@
                 <TextView
                     android:id="@+id/submission_test_result_consent_given_body"
                     style="@style/body1"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_medium"
                     android:accessibilityHeading="true"
@@ -92,7 +92,7 @@
         <Button
             android:id="@+id/submission_test_result_button_consent_given_continue"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/submission_test_result_positive_continue_button_with_symptoms"
             app:layout_constraintBottom_toTopOf="@+id/submission_test_result_button__consent_given_continue_without_symptoms"
@@ -103,7 +103,7 @@
         <Button
             android:id="@+id/submission_test_result_button_consent_given_continue_without_symptoms"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/submission_test_result_consent_given_breakup_button"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_test_result_invalid.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_test_result_invalid.xml
@@ -12,7 +12,7 @@
         <include
             android:id="@+id/submission_test_result_header"
             layout="@layout/include_header"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:icon="@{@drawable/ic_close}"
             app:layout_constraintEnd_toEndOf="parent"
@@ -96,7 +96,7 @@
         <Button
             android:id="@+id/submission_test_result_button_invalid_remove_test"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_margin="@dimen/spacing_normal"
             android:text="@string/submission_test_result_invalid_remove_test_button"

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_test_result_negative.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_test_result_negative.xml
@@ -12,7 +12,7 @@
         <include
             android:id="@+id/submission_test_result_header"
             layout="@layout/include_header"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:icon="@{@drawable/ic_close}"
             app:layout_constraintEnd_toEndOf="parent"
@@ -122,7 +122,7 @@
         <Button
             android:id="@+id/submission_test_result_button_negative_remove_test"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_margin="@dimen/spacing_normal"
             android:text="@string/submission_test_result_negative_remove_test_button"

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_test_result_positive_no_consent.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_test_result_positive_no_consent.xml
@@ -15,7 +15,7 @@
         <include
             android:id="@+id/submission_test_result_consent_given_header"
             layout="@layout/include_header"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:icon="@{@drawable/ic_close}"
             app:layout_constraintEnd_toEndOf="parent"
@@ -24,8 +24,8 @@
             app:title="@{@string/submission_test_result_consent_given_heading}" />
 
         <ScrollView
-            android:layout_width="@dimen/match_constraint"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             android:layout_marginBottom="@dimen/spacing_normal"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -42,7 +42,7 @@
 
                 <de.rki.coronawarnapp.ui.view.TestResultSectionView
                     android:id="@+id/submission_test_result_section"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_small"
                     android:focusable="true"
@@ -55,7 +55,7 @@
                     android:id="@+id/submission_test_result_positive_no_consent_subtitle"
                     style="@style/headline5"
                     android:accessibilityHeading="true"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_medium"
                     android:text="@string/submission_test_result_positive_no_consent_subtitle"
@@ -80,7 +80,7 @@
 
                 <TextView
                     android:id="@+id/submission_test_result_positive_no_consent_text_1"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     android:layout_marginStart="@dimen/spacing_small"
@@ -106,7 +106,7 @@
 
                 <TextView
                     android:id="@+id/submission_test_result_positive_no_consent_text_2"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     android:layout_marginStart="@dimen/spacing_small"
@@ -131,7 +131,7 @@
 
                 <TextView
                     android:id="@+id/submission_test_result_positive_no_consent_text_3"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
                     android:layout_marginStart="@dimen/spacing_small"
@@ -148,7 +148,7 @@
         <Button
             android:id="@+id/submission_test_result_positive_no_consent_button_warn_others"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginVertical="@dimen/spacing_normal"
             android:text="@string/submission_test_result_positive_no_consent_button_warn_others"
@@ -159,7 +159,7 @@
         <Button
             android:id="@+id/submission_test_result_positive_no_consent_button_abort"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginVertical="@dimen/spacing_normal"
             android:text="@string/submission_test_result_positive_no_consent_button_abort"

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_your_consent.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_your_consent.xml
@@ -14,7 +14,7 @@
         <include
             android:id="@+id/submission_your_consent_title"
             layout="@layout/include_header"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:icon="@{@drawable/ic_back}"
             app:layout_constraintEnd_toEndOf="parent"
@@ -23,8 +23,8 @@
             app:title="@{@string/submission_your_consent_title}" />
 
         <ScrollView
-            android:layout_width="@dimen/match_constraint"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             app:layout_constraintBottom_toBottomOf="@id/guideline_bottom"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="1.0"
@@ -40,7 +40,7 @@
                 <include
                     android:id="@+id/submission_your_consent_switch"
                     layout="@layout/include_settings_switch_row"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_small"
                     app:enabled="@{true}"
@@ -53,7 +53,7 @@
                 <TextView
                     android:id="@+id/submission_your_consent_about_text"
                     style="@style/subtitle"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_small"
                     android:text="@string/submission_your_consent_about_agreement"
@@ -64,7 +64,7 @@
                 <LinearLayout
                     android:id="@+id/submission_your_consent_agreement_card"
                     style="@style/cardTracing"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_medium"
                     android:focusable="true"
@@ -109,7 +109,7 @@
 
                 <View
                     android:id="@+id/submission_your_consent_agreement_details_divider_top"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="@dimen/card_divider"
                     android:layout_marginTop="@dimen/spacing_medium"
                     android:background="@color/colorHairline"
@@ -120,7 +120,7 @@
                 <TextView
                     android:id="@+id/submission_your_consent_agreement_details_text"
                     style="@style/subtitle"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:background="?selectableItemBackground"
                     android:paddingTop="@dimen/spacing_small"
@@ -132,7 +132,7 @@
 
                 <View
                     android:id="@+id/submission_your_consent_agreement_details_divider_bottom"
-                    android:layout_width="@dimen/match_constraint"
+                    android:layout_width="0dp"
                     android:layout_height="@dimen/card_divider"
                     android:background="@color/colorHairline"
                     app:layout_constraintEnd_toEndOf="@+id/guideline_end"

--- a/Corona-Warn-App/src/main/res/layout/home_faq_card_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_faq_card_layout.xml
@@ -25,7 +25,7 @@
         <TextView
             android:id="@+id/main_card_header_headline"
             style="@style/headline5"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_marginStart="@dimen/spacing_small"
             android:layout_marginEnd="@dimen/spacing_small"
@@ -50,7 +50,7 @@
         <TextView
             android:id="@+id/main_card_content_body"
             style="@style/subtitleMedium"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_small"
             android:text="@string/main_about_body"

--- a/Corona-Warn-App/src/main/res/layout/home_submission_status_card_done.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_submission_status_card_done.xml
@@ -11,7 +11,7 @@
         <TextView
             android:id="@+id/submission_done_card_title"
             style="@style/headline5"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/spacing_normal"
             android:layout_marginTop="@dimen/spacing_normal"
@@ -24,7 +24,7 @@
 
         <ImageView
             android:id="@+id/submission_done_card_illustration"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_tiny"
             android:contentDescription="@string/submission_done_illustration_description"
@@ -38,7 +38,7 @@
         <include
             android:id="@+id/submission_done_card_content"
             layout="@layout/include_submission_done_content"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             app:illustrationDescription="@{@string/submission_done_illustration_description}"

--- a/Corona-Warn-App/src/main/res/layout/home_submission_status_card_error.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_submission_status_card_error.xml
@@ -11,7 +11,7 @@
         <TextView
             android:id="@+id/title"
             style="@style/headline5"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/card_padding"
             android:layout_marginTop="@dimen/card_padding"
@@ -26,7 +26,7 @@
         <TextView
             android:id="@+id/subtitle"
             style="@style/headline6"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/card_padding"
             android:layout_marginTop="@dimen/spacing_normal"
@@ -41,7 +41,7 @@
         <TextView
             android:id="@+id/body"
             style="@style/subtitleMedium"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/card_padding"
             android:layout_marginTop="@dimen/spacing_tiny"
@@ -71,7 +71,7 @@
         <Button
             android:id="@+id/show_test_action"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/card_padding"
             android:layout_marginTop="@dimen/spacing_normal"

--- a/Corona-Warn-App/src/main/res/layout/home_submission_status_card_fetching.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_submission_status_card_fetching.xml
@@ -12,7 +12,7 @@
         <TextView
             android:id="@+id/submission_status_card_fetching_title"
             style="@style/headline5"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:accessibilityHeading="true"
             android:text="@string/submission_status_card_title_fetching"
@@ -32,7 +32,7 @@
         <TextView
             android:id="@+id/submission_status_card_fetching_body"
             style="@style/subtitle"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/spacing_normal"
             android:text="@string/submission_status_card_body_fetching"
@@ -44,7 +44,7 @@
         <Button
             android:id="@+id/show_test_action"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             android:enabled="false"

--- a/Corona-Warn-App/src/main/res/layout/home_submission_status_card_invalid.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_submission_status_card_invalid.xml
@@ -26,7 +26,7 @@
         <TextView
             android:id="@+id/body"
             style="@style/subtitleMedium"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             android:layout_marginEnd="@dimen/spacing_small"
@@ -56,7 +56,7 @@
         <Button
             android:id="@+id/delete_test_action"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/card_padding"
             android:layout_marginTop="@dimen/spacing_normal"

--- a/Corona-Warn-App/src/main/res/layout/home_submission_status_card_negative.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_submission_status_card_negative.xml
@@ -11,7 +11,7 @@
         <TextView
             android:id="@+id/title"
             style="@style/headline5"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/card_padding"
             android:layout_marginTop="@dimen/card_padding"
@@ -26,7 +26,7 @@
         <TextView
             android:id="@+id/subtitle"
             style="@style/headline6"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/card_padding"
             android:layout_marginTop="@dimen/spacing_normal"
@@ -41,7 +41,7 @@
         <TextView
             android:id="@+id/body"
             style="@style/subtitleMedium"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/card_padding"
             android:layout_marginTop="@dimen/spacing_tiny"
@@ -71,7 +71,7 @@
         <Button
             android:id="@+id/show_test_action"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/card_padding"
             android:layout_marginTop="@dimen/spacing_normal"

--- a/Corona-Warn-App/src/main/res/layout/home_submission_status_card_pending.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_submission_status_card_pending.xml
@@ -11,7 +11,7 @@
         <TextView
             android:id="@+id/title"
             style="@style/headline5"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/card_padding"
             android:layout_marginTop="@dimen/card_padding"
@@ -26,7 +26,7 @@
         <TextView
             android:id="@+id/body"
             style="@style/subtitleMedium"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/card_padding"
             android:layout_marginTop="@dimen/spacing_tiny"
@@ -56,7 +56,7 @@
         <Button
             android:id="@+id/show_test_action"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/card_padding"
             android:layout_marginTop="@dimen/spacing_small"

--- a/Corona-Warn-App/src/main/res/layout/home_submission_status_card_positive.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_submission_status_card_positive.xml
@@ -12,7 +12,7 @@
         <TextView
             android:id="@+id/submission_status_card_positive_title"
             style="@style/headline5"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginEnd="@dimen/spacing_small"
             android:accessibilityHeading="true"
@@ -55,7 +55,7 @@
         <TextView
             android:id="@+id/submission_status_card_positive_result_subtitle"
             style="@style/headline5"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             android:accessibilityHeading="true"
@@ -67,7 +67,7 @@
         <include
             android:id="@+id/submission_status_card_positive_result_contact"
             layout="@layout/include_submission_behaviour_row"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             app:body="@{@string/submission_status_card_positive_result_contact}"
@@ -79,7 +79,7 @@
         <include
             android:id="@+id/submission_status_card_positive_result_contagious"
             layout="@layout/include_submission_behaviour_row"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             app:body="@{@string/submission_status_card_positive_result_contagious}"
@@ -91,7 +91,7 @@
         <include
             android:id="@+id/submission_status_card_positive_result_share"
             layout="@layout/include_submission_behaviour_row"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             app:body="@{@string/submission_status_card_positive_result_share}"
@@ -103,7 +103,7 @@
         <Button
             android:id="@+id/submission_status_card_positive_button"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             android:text="@string/submission_test_result_positive_no_consent_button_warn_others"

--- a/Corona-Warn-App/src/main/res/layout/home_submission_status_card_ready.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_submission_status_card_ready.xml
@@ -11,7 +11,7 @@
         <TextView
             android:id="@+id/title"
             style="@style/headline5"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/card_padding"
             android:layout_marginTop="@dimen/card_padding"
@@ -26,7 +26,7 @@
         <TextView
             android:id="@+id/subtitle"
             style="@style/headline6Sixteen"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             android:layout_marginEnd="@dimen/spacing_small"
@@ -39,7 +39,7 @@
         <TextView
             android:id="@+id/body"
             style="@style/subtitleMedium"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             android:layout_marginEnd="@dimen/spacing_small"
@@ -69,7 +69,7 @@
         <Button
             android:id="@+id/show_test_action"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/card_padding"
             android:layout_marginTop="@dimen/spacing_normal"

--- a/Corona-Warn-App/src/main/res/layout/home_submission_status_card_unregistered.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_submission_status_card_unregistered.xml
@@ -11,7 +11,7 @@
         <TextView
             android:id="@+id/title"
             style="@style/headline5"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/card_padding"
             android:layout_marginTop="@dimen/card_padding"
@@ -26,7 +26,7 @@
         <TextView
             android:id="@+id/body"
             style="@style/subtitleMedium"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/card_padding"
             android:layout_marginTop="@dimen/spacing_normal"
@@ -56,7 +56,7 @@
         <Button
             android:id="@+id/next_steps_action"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/card_padding"
             android:layout_marginTop="@dimen/spacing_small"

--- a/Corona-Warn-App/src/main/res/layout/include_16_years.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_16_years.xml
@@ -29,7 +29,7 @@
         <TextView
             android:id="@+id/sixteen_years_body"
             style="@style/subtitleSixteen"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_small"
             android:text="@string/sixteen_description_text"

--- a/Corona-Warn-App/src/main/res/layout/include_dispatcher_card.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_dispatcher_card.xml
@@ -33,7 +33,7 @@
             android:id="@+id/dispatcher_card_title"
             style="@style/headline6"
             android:accessibilityHeading="true"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/spacing_normal"
             android:layout_marginTop="@dimen/spacing_normal"
@@ -59,7 +59,7 @@
         <TextView
             android:id="@+id/submission_dispatcher_card_text"
             style="@style/subtitle"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/spacing_normal"
             android:layout_marginTop="@dimen/spacing_normal"

--- a/Corona-Warn-App/src/main/res/layout/include_onboarding.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_onboarding.xml
@@ -183,7 +183,7 @@
             <include
                 android:id="@+id/onboarding_location_card"
                 layout="@layout/include_tracing_status_card"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_large"
                 android:focusable="true"
@@ -198,7 +198,7 @@
             <include
                 android:id="@+id/onboarding_location_card_16_years"
                 layout="@layout/include_16_years"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_small"
                 android:focusable="true"
@@ -211,7 +211,7 @@
             <include
                 android:id="@+id/onboarding_card"
                 layout="@layout/include_tracing_status_card"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_small"
                 android:focusable="true"

--- a/Corona-Warn-App/src/main/res/layout/include_privacy_card.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_privacy_card.xml
@@ -14,7 +14,7 @@
             android:id="@+id/privacy_card_title"
             style="@style/headline6"
             android:accessibilityHeading="true"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/submission_positive_other_warning_privacy_title"
             android:focusable="true"
@@ -25,7 +25,7 @@
         <TextView
             android:id="@+id/privacy_card_text"
             style="@style/subtitle"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             android:text="@string/submission_positive_other_warning_privacy_body"

--- a/Corona-Warn-App/src/main/res/layout/include_privacy_card_no_consent.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_privacy_card_no_consent.xml
@@ -14,7 +14,7 @@
             android:id="@+id/privacy_card_title"
             style="@style/headline6"
             android:accessibilityHeading="true"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/submission_consent_your_consent_subsection_headline"
             android:focusable="true"
@@ -25,7 +25,7 @@
         <TextView
             android:id="@+id/privacy_card_text_part_first"
             style="@style/subtitle"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             android:text="@string/submission_no_consent_your_consent_subsection_body_first_part"
@@ -37,7 +37,7 @@
         <TextView
             android:id="@+id/privacy_card_text_part_second"
             style="@style/subtitle"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             android:text="@string/submission_no_consent_your_consent_subsection_body_second_part"
@@ -49,7 +49,7 @@
         <TextView
             android:id="@+id/privacy_card_text_part_third"
             style="@style/subtitle"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             android:text="@string/submission_no_consent_your_consent_subsection_body_third_part"

--- a/Corona-Warn-App/src/main/res/layout/include_step_entry_simple_body.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_step_entry_simple_body.xml
@@ -9,7 +9,7 @@
         android:id="@+id/simple_step_entry_title"
         style="@style/headline6"
         android:accessibilityHeading="true"
-        android:layout_width="@dimen/match_constraint"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -19,7 +19,7 @@
     <TextView
         android:id="@+id/simple_step_entry_body"
         style="@style/subtitle"
-        android:layout_width="@dimen/match_constraint"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/spacing_small"
         app:layout_constraintEnd_toEndOf="parent"

--- a/Corona-Warn-App/src/main/res/layout/include_submission_consent_body.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_submission_consent_body.xml
@@ -10,8 +10,8 @@
     android:layout_height="wrap_content">
         
     <FrameLayout
-        android:layout_width="@dimen/match_constraint"
-        android:layout_height="@dimen/match_constraint"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@id/submission_consent_your_consent_subsection_headline"
@@ -20,7 +20,7 @@
 
     <TextView
         android:id="@+id/submission_consent_your_consent_subsection_headline"
-        android:layout_width="@dimen/match_constraint"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:text="@string/submission_consent_your_consent_subsection_headline"
         android:paddingTop="@dimen/spacing_normal"
@@ -31,7 +31,7 @@
 
     <TextView
         android:id="@+id/submission_consent_your_consent_subsection_tapping_agree"
-        android:layout_width="@dimen/match_constraint"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/spacing_normal"
         app:layout_constraintTop_toBottomOf="@+id/submission_consent_your_consent_subsection_headline"
@@ -42,7 +42,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/submission_consent_your_consent_subsection_first_point"
-        android:layout_width="@dimen/match_constraint"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:paddingVertical="@dimen/spacing_normal"
         app:layout_constraintTop_toBottomOf="@id/submission_consent_your_consent_subsection_tapping_agree"
@@ -57,7 +57,7 @@
         <TextView
             android:id="@+id/submission_consent_your_consent_subsection_first_point_text"
             style="@style/subtitle"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/bullet_point_spacing_after"
             app:layout_constraintEnd_toEndOf="parent"
@@ -69,7 +69,7 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/submission_consent_your_consent_subsection_second_point"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:paddingBottom="@dimen/spacing_normal"
             app:layout_constraintTop_toBottomOf="@id/submission_consent_your_consent_subsection_first_point"
@@ -84,7 +84,7 @@
             <TextView
                 android:id="@+id/submission_consent_your_consent_subsection_second_point_text"
                 style="@style/subtitle"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/bullet_point_spacing_after"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -97,7 +97,7 @@
     <TextView
         android:id="@+id/submission_consent_your_consent_subsection_third_point"
         style="@style/subtitle"
-        android:layout_width="@dimen/match_constraint"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/bullet_point_size"
         android:paddingStart="@dimen/spacing_normal"
@@ -110,7 +110,7 @@
 
     <include layout="@layout/view_bullet_point_text"
         android:id="@+id/submission_consent_main_first_point"
-        android:layout_width="@dimen/match_constraint"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/spacing_normal"
         app:layout_constraintEnd_toEndOf="@id/guideline_end"
@@ -120,7 +120,7 @@
 
     <include layout="@layout/view_bullet_point_text"
         android:id="@+id/submission_consent_main_second_point"
-        android:layout_width="@dimen/match_constraint"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="@id/guideline_end"
         app:layout_constraintStart_toStartOf="@id/guideline_start"
@@ -129,7 +129,7 @@
 
     <include layout="@layout/view_bullet_point_text"
         android:id="@+id/submission_consent_main_third_point"
-        android:layout_width="@dimen/match_constraint"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         app:layout_constraintTop_toBottomOf="@id/submission_consent_main_second_point"
         app:layout_constraintEnd_toEndOf="@id/guideline_end"
@@ -139,7 +139,7 @@
 
     <include layout="@layout/view_bullet_point_text"
         android:id="@+id/submission_consent_main_fourth_point"
-        android:layout_width="@dimen/match_constraint"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         app:layout_constraintTop_toBottomOf="@id/submission_consent_main_third_point"
         app:layout_constraintEnd_toEndOf="@id/guideline_end"

--- a/Corona-Warn-App/src/main/res/layout/include_submission_consent_intro.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_submission_consent_intro.xml
@@ -8,7 +8,7 @@
 
         <TextView
             android:id="@+id/submission_consent_main_headline_body"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toBottomOf="@+id/submission_consent_illustration"
             app:layout_constraintStart_toStartOf="@id/guideline_start"
@@ -18,7 +18,7 @@
 
         <TextView
             android:id="@+id/submission_consent_call_test_result"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             app:layout_constraintTop_toBottomOf="@+id/submission_consent_main_headline_body"
@@ -29,7 +29,7 @@
 
         <TextView
             android:id="@+id/submission_consent_call_test_result_body"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             app:layout_constraintTop_toBottomOf="@+id/submission_consent_call_test_result"
@@ -53,7 +53,7 @@
 
         <TextView
             android:id="@+id/submission_consent_call_test_result_scan_your_test_only"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             android:layout_marginStart="@dimen/spacing_tiny"
@@ -78,7 +78,7 @@
 
         <TextView
             android:id="@+id/submission_consent_call_test_result_scan_test_only_once"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             android:layout_marginStart="@dimen/spacing_tiny"
@@ -90,7 +90,7 @@
 
         <TextView
             android:id="@+id/submission_consent_help_by_warning_others_headline"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             app:layout_constraintTop_toBottomOf="@+id/submission_consent_call_test_result_scan_test_only_once"
@@ -101,7 +101,7 @@
 
         <TextView
             android:id="@+id/submission_consent_help_by_warning_others_body"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             app:layout_constraintTop_toBottomOf="@+id/submission_consent_help_by_warning_others_headline"

--- a/Corona-Warn-App/src/main/res/layout/include_submission_contact.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_submission_contact.xml
@@ -14,7 +14,7 @@
 
             <ImageView
                 android:id="@+id/submission_contact_illustration"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:src="@drawable/ic_submission_illustration_hotline"
                 android:focusable="true"
@@ -27,7 +27,7 @@
             <TextView
                 android:id="@+id/submission_contact_body"
                 style="@style/subtitle"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_small"
                 android:text="@string/submission_contact_body"
@@ -40,7 +40,7 @@
                 android:id="@+id/submission_contact_headline"
                 style="@style/headline5"
                 android:accessibilityHeading="true"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_medium"
                 android:text="@string/submission_contact_headline"
@@ -51,7 +51,7 @@
 
             <de.rki.coronawarnapp.ui.view.StepEntry
                 android:id="@+id/submission_contact_step_1"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_normal"
                 android:focusable="true"
@@ -69,7 +69,7 @@
                     <TextView
                         android:id="@+id/submission_contact_step_1_body"
                         style="@style/subtitle"
-                        android:layout_width="@dimen/match_constraint"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="@dimen/button_icon_margin"
                         android:text="@string/submission_contact_step_1_body"
@@ -81,7 +81,7 @@
                         android:id="@+id/submission_contact_step_1_number"
                         style="@style/headline5"
                         android:accessibilityHeading="true"
-                        android:layout_width="@dimen/match_constraint"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="@dimen/spacing_small"
                         android:text="@string/submission_contact_number_display"
@@ -94,7 +94,7 @@
                     <TextView
                         android:id="@+id/submission_contact_operating_hours_body"
                         style="@style/body2"
-                        android:layout_width="@dimen/match_constraint"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="@dimen/spacing_small"
                         android:text="@string/submission_contact_operating_hours_body"
@@ -105,7 +105,7 @@
                     <TextView
                         android:id="@+id/submission_contact_body_other"
                         style="@style/body2"
-                        android:layout_width="@dimen/match_constraint"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="@dimen/spacing_small"
                         android:text="@string/submission_contact_body_other"
@@ -119,7 +119,7 @@
 
             <de.rki.coronawarnapp.ui.view.StepEntry
                 android:id="@+id/submission_contact_step_2"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:focusable="true"
                 android:contentDescription="@string/submission_contact_step_2_content"
@@ -135,7 +135,7 @@
 
                     <TextView
                         style="@style/subtitle"
-                        android:layout_width="@dimen/match_constraint"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="@dimen/button_icon_margin"
                         android:text="@string/submission_contact_step_2_body"

--- a/Corona-Warn-App/src/main/res/layout/include_submission_country_no_selection.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_submission_country_no_selection.xml
@@ -22,7 +22,7 @@
         <TextView
             android:id="@+id/submission_country_no_selection_header"
             style="@style/headline5"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginVertical="@dimen/spacing_normal"
             android:focusable="true"

--- a/Corona-Warn-App/src/main/res/layout/include_submission_country_selector.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_submission_country_selector.xml
@@ -30,7 +30,7 @@
         <TextView
             android:id="@+id/submission_country_selector_header"
             style="@style/headline5"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             android:focusable="true"
@@ -43,7 +43,7 @@
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/submission_country_selector_recyclerview"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/spacing_mega_tiny"
             android:layout_marginTop="@dimen/spacing_normal"

--- a/Corona-Warn-App/src/main/res/layout/include_submission_done.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_submission_done.xml
@@ -15,7 +15,7 @@
 
             <ImageView
                 android:id="@+id/submission_done_hero_illustration"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:focusable="true"
                 android:src="@drawable/ic_illustration_together"
@@ -29,7 +29,7 @@
                 android:id="@+id/submission_done_headline"
                 style="@style/headline4"
                 android:accessibilityHeading="true"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_normal"
                 android:text="@string/submission_done_title"
@@ -41,7 +41,7 @@
             <include
                 android:id="@+id/submission_done_content"
                 layout="@layout/include_submission_done_content"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_normal"
                 app:illustrationDescription="@{@string/submission_done_illustration_description}"

--- a/Corona-Warn-App/src/main/res/layout/include_submission_done_content.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_submission_done_content.xml
@@ -16,7 +16,7 @@
         <TextView
             android:id="@+id/submission_done_text"
             style="@style/subtitle"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/submission_done_body"
             android:focusable="true"
@@ -28,7 +28,7 @@
             android:id="@+id/submission_done_subtitle"
             style="@style/headline5"
             android:accessibilityHeading="true"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             android:text="@string/submission_done_subtitle"
@@ -40,7 +40,7 @@
         <include
             android:id="@+id/submission_done_contagious"
             layout="@layout/include_submission_behaviour_row"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             app:body="@{@string/submission_done_contagious}"
@@ -52,7 +52,7 @@
         <include
             android:id="@+id/submission_done_isolate"
             layout="@layout/include_submission_behaviour_row"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             app:body="@{@string/submission_done_isolate}"
@@ -63,7 +63,7 @@
 
         <include
             layout="@layout/include_submission_done_further_info"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             app:layout_constraintEnd_toEndOf="parent"

--- a/Corona-Warn-App/src/main/res/layout/include_submission_done_further_info.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_submission_done_further_info.xml
@@ -14,7 +14,7 @@
             android:id="@+id/further_info_title"
             style="@style/headline5"
             android:accessibilityHeading="true"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:focusable="true"
             android:text="@string/submission_done_further_info_title"
@@ -24,7 +24,7 @@
 
         <de.rki.coronawarnapp.ui.view.BulletPointList
             android:id="@+id/further_info_text"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:focusable="true"
             android:layout_marginTop="@dimen/spacing_normal"

--- a/Corona-Warn-App/src/main/res/layout/include_submission_positive_other_warning.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_submission_positive_other_warning.xml
@@ -22,7 +22,7 @@
 
             <ImageView
                 android:id="@+id/submission_positive_other_warning_hero_illustration"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 bind:cwaContentDescription="@{@string/submission_positive_other_illustration_description}"
                 android:src="@drawable/ic_submission_illustration_other_warning"
@@ -35,7 +35,7 @@
                 android:id="@+id/submission_positive_other_warning_headline"
                 android:accessibilityHeading="true"
                 style="@style/headline5"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_normal"
                 android:text="@string/submission_positive_other_warning_headline"
@@ -47,7 +47,7 @@
             <TextView
                 android:id="@+id/submission_positive_other_warning_text"
                 style="@style/subtitle"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_normal"
                 android:focusable="true"
@@ -59,7 +59,7 @@
             <TextView
                 android:id="@+id/submission_country_header_description"
                 style="@style/headline6"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_normal"
                 android:text="@{@string/submission_interoperability_list_title}"
@@ -69,7 +69,7 @@
 
             <de.rki.coronawarnapp.ui.view.CountryListView
                 android:id="@+id/countryList"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_tiny"
                 app:layout_constraintEnd_toEndOf="@+id/submission_country_header_description"
@@ -80,7 +80,7 @@
             <include
                 android:id="@+id/submission_positive_location_card_16_years"
                 layout="@layout/include_16_years"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_small"
                 android:focusable="true"
@@ -91,7 +91,7 @@
             <include
                 android:id="@+id/submission_positive_other_privacy"
                 layout="@layout/include_privacy_card"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_small"
                 app:layout_constraintEnd_toStartOf="@+id/guideline_card_end"

--- a/Corona-Warn-App/src/main/res/layout/include_submission_tan.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_submission_tan.xml
@@ -14,7 +14,7 @@
             <TextView
                 android:id="@+id/submission_tan_body"
                 style="@style/subtitle"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_small"
                 android:focusable="false"
@@ -25,7 +25,7 @@
 
             <de.rki.coronawarnapp.ui.submission.tan.TanInput
                 android:id="@+id/submission_tan_input"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_large"
                 android:importantForAccessibility="no"
@@ -36,7 +36,7 @@
             <TextView
                 android:id="@+id/submission_tan_character_error"
                 style="@style/subtitle"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_small"
                 android:accessibilityLiveRegion="polite"
@@ -51,7 +51,7 @@
             <TextView
                 android:id="@+id/submission_tan_error"
                 style="@style/subtitle"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_small"
                 android:accessibilityLiveRegion="polite"

--- a/Corona-Warn-App/src/main/res/layout/include_test_result_card.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_test_result_card.xml
@@ -26,7 +26,7 @@
             android:id="@+id/test_result_card_headline"
             style="@style/body2"
             android:accessibilityHeading="true"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginEnd="@dimen/spacing_small"
             android:text="@string/test_result_card_headline"
@@ -37,7 +37,7 @@
         <TextView
             android:id="@+id/test_result_card_content"
             style="@style/headline5"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginEnd="@dimen/spacing_small"
             android:layout_marginBottom="@dimen/spacing_normal"
@@ -61,7 +61,7 @@
         <TextView
             android:id="@+id/test_result_card_registered_at_text"
             style="@style/body2"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             android:layout_marginEnd="@dimen/spacing_small"

--- a/Corona-Warn-App/src/main/res/layout/include_test_result_card_positive.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_test_result_card_positive.xml
@@ -12,7 +12,7 @@
             android:id="@+id/test_result_card_positive_title"
             style="@style/headline6"
             android:accessibilityHeading="true"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginEnd="@dimen/spacing_small"
             android:text="@string/submission_test_result_card_positive_title"
@@ -33,7 +33,7 @@
         <TextView
             android:id="@+id/test_result_card_positive_body"
             style="@style/body2"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             android:layout_marginEnd="@dimen/spacing_small"

--- a/Corona-Warn-App/src/main/res/layout/include_tracing_status_card.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_tracing_status_card.xml
@@ -36,7 +36,7 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/tracing_status_card_header"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -72,7 +72,7 @@
         <TextView
             android:id="@+id/tracing_status_card_body"
             style="@style/subtitle"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_small"
             android:text="@{body}"
@@ -83,7 +83,7 @@
         <Button
             android:id="@+id/tracing_status_card_button"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             android:text="@{buttonText}"

--- a/Corona-Warn-App/src/main/res/layout/include_tracing_status_card_location.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_tracing_status_card_location.xml
@@ -32,7 +32,7 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/tracing_status_card_header"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -68,7 +68,7 @@
         <de.rki.coronawarnapp.ui.view.LocationTracingStatusCardBodyTextView
             android:id="@+id/tracing_status_card_body"
             style="@style/subtitle"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_small"
             app:layout_constraintEnd_toEndOf="parent"
@@ -78,7 +78,7 @@
         <Button
             android:id="@+id/tracing_status_card_button"
             style="@style/buttonPrimary"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             android:text="@{buttonText}"

--- a/Corona-Warn-App/src/main/res/layout/tracing_content_disabled_view.xml
+++ b/Corona-Warn-App/src/main/res/layout/tracing_content_disabled_view.xml
@@ -42,7 +42,7 @@
         <TextView
             android:id="@+id/body_text"
             style="@style/subtitle"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_small"
             android:text="@string/risk_card_body_tracing_off"
@@ -52,7 +52,7 @@
 
         <de.rki.coronawarnapp.ui.view.TracingCardInfoRow
             android:id="@+id/risk_card_row_saved_risk"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_small"
             android:icon="@drawable/ic_risk_card_saved_risk"
@@ -66,7 +66,7 @@
 
         <de.rki.coronawarnapp.ui.view.TracingCardInfoRow
             android:id="@+id/row_time_fetched"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:icon="@drawable/ic_risk_card_time_fetched"
             android:text="@{state.getTimeFetched(context)}"
@@ -81,7 +81,7 @@
             android:id="@+id/enable_tracing_action"
             style="@style/buttonPrimary"
             gone="@{!state.showEnableTracingButton}"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_small"
             android:text="@string/risk_details_button_enable_tracing"

--- a/Corona-Warn-App/src/main/res/layout/tracing_content_failed_view.xml
+++ b/Corona-Warn-App/src/main/res/layout/tracing_content_failed_view.xml
@@ -41,7 +41,7 @@
         <TextView
             android:id="@+id/risk_card_body"
             style="@style/subtitle"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             android:text="@string/risk_card_check_failed_no_internet_body"
@@ -51,7 +51,7 @@
 
         <de.rki.coronawarnapp.ui.view.TracingCardInfoRow
             android:id="@+id/risk_card_row_saved_risk"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_small"
             android:icon="@drawable/ic_risk_card_saved_risk"
@@ -65,7 +65,7 @@
 
         <de.rki.coronawarnapp.ui.view.TracingCardInfoRow
             android:id="@+id/risk_card_row_time_fetched"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:icon="@drawable/ic_risk_card_time_fetched"
             android:text="@{state.getTimeFetched(context)}"
@@ -80,7 +80,7 @@
             android:id="@+id/risk_card_button_update"
             style="@style/buttonPrimary"
             gone="@{!state.showRestartButton}"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_small"
             android:text="@string/risk_card_check_failed_no_internet_restart_button"

--- a/Corona-Warn-App/src/main/res/layout/tracing_content_increased_view.xml
+++ b/Corona-Warn-App/src/main/res/layout/tracing_content_increased_view.xml
@@ -42,7 +42,7 @@
 
         <de.rki.coronawarnapp.ui.view.TracingCardInfoRow
             android:id="@+id/row_contact"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_small"
             android:icon="@drawable/ic_risk_card_contact_increased"
@@ -57,7 +57,7 @@
         <de.rki.coronawarnapp.ui.view.TracingCardInfoRow
             android:id="@+id/row_contact_last"
             gone="@{state.getRiskContactLast(context) == null}"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:icon="@drawable/ic_risk_card_calendar"
             android:text="@{state.getRiskContactLast(context)}"
@@ -71,7 +71,7 @@
         <de.rki.coronawarnapp.ui.view.TracingCardInfoRow
             android:id="@+id/row_tracing_days"
             gone="@{!state.inDetailsMode}"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:icon="@drawable/ic_risk_card_calendar"
             android:text="@{state.getRiskActiveTracingDaysInRetentionPeriod(context)}"
@@ -84,7 +84,7 @@
 
         <de.rki.coronawarnapp.ui.view.TracingCardInfoRow
             android:id="@+id/row_time_fetched"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:icon="@drawable/ic_risk_card_time_fetched"
             android:text="@{state.getTimeFetched(context)}"
@@ -99,7 +99,7 @@
             android:id="@+id/update_action"
             style="@style/buttonLight"
             gone="@{!state.showUpdateButton}"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_small"
             android:text="@string/risk_card_button_update"

--- a/Corona-Warn-App/src/main/res/layout/tracing_content_low_view.xml
+++ b/Corona-Warn-App/src/main/res/layout/tracing_content_low_view.xml
@@ -45,7 +45,7 @@
 
         <de.rki.coronawarnapp.ui.view.TracingCardInfoRow
             android:id="@+id/row_contact"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             android:icon="@drawable/ic_risk_card_contact"
@@ -59,7 +59,7 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/row_saved_days"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -82,7 +82,7 @@
             <TextView
                 android:id="@+id/risk_card_row_saved_days_body"
                 style="@style/subtitle"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_tiny"
                 android:layout_marginBottom="@dimen/spacing_tiny"
@@ -99,7 +99,7 @@
 
         <de.rki.coronawarnapp.ui.view.TracingCardInfoRow
             android:id="@+id/row_time_fetched"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:icon="@drawable/ic_risk_card_time_fetched"
             android:text="@{state.getTimeFetched(context)}"
@@ -114,7 +114,7 @@
             android:id="@+id/update_action"
             style="@style/buttonLight"
             gone="@{!state.showUpdateButton}"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_small"
             android:text="@string/risk_card_button_update"

--- a/Corona-Warn-App/src/main/res/layout/tracing_content_progress_view.xml
+++ b/Corona-Warn-App/src/main/res/layout/tracing_content_progress_view.xml
@@ -54,7 +54,7 @@
         <TextView
             android:id="@+id/body_text"
             style="@style/subtitle"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/spacing_small"
             android:layout_marginTop="@dimen/spacing_small"

--- a/Corona-Warn-App/src/main/res/layout/tracing_details_fragment_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/tracing_details_fragment_layout.xml
@@ -109,7 +109,7 @@
             <Button
                 android:id="@+id/risk_details_button_enable_tracing"
                 style="@style/buttonPrimary"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:text="@string/risk_card_button_enable_tracing"
                 gone="@{!tracingDetailsState.isRiskDetailsEnableTracingButtonVisible()}"
@@ -121,7 +121,7 @@
             <Button
                 android:id="@+id/risk_details_button_update"
                 style="@style/buttonPrimary"
-                android:layout_width="@dimen/match_constraint"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:enabled="@{tracingDetailsState.isUpdateButtonEnabled()}"
                 android:text="@{tracingDetailsState.getUpdateButtonText(context)}"

--- a/Corona-Warn-App/src/main/res/layout/view_bullet_point_entry.xml
+++ b/Corona-Warn-App/src/main/res/layout/view_bullet_point_entry.xml
@@ -20,7 +20,7 @@
     <TextView
         android:id="@+id/bullet_point_content"
         style="@style/subtitle"
-        android:layout_width="@dimen/match_constraint"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/bullet_point_spacing_after"
         app:layout_constraintEnd_toEndOf="parent"

--- a/Corona-Warn-App/src/main/res/layout/view_bullet_point_text.xml
+++ b/Corona-Warn-App/src/main/res/layout/view_bullet_point_text.xml
@@ -27,7 +27,7 @@
         <TextView
             android:id="@+id/bullet_point_content"
             style="@style/subtitle"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/bullet_point_spacing_after"
             app:layout_constraintEnd_toEndOf="parent"

--- a/Corona-Warn-App/src/main/res/layout/view_consent_status.xml
+++ b/Corona-Warn-App/src/main/res/layout/view_consent_status.xml
@@ -35,7 +35,7 @@
     <TextView
         android:id="@+id/consent_status_message"
         style="@style/headline6"
-        android:layout_width="@dimen/match_constraint"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="56dp"
         android:layout_marginTop="16dp"

--- a/Corona-Warn-App/src/main/res/layout/view_step_entry.xml
+++ b/Corona-Warn-App/src/main/res/layout/view_step_entry.xml
@@ -18,7 +18,7 @@
 
         <FrameLayout
             android:id="@+id/step_entry_wrapper_children"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/spacing_small"
             app:layout_constraintEnd_toEndOf="parent"
@@ -29,7 +29,7 @@
 
         <View
             android:id="@+id/step_entry_placeholder"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="@dimen/spacing_large"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="@id/step_entry_icon"
@@ -38,7 +38,7 @@
         <View
             android:id="@+id/step_entry_line"
             android:layout_width="@dimen/test_result_step_progress_line_width"
-            android:layout_height="@dimen/match_constraint"
+            android:layout_height="0dp"
             android:background="@color/colorSurface2"
             app:layout_constraintBottom_toBottomOf="@+id/step_entry_placeholder"
             app:layout_constraintEnd_toEndOf="@id/step_entry_icon"

--- a/Corona-Warn-App/src/main/res/layout/view_test_result_section.xml
+++ b/Corona-Warn-App/src/main/res/layout/view_test_result_section.xml
@@ -15,7 +15,7 @@
             android:id="@+id/test_result_section_headline"
             style="@style/body2"
             android:accessibilityHeading="true"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginEnd="@dimen/spacing_small"
             app:layout_constraintEnd_toStartOf="@id/test_result_section_status_icon"
@@ -26,7 +26,7 @@
         <TextView
             android:id="@+id/test_result_section_content"
             style="@style/headline5"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginEnd="@dimen/spacing_small"
             android:layout_marginBottom="@dimen/spacing_normal"
@@ -48,7 +48,7 @@
         <TextView
             android:id="@+id/test_result_section_registered_at_text"
             style="@style/body2"
-            android:layout_width="@dimen/match_constraint"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
             android:layout_marginEnd="@dimen/spacing_small"

--- a/Corona-Warn-App/src/main/res/values/dimens.xml
+++ b/Corona-Warn-App/src/main/res/values/dimens.xml
@@ -126,7 +126,6 @@
     <dimen name="bullet_point_spacing_before">@dimen/spacing_tiny</dimen>
     <dimen name="bullet_point_spacing_after">@dimen/spacing_normal</dimen>
 
-    <dimen name="match_constraint">0dp</dimen>
     <dimen name="no_padding">0dp</dimen>
 
     <!-- Calendar -->

--- a/Corona-Warn-App/src/main/res/values/styles.xml
+++ b/Corona-Warn-App/src/main/res/values/styles.xml
@@ -163,11 +163,11 @@
     </style>
 
     <style name="rowSettings" parent="@style/row">
-        <item name="android:paddingStart">@dimen/match_constraint</item>
+        <item name="android:paddingStart">0dp</item>
     </style>
 
     <style name="rowOverview" parent="@style/row">
-        <item name="android:paddingStart">@dimen/match_constraint</item>
+        <item name="android:paddingStart">0dp</item>
         <item name="android:paddingTop">@dimen/spacing_tiny</item>
         <item name="android:paddingBottom">@dimen/spacing_tiny</item>
     </style>


### PR DESCRIPTION
Replace `@dimen/match_constraint` with hardcoded `0dp`.
There is no reason this would be changed, and while it may be nice for some to understand what `0dp` means, it conflicts with using the built-in layout editor which when used via GUI and not XML code, will replace it with `0dp` everytime leading to a mix of both in the project.

 I just did a search+replace to change this.

### Testing
* Check that it still compiles.
* Run it on your device, visit a few screens, in tester and non-tester builds variants.