### PR TITLE
Fix invisible tracing settings screen if the last calculation failed (EXPOSUREAPP-4717)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/settings/SettingsTracingFragmentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/settings/SettingsTracingFragmentViewModel.kt
@@ -11,8 +11,8 @@ import de.rki.coronawarnapp.exception.ExceptionCategory
 import de.rki.coronawarnapp.exception.reporting.report
 import de.rki.coronawarnapp.nearby.InternalExposureNotificationClient
 import de.rki.coronawarnapp.nearby.TracingPermissionHelper
+import de.rki.coronawarnapp.storage.TracingRepository
 import de.rki.coronawarnapp.tracing.GeneralTracingStatus
-import de.rki.coronawarnapp.tracing.ui.details.TracingDetailsItemProvider
 import de.rki.coronawarnapp.tracing.ui.details.items.periodlogged.PeriodLoggedBox
 import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
 import de.rki.coronawarnapp.util.device.BackgroundModeStatus
@@ -24,23 +24,20 @@ import de.rki.coronawarnapp.worker.BackgroundWorkScheduler
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.plus
 import timber.log.Timber
 
 class SettingsTracingFragmentViewModel @AssistedInject constructor(
     dispatcherProvider: DispatcherProvider,
-    tracingDetailsItemProvider: TracingDetailsItemProvider,
     tracingStatus: GeneralTracingStatus,
+    tracingRepository: TracingRepository,
     private val backgroundStatus: BackgroundModeStatus,
     tracingPermissionHelperFactory: TracingPermissionHelper.Factory
 ) : CWAViewModel(dispatcherProvider = dispatcherProvider) {
 
-    val loggingPeriod: LiveData<PeriodLoggedBox.Item> = tracingDetailsItemProvider.state
-        .mapNotNull { items ->
-            items.firstOrNull { it is PeriodLoggedBox.Item } as? PeriodLoggedBox.Item
-        }
+    val loggingPeriod: LiveData<PeriodLoggedBox.Item> = tracingRepository.activeTracingDaysInRetentionPeriod
+        .map { PeriodLoggedBox.Item(activeTracingDaysInRetentionPeriod = it.toInt()) }
         .onEach { Timber.v("logginPeriod onEach") }
         .asLiveData(dispatcherProvider.Main)
 


### PR DESCRIPTION
TracingDetailsItemProvider is used for the tracing/risk details screen.
This has specific behavior that the logging period is not shown if the last calculation failed.
By reusing this data provider for the tracing settings, if the last calculation failed, we never set "loggingPeriod".
If loggingPeriod is null, the databinding causes the layout to be invisible.


### Testing
* Produce a "risk calculation failed" card on the homescreen. 
* Tap the risk status bar which should take you to the settings.
    * Before: Invisible layout
    * Now:  Visible layout :partying_face: 


[Screenshot from 2021-01-21 18-46-40](https://user-images.githubusercontent.com/1439229/105390185-099aa680-5c19-11eb-9dfc-625ecf982baa.png)
[Screenshot from 2021-01-21 18-46-30](https://user-images.githubusercontent.com/1439229/105390187-0a333d00-5c19-11eb-994e-a91b8d7b07b3.png)
