### PR TITLE
Update worker dependecies to last (EXPSOUREAPP-4765)

### DIFF
--- a/Corona-Warn-App/build.gradle
+++ b/Corona-Warn-App/build.gradle
@@ -306,7 +306,7 @@ dependencies {
     implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.preference:preference-ktx:1.1.1'
-    implementation 'androidx.work:work-runtime-ktx:2.5.0-beta02'
+    implementation 'androidx.work:work-runtime-ktx:2.5.0-rc01'
 
     implementation 'androidx.lifecycle:lifecycle-common-java8:2.2.0'
     implementation 'androidx.lifecycle:lifecycle-process:2.2.0'
@@ -376,7 +376,7 @@ dependencies {
     androidTestImplementation 'androidx.test:rules:1.3.0'
     androidTestImplementation 'androidx.test.ext:truth:1.3.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.work:work-testing:2.5.0-beta02'
+    androidTestImplementation 'androidx.work:work-testing:2.5.0-rc01'
     androidTestImplementation "io.mockk:mockk-android:1.10.4"
     debugImplementation 'androidx.fragment:fragment-testing:1.2.5'
 


### PR DESCRIPTION
This PR updates the work-runtime-ktx & work:work-testing from beta to RC1

