### PR TITLE
Inconsistent ( X icon ) navigation behaviour (EXPOSUREAPP-4256)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/consent/SubmissionConsentFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/consent/SubmissionConsentFragment.kt
@@ -10,6 +10,7 @@ import de.rki.coronawarnapp.ui.submission.viewmodel.SubmissionNavigationEvents
 import de.rki.coronawarnapp.util.di.AutoInject
 import de.rki.coronawarnapp.util.ui.doNavigate
 import de.rki.coronawarnapp.util.ui.observe2
+import de.rki.coronawarnapp.util.ui.popBackStack
 import de.rki.coronawarnapp.util.ui.viewBindingLazy
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactoryProvider
 import de.rki.coronawarnapp.util.viewmodel.cwaViewModels
@@ -32,9 +33,7 @@ class SubmissionConsentFragment : Fragment(R.layout.fragment_submission_consent)
                 is SubmissionNavigationEvents.NavigateToQRCodeScan -> doNavigate(
                     SubmissionConsentFragmentDirections.actionSubmissionConsentFragmentToSubmissionQRCodeScanFragment()
                 )
-                is SubmissionNavigationEvents.NavigateToDispatcher -> doNavigate(
-                    SubmissionConsentFragmentDirections.actionSubmissionConsentFragmentToHomeFragment()
-                )
+                is SubmissionNavigationEvents.NavigateToDispatcher -> popBackStack()
                 is SubmissionNavigationEvents.NavigateToDataPrivacy -> doNavigate(
                     SubmissionConsentFragmentDirections.actionSubmissionConsentFragmentToInformationPrivacyFragment()
                 )

--- a/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
+++ b/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
@@ -412,10 +412,6 @@
             android:id="@+id/action_submissionConsentFragment_to_submissionQRCodeScanFragment"
             app:destination="@id/submissionQRCodeScanFragment" />
         <action
-            android:id="@+id/action_submissionConsentFragment_to_homeFragment"
-            app:popUpTo="@id/mainFragment"
-            app:popUpToInclusive="false" />
-        <action
             android:id="@+id/action_submissionConsentFragment_to_informationPrivacyFragment"
             app:destination="@id/informationPrivacyFragment" />
     </fragment>


### PR DESCRIPTION
Change behaviour of `X` in SubmissionConsentFragment to go back.
According to: https://material.io/components/dialogs#full-screen-dialog 
- `X` and `<-` go back. 
- `X` should be used in cases where it acts as `dismiss` while ⬅️  should be not be used as it gives the user an impression that state is stored (This a different story and does not change the behaviour when they are clicked).

New behaviour:
https://user-images.githubusercontent.com/25054729/105712912-c8590e00-5f1a-11eb-82ad-faad5fb1dfa0.mp4

Similar case from Google Maps:
https://user-images.githubusercontent.com/25054729/105713193-1cfc8900-5f1b-11eb-8fbf-1949d9bfab76.mp4



