### PR TITLE
Fix typo in german and english strings for finland country name (EXPOSUREAPP-4565) (closes #2069)

### DIFF
--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -1382,7 +1382,7 @@
     <!-- XHED: Country Entry for Spain -->
     <string name="country_name_es">Spanien</string>
     <!-- XHED: Country Entry for Finland -->
-    <string name="country_name_fi">Finland</string>
+    <string name="country_name_fi">Finnland</string>
     <!-- XHED: Country Entry for France -->
     <string name="country_name_fr">Frankreich</string>
     <!-- XHED: Country Entry for Great Britain -->

--- a/Corona-Warn-App/src/main/res/values-en/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-en/strings.xml
@@ -1351,7 +1351,7 @@
     <!-- XHED: Country Entry for Spain -->
     <string name="country_name_es">"Spain"</string>
     <!-- XHED: Country Entry for Finland -->
-    <string name="country_name_fi">"Finnland"</string>
+    <string name="country_name_fi">"Finland"</string>
     <!-- XHED: Country Entry for France -->
     <string name="country_name_fr">"France"</string>
     <!-- XHED: Country Entry for Great Britain -->

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -1392,7 +1392,7 @@
     <!-- XHED: Country Entry for Spain -->
     <string name="country_name_es">"Spain"</string>
     <!-- XHED: Country Entry for Finland -->
-    <string name="country_name_fi">"Finnland"</string>
+    <string name="country_name_fi">"Finland"</string>
     <!-- XHED: Country Entry for France -->
     <string name="country_name_fr">"France"</string>
     <!-- XHED: Country Entry for Great Britain -->


### PR DESCRIPTION
## Description

This PR fixes a small typo in the country name of Finland for the German and English (and default) strings. For more information see #2069 

---
Internal Tracking ID : EXPOSUREAPP-4565