### PR TITLE
Remove recommendation to create labels in new issues (COMMUNITY)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,5 +55,3 @@ The following rule governs documentation contributions:
 * Please provide as much context as possible when you open an issue. The information you provide must be comprehensive enough to reproduce that issue for the assignee. Therefore, contributors should use but aren't restricted to the issue template provided by the project maintainers.
 
 * When creating an issue, try using one of our issue templates which already contain some guidelines on which content is expected to process the issue most efficiently. If no template applies, you can of course also create an issue from scratch.
-
-* Please apply one or more applicable [labels](https://github.com/corona-warn-app/cwa-app-android/labels) to your issue so that all community members are able to cluster the issues better.


### PR DESCRIPTION
### Description

This PR removes the recommendation:

* Please apply one or more applicable [labels](https://github.com/corona-warn-app/cwa-app-android/labels) to your issue so that all community members are able to cluster the issues better.

in CONTRIBUTING.md because community members do not have privileges to create labels in this repository.

This follows on from an identical discussion in https://github.com/corona-warn-app/cwa-website/issues/574 and related PR https://github.com/corona-warn-app/cwa-website/pull/652 regarding the cwa-website repository.

### Steps to reproduce

1. Create a bug issue through https://github.com/corona-warn-app/cwa-app-android/issues/new/choose signed in to GitHub as community member.
2. View the issue and note that there is no option to create a new label
![image](https://user-images.githubusercontent.com/66998419/104836766-87c11b00-58b0-11eb-8252-5e5a343b2152.png)

