### PR TITLE
Change R8 version to fix pipeline issues (DEV)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,12 +11,9 @@ buildscript {
         maven {
             url "https://plugins.gradle.org/m2/"
         }
-        maven {
-            url 'https://storage.googleapis.com/r8-releases/raw'
-        }
     }
     dependencies {
-        classpath 'com.android.tools:r8:2.0.74'
+        classpath 'com.android.tools:r8:2.0.88'
         classpath 'com.android.tools.build:gradle:4.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.google.protobuf:protobuf-gradle-plugin:$protobufVersion"


### PR DESCRIPTION
Change to a R8 version that is available on maven, but still fixes the regression.
We initially downgraded to fix a bug in R8, but internal tooling was not happy due to the versions not being available on maven.
`2.0.88` is on maven, and also does not exhibit the issue.