### PR TITLE
Prioritized Background Title not announced (EXPOSUREAPP-4097)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/backgroundpriority/SettingsBackgroundPriorityFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/backgroundpriority/SettingsBackgroundPriorityFragment.kt
@@ -38,7 +38,7 @@ class SettingsBackgroundPriorityFragment : Fragment(R.layout.fragment_settings_b
 
     override fun onResume() {
         super.onResume()
-        binding.settingsBackgroundPriorityContainer.sendAccessibilityEvent(AccessibilityEvent.TYPE_ANNOUNCEMENT)
+        binding.settingsBackgroundPriorityContainer.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED)
     }
 
     private fun setButtonOnClickListener() {

--- a/Corona-Warn-App/src/main/res/layout/fragment_settings_background_priority.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_settings_background_priority.xml
@@ -12,7 +12,6 @@
         android:id="@+id/settings_background_priority_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:contentDescription="@string/settings_background_priority_title"
         android:focusable="true">
 
         <include
@@ -20,6 +19,8 @@
             layout="@layout/include_header"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:contentDescription="@string/settings_background_priority_title"
+            android:focusable="true"
             app:icon="@{@drawable/ic_back}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Fixes an issue that prevented TalkBack to announce the title when opening the Prioritized Background Activity View from the Settings.
