### PR TITLE
Samsung S6: freshly installed app does not open (EXPOSUREAPP-4647)

### DIFF
--- a/Corona-Warn-App/build.gradle
+++ b/Corona-Warn-App/build.gradle
@@ -64,7 +64,6 @@ android {
                 arguments += ["room.schemaLocation": "$projectDir/schemas".toString()]
             }
         }
-        vectorDrawables.useSupportLibrary = true
     }
 
     def signingPropFile = file("../keystore.properties")


### PR DESCRIPTION
enabling support vector drawables on devices pre api level 24 results in a crash on launch as we use some features in our drawables that are not supported by the support lib