### PR TITLE
Capitalise security error messages (EXPOSUREAPP-4655) (closes #2120)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/exception/CwaSecurityException.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/exception/CwaSecurityException.kt
@@ -5,7 +5,7 @@ import de.rki.coronawarnapp.exception.reporting.ReportedException
 
 class CwaSecurityException(cause: Throwable) : ReportedException(
     ErrorCodes.CWA_SECURITY_PROBLEM.code,
-    "something went wrong during a critical part of the application ensuring security, please refer" +
+    "Something went wrong during a critical part of the application ensuring security, please refer" +
             " to the details for more information",
     cause
 )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/exception/CwaWebSecurityException.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/exception/CwaWebSecurityException.kt
@@ -5,6 +5,6 @@ import de.rki.coronawarnapp.exception.reporting.ReportedIOException
 
 class CwaWebSecurityException(cause: Throwable) : ReportedIOException(
     ErrorCodes.CWA_WEB_SECURITY_PROBLEM.code,
-    "an error occurred while trying to establish a secure connection to the server",
+    "An error occurred while trying to establish a secure connection to the server",
     cause
 )


### PR DESCRIPTION
### Description

This PR capitalises the first letter in error strings in two security exception modules for consistency with other hard-coded error strings.

In `CwaWebSecurityException.kt` the message is now:

`An error occurred while trying to establish a secure connection to the server`

In `CwaSecurityException.kt` the concatenated message is now:

`Something went wrong during a critical part of the application ensuring security, please refer to the details for more information`

For comparison
![image](https://user-images.githubusercontent.com/66998419/104813654-cf8d6700-580a-11eb-85a9-d1a8b5271ed3.png)

---
Internal Tracking ID: [EXPOSUREAPP-4655](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4655)