### PR TITLE
Fix flickering of statistics cards when returning from statistics information screen (EXPOSUREAPP-4704)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/StatisticsHomeCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/StatisticsHomeCard.kt
@@ -47,10 +47,25 @@ class StatisticsHomeCard(
         }.let { statsAdapter.update(it) }
     }
 
+    @Suppress("EqualsOrHashCode") // ignore warning: custom implementation of hashCode() not needed
     data class Item(
         val data: StatisticsData,
         val onHelpAction: (StatsItem) -> Unit
     ) : HomeItem {
         override val stableId: Long = Item::class.java.name.hashCode().toLong()
+
+        // ignore onHelpAction so that view is not re-drawn when only the onHelpAction click listener is updated
+        // Auto-generated
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as Item
+
+            if (data != other.data) return false
+            if (stableId != other.stableId) return false
+
+            return true
+        }
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/StatisticsHomeCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/StatisticsHomeCard.kt
@@ -47,7 +47,6 @@ class StatisticsHomeCard(
         }.let { statsAdapter.update(it) }
     }
 
-    @Suppress("EqualsOrHashCode") // ignore warning: custom implementation of hashCode() not needed
     data class Item(
         val data: StatisticsData,
         val onHelpAction: (StatsItem) -> Unit
@@ -55,7 +54,6 @@ class StatisticsHomeCard(
         override val stableId: Long = Item::class.java.name.hashCode().toLong()
 
         // ignore onHelpAction so that view is not re-drawn when only the onHelpAction click listener is updated
-        // Auto-generated
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
             if (javaClass != other?.javaClass) return false
@@ -66,6 +64,12 @@ class StatisticsHomeCard(
             if (stableId != other.stableId) return false
 
             return true
+        }
+
+        override fun hashCode(): Int {
+            var result = data.hashCode()
+            result = 31 * result + stableId.hashCode()
+            return result
         }
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/statistics/ui/homecards/StatisticsHomeCardItemTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/statistics/ui/homecards/StatisticsHomeCardItemTest.kt
@@ -1,0 +1,35 @@
+package de.rki.coronawarnapp.statistics.ui.homecards
+
+import de.rki.coronawarnapp.statistics.StatisticsData
+import io.kotest.assertions.fail
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+
+internal class StatisticsHomeCardItemTest {
+
+    @Test
+    fun `test equals() of statistics item should return true when onHelpAction click listener is different`() {
+
+        val itemWithClickListener1 = StatisticsHomeCard.Item(StatisticsData(emptyList())) {
+            // ClickListener1
+        }
+
+        val itemWithClickListener2 = StatisticsHomeCard.Item(StatisticsData(emptyList())) {
+            // ClickListener2
+        }
+
+        // Check if click listeners are actually different
+        if (itemWithClickListener1.onHelpAction == itemWithClickListener2.onHelpAction) {
+            fail("Different Click Listeners should be set to StatisticsHomeCard.Item")
+        }
+
+        // basic assertion
+        (itemWithClickListener1 == itemWithClickListener2) shouldBe true
+
+        // assert symmetry
+        (itemWithClickListener2 == itemWithClickListener1) shouldBe true
+
+        // assert reflexivity
+        (itemWithClickListener1 == itemWithClickListener1) shouldBe true
+    }
+}


### PR DESCRIPTION
This PR overrides `equals()` of the Statistics Items so that it ignores the `onClickListener` that is reset when resuming from the information screen, causing the statistics cards to re-draw. 

The respective Jira Ticket contains more technical information about the bug.