### PR TITLE
Contact Journal Location/Person not announced (EXPOSUREAPP-4459)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/overview/ContactDiaryOverviewViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/overview/ContactDiaryOverviewViewModel.kt
@@ -83,7 +83,7 @@ class ContactDiaryOverviewViewModel @AssistedInject constructor(
                 ListItem.Data(
                     R.drawable.ic_contact_diary_person_item,
                     personEncounter.contactDiaryPerson.fullName,
-                    "Person"
+                    ListItem.Type.PERSON
                 )
             }
     }
@@ -98,7 +98,7 @@ class ContactDiaryOverviewViewModel @AssistedInject constructor(
                 ListItem.Data(
                     R.drawable.ic_contact_diary_location_item,
                     locationVisit.contactDiaryLocation.locationName,
-                    "Location"
+                    ListItem.Type.LOCATION
                 )
             }
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/overview/ContactDiaryOverviewViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/overview/ContactDiaryOverviewViewModel.kt
@@ -82,7 +82,8 @@ class ContactDiaryOverviewViewModel @AssistedInject constructor(
             .map { personEncounter ->
                 ListItem.Data(
                     R.drawable.ic_contact_diary_person_item,
-                    personEncounter.contactDiaryPerson.fullName
+                    personEncounter.contactDiaryPerson.fullName,
+                    "Person"
                 )
             }
     }
@@ -96,7 +97,8 @@ class ContactDiaryOverviewViewModel @AssistedInject constructor(
             .map { locationVisit ->
                 ListItem.Data(
                     R.drawable.ic_contact_diary_location_item,
-                    locationVisit.contactDiaryLocation.locationName
+                    locationVisit.contactDiaryLocation.locationName,
+                    "Location"
                 )
             }
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/overview/adapter/ContactDiaryOverviewNestedAdapter.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/overview/adapter/ContactDiaryOverviewNestedAdapter.kt
@@ -39,6 +39,10 @@ class ContactDiaryOverviewNestedAdapter(
             { key, _ ->
                 contactDiaryOverviewElementImage.setImageResource(key.drawableId)
                 contactDiaryOverviewElementName.text = key.text
+                contactDiaryOverviewElementName.contentDescription = if (key.type == "Location") context.getString(R.string.accessibility_location, key.text) else context.getString(R.string.accessibility_person, key.text)
+
+
+
                 contactDiaryOverviewElementNestedContainer.setOnClickListener { onItemSelectionListener(element) }
             }
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/overview/adapter/ContactDiaryOverviewNestedAdapter.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/overview/adapter/ContactDiaryOverviewNestedAdapter.kt
@@ -39,9 +39,9 @@ class ContactDiaryOverviewNestedAdapter(
             { key, _ ->
                 contactDiaryOverviewElementImage.setImageResource(key.drawableId)
                 contactDiaryOverviewElementName.text = key.text
-                contactDiaryOverviewElementName.contentDescription = if (key.type == "Location") context.getString(R.string.accessibility_location, key.text) else context.getString(R.string.accessibility_person, key.text)
-
-
+                contactDiaryOverviewElementName.contentDescription = if (key.type == ListItem.Type.LOCATION)
+                    context.getString(R.string.accessibility_location, key.text) else
+                        context.getString(R.string.accessibility_person, key.text)
 
                 contactDiaryOverviewElementNestedContainer.setOnClickListener { onItemSelectionListener(element) }
             }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/overview/adapter/ContactDiaryOverviewNestedAdapter.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/overview/adapter/ContactDiaryOverviewNestedAdapter.kt
@@ -39,9 +39,11 @@ class ContactDiaryOverviewNestedAdapter(
             { key, _ ->
                 contactDiaryOverviewElementImage.setImageResource(key.drawableId)
                 contactDiaryOverviewElementName.text = key.text
-                contactDiaryOverviewElementName.contentDescription = if (key.type == ListItem.Type.LOCATION)
-                    context.getString(R.string.accessibility_location, key.text) else
-                        context.getString(R.string.accessibility_person, key.text)
+                contactDiaryOverviewElementName.contentDescription = when (key.type) {
+                    ListItem.Type.LOCATION -> context.getString(R.string.accessibility_location, key.text)
+                    ListItem.Type.PERSON -> context.getString(R.string.accessibility_person, key.text)
+                    else -> key.text
+                }
 
                 contactDiaryOverviewElementNestedContainer.setOnClickListener { onItemSelectionListener(element) }
             }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/overview/adapter/ListItem.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/overview/adapter/ListItem.kt
@@ -9,6 +9,7 @@ data class ListItem(
 
     data class Data(
         val drawableId: Int,
-        val text: String
+        val text: String,
+        val type: String
     )
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/overview/adapter/ListItem.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/overview/adapter/ListItem.kt
@@ -10,6 +10,10 @@ data class ListItem(
     data class Data(
         val drawableId: Int,
         val text: String,
-        val type: String
+        val type: Type
     )
+
+    enum class Type {
+        LOCATION, PERSON
+    }
 }


### PR DESCRIPTION
**Changes were already merged in #2129 but due to a target base change to 1.11 this PR was reopened for 1.11.x**

Fixes an issue where only the names of locations and persons in the contact journal overview screen were announced but not the types e.g. "John Doe" instead of "Person John Doe".

To test this changes, activate TalkBack, navigate to the contact journal overview screen and focus a person or location within a day element.

![device-2021-01-18-143447](https://user-images.githubusercontent.com/75120552/105021198-904c5980-5a48-11eb-9cf6-982cc7c43ca7.png)
