### PR TITLE
Contact Journal Edit Screen Title not accounced (EXPOSUREAPP-4456)

### DIFF
--- a/Corona-Warn-App/src/main/AndroidManifest.xml
+++ b/Corona-Warn-App/src/main/AndroidManifest.xml
@@ -81,6 +81,7 @@
             android:exported="false"
             android:screenOrientation="portrait"
             android:launchMode="singleTop"
+            android:label=""
             android:theme="@style/AppTheme.ContactDiary"
             android:windowSoftInputMode="adjustResize" />
 

--- a/Corona-Warn-App/src/main/AndroidManifest.xml
+++ b/Corona-Warn-App/src/main/AndroidManifest.xml
@@ -81,7 +81,7 @@
             android:exported="false"
             android:screenOrientation="portrait"
             android:launchMode="singleTop"
-            android:label=""
+            android:label="@string/empty_string_to_avoid_toolbar_announcement"
             android:theme="@style/AppTheme.ContactDiary"
             android:windowSoftInputMode="adjustResize" />
 

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -1507,4 +1507,8 @@
     <!-- XBUT: Abort button for test result positive no consent screen -->
     <string name="submission_test_result_positive_no_consent_button_abort">"Cancel"</string>
 
+    <!-- XTXT: Empty label for an activity -->
+    <string name="empty_string_to_avoid_toolbar_announcement" translatable="false">""</string>
+
+
 </resources>


### PR DESCRIPTION
Fixes a bug in the contact journal that announced the app name + the title when opening the edit screen views e.g. "Corona-Warn, Edit Places". Speech output is not just "Edit Places". 

In addition, this changed behavior is applied to all views within the contact journal that uses the default android `Toolbar` as header. 