### PR TITLE
Contact Journal clickable cards

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/overview/adapter/ContactDiaryOverviewAdapter.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/overview/adapter/ContactDiaryOverviewAdapter.kt
@@ -36,14 +36,10 @@ class ContactDiaryOverviewAdapter(
         override val viewBinding: Lazy<ContactDiaryOverviewListItemBinding> =
             lazy { ContactDiaryOverviewListItemBinding.bind(itemView) }
 
-        private val nestedItemAdapter = ContactDiaryOverviewNestedAdapter()
-
-        init {
-            viewBinding.value.contactDiaryOverviewNestedRecyclerView.adapter = nestedItemAdapter
-        }
-
         override val onBindData: ContactDiaryOverviewListItemBinding.(item: ListItem, payloads: List<Any>) -> Unit =
             { item, _ ->
+                val nestedItemAdapter = ContactDiaryOverviewNestedAdapter(item, onItemSelectionListener)
+                viewBinding.value.contactDiaryOverviewNestedRecyclerView.adapter = nestedItemAdapter
                 contactDiaryOverviewElementName.text = dateFormatter(item.date)
                 contactDiaryOverviewElementName.contentDescription = dateFormatterForAccessibility(item.date)
                 contactDiaryOverviewElementBody.setOnClickListener { onItemSelectionListener(item) }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/overview/adapter/ContactDiaryOverviewNestedAdapter.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/overview/adapter/ContactDiaryOverviewNestedAdapter.kt
@@ -7,8 +7,10 @@ import de.rki.coronawarnapp.databinding.ContactDiaryOverviewNestedListItemBindin
 import de.rki.coronawarnapp.ui.lists.BaseAdapter
 import de.rki.coronawarnapp.util.lists.BindableVH
 
-class ContactDiaryOverviewNestedAdapter :
-    BaseAdapter<ContactDiaryOverviewNestedAdapter.NestedItemViewHolder>() {
+class ContactDiaryOverviewNestedAdapter(
+    private val element: ListItem,
+    private val onItemSelectionListener: (ListItem) -> Unit
+) : BaseAdapter<ContactDiaryOverviewNestedAdapter.NestedItemViewHolder>() {
 
     private val dataList: MutableList<ListItem.Data> = mutableListOf()
 
@@ -19,12 +21,13 @@ class ContactDiaryOverviewNestedAdapter :
 
     override fun onCreateBaseVH(parent: ViewGroup, viewType: Int): NestedItemViewHolder = NestedItemViewHolder(parent)
 
-    override fun onBindBaseVH(holder: NestedItemViewHolder, position: Int, payloads: MutableList<Any>) =
+    override fun onBindBaseVH(holder: NestedItemViewHolder, position: Int, payloads: MutableList<Any>) {
         holder.bind(dataList[position], payloads)
+    }
 
     override fun getItemCount(): Int = dataList.size
 
-    class NestedItemViewHolder(parent: ViewGroup) :
+    inner class NestedItemViewHolder(parent: ViewGroup) :
         BaseAdapter.VH(R.layout.contact_diary_overview_nested_list_item, parent),
         BindableVH<ListItem.Data, ContactDiaryOverviewNestedListItemBinding> {
         override val viewBinding:
@@ -36,6 +39,7 @@ class ContactDiaryOverviewNestedAdapter :
             { key, _ ->
                 contactDiaryOverviewElementImage.setImageResource(key.drawableId)
                 contactDiaryOverviewElementName.text = key.text
+                contactDiaryOverviewElementNestedContainer.setOnClickListener { onItemSelectionListener(element) }
             }
     }
 }


### PR DESCRIPTION
This PR makes the whole contact diary cards clickable on the overview page. Up until now, only the header of the cards was clickable when when the persons and places lists were populated. 

How to test:

- Navigate to the contact diary. 
- On the Contact Journal page click anywhere on a date entry that has some people and/or places assigned. You should be able to navigate to the next screen no matter where you click on the card.
- If none of the dates have any people assigned, first tap on one of the dates to navigate to the people/places screen and enter some data, then go back to the Contact Journal and try tapping anywhere on the date card with data. 