### PR TITLE
Wrong navigation in "Symptom-Erfassung" (EXPOSUREAPP-4703)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/contactdiary/ContactDiaryOverviewFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/contactdiary/ContactDiaryOverviewFragmentTest.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import dagger.Module
 import dagger.android.ContributesAndroidInjector
-import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.contactdiary.storage.repo.ContactDiaryRepository
 import de.rki.coronawarnapp.contactdiary.ui.overview.ContactDiaryOverviewFragment
 import de.rki.coronawarnapp.contactdiary.ui.overview.ContactDiaryOverviewViewModel

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/symptoms/introduction/SubmissionSymptomIntroductionViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/symptoms/introduction/SubmissionSymptomIntroductionViewModel.kt
@@ -49,7 +49,15 @@ class SubmissionSymptomIntroductionViewModel @AssistedInject constructor(
                     }
                     doSubmit()
                 }
-                Symptoms.Indication.NO_INFORMATION -> showCancelDialog.postValue(Unit)
+                Symptoms.Indication.NO_INFORMATION -> {
+                    submissionRepository.currentSymptoms.update {
+                        Symptoms(
+                            startOfSymptoms = null,
+                            symptomIndication = Symptoms.Indication.NO_INFORMATION
+                        )
+                    }
+                    doSubmit()
+                }
             }
         }
     }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/symptoms/introduction/SubmissionSymptomIntroductionViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/symptoms/introduction/SubmissionSymptomIntroductionViewModelTest.kt
@@ -53,18 +53,6 @@ class SubmissionSymptomIntroductionViewModelTest : BaseTest() {
     )
 
     @Test
-    fun `symptom indication is not written to settings`() {
-        createViewModel().apply {
-            onPositiveSymptomIndication()
-            onNegativeSymptomIndication()
-            onNoInformationSymptomIndication()
-            onNextClicked()
-        }
-
-        verify(exactly = 0) { submissionRepository.currentSymptoms }
-    }
-
-    @Test
     fun `positive symptom indication is forwarded using navigation arguments`() {
         createViewModel().apply {
             onPositiveSymptomIndication()
@@ -95,15 +83,19 @@ class SubmissionSymptomIntroductionViewModelTest : BaseTest() {
     }
 
     @Test
-    fun `no information symptom indication leads to cancel dialog`() {
+    fun `no information symptom indication leads to submission`() {
         createViewModel().apply {
             onNoInformationSymptomIndication()
             onNextClicked()
-            navigation.value shouldBe null
-            showCancelDialog.value shouldBe Unit
+            navigation.value shouldBe SubmissionSymptomIntroductionFragmentDirections
+                .actionSubmissionSymptomIntroductionFragmentToMainFragment()
+            currentSymptoms.value shouldBe Symptoms(
+                startOfSymptoms = null,
+                symptomIndication = Symptoms.Indication.NO_INFORMATION
+            )
         }
 
-        verify(exactly = 0) { submissionRepository.currentSymptoms }
+        coVerify { autoSubmission.runSubmissionNow() }
     }
 
     @Test


### PR DESCRIPTION
No Pop-up is to be shown, when user selects 'no information'.