### PR TITLE
Improve 7-Day-R-Value layout resilience (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/home_statistics_cards_sevendayrvalue_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_statistics_cards_sevendayrvalue_layout.xml
@@ -33,10 +33,13 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/spacing_normal"
-            android:layout_marginTop="@dimen/spacing_large"
+            android:layout_marginTop="16dp"
             android:text="@string/statistics_reproduction_title"
+            app:layout_constraintBottom_toTopOf="@+id/primary_value"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/primary_title" />
+            app:layout_constraintTop_toBottomOf="@id/primary_title"
+            app:layout_constraintVertical_bias="0.3"
+            app:layout_constraintVertical_chainStyle="packed" />
 
         <TextView
             android:id="@+id/primary_value"
@@ -44,6 +47,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/spacing_normal"
+            app:layout_constraintBottom_toTopOf="@+id/secondary_label"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/primary_label"
             tools:text="1,04" />
@@ -63,23 +67,26 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/spacing_normal"
-            android:layout_marginTop="@dimen/spacing_normal"
+            android:layout_marginTop="16dp"
             android:layout_marginEnd="@dimen/spacing_tiny"
             android:text="@string/statistics_reproduction_average"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/illustration"
-            app:layout_constraintTop_toBottomOf="@id/primary_value" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/primary_value"
+            app:layout_constraintVertical_bias="0.0" />
 
         <ImageView
             android:id="@+id/illustration"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="36dp"
-            android:src="@drawable/ic_7_day_r_value"
             android:importantForAccessibility="no"
+            android:src="@drawable/ic_7_day_r_value"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/secondary_label"
-            app:layout_constraintTop_toBottomOf="@id/primary_label" />
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.68" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
New Normal:
![Screenshot from 2021-01-20 11-56-50](https://user-images.githubusercontent.com/1439229/105165734-fef7e880-5b16-11eb-8227-829c1d91e880.png)

Before Large Text:
![Screenshot from 2021-01-20 11-57-38](https://user-images.githubusercontent.com/1439229/105165758-07502380-5b17-11eb-8ea0-c6f7ec1049cb.png)

Now Large Text:
![Screenshot from 2021-01-20 11-57-04](https://user-images.githubusercontent.com/1439229/105165785-0e773180-5b17-11eb-995b-ceb47e26a983.png)
