### PR TITLE
CircleCI config overhaul, instrumentation tests & screenshot automation (EXPOSUREAPP-4480,DEV)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -485,7 +485,6 @@ workflows:
           requires:
             - unit_tests_device_release
       - instrumentation_tests_device
-      - device_screenshots
 
   check_buildtype_device_for_testers:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,9 +257,9 @@ jobs:
             - ./project
       - compress-path:
           input: ./Corona-Warn-App/build/test-results
-          output: /tmp/unit_tests_device_release-$CIRCLE_SHA1.zip
+          output: /tmp/unit_tests_device_release.zip
       - store_artifacts:
-          path: /tmp/unit_tests_device_release-$CIRCLE_SHA1.zip
+          path: /tmp/unit_tests_device_release.zip
           destination: zips
 
   unit_tests_device_for_testers_release:
@@ -328,9 +328,9 @@ jobs:
           destination: reports
       - compress-path:
           input: ./Corona-Warn-App/build/reports
-          output: /tmp/ktlint_device_release_check-$CIRCLE_SHA1.zip
+          output: /tmp/ktlint_device_release_check.zip
       - store_artifacts:
-          path: /tmp/ktlint_device_release_check-$CIRCLE_SHA1.zip
+          path: /tmp/ktlint_device_release_check.zip
           destination: zips
 
   ktlint_device_for_testers_release_check:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,7 +260,7 @@ jobs:
           output: /tmp/unit_tests_device_release.zip
       - store_artifacts:
           path: /tmp/unit_tests_device_release.zip
-          destination: zips
+          destination: zips/unit_tests_device_release.zip
 
   unit_tests_device_for_testers_release:
     executor: android/android
@@ -326,12 +326,6 @@ jobs:
       - store_artifacts:
           path: Corona-Warn-App/build/reports
           destination: reports
-      - compress-path:
-          input: ./Corona-Warn-App/build/reports
-          output: /tmp/ktlint_device_release_check.zip
-      - store_artifacts:
-          path: /tmp/ktlint_device_release_check.zip
-          destination: zips
 
   ktlint_device_for_testers_release_check:
     executor: android/android
@@ -471,6 +465,12 @@ jobs:
       - store_artifacts:
           path: fastlane/metadata/android
           destination: screenshots
+      - compress-path:
+          input: ./fastlane/metadata/android
+          output: /tmp/device_screenshots.zip
+      - store_artifacts:
+          path: /tmp/device_screenshots.zip
+          destination: zips/device_screenshots.zip
 
 
 #######################

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -434,6 +434,12 @@ jobs:
       - kill-all-emulators
       - store_test_results:
           path: Corona-Warn-App/build/outputs/androidTest-results
+      - compress-path:
+          input: ./Corona-Warn-App/build/outputs/androidTest-results
+          output: /tmp/instrumentation_tests_device.zip
+      - store_artifacts:
+          path: /tmp/instrumentation_tests_device.zip
+          destination: zips/instrumentation_tests_device.zip
 
   device_screenshots:
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,16 +2,23 @@ version: 2.1
 orbs:
   android: circleci/android@0.2.1
   sonarcloud: sonarsource/sonarcloud@1.0.2
+
+#######################
+# Commands section
+# For code reuse.
+#######################
 commands:
   install-ndk: android/install-ndk
   restore-android-build-cache: android/restore-build-cache
   save-android-build-cache: android/save-build-cache
   scan-sonar: sonarcloud/scan
+
   restore-gradle-cache:
     description: "Restore gradle caches"
     steps:
       - restore_cache:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "Corona-Warn-App/build.gradle" }}-{{ checksum  "Server-Protocol-Buffer/build.gradle" }}
+
   save-gradle-cache:
     description: "Save gradle caches"
     steps:
@@ -19,17 +26,7 @@ commands:
           paths:
             - ~/.gradle
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "Corona-Warn-App/build.gradle" }}-{{ checksum  "Server-Protocol-Buffer/build.gradle" }}
-  require-version-bump:
-    description: "Require version bump for binary assembling"
-    steps:
-      - run:
-          name: "Check if assemble required"
-          command: |
-            last_commit=$(git log -1 --pretty=%B)
-            if [[ $last_commit != *"Version bump"* ]]; then
-              circleci-agent step halt
-              echo "Skipping job"
-            fi
+
   run-gradle-cmd:
     description: "Running gradle command with environment options"
     parameters:
@@ -41,10 +38,19 @@ commands:
     steps:
       - run:
           name: << parameters.desc >>
-          command: ./gradlew << parameters.cmd >>
+          command: >
+            ./gradlew -PdisablePreDex
+            << parameters.cmd >>
+          no_output_timeout: 30m
           environment:
-            JVM_OPTS: -Xmx2048m
-            GRADLE_OPTS: -Xmx1536m -XX:+HeapDumpOnOutOfMemoryError -Dorg.gradle.caching=true -Dorg.gradle.configureondemand=true -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false
+            JVM_OPTS: -Xmx4096m
+            GRADLE_OPTS: >
+              -Xmx1536m -XX:+HeapDumpOnOutOfMemoryError
+              -Dorg.gradle.caching=true
+              -Dorg.gradle.configureondemand=true
+              -Dkotlin.compiler.execution.strategy=in-process
+              -Dkotlin.incremental=false
+
   run-gradle-cmd-test-splitting:
     description: "Running gradle command with environment options and test splitting"
     parameters:
@@ -59,13 +65,122 @@ commands:
           command: circleci tests glob "**/test*/**/*.kt" | circleci tests split | xargs -n 1 echo
       - run:
           name: << parameters.desc >>
-          command: ./gradlew << parameters.cmd >> -i -PtestFilter="`circleci tests glob "**/test*/**/*.kt" | circleci tests split`"
+          command: >
+            ./gradlew -PdisablePreDex
+            << parameters.cmd >>
+            -i -PtestFilter="`circleci tests glob "**/test*/**/*.kt" | circleci tests split`"
           environment:
-            JVM_OPTS: -Xmx2048m
-            GRADLE_OPTS: -Xmx1536m -XX:+HeapDumpOnOutOfMemoryError -Dorg.gradle.caching=true -Dorg.gradle.configureondemand=true -Dkotlin.compiler.execution.strategy=in-process -Dkotlin.incremental=false
+            JVM_OPTS: -Xmx4096m
+            GRADLE_OPTS: >
+              -Xmx1536m -XX:+HeapDumpOnOutOfMemoryError
+              -Dorg.gradle.caching=true
+              -Dorg.gradle.configureondemand=true
+              -Dkotlin.compiler.execution.strategy=in-process
+              -Dkotlin.incremental=false
 
+  skip-for-external-pull-requests:
+    description: "Skip for external pull requests due to missing access to secrets."
+    steps:
+      - run:
+          name: Early return if this build is from a forked PR
+          command: |
+            if [ -n "$CIRCLE_PR_NUMBER" ]; then
+              echo "Nothing to do for forked PRs, so marking this step successful"
+              circleci step halt
+            fi
+
+  setup-google-cloud:
+    description: "Setup Google Cloud access."
+    steps:
+      - run:
+          name: Store Google Service Account
+          command: echo $GCLOUD_SERVICE_KEY_BASE64 | base64 -di > ${HOME}/gcloud-service-key.json
+      - run:
+          name: Authorize gcloud and set config defaults
+          command: |
+            sudo gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
+            sudo gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
+
+  setup-android-macos:
+    description: "Setup Android environment on macOS executor"
+    steps:
+      - restore_cache:
+          key: android-sdk-v1-{{ arch }}-{{ checksum ".circleci/install-android-sdk.sh" }}
+      - run:
+          name: Set ANDROID_SDK_ROOT environment variable
+          command: echo 'export ANDROID_SDK_ROOT=$HOME/android-sdk'  >> $BASH_ENV
+      - run:
+          name: Install Android SDK
+          command: |
+            sh .circleci/install-android-sdk.sh
+            echo 'export PATH=$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$PATH'  >> $BASH_ENV
+            echo 'export PATH=$ANDROID_SDK_ROOT/cmdline-tools/latest:$PATH'  >> $BASH_ENV
+            echo 'export PATH=$ANDROID_SDK_ROOT/platform-tools:$PATH'  >> $BASH_ENV
+            echo 'export PATH=$ANDROID_SDK_ROOT/emulator:$PATH'  >> $BASH_ENV
+            echo 'export PATH=$ANDROID_SDK_ROOT/build-tools/29.0.3:$PATH'  >> $BASH_ENV
+            source $BASH_ENV
+            sdkmanager --list
+      - save_cache:
+          key: android-sdk-v1-{{ arch }}-{{ checksum ".circleci/install-android-sdk.sh" }}
+          paths:
+            - /Users/distiller/android-sdk
+
+  run-emulator-for-api:
+    parameters:
+      apilevel:
+        type: integer
+    description: "Setup and start emulator for API<< parameters.apilevel >>"
+    steps:
+      - run:
+          name: Create emulator AVD
+          command: >
+            echo "no" | avdmanager --verbose create avd --force
+            --name "emulator_API<< parameters.apilevel >>"
+            --package "system-images;android-<< parameters.apilevel >>;google_apis;x86_64"
+      - run:
+          name: Configure emulator settings
+          command: |
+            cd $HOME/.android/avd/emulator_API<< parameters.apilevel >>.avd
+            sed -i '' -e 's/hw.lcd.density=[0-9]*/hw.lcd.density=560/g' config.ini
+            sed -i '' -e 's/hw.lcd.height=[0-9]*/hw.lcd.height=2880/g' config.ini
+            sed -i '' -e 's/hw.lcd.width=[0-9]*/hw.lcd.width=1440/g' config.ini
+            sed -i '' -e 's/hw.ramSize=[0-9]*/hw.ramSize=1536/g' config.ini
+      - run:
+          name: Start emulator AVD
+          command: >
+            emulator @emulator_API<< parameters.apilevel >> -no-window -no-audio -no-boot-anim
+          background: true
+          no_output_timeout: 60m
+      - run:
+          name: Wait for emulator
+          command: |
+            adb wait-for-device shell 'while [[ -z $(getprop dev.bootcomplete) ]]; do sleep 1; done;'
+            adb devices
+            sleep 5
+      - run:
+          name: Disable animations
+          command: |
+            adb shell settings put global window_animation_scale 0
+            adb shell settings put global transition_animation_scale 0
+            adb shell settings put global animator_duration_scale 0
+
+  kill-all-emulators:
+    description: "Kill all emulators"
+    steps:
+      - run:
+          name: Kill all emulators
+          command: |
+            adb devices | grep emulator | cut -f1 | while read line; do adb -s $line emu kill; done
+            sleep 2
+            adb kill-server
+            sleep 2
+
+#######################
+# Jobs section
+# Tasks that get executed
+#######################
 jobs:
-  quick_build_device_release_no_tests:
+  detekt:
     executor: android/android
     resource_class: large
     working_directory: ~/project
@@ -73,7 +188,21 @@ jobs:
       - checkout
       - restore-gradle-cache
       - restore-android-build-cache
-      - require-version-bump
+      - run-gradle-cmd:
+          desc: Detekt check
+          cmd: ":Corona-Warn-App:detekt"
+      - store_artifacts:
+          path: Corona-Warn-App/build/reports
+          destination: reports
+
+  quick_build_device_release_no_tests:
+    executor: android/android
+    resource_class: xlarge
+    working_directory: ~/project
+    steps:
+      - checkout
+      - restore-gradle-cache
+      - restore-android-build-cache
       - run-gradle-cmd:
           desc: Quick Build
           cmd: "assembleDeviceRelease"
@@ -82,15 +211,15 @@ jobs:
       - store_artifacts:
           path: Corona-Warn-App/build/reports
           destination: reports
+
   quick_build_device_for_testers_release_no_tests:
     executor: android/android
-    resource_class: large
+    resource_class: xlarge
     working_directory: ~/project
     steps:
       - checkout
       - restore-gradle-cache
       - restore-android-build-cache
-      - require-version-bump
       - run-gradle-cmd:
           desc: Quick Build
           cmd: ":Corona-Warn-App:assembleDeviceForTestersRelease"
@@ -99,9 +228,10 @@ jobs:
       - store_artifacts:
           path: Corona-Warn-App/build/reports
           destination: reports
-  device_release_unit_tests:
+
+  unit_tests_device_release:
     executor: android/android
-    resource_class: large
+    resource_class: xlarge
     working_directory: ~/project
     parallelism: 3
     steps:
@@ -122,9 +252,10 @@ jobs:
           root: /home/circleci
           paths:
             - ./project
-  device_for_testers_release_unit_tests:
+
+  unit_tests_device_for_testers_release:
     executor: android/android
-    resource_class: large
+    resource_class: xlarge
     working_directory: ~/project
     parallelism: 3
     steps:
@@ -141,9 +272,10 @@ jobs:
           destination: reports
       - store_test_results:
           path: Corona-Warn-App/build/test-results
+
   lint_device_release_check:
     executor: android/android
-    resource_class: large
+    resource_class: xlarge
     working_directory: ~/project
     steps:
       - checkout
@@ -155,6 +287,22 @@ jobs:
       - store_artifacts:
           path: Corona-Warn-App/build/reports
           destination: reports
+
+  lint_device_for_testers_release_check:
+    executor: android/android
+    resource_class: xlarge
+    working_directory: ~/project
+    steps:
+      - checkout
+      - restore-gradle-cache
+      - restore-android-build-cache
+      - run-gradle-cmd:
+          desc: Lint check deviceForTestersRelease
+          cmd: ":Corona-Warn-App:lintDeviceForTestersRelease -i"
+      - store_artifacts:
+          path: Corona-Warn-App/build/reports
+          destination: reports
+
   ktlint_device_release_check:
     executor: android/android
     resource_class: medium
@@ -169,20 +317,7 @@ jobs:
       - store_artifacts:
           path: Corona-Warn-App/build/reports
           destination: reports
-  lint_device_for_testers_release_check:
-    executor: android/android
-    resource_class: large
-    working_directory: ~/project
-    steps:
-      - checkout
-      - restore-gradle-cache
-      - restore-android-build-cache
-      - run-gradle-cmd:
-          desc: Lint check deviceForTestersRelease
-          cmd: ":Corona-Warn-App:lintDeviceForTestersRelease -i"
-      - store_artifacts:
-          path: Corona-Warn-App/build/reports
-          destination: reports
+
   ktlint_device_for_testers_release_check:
     executor: android/android
     resource_class: medium
@@ -197,25 +332,13 @@ jobs:
       - store_artifacts:
           path: Corona-Warn-App/build/reports
           destination: reports
-  detekt:
-    executor: android/android
-    resource_class: medium
-    working_directory: ~/project
-    steps:
-      - checkout
-      - restore-gradle-cache
-      - restore-android-build-cache
-      - run-gradle-cmd:
-          desc: Detekt check
-          cmd: ":Corona-Warn-App:detekt"
-      - store_artifacts:
-          path: Corona-Warn-App/build/reports
-          destination: reports
+
   run_sonar:
     executor: android/android
-    resource_class: large
+    resource_class: xlarge
     working_directory: ~/project
     steps:
+      - skip-for-external-pull-requests
       - attach_workspace:
           at: /home/circleci
       - restore-gradle-cache
@@ -224,9 +347,10 @@ jobs:
           desc: JaCoCo report
           cmd: ":Corona-Warn-App:jacocoTestReportDeviceRelease -i"
       - scan-sonar
+
   quick_build_device_for_testers_signed:
     executor: android/android
-    resource_class: large
+    resource_class: xlarge
     working_directory: ~/project
     steps:
       - checkout
@@ -276,22 +400,101 @@ jobs:
             curl --location --request POST $tsystems_upload_url \
             --header "Authorization: Bearer $tsystems_upload_bearer" \
             --form "file=@${fileName}" \
+
+  instrumentation_tests_device:
+    macos:
+      xcode: "12.3.0"
+    resource_class: large
+    steps:
+      - checkout
+      - setup-android-macos
+      - run-gradle-cmd:
+          desc: Build Apks for instrumentation test
+          cmd: >
+            :Corona-Warn-App:assembleDeviceDebug
+            :Corona-Warn-App:assembleDeviceDebugAndroidTest
+      - run-emulator-for-api:
+          apilevel: 29
+      - run-gradle-cmd:
+          desc: Run instrumentation tests on device
+          cmd: >
+            :Corona-Warn-App:connectedDeviceDebugAndroidTest
+            --info --continue
+            -Pandroid.testInstrumentationRunnerArguments.notAnnotation=testhelpers.Screenshot
+            -Pandroid.testInstrumentationRunnerArguments.clearPackageData=true
+      #      - kill-all-emulators
+      #      - run-emulator-api23
+      #      - run-gradle-cmd:
+      #          desc: Run instrumentation test command
+      #          cmd: |
+      #            :Corona-Warn-App:connectedDeviceForTestersDebugAndroidTest \
+      #            --info \
+      #            --continue \
+      #            -Pandroid.testInstrumentationRunnerArguments.notAnnotation=testhelpers.Screenshot \
+      #            -Pandroid.testInstrumentationRunnerArguments.clearPackageData=true
+      - kill-all-emulators
+      - store_test_results:
+          path: Corona-Warn-App/build/outputs/androidTest-results
+
+  device_screenshots:
+    macos:
+      xcode: "12.3.0"
+    resource_class: large
+    steps:
+      - checkout
+      - restore_cache:
+          key: gem-cache-v1-{{ arch }}-{{ checksum "Gemfile.lock" }}
+      - run: bundle check || bundle install --path vendor/bundle
+      - save_cache:
+          key: gem-cache-v1-{{ arch }}-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
+      - setup-android-macos
+      - run-gradle-cmd:
+          desc: Build APKs for screenshots
+          cmd: >
+            :Corona-Warn-App:assembleDebug
+            :Corona-Warn-App:assembleAndroidTest
+      - run-emulator-for-api:
+          apilevel: 29
+      - run:
+          name: Run fastlane screengrab
+          command: |
+            for i in {1..5}; do bundle exec fastlane screengrab && break || sleep 15; done
+          no_output_timeout: 30m
+      - kill-all-emulators
+      - store_artifacts:
+          path: fastlane/metadata/android
+          destination: screenshots
+
+
+#######################
+# Workflow section
+# Job execution orders
+#######################
 workflows:
   version: 2
-  quick_build:
+  check_buildtype_device:
     jobs:
-      - quick_build_device_release_no_tests
-      - quick_build_device_for_testers_release_no_tests
-      - device_release_unit_tests
-      - device_for_testers_release_unit_tests
-      - lint_device_release_check
-      - lint_device_for_testers_release_check
-      - ktlint_device_release_check
-      - ktlint_device_for_testers_release_check
       - detekt
+      - lint_device_release_check
+      - ktlint_device_release_check
+      - quick_build_device_release_no_tests
+      - unit_tests_device_release
       - run_sonar:
           requires:
-            - device_release_unit_tests
+            - unit_tests_device_release
+      - instrumentation_tests_device
+      - device_screenshots
+
+  check_buildtype_device_for_testers:
+    jobs:
+      - detekt
+      - lint_device_for_testers_release_check
+      - ktlint_device_for_testers_release_check
+      - quick_build_device_for_testers_release_no_tests
+      - unit_tests_device_for_testers_release
+
   signed_build:
     jobs:
       - quick_build_device_for_testers_signed:
@@ -301,3 +504,6 @@ workflows:
                 - /^v.*/
             branches:
               ignore: /.*/
+      - device_screenshots:
+          requires:
+            - quick_build_device_for_testers_signed

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,18 +89,6 @@ commands:
               circleci step halt
             fi
 
-  setup-google-cloud:
-    description: "Setup Google Cloud access."
-    steps:
-      - run:
-          name: Store Google Service Account
-          command: echo $GCLOUD_SERVICE_KEY_BASE64 | base64 -di > ${HOME}/gcloud-service-key.json
-      - run:
-          name: Authorize gcloud and set config defaults
-          command: |
-            sudo gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
-            sudo gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
-
   setup-android-macos:
     description: "Setup Android environment on macOS executor"
     steps:
@@ -422,16 +410,6 @@ jobs:
             --info --continue
             -Pandroid.testInstrumentationRunnerArguments.notAnnotation=testhelpers.Screenshot
             -Pandroid.testInstrumentationRunnerArguments.clearPackageData=true
-      #      - kill-all-emulators
-      #      - run-emulator-api23
-      #      - run-gradle-cmd:
-      #          desc: Run instrumentation test command
-      #          cmd: |
-      #            :Corona-Warn-App:connectedDeviceForTestersDebugAndroidTest \
-      #            --info \
-      #            --continue \
-      #            -Pandroid.testInstrumentationRunnerArguments.notAnnotation=testhelpers.Screenshot \
-      #            -Pandroid.testInstrumentationRunnerArguments.clearPackageData=true
       - kill-all-emulators
       - store_test_results:
           path: Corona-Warn-App/build/outputs/androidTest-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,9 +146,19 @@ commands:
             sed -i '' -e 's/hw.lcd.width=[0-9]*/hw.lcd.width=1440/g' config.ini
             sed -i '' -e 's/hw.ramSize=[0-9]*/hw.ramSize=1536/g' config.ini
       - run:
+          name: Check host state
+          command: |
+            emulator -accel-check
+            emulator -version
+      - run:
           name: Start emulator AVD
           command: >
-            emulator @emulator_API<< parameters.apilevel >> -no-window -no-audio -no-boot-anim
+            emulator @emulator_API<< parameters.apilevel >>
+            -no-window
+            -no-audio
+            -no-boot-anim
+            -memory 2048
+            -nojni
           background: true
           no_output_timeout: 60m
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,6 +163,21 @@ commands:
             adb kill-server
             sleep 2
 
+  compress-path:
+    parameters:
+      input:
+        type: string
+      output:
+        type: string
+    description: "Compress << parameters.input >> to << parameters.output >>"
+    steps:
+      - run:
+          name: Compress files
+          command: >
+            zip -r
+            << parameters.output >>
+            << parameters.input >>
+
 #######################
 # Jobs section
 # Tasks that get executed
@@ -240,6 +255,12 @@ jobs:
           root: /home/circleci
           paths:
             - ./project
+      - compress-path:
+          input: Corona-Warn-App/build/test-results
+          output: /tmp/unit_tests_device_release-$CIRCLE_SHA1.zip
+      - store_artifacts:
+          path: /tmp/unit_tests_device_release-$CIRCLE_SHA1.zip
+          destination: zips
 
   unit_tests_device_for_testers_release:
     executor: android/android
@@ -275,6 +296,12 @@ jobs:
       - store_artifacts:
           path: Corona-Warn-App/build/reports
           destination: reports
+      - compress-path:
+          input: Corona-Warn-App/build/test-results
+          output: /tmp/lint_device_release_check-$CIRCLE_SHA1.zip
+      - store_artifacts:
+          path: /tmp/lint_device_release_check-$CIRCLE_SHA1.zip
+          destination: zips
 
   lint_device_for_testers_release_check:
     executor: android/android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,7 +256,7 @@ jobs:
           paths:
             - ./project
       - compress-path:
-          input: Corona-Warn-App/build/test-results
+          input: $HOME/Corona-Warn-App/build/test-results
           output: /tmp/unit_tests_device_release-$CIRCLE_SHA1.zip
       - store_artifacts:
           path: /tmp/unit_tests_device_release-$CIRCLE_SHA1.zip
@@ -296,12 +296,6 @@ jobs:
       - store_artifacts:
           path: Corona-Warn-App/build/reports
           destination: reports
-      - compress-path:
-          input: Corona-Warn-App/build/test-results
-          output: /tmp/lint_device_release_check-$CIRCLE_SHA1.zip
-      - store_artifacts:
-          path: /tmp/lint_device_release_check-$CIRCLE_SHA1.zip
-          destination: zips
 
   lint_device_for_testers_release_check:
     executor: android/android
@@ -332,6 +326,12 @@ jobs:
       - store_artifacts:
           path: Corona-Warn-App/build/reports
           destination: reports
+      - compress-path:
+          input: $HOME/Corona-Warn-App/build/reports
+          output: /tmp/ktlint_device_release_check-$CIRCLE_SHA1.zip
+      - store_artifacts:
+          path: /tmp/ktlint_device_release_check-$CIRCLE_SHA1.zip
+          destination: zips
 
   ktlint_device_for_testers_release_check:
     executor: android/android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,9 +246,6 @@ jobs:
           cmd: ":Corona-Warn-App:testDeviceReleaseUnitTest -i"
       - save-gradle-cache
       - save-android-build-cache
-      - store_artifacts:
-          path: Corona-Warn-App/build/reports
-          destination: reports
       - store_test_results:
           path: Corona-Warn-App/build/test-results
       - persist_to_workspace:
@@ -256,7 +253,7 @@ jobs:
           paths:
             - ./project
       - compress-path:
-          input: ./Corona-Warn-App/build/test-results
+          input: ./Corona-Warn-App/build/reports
           output: /tmp/unit_tests_device_release.zip
       - store_artifacts:
           path: /tmp/unit_tests_device_release.zip
@@ -276,11 +273,15 @@ jobs:
           cmd: ":Corona-Warn-App:testDeviceForTestersReleaseUnitTest"
       - save-gradle-cache
       - save-android-build-cache
-      - store_artifacts:
-          path: Corona-Warn-App/build/reports
-          destination: reports
       - store_test_results:
           path: Corona-Warn-App/build/test-results
+      - compress-path:
+          input: ./Corona-Warn-App/build/reports
+          output: /tmp/unit_tests_device_for_testers_release.zip
+      - store_artifacts:
+          path: /tmp/unit_tests_device_for_testers_release.zip
+          destination: zips/unit_tests_device_for_testers_release.zip
+
 
   lint_device_release_check:
     executor: android/android
@@ -435,7 +436,7 @@ jobs:
       - store_test_results:
           path: Corona-Warn-App/build/outputs/androidTest-results
       - compress-path:
-          input: ./Corona-Warn-App/build/outputs/androidTest-results
+          input: ./Corona-Warn-App/build/reports
           output: /tmp/instrumentation_tests_device.zip
       - store_artifacts:
           path: /tmp/instrumentation_tests_device.zip
@@ -477,7 +478,6 @@ jobs:
       - store_artifacts:
           path: /tmp/device_screenshots.zip
           destination: zips/device_screenshots.zip
-
 
 #######################
 # Workflow section

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,7 +256,7 @@ jobs:
           paths:
             - ./project
       - compress-path:
-          input: $HOME/Corona-Warn-App/build/test-results
+          input: ./Corona-Warn-App/build/test-results
           output: /tmp/unit_tests_device_release-$CIRCLE_SHA1.zip
       - store_artifacts:
           path: /tmp/unit_tests_device_release-$CIRCLE_SHA1.zip
@@ -327,7 +327,7 @@ jobs:
           path: Corona-Warn-App/build/reports
           destination: reports
       - compress-path:
-          input: $HOME/Corona-Warn-App/build/reports
+          input: ./Corona-Warn-App/build/reports
           output: /tmp/ktlint_device_release_check-$CIRCLE_SHA1.zip
       - store_artifacts:
           path: /tmp/ktlint_device_release_check-$CIRCLE_SHA1.zip

--- a/.circleci/install-android-sdk.sh
+++ b/.circleci/install-android-sdk.sh
@@ -1,0 +1,30 @@
+if [ -d $ANDROID_SDK_ROOT ]
+then
+    echo "Directory $ANDROID_SDK_ROOT already exists so we're skipping the install. If you'd like to install fresh tools, edit this script to invalidate the CI cache..."
+    exit 0
+fi
+
+mkdir -p $ANDROID_SDK_ROOT
+cd $ANDROID_SDK_ROOT
+curl https://dl.google.com/android/repository/commandlinetools-mac-6858069_latest.zip -o cmdline-tools.zip
+
+unzip cmdline-tools.zip -d $ANDROID_SDK_ROOT/cmdline-tools
+mv $ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools $ANDROID_SDK_ROOT/cmdline-tools/latest
+
+mkdir -p "$ANDROID_SDK_ROOT/licenses"
+
+echo "24333f8a63b6825ea9c5514f83c2829b004d1fee" > "$ANDROID_SDK_ROOT/licenses/android-sdk-license"
+echo "84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_SDK_ROOT/licenses/android-sdk-preview-license"
+echo "d975f751698a77b662f1254ddbeed3901e976f5a" > "$ANDROID_SDK_ROOT/licenses/intel-android-extra-license"
+
+SDKMANAGER=$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager
+
+$SDKMANAGER "platform-tools"
+$SDKMANAGER "platforms;android-29"
+$SDKMANAGER "build-tools;29.0.3"
+$SDKMANAGER "ndk-bundle"
+$SDKMANAGER "system-images;android-29;google_apis;x86_64"
+$SDKMANAGER "system-images;android-23;google_apis;x86_64"
+$SDKMANAGER "emulator"
+
+echo "y" | sudo $SDKMANAGER --install "ndk;21.2.6472646" --sdk_root=${ANDROID_SDK_ROOT}

--- a/.circleci/install-android-sdk.sh
+++ b/.circleci/install-android-sdk.sh
@@ -24,7 +24,6 @@ $SDKMANAGER "platforms;android-29"
 $SDKMANAGER "build-tools;29.0.3"
 $SDKMANAGER "ndk-bundle"
 $SDKMANAGER "system-images;android-29;google_apis;x86_64"
-$SDKMANAGER "system-images;android-23;google_apis;x86_64"
 $SDKMANAGER "emulator"
 
 echo "y" | sudo $SDKMANAGER --install "ndk;21.2.6472646" --sdk_root=${ANDROID_SDK_ROOT}

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@
 /test_environments.json
 *.jks
 /keystore.properties
+.local/*
 fastlane/metadata

--- a/Corona-Warn-App/build.gradle
+++ b/Corona-Warn-App/build.gradle
@@ -196,6 +196,12 @@ android {
             includeAndroidResources = true
             returnDefaultValues = true
         }
+
+        // Using orchestration toegether with mockk on x86 (32bit) emulator images crashes
+        // Leaving this in here as reminder
+        // https://github.com/android/android-test/issues/352
+        // https://github.com/mockk/mockk/issues/466
+        // execution 'ANDROIDX_TEST_ORCHESTRATOR'
     }
 
     kapt {
@@ -317,9 +323,11 @@ dependencies {
     implementation "com.google.dagger:dagger-android:$dagger_version"
     implementation "com.google.dagger:dagger-android-support:$dagger_version"
     kapt "com.google.dagger:dagger-compiler:$dagger_version"
-    kapt "com.google.dagger:dagger-android-processor:$dagger_version"
     kaptTest "com.google.dagger:dagger-compiler:$dagger_version"
     kaptAndroidTest "com.google.dagger:dagger-compiler:$dagger_version"
+    kapt "com.google.dagger:dagger-android-processor:$dagger_version"
+    kaptTest "com.google.dagger:dagger-android-processor:$dagger_version"
+    kaptAndroidTest "com.google.dagger:dagger-android-processor:$dagger_version"
 
     def assisted_injection_version = "0.6.0"
     compileOnly "com.squareup.inject:assisted-inject-annotations-dagger2:$assisted_injection_version"

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/contactdiary/DiaryData.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/contactdiary/DiaryData.kt
@@ -14,22 +14,26 @@ object DiaryData {
     val LIST_ITEMS = listOf(
         ListItem.Data(
             R.drawable.ic_contact_diary_person_item,
-            "Max Mustermann"
+            "Max Mustermann",
+            ListItem.Type.PERSON
         ),
 
         ListItem.Data(
             R.drawable.ic_contact_diary_person_item,
-            "Erika Mustermann"
+            "Erika Mustermann",
+            ListItem.Type.PERSON
         ),
 
         ListItem.Data(
             R.drawable.ic_contact_diary_location,
-            "Fitnessstudio"
+            "Fitnessstudio",
+            ListItem.Type.LOCATION
         ),
 
         ListItem.Data(
             R.drawable.ic_contact_diary_location,
-            "Supermarket"
+            "Supermarket",
+            ListItem.Type.LOCATION
         )
     )
 


### PR DESCRIPTION
@mtwalli, @AlexanderAlferov and me overhauled the CircleCI config, added instrumentation testing and automatic screenshots.

Highlights:
* Refactored the config (yes you can refactor YAML :dizzy_face:) to make use more use of re-usable functions
* Use larger instances for faster test execution
* Adjusted gradle/JVM options to improve performance and use larger instances better
* Run instrumentation tests via macOS CircleCI executor
* Run automated screenshot routine via fastlane when a new release candidate is build
* Improved caching behavior
* Split works for better job restart and improved dependencies between tasks
* Renamed tasks and work flows to be easier to understand

We tried Firebase Testlab, but it was not working out, due to lack of control over the whole process (more of a black box) and inability to use fastlane with it. There were also issues with our mocking library which could fail on newer API emulators if not run on `x86_64` architecture emulators, and firebase testlab doesn't allow us to enforce it.

Because we previously didn't run instrumentation tests via CI, a few tests fell into disarray and will need fixing. The current config setup is already a huge improvement over the previous config and I think should merge it despite the failing instrumentation tests. Until we enforce the check to pass for branches, there should be no issue. A follow up PR can then be made stress free to fix the failing tests.

This was initially targeted for 1.12, but as this will require adjusting the branch restrictions, it would make sense to merge this into 1.11, we share the same branch restrictions between all branches. Then the only problematic branch would be 1.10.x which will soon be superseeded by 1.11.x.

Once the config is merged I will change the restrictions and all open PRs will have to pull the new config to run the correct tests.