### PR TITLE
Error 2001 - App does not work anymore (EXPOSUREAPP-2009)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/exception/CwaWebSecurityException.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/exception/CwaWebSecurityException.kt
@@ -1,10 +1,12 @@
 package de.rki.coronawarnapp.exception
 
+import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.exception.reporting.ErrorCodes
 import de.rki.coronawarnapp.exception.reporting.ReportedIOException
 
 class CwaWebSecurityException(cause: Throwable) : ReportedIOException(
     ErrorCodes.CWA_WEB_SECURITY_PROBLEM.code,
     "An error occurred while trying to establish a secure connection to the server",
-    cause
+    cause,
+    R.string.errors_ssl_certificate_deactivated
 )

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -1403,6 +1403,9 @@
     <string name="errors_risk_detection_limit_reached_title">"Limit bereits erreicht"</string>
     <!-- XTXT: error dialog - Error description when the provideDiagnosisKeys quota limit was reached. -->
     <string name="errors_risk_detection_limit_reached_description">"Heute sind keine weiteren Risiko-Überprüfungen möglich, weil das von Ihrem Betriebssystem festgelegte Limit von Risiko-Überprüfungen pro Tag bereits erreicht ist. Bitte überprüfen Sie Ihren Risikostatus morgen wieder."</string>
+    <!-- XTXT: error dialog - Error description when the ssl certificate is deactivated on the device. -->
+    <string name="errors_ssl_certificate_deactivated">Bitte aktiviere das SYSTEM Sicherheitszertifikat T-Systems Enterprise Services GmbH, T-TeleSec GlobalRoot Class 2 auf ihrem Gerät. Mehr Informationen finden sie im FAQ auf https://coronawarn.app</string>
+
     <!-- ####################################
                Generic Error Messages
         ###################################### -->

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -1404,7 +1404,7 @@
     <!-- XTXT: error dialog - Error description when the provideDiagnosisKeys quota limit was reached. -->
     <string name="errors_risk_detection_limit_reached_description">"Heute sind keine weiteren Risiko-Überprüfungen möglich, weil das von Ihrem Betriebssystem festgelegte Limit von Risiko-Überprüfungen pro Tag bereits erreicht ist. Bitte überprüfen Sie Ihren Risikostatus morgen wieder."</string>
     <!-- XTXT: error dialog - Error description when the ssl certificate is deactivated on the device. -->
-    <string name="errors_ssl_certificate_deactivated">Bitte aktiviere das SYSTEM Sicherheitszertifikat T-Systems Enterprise Services GmbH, T-TeleSec GlobalRoot Class 2 auf ihrem Gerät. Mehr Informationen finden sie im FAQ auf https://coronawarn.app</string>
+    <string name="errors_ssl_certificate_deactivated">Bitte aktivieren Sie das SYSTEM Sicherheitszertifikat T-Systems Enterprise Services GmbH, T-TeleSec GlobalRoot Class 2 auf Ihrem Gerät. Mehr Informationen finden Sie in den FAQs auf https://coronawarn.app unter „URSACHE 2001".</string>
 
     <!-- ####################################
                Generic Error Messages

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -1404,7 +1404,7 @@
     <!-- XTXT: error dialog - Error description when the provideDiagnosisKeys quota limit was reached. -->
     <string name="errors_risk_detection_limit_reached_description">"Heute sind keine weiteren Risiko-Überprüfungen möglich, weil das von Ihrem Betriebssystem festgelegte Limit von Risiko-Überprüfungen pro Tag bereits erreicht ist. Bitte überprüfen Sie Ihren Risikostatus morgen wieder."</string>
     <!-- XTXT: error dialog - Error description when the ssl certificate is deactivated on the device. -->
-    <string name="errors_ssl_certificate_deactivated">Bitte aktivieren Sie das SYSTEM Sicherheitszertifikat T-Systems Enterprise Services GmbH, T-TeleSec GlobalRoot Class 2 auf Ihrem Gerät. Mehr Informationen finden Sie in den FAQs auf https://coronawarn.app unter „URSACHE 2001".</string>
+    <string name="errors_ssl_certificate_deactivated">"Bitte aktivieren Sie das SYSTEM Sicherheitszertifikat T-Systems Enterprise Services GmbH, T-TeleSec GlobalRoot Class 2 auf Ihrem Gerät. Mehr Informationen finden Sie in den FAQs auf https://coronawarn.app unter „URSACHE 2001“."</string>
 
     <!-- ####################################
                Generic Error Messages

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -1408,7 +1408,6 @@
     <string name="errors_not_enough_device_storage">"You do not have sufficient free memory."</string>
     <!-- XTXT: error dialog - detailed text if there is error with Google API  -->
     <string name="errors_communication_with_api">"Error during communication with Google interface"</string>
-    <string name="errors_communication_with_api_test">"Test ABC"</string>
     <!-- XTXT: error dialog - detailed text if there is an error during external navigation / external action -->
     <string name="errors_external_action">"You cannot perform this action. Please contact the hotline."</string>
     <!-- XTXT: error dialog - phone still needs Google Play Services or Google Mobile Services update -->

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -1408,6 +1408,7 @@
     <string name="errors_not_enough_device_storage">"You do not have sufficient free memory."</string>
     <!-- XTXT: error dialog - detailed text if there is error with Google API  -->
     <string name="errors_communication_with_api">"Error during communication with Google interface"</string>
+    <string name="errors_communication_with_api_test">"Test ABC"</string>
     <!-- XTXT: error dialog - detailed text if there is an error during external navigation / external action -->
     <string name="errors_external_action">"You cannot perform this action. Please contact the hotline."</string>
     <!-- XTXT: error dialog - phone still needs Google Play Services or Google Mobile Services update -->
@@ -1418,6 +1419,9 @@
     <string name="errors_risk_detection_limit_reached_title">"Limit already reached"</string>
     <!-- XTXT: error dialog - Error description when the provideDiagnosisKeys quota limit was reached. -->
     <string name="errors_risk_detection_limit_reached_description">"No more exposure checks possible today, as you have reached the maximum number of checks per day defined by your operating system. Please check your risk status again tomorrow."</string>
+    <!-- XTXT: error dialog - Error description when the ssl certificate is deactivated on the device. -->
+    <string name="errors_ssl_certificate_deactivated">Bitte aktiviere das SYSTEM Sicherheitszertifikat T-Systems Enterprise Services GmbH, T-TeleSec GlobalRoot Class 2 auf ihrem Gerät. Mehr Informationen finden sie im FAQ auf https://coronawarn.app"</string>
+
     <!-- ####################################
                Generic Error Messages
         ###################################### -->

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -1419,7 +1419,7 @@
     <!-- XTXT: error dialog - Error description when the provideDiagnosisKeys quota limit was reached. -->
     <string name="errors_risk_detection_limit_reached_description">"No more exposure checks possible today, as you have reached the maximum number of checks per day defined by your operating system. Please check your risk status again tomorrow."</string>
     <!-- XTXT: error dialog - Error description when the ssl certificate is deactivated on the device. -->
-    <string name="errors_ssl_certificate_deactivated">Bitte aktiviere das SYSTEM Sicherheitszertifikat T-Systems Enterprise Services GmbH, T-TeleSec GlobalRoot Class 2 auf ihrem Gerät. Mehr Informationen finden sie im FAQ auf https://coronawarn.app"</string>
+    <string name="errors_ssl_certificate_deactivated">"Bitte aktivieren Sie das SYSTEM Sicherheitszertifikat T-Systems Enterprise Services GmbH, T-TeleSec GlobalRoot Class 2 auf Ihrem Gerät. Mehr Informationen finden Sie in den FAQs auf https://coronawarn.app unter „URSACHE 2001“."</string>
 
     <!-- ####################################
                Generic Error Messages


### PR DESCRIPTION
Users that deactivate the certificate `T-Systems Enterprise Services GmbH, T-TeleSec GlobalRoot Class 2` receive an "Error 2001" and see this error dialog: 

![Error2001-Before](https://user-images.githubusercontent.com/10398034/105679184-61256480-5eee-11eb-9857-001764696a03.jpg)

This PR sets a custom message to the error dialog: 

![Error2001-After](https://user-images.githubusercontent.com/10398034/105679199-671b4580-5eee-11eb-8f98-11fb6956caf1.jpg)

Initially, it was planned to add a link to the faq entry of this error (https://www.coronawarn.app/en/faq/#cause2001). However, since the website on which the FAQs are hosted uses the same (deactivated) certificate, the browser won't let the user access this site. 

I clarified this issue with Thomas Augsten and we adapted the error message.

How to test: Open Settings - "Biometrics and Security" - "Other Security Settings" - "View security certificates" and deactivate the following certificate: 

![deactivate_certificate](https://user-images.githubusercontent.com/10398034/105679666-10fad200-5eef-11eb-8b51-d08e70a8acbf.jpg)
 