### PR TITLE
API downgrade to 29 (DEV)

### DIFF
--- a/Corona-Warn-App/build.gradle
+++ b/Corona-Warn-App/build.gradle
@@ -38,13 +38,13 @@ android {
     println("Current VERSION_PATCH: ${VERSION_PATCH}")
     println("Current VERSION_BUILD: ${VERSION_BUILD}")
 
-    compileSdkVersion 30
+    compileSdkVersion 29
     buildToolsVersion "29.0.3"
 
     defaultConfig {
         applicationId 'de.rki.coronawarnapp'
         minSdkVersion 23
-        targetSdkVersion 30
+        targetSdkVersion 29
 
         ndkVersion "21.2.6472646"
 


### PR DESCRIPTION
Downgrade target API to 29
For the following reasons:
1- UI tests are not running on API 30 due to an issue in MockK https://github.com/mockk/mockk/issues/519
2- SAP internal Pipelines does not support it yet.