### PR TITLE
Improve CircleCI instrumentation test performance (DEV)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ commands:
     description: "Restore gradle caches"
     steps:
       - restore_cache:
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "Corona-Warn-App/build.gradle" }}-{{ checksum  "Server-Protocol-Buffer/build.gradle" }}
+          key: gradle-v1-{{ arch }}-{{ checksum "build.gradle" }}-{{ checksum  "Corona-Warn-App/build.gradle" }}-{{ checksum  "Server-Protocol-Buffer/build.gradle" }}
 
   save-gradle-cache:
     description: "Save gradle caches"
@@ -25,7 +25,7 @@ commands:
       - save_cache:
           paths:
             - ~/.gradle
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "Corona-Warn-App/build.gradle" }}-{{ checksum  "Server-Protocol-Buffer/build.gradle" }}
+          key: gradle-v1-{{ arch }}-{{ checksum "build.gradle" }}-{{ checksum  "Corona-Warn-App/build.gradle" }}-{{ checksum  "Server-Protocol-Buffer/build.gradle" }}
 
   run-gradle-cmd:
     description: "Running gradle command with environment options"
@@ -428,11 +428,15 @@ jobs:
     steps:
       - checkout
       - setup-android-macos
+      - restore-gradle-cache
+      - restore-android-build-cache
       - run-gradle-cmd:
           desc: Build Apks for instrumentation test
           cmd: >
             :Corona-Warn-App:assembleDeviceDebug
             :Corona-Warn-App:assembleDeviceDebugAndroidTest
+      - save-gradle-cache
+      - save-android-build-cache
       - run-emulator-for-api:
           apilevel: 29
       - run-gradle-cmd:
@@ -466,11 +470,15 @@ jobs:
           paths:
             - vendor/bundle
       - setup-android-macos
+      - restore-gradle-cache
+      - restore-android-build-cache
       - run-gradle-cmd:
           desc: Build APKs for screenshots
           cmd: >
             :Corona-Warn-App:assembleDebug
             :Corona-Warn-App:assembleAndroidTest
+      - save-gradle-cache
+      - save-android-build-cache
       - run-emulator-for-api:
           apilevel: 29
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,21 @@ commands:
             - ~/.gradle
           key: gradle-v1-{{ arch }}-{{ checksum "build.gradle" }}-{{ checksum  "Corona-Warn-App/build.gradle" }}-{{ checksum  "Server-Protocol-Buffer/build.gradle" }}
 
+  restore-android-build-cache-macos:
+    description: "Restore Android build caches on macOS"
+    steps:
+      - restore_cache:
+          key: android-buildcache-v1-{{ arch }}
+
+  save-android-build-cache-macos:
+    description: "Save Android build caches on macOS"
+    steps:
+      - save_cache:
+          paths:
+            - ~/.android/build-cache
+            - ~/.android/cache
+          key: android-buildcache-v1-{{ arch }}-{{ epoch }}
+
   run-gradle-cmd:
     description: "Running gradle command with environment options"
     parameters:
@@ -429,14 +444,14 @@ jobs:
       - checkout
       - setup-android-macos
       - restore-gradle-cache
-      - restore-android-build-cache
+      - restore-android-build-cache-macos
       - run-gradle-cmd:
           desc: Build Apks for instrumentation test
           cmd: >
             :Corona-Warn-App:assembleDeviceDebug
             :Corona-Warn-App:assembleDeviceDebugAndroidTest
       - save-gradle-cache
-      - save-android-build-cache
+      - save-android-build-cache-macos
       - run-emulator-for-api:
           apilevel: 29
       - run-gradle-cmd:
@@ -471,14 +486,14 @@ jobs:
             - vendor/bundle
       - setup-android-macos
       - restore-gradle-cache
-      - restore-android-build-cache
+      - restore-android-build-cache-macos
       - run-gradle-cmd:
           desc: Build APKs for screenshots
           cmd: >
             :Corona-Warn-App:assembleDebug
             :Corona-Warn-App:assembleAndroidTest
       - save-gradle-cache
-      - save-android-build-cache
+      - save-android-build-cache-macos
       - run-emulator-for-api:
           apilevel: 29
       - run:


### PR DESCRIPTION
We now make use of caching mechanisms for the builds on macOS too.