### PR TITLE
Small LocalData cleanup (DEV, EXPOSUREAPP-2126)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/LocalData.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/LocalData.kt
@@ -22,6 +22,7 @@ object LocalData {
 
     private const val PREFERENCE_HAS_RISK_STATUS_LOWERED =
         "preference_has_risk_status_lowered"
+
     /****************************************************
      * ONBOARDING DATA
      ****************************************************/
@@ -346,16 +347,15 @@ object LocalData {
      * SUBMISSION DATA
      ****************************************************/
 
+    private const val PREFERENCE_REGISTRATION_TOKEN = "preference_registration_token"
+
     /**
      * Gets the registration token that is needed for the submission process
      *
      * @return the registration token
      */
-    fun registrationToken(): String? = getSharedPreferenceInstance().getString(
-        CoronaWarnApplication.getAppContext()
-            .getString(R.string.preference_registration_token),
-        null
-    )
+    fun registrationToken(): String? = getSharedPreferenceInstance()
+        .getString(PREFERENCE_REGISTRATION_TOKEN, null)
 
     /**
      * Sets the registration token that is needed for the submission process
@@ -364,11 +364,7 @@ object LocalData {
      */
     fun registrationToken(value: String?) {
         getSharedPreferenceInstance().edit(true) {
-            putString(
-                CoronaWarnApplication.getAppContext()
-                    .getString(R.string.preference_registration_token),
-                value
-            )
+            putString(PREFERENCE_REGISTRATION_TOKEN, value)
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/LocalData.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/storage/LocalData.kt
@@ -342,26 +342,6 @@ object LocalData {
             putInt(PKEY_POSITIVE_TEST_RESULT_REMINDER_COUNT, value)
         }
 
-    /**
-     * Gets the decision if background jobs are enabled
-     *
-     * @return
-     */
-    fun isBackgroundJobEnabled(): Boolean = getSharedPreferenceInstance().getBoolean(
-        CoronaWarnApplication.getAppContext().getString(R.string.preference_background_job_allowed),
-        false
-    )
-
-    /**
-     * Gets the boolean if the user has mobile data enabled
-     *
-     * @return
-     */
-    fun isMobileDataEnabled(): Boolean = getSharedPreferenceInstance().getBoolean(
-        CoronaWarnApplication.getAppContext().getString(R.string.preference_mobile_data_allowed),
-        false
-    )
-
     /****************************************************
      * SUBMISSION DATA
      ****************************************************/

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -23,10 +23,6 @@
     <!-- NOTR -->
     <string name="preference_timestamp_manual_diagnosis_keys_retrieval"><xliff:g id="preference">"preference_timestamp_manual_diagnosis_keys_retrieval"</xliff:g></string>
     <!-- NOTR -->
-    <string name="preference_background_job_allowed"><xliff:g id="preference">"preference_background_job_enabled"</xliff:g></string>
-    <!-- NOTR -->
-    <string name="preference_mobile_data_allowed"><xliff:g id="preference">"preference_mobile_data_enabled"</xliff:g></string>
-    <!-- NOTR -->
     <string name="preference_registration_token"><xliff:g id="preference">"preference_registration_token"</xliff:g></string>
     <!-- NOTR -->
     <string name="preference_device_pairing_successful_time"><xliff:g id="preference">"preference_device_pairing_successful_time"</xliff:g></string>

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -23,8 +23,6 @@
     <!-- NOTR -->
     <string name="preference_timestamp_manual_diagnosis_keys_retrieval"><xliff:g id="preference">"preference_timestamp_manual_diagnosis_keys_retrieval"</xliff:g></string>
     <!-- NOTR -->
-    <string name="preference_registration_token"><xliff:g id="preference">"preference_registration_token"</xliff:g></string>
-    <!-- NOTR -->
     <string name="preference_device_pairing_successful_time"><xliff:g id="preference">"preference_device_pairing_successful_time"</xliff:g></string>
     <!-- NOTR -->
     <string name="preference_initial_tracing_activation_time"><xliff:g id="preference">"preference_initial_tracing_activation_time"</xliff:g></string>


### PR DESCRIPTION
Small clean up of LocalData.
See EXPOSUREAPP-2126 / #1421.
While I really don't see how this could happen, this removes another "unknown" and preference-keys in XMLs is undesirable anyways.

Yes we should remove all preference keys for everything in LocalData from XMLs, but it's scheduled for another time when we refactor LocalData completely.