### PR TITLE
Add snapping scroll behavior to the statistic cards (EXPOSUREAPP-4520)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/StatisticsHomeCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/StatisticsHomeCard.kt
@@ -4,6 +4,7 @@ import android.view.ViewGroup
 import androidx.annotation.LayoutRes
 import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.PagerSnapHelper
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.HomeStatisticsScrollcontainerBinding
 import de.rki.coronawarnapp.statistics.StatisticsData
@@ -28,6 +29,7 @@ class StatisticsHomeCard(
                 itemAnimator = DefaultItemAnimator()
                 addItemDecoration(StatisticsCardPaddingDecorator(startPadding = R.dimen.spacing_small))
             }
+            PagerSnapHelper().attachToRecyclerView(statisticsRecyclerview)
         }
     }
 


### PR DESCRIPTION
When scrolling horizontally through the statistic cards on the home screen, they should snap to the center of the respective card.