### PR TITLE
Adjust circleCI config to run screenshots on release candidates (DEV)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -525,5 +525,9 @@ workflows:
             branches:
               ignore: /.*/
       - device_screenshots:
-          requires:
-            - quick_build_device_for_testers_signed
+          filters:
+            tags:
+              only:
+                - /^v.*/
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
Seems the conditional to require the signed build to pass first, does not work :thinking:.