### PR TITLE
Fix statistics data missing on in-app data reset (EXPOSUREAPP-4715)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/source/StatisticsProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/source/StatisticsProvider.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import org.joda.time.Duration
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -29,7 +30,10 @@ class StatisticsProvider @Inject constructor(
         loggingTag = TAG,
         scope = scope,
         coroutineContext = dispatcherProvider.IO,
-        sharingBehavior = SharingStarted.Lazily
+        sharingBehavior = SharingStarted.WhileSubscribed(
+            stopTimeoutMillis = Duration.standardSeconds(5).millis,
+            replayExpirationMillis = 0
+        )
     ) {
         try {
             fromCache() ?: fromServer()
@@ -84,13 +88,10 @@ class StatisticsProvider @Inject constructor(
         }
     }
 
-    suspend fun clear() {
+    fun clear() {
         Timber.d("clear()")
         server.clear()
         localCache.save(null)
-        statisticsData.updateBlocking {
-            StatisticsData()
-        }
     }
 
     companion object {

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/statistics/source/StatisticsProviderTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/statistics/source/StatisticsProviderTest.kt
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
-import testhelpers.TestDispatcherProvider
+import testhelpers.asDispatcherProvider
 import testhelpers.coroutines.runBlockingTest2
 import testhelpers.coroutines.test
 import java.io.IOException
@@ -66,7 +66,7 @@ class StatisticsProviderTest : BaseTest() {
         localCache = localCache,
         parser = parser,
         foregroundState = foregroundState,
-        dispatcherProvider = TestDispatcherProvider
+        dispatcherProvider = scope.asDispatcherProvider()
     )
 
     @Test
@@ -124,7 +124,7 @@ class StatisticsProviderTest : BaseTest() {
     }
 
     @Test
-    fun `clear deletes cache and current flow`() = runBlockingTest2(ignoreActive = true) {
+    fun `clear deletes cache`() = runBlockingTest2(ignoreActive = true) {
         val instance = createInstance(this)
 
         val testCollector = instance.current.test(startOnScope = this)
@@ -136,7 +136,5 @@ class StatisticsProviderTest : BaseTest() {
             server.clear()
             localCache.save(null)
         }
-
-        testCollector.latestValue shouldBe StatisticsData()
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/statistics/source/StatisticsProviderTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/statistics/source/StatisticsProviderTest.kt
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
-import testhelpers.asDispatcherProvider
+import testhelpers.TestDispatcherProvider
 import testhelpers.coroutines.runBlockingTest2
 import testhelpers.coroutines.test
 import java.io.IOException
@@ -66,7 +66,7 @@ class StatisticsProviderTest : BaseTest() {
         localCache = localCache,
         parser = parser,
         foregroundState = foregroundState,
-        dispatcherProvider = scope.asDispatcherProvider()
+        dispatcherProvider = TestDispatcherProvider
     )
 
     @Test


### PR DESCRIPTION
Fix statistics data missing on in-app data reset due to no refresh being triggered.
Don't do a full reset and add statistics data subscription timeout.
