### PR TITLE
Make talkback speak out german comma values appropriately (EXPOSUREAPP-4665)

### DIFF
--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -1300,6 +1300,9 @@
     <!-- XTXT: Text displayed in the bottom of submission statistics card-->
     <string name="statistics_card_submission_bottom_text">"bundesweit warnende Personen"</string>
 
+    <!-- XACT: Description for the decimal separator symbol that is pronounced when the screen reader reads decimal values -->
+    <string name="statistics_value_decimal_separator_description">"Komma"</string>
+
     <!-- XTXT: Timestamp refers to today's date in submission and infections cards -->
     <string name="statistics_primary_value_today">"Heute"</string>
     <!-- XTXT: Timestamp refers to yesterday's date in submission and infections cards -->

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -1308,6 +1308,9 @@
     <!-- XTXT: Text displayed in the bottom of submission statistics card-->
     <string name="statistics_card_submission_bottom_text">"bundesweit warnende Personen"</string>
 
+    <!-- XACT: Description for the decimal separator symbol that is pronounced when the screen reader reads decimal values -->
+    <string name="statistics_value_decimal_separator_description">"Komma"</string>
+
     <!-- XTXT: Timestamp refers to today's date in submission and infections cards -->
     <string name="statistics_primary_value_today">"Heute"</string>
     <!-- XTXT: Timestamp refers to yesterday's date in submission and infections cards -->


### PR DESCRIPTION
Decimal numbers are spoken out correctly when the locale is "en". 

But unfortunately, Talkback ignores the German "Komma" (,) Symbol and speaks out numbers like 134,4 as 1344. 

This is probably also not working for our other supported languages.

This PR is just about the translation for the decimal separator. 