### PR TITLE
Make talkback speak out decimal values appropriately (EXPOSUREAPP-4665)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/util/AccessibilityHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/util/AccessibilityHelper.kt
@@ -1,0 +1,13 @@
+package de.rki.coronawarnapp.statistics.util
+
+import android.content.Context
+import android.text.SpannableString
+import android.text.style.LocaleSpan
+import de.rki.coronawarnapp.contactdiary.util.getLocale
+
+/**
+ * returns localized spannable string so that screen readers read out decimal values appropriately
+ */
+fun getLocalizedSpannableString(context: Context, source: String) = SpannableString(source).apply {
+    setSpan(LocaleSpan(context.getLocale()), 0, this.length, 0)
+}


### PR DESCRIPTION
Talkback only works appropriately in German with decimal numbers when setting the text as a localized spannable. 

This implementation provides a helper function that converts a string to a localized spannable. 