### PR TITLE
Contact Journal Day date is not announced (EXPOSUREAPP-4457)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/day/ContactDiaryDayViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/day/ContactDiaryDayViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.lifecycle.asLiveData
 import com.squareup.inject.assisted.Assisted
 import com.squareup.inject.assisted.AssistedInject
+import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.contactdiary.ui.day.tabs.ContactDiaryDayTab
 import de.rki.coronawarnapp.contactdiary.util.getLocale
 import de.rki.coronawarnapp.contactdiary.util.toFormattedDay
@@ -27,7 +28,7 @@ class ContactDiaryDayViewModel @AssistedInject constructor(
     val uiState = displayedDay.map { day ->
         UIState(
             dayText = { day.toFormattedDay(it.getLocale()) },
-            dayTextContentDescription = { day.toFormattedDayForAccessibility(it.getLocale()) })
+            dayTextContentDescription = { day.toFormattedDayForAccessibility(it.getLocale()) + it.getString(R.string.accessibility_day_view_header) })
     }.asLiveData()
 
     fun onCreateButtonClicked(activeTab: ContactDiaryDayTab) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/day/ContactDiaryDayViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/day/ContactDiaryDayViewModel.kt
@@ -28,7 +28,8 @@ class ContactDiaryDayViewModel @AssistedInject constructor(
     val uiState = displayedDay.map { day ->
         UIState(
             dayText = { day.toFormattedDay(it.getLocale()) },
-            dayTextContentDescription = { day.toFormattedDayForAccessibility(it.getLocale()) + it.getString(R.string.accessibility_day_view_header) })
+            dayTextContentDescription = { day.toFormattedDayForAccessibility(it.getLocale()) +
+                it.getString(R.string.accessibility_day_view_header) })
     }.asLiveData()
 
     fun onCreateButtonClicked(activeTab: ContactDiaryDayTab) {

--- a/Corona-Warn-App/src/main/res/layout/contact_diary_day_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/contact_diary_day_fragment.xml
@@ -15,6 +15,7 @@
             android:layout_height="wrap_content"
             android:background="@drawable/contact_diary_background"
             android:elevation="@dimen/elevation_weak"
+            android:focusable="true"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"

--- a/Corona-Warn-App/src/main/res/values-de/contact_diary_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/contact_diary_strings.xml
@@ -111,6 +111,8 @@
     <string name="accessibility_location_selected">Ort %s ist ausgewählt</string>
     <!-- XTXT: person is selected (description for screen readers) -->
     <string name="accessibility_person_selected">Person %s ist ausgewählt</string>
+    <!-- XTXT: Day View headline (description for screen readers) -->
+    <string name="accessibility_day_view_header">"Tagesansicht"</string>
 
     <!-- XTXT: Select (description for screen readers) -->
     <string name="accessibility_action_select">Auswählen</string>

--- a/Corona-Warn-App/src/main/res/values-de/contact_diary_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/contact_diary_strings.xml
@@ -100,24 +100,24 @@
     <string name="contact_diary_delete_person_title">"Wollen Sie wirklich diese Person entfernen?"</string>
 
     <!-- XTXT: location (description for screen readers) -->
-    <string name="accessibility_location">Ort %s</string>
+    <string name="accessibility_location">"Ort %s"</string>
     <!-- XTXT: person (description for screen readers) -->
-    <string name="accessibility_person">Person %s</string>
+    <string name="accessibility_person">"Person %s"</string>
     <!-- XTXT: location is not selected (description for screen readers) -->
-    <string name="accessibility_location_unselected">Ort %s ist nicht ausgewählt</string>
+    <string name="accessibility_location_unselected">"Ort %s ist nicht ausgewählt"</string>
     <!-- XTXT: person is not selected (description for screen readers) -->
-    <string name="accessibility_person_unselected">Person %s ist nicht ausgewählt</string>
+    <string name="accessibility_person_unselected">"Person %s ist nicht ausgewählt"</string>
     <!-- XTXT: location is selected (description for screen readers) -->
-    <string name="accessibility_location_selected">Ort %s ist ausgewählt</string>
+    <string name="accessibility_location_selected">"Ort %s ist ausgewählt"</string>
     <!-- XTXT: person is selected (description for screen readers) -->
-    <string name="accessibility_person_selected">Person %s ist ausgewählt</string>
+    <string name="accessibility_person_selected">"Person %s ist ausgewählt"</string>
     <!-- XTXT: Day View headline (description for screen readers) -->
     <string name="accessibility_day_view_header">"Tagesansicht"</string>
 
     <!-- XTXT: Select (description for screen readers) -->
-    <string name="accessibility_action_select">Auswählen</string>
+    <string name="accessibility_action_select">"Auswählen"</string>
     <!-- XTXT: Deselect (description for screen readers) -->
-    <string name="accessibility_action_deselect">Auswahl aufheben</string>
+    <string name="accessibility_action_deselect">"Auswahl aufheben"</string>
     <!-- XTXT: Edit (description for screen readers) -->
-    <string name="accessibility_edit">Bearbeiten</string>
+    <string name="accessibility_edit">"Bearbeiten"</string>
 </resources>

--- a/Corona-Warn-App/src/main/res/values/contact_diary_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/contact_diary_strings.xml
@@ -118,6 +118,8 @@
     <string name="accessibility_location_selected">"Place %s is selected"</string>
     <!-- XTXT: person is selected (description for screen readers) -->
     <string name="accessibility_person_selected">"Person %s is selected"</string>
+    <!-- XTXT: Day View headline (description for screen readers) -->
+    <string name="accessibility_day_view_header"></string>
 
     <!-- XTXT: Select (description for screen readers) -->
     <string name="accessibility_action_select">"Select"</string>


### PR DESCRIPTION
Small PR to adjust the TalkBack behavior when opening the contact journal day screen - removed announcement of unneeded information.

In addition, I added the text "Day View" or "Tagesansicht" which is announces directly after the current date when opening the day screen. This allows to better understand on which view you are currently located.

![device-2021-01-18-115415](https://user-images.githubusercontent.com/75120552/105017887-9d674980-5a44-11eb-89c5-7bb0a0632cc1.png)

To test the changes, activate TalkBack on your device and navigate to the contact journal day screen.