### PR TITLE
Fix parsing of StatisticsData (EXPOSUREAPP-3674)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/source/StatisticsParser.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/source/StatisticsParser.kt
@@ -27,7 +27,7 @@ class StatisticsParser @Inject constructor() {
 
         val mappedItems: Set<StatsItem> = parsed.keyFigureCardsList.mapNotNull { rawCard ->
             try {
-                val updatedAt = Instant.ofEpochMilli(rawCard.header.updatedAt)
+                val updatedAt = Instant.ofEpochSecond(rawCard.header.updatedAt)
                 val keyFigures = rawCard.keyFiguresList
                 when (StatsItem.Type.values().singleOrNull { it.id == rawCard.header.cardId }) {
                     StatsItem.Type.INFECTION -> InfectionStats(updatedAt = updatedAt, keyFigures = keyFigures)

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/statistics/source/StatisticsParserTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/statistics/source/StatisticsParserTest.kt
@@ -171,7 +171,7 @@ class StatisticsParserTest : BaseTest() {
         }.build()
 
         val INFECTION_STATS = InfectionStats(
-            updatedAt = Instant.ofEpochMilli(123456778890),
+            updatedAt = Instant.ofEpochSecond(123456778890),
             keyFigures = listOf(
                 KeyFigureCardOuterClass.KeyFigure.newBuilder().apply {
                     rank = KeyFigureCardOuterClass.KeyFigure.Rank.PRIMARY
@@ -216,7 +216,7 @@ class StatisticsParserTest : BaseTest() {
         }.build()
 
         val INCIDENCE_STATS = IncidenceStats(
-            updatedAt = Instant.ofEpochMilli(1604839761),
+            updatedAt = Instant.ofEpochSecond(1604839761),
             keyFigures = listOf(
                 KeyFigureCardOuterClass.KeyFigure.newBuilder().apply {
                     rank = KeyFigureCardOuterClass.KeyFigure.Rank.PRIMARY
@@ -262,7 +262,7 @@ class StatisticsParserTest : BaseTest() {
         }.build()
 
         val KEYSUBMISSION_STATS = KeySubmissionsStats(
-            updatedAt = Instant.ofEpochMilli(0),
+            updatedAt = Instant.ofEpochSecond(0),
             keyFigures = listOf(
                 KeyFigureCardOuterClass.KeyFigure.newBuilder().apply {
                     rank = KeyFigureCardOuterClass.KeyFigure.Rank.PRIMARY
@@ -308,7 +308,7 @@ class StatisticsParserTest : BaseTest() {
         }.build()
 
         val SEVENDAYRVALUE_STATS = SevenDayRValue(
-            updatedAt = Instant.ofEpochMilli(1604839761),
+            updatedAt = Instant.ofEpochSecond(1604839761),
             keyFigures = listOf(
                 KeyFigureCardOuterClass.KeyFigure.newBuilder().apply {
                     rank = KeyFigureCardOuterClass.KeyFigure.Rank.PRIMARY


### PR DESCRIPTION
Fix parsing of StatisticsData
- `updatedAt` is in Unix timestamp