### PR TITLE
Exposure logging switch not working when screen reader is active (EXPOSUREAPP-2758)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/settings/SettingsTracingFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/settings/SettingsTracingFragment.kt
@@ -51,7 +51,8 @@ class SettingsTracingFragment : Fragment(R.layout.fragment_settings_tracing), Au
                     TracingSettingsState.LocationDisabled -> setOnClickListener(null)
                     TracingSettingsState.TracingInactive,
                     TracingSettingsState.TracingActive -> setOnClickListener {
-                        binding.settingsTracingSwitchRow.settingsSwitchRowSwitch.performClick()
+                        val switch = binding.settingsTracingSwitchRow.settingsSwitchRowSwitch
+                        onTracingToggled(!switch.isChecked)
                     }
                 }
             }
@@ -92,13 +93,12 @@ class SettingsTracingFragment : Fragment(R.layout.fragment_settings_tracing), Au
         val bluetooth = binding.settingsTracingStatusBluetooth.tracingStatusCardButton
         val location = binding.settingsTracingStatusLocation.tracingStatusCardButton
         val interoperability = binding.settingsInteroperabilityRow.settingsPlainRow
-        val row = binding.settingsTracingSwitchRow.settingsSwitchRow
 
-        switch.setOnCheckedChangeListener { _, isChecked ->
-            if (switch.isPressed || row.isPressed) {
-                onTracingToggled(isChecked)
-            }
+        switch.setOnCheckedChangeListener { view, isChecked ->
+            if (!view.isPressed) return@setOnCheckedChangeListener
+            onTracingToggled(isChecked)
         }
+
         back.setOnClickListener {
             (activity as MainActivity).goBack()
         }
@@ -114,9 +114,6 @@ class SettingsTracingFragment : Fragment(R.layout.fragment_settings_tracing), Au
     }
 
     private fun onTracingToggled(isChecked: Boolean) {
-        // Focus on the body text after to announce the tracing status for accessibility reasons
-        binding.settingsTracingSwitchRow.settingsSwitchRowHeaderBody
-            .sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED)
         vm.onTracingToggled(isChecked)
     }
 


### PR DESCRIPTION
The problem was that Exposure logging cannot be turned off or on when TalkBack is activated. 

Although the switch state itself changes, the actual state of this setting does _not_. 

The problem was that there is this check in the `setOnCheckedChangeListener` of the `Switch`:
`if (switch.isPressed || row.isPressed)`

This check is needed in order to only execute code in the lambda of the listener when the `Switch` was actually pressed by the user and not set programmatically. 

The problem though is that when TalkBack is activated and the user double taps to change the `Switch` value, neither `switch.isPressed` nor `row.isPressed` is true and therefore the code in the lambda was never executed. 

My solution here is to set an `onClickListener` on the whole row, which is triggered when the user uses TalkBack but not triggered when we change the value of the `Switch` programmatically. 