### PR TITLE
Fix class cast exception on pending tests (EXPOSUREAPP-4909)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/testresult/pending/SubmissionTestResultPendingFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/testresult/pending/SubmissionTestResultPendingFragment.kt
@@ -9,7 +9,6 @@ import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.FragmentSubmissionTestResultPendingBinding
 import de.rki.coronawarnapp.exception.http.CwaClientError
 import de.rki.coronawarnapp.exception.http.CwaServerError
-import de.rki.coronawarnapp.exception.http.CwaWebException
 import de.rki.coronawarnapp.util.ContextExtensions.getColorCompat
 import de.rki.coronawarnapp.util.DialogHelper
 import de.rki.coronawarnapp.util.NetworkRequestWrapper
@@ -119,30 +118,28 @@ class SubmissionTestResultPendingFragment : Fragment(R.layout.fragment_submissio
         }
     }
 
-    private fun handleError(exception: CwaWebException) {
-        errorDialog = when (exception) {
-            is CwaClientError, is CwaServerError -> {
-                DialogHelper.showDialog(buildErrorDialog(exception))
-            }
-            else -> {
-                DialogHelper.showDialog(genericErrorDialog)
-            }
+    private fun handleError(exception: Throwable) {
+        val dialogInstance = when (exception) {
+            is CwaClientError, is CwaServerError -> networkErrorDialog
+            else -> genericErrorDialog
         }
+        errorDialog = DialogHelper.showDialog(dialogInstance)
     }
 
     private fun navigateToMainScreen() {
         popBackStack()
     }
 
-    private fun buildErrorDialog(exception: CwaWebException) = DialogHelper.DialogInstance(
-        requireActivity(),
-        R.string.submission_error_dialog_web_generic_error_title,
-        R.string.submission_error_dialog_web_generic_network_error_body,
-        R.string.submission_error_dialog_web_generic_error_button_positive,
-        null,
-        true,
-        ::navigateToMainScreen
-    )
+    private val networkErrorDialog: DialogHelper.DialogInstance
+        get() = DialogHelper.DialogInstance(
+            requireActivity(),
+            R.string.submission_error_dialog_web_generic_error_title,
+            R.string.submission_error_dialog_web_generic_network_error_body,
+            R.string.submission_error_dialog_web_generic_error_button_positive,
+            null,
+            true,
+            ::navigateToMainScreen
+        )
 
     private val genericErrorDialog: DialogHelper.DialogInstance
         get() = DialogHelper.DialogInstance(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/testresult/pending/SubmissionTestResultPendingViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/testresult/pending/SubmissionTestResultPendingViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.asLiveData
 import androidx.navigation.NavDirections
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import de.rki.coronawarnapp.exception.http.CwaWebException
 import de.rki.coronawarnapp.notification.ShareTestResultNotificationService
 import de.rki.coronawarnapp.submission.SubmissionRepository
 import de.rki.coronawarnapp.ui.submission.testresult.TestResultUIState
@@ -90,7 +89,7 @@ class SubmissionTestResultPendingViewModel @AssistedInject constructor(
         .asLiveData(context = dispatcherProvider.Default)
 
     val cwaWebExceptionLiveData = submissionRepository.deviceUIStateFlow
-        .filterIsInstance<NetworkRequestWrapper.RequestFailed<DeviceUIState, CwaWebException>>()
+        .filterIsInstance<NetworkRequestWrapper.RequestFailed<DeviceUIState, Throwable>>()
         .map { it.error }
         .asLiveData()
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/NetworkRequestWrapper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/NetworkRequestWrapper.kt
@@ -1,13 +1,13 @@
 package de.rki.coronawarnapp.util
 
-sealed class NetworkRequestWrapper<out T, out U> {
+sealed class NetworkRequestWrapper<out T : Any, out U : Any> {
     object RequestIdle : NetworkRequestWrapper<Nothing, Nothing>()
     object RequestStarted : NetworkRequestWrapper<Nothing, Nothing>()
-    data class RequestSuccessful<T, U>(val data: T) : NetworkRequestWrapper<T, U>()
-    data class RequestFailed<T, U>(val error: U) : NetworkRequestWrapper<T, U>()
+    data class RequestSuccessful<T : Any, U : Any>(val data: T) : NetworkRequestWrapper<T, U>()
+    data class RequestFailed<T : Any, U : Throwable>(val error: U) : NetworkRequestWrapper<T, U>()
 
     companion object {
-        fun <T, U, W> NetworkRequestWrapper<T, U>?.withSuccess(without: W, block: (data: T) -> W): W {
+        fun <T : Any, U : Any, W> NetworkRequestWrapper<T, U>?.withSuccess(without: W, block: (data: T) -> W): W {
             return if (this is RequestSuccessful) {
                 block(this.data)
             } else {
@@ -15,13 +15,13 @@ sealed class NetworkRequestWrapper<out T, out U> {
             }
         }
 
-        fun <T, U> NetworkRequestWrapper<T, U>?.withSuccess(block: (data: T) -> Unit) {
+        fun <T : Any, U : Any> NetworkRequestWrapper<T, U>?.withSuccess(block: (data: T) -> Unit) {
             if (this is RequestSuccessful) {
                 block(this.data)
             }
         }
 
-        fun <T, U> NetworkRequestWrapper<T, U>?.withFailure(block: (error: U) -> Unit) {
+        fun <T : Any, U : Any> NetworkRequestWrapper<T, U>?.withFailure(block: (error: U) -> Unit) {
             if (this is RequestFailed) {
                 block(this.error)
             }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/submission/testresult/pending/SubmissionTestResultPendingViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/submission/testresult/pending/SubmissionTestResultPendingViewModelTest.kt
@@ -1,0 +1,71 @@
+package de.rki.coronawarnapp.submission.testresult.pending
+
+import de.rki.coronawarnapp.exception.http.CwaWebException
+import de.rki.coronawarnapp.notification.ShareTestResultNotificationService
+import de.rki.coronawarnapp.submission.SubmissionRepository
+import de.rki.coronawarnapp.ui.submission.testresult.pending.SubmissionTestResultPendingViewModel
+import de.rki.coronawarnapp.util.DeviceUIState
+import de.rki.coronawarnapp.util.NetworkRequestWrapper
+import io.kotest.matchers.shouldBe
+import io.mockk.MockKAnnotations
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.TestCoroutineScope
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import testhelpers.BaseTest
+import testhelpers.asDispatcherProvider
+import testhelpers.extensions.InstantExecutorExtension
+
+@ExtendWith(InstantExecutorExtension::class)
+class SubmissionTestResultPendingViewModelTest : BaseTest() {
+
+    @MockK lateinit var shareTestResultNotificationService: ShareTestResultNotificationService
+    @MockK lateinit var submissionRepository: SubmissionRepository
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this)
+
+        submissionRepository.apply {
+            every { hasGivenConsentToSubmission } returns emptyFlow()
+            every { deviceUIStateFlow } returns emptyFlow()
+            every { testResultReceivedDateFlow } returns emptyFlow()
+        }
+    }
+
+    @AfterEach
+    fun teardown() {
+        clearAllMocks()
+    }
+
+    fun createInstance(scope: CoroutineScope = TestCoroutineScope()) = SubmissionTestResultPendingViewModel(
+        dispatcherProvider = scope.asDispatcherProvider(),
+        shareTestResultNotificationService = shareTestResultNotificationService,
+        submissionRepository = submissionRepository
+    )
+
+    @Test
+    fun `web exception handling`() {
+        val expectedType = NetworkRequestWrapper.RequestFailed<DeviceUIState, CwaWebException>(
+            CwaWebException(statusCode = 1, message = "message")
+        )
+        val unexpectedType =
+            NetworkRequestWrapper.RequestFailed<DeviceUIState, Throwable>(UnsupportedOperationException())
+        val deviceUI = MutableStateFlow<NetworkRequestWrapper<DeviceUIState, Throwable>>(expectedType)
+        every { submissionRepository.deviceUIStateFlow } returns deviceUI
+        createInstance().apply {
+            cwaWebExceptionLiveData.observeForever {}
+            cwaWebExceptionLiveData.value shouldBe expectedType.error
+
+            deviceUI.value = unexpectedType
+            cwaWebExceptionLiveData.value shouldBe unexpectedType.error
+        }
+    }
+}


### PR DESCRIPTION
The viewmodel on the pending test has a livedata object to show errors to the user, the code looks like this:

```Kotlin
submissionRepository.deviceUIStateFlow
        .filterIsInstance<NetworkRequestWrapper.RequestFailed<DeviceUIState, CwaWebexception>>()
        .map { it.error }
        .asLiveData()
```

The UI code consuming this calls:

```kotlin
fun handleError(exception: CwaWebException)
```

The stacktrace shows a class cast exception at that point.

<details>
<summary>Stacktrace from Play Console</summary>

```kotlin
java.lang.ClassCastException: 
  at de.rki.coronawarnapp.ui.submission.testresult.pending.SubmissionTestResultPendingFragment$onResume$1.invoke (SubmissionTestResultPendingFragment.kt:1)
  at de.rki.coronawarnapp.util.ui.LiveDataExtensionsKt$observeOnce$internalObserver$1.onChanged (LiveDataExtensions.kt:1)
  at androidx.lifecycle.LiveData.considerNotify (LiveData.java:6)
  at androidx.lifecycle.LiveData.dispatchingValue (LiveData.java:8)
  at androidx.lifecycle.MutableLiveData.setValue (MutableLiveData.java:4)
  at androidx.lifecycle.LiveDataScopeImpl$emit$2.invokeSuspend (CoroutineLiveData.kt:10)
  at androidx.lifecycle.LiveDataScopeImpl$emit$2.invoke (CoroutineLiveData.kt:2)
  at com.google.zxing.client.android.R$id.startUndispatchedOrReturn (Unknown Source)
  at com.google.zxing.client.android.R$id.withContext (Unknown Source)
  at androidx.lifecycle.LiveDataScopeImpl.emit (CoroutineLiveData.kt:1)
  at androidx.lifecycle.FlowLiveDataConversions$asLiveData$1$invokeSuspend$$inlined$collect$1.emit (Collect.kt:5)
  at de.rki.coronawarnapp.ui.submission.testresult.pending.SubmissionTestResultPendingViewModel$$special$$inlined$map$1$2.emit (Collect.kt:8)
  at de.rki.coronawarnapp.ui.submission.testresult.pending.SubmissionTestResultPendingViewModel$$special$$inlined$filterIsInstance$1$2.emit (Collect.kt:6)
  at kotlinx.coroutines.flow.StateFlowImpl.collect (StateFlow.kt:13)
  at kotlinx.coroutines.flow.StateFlowImpl$collect$1.invokeSuspend (StateFlow.kt)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:3)
  at kotlinx.coroutines.DispatchedTask.run (DispatchedTask.kt:15)
  at android.os.Handler.handleCallback (Handler.java:751)
  at android.os.Handler.dispatchMessage (Handler.java:95)
  at android.os.Looper.loop (Looper.java:154)
  at android.app.ActivityThread.main (ActivityThread.java:6316)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run (ZygoteInit.java:872)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:762)
```

</details>

While I can't reproduce it, what I think happens is `filterIsInstance` can't filter based on the generics so

`NetworkRequestWrapper.RequestFailed<DeviceUIState, CwaWebexception>`

becomes

`NetworkRequestWrapper.RequestFailed<DeviceUIState, Throwable>`

the compiler doesn't notice this during build time though (type erasure?).

When then an exception is  thrown that is not a `CwaWebexception` we try to cast it to one anyways -> Crash :bomb: 

`NetworkRequestWrapper` does not enforce any types for the generics both value and error are `<out T, out U>`

So I also thought that there might be a null exception being passed, but that was not the case, the crash on a null exception looks like this.

<details>
<summary>Stacktrace on crash due to null exception</summary>

```kotlin
2021-02-01 12:25:43.340 30834-30834/de.rki.coronawarnapp.test E/AndroidRuntime: FATAL EXCEPTION: main @coroutine#472
    Process: de.rki.coronawarnapp.test, PID: 30834
    java.lang.NullPointerException: Parameter specified as non-null is null: method kotlin.jvm.internal.Intrinsics.checkNotNullParameter, parameter exception
        at de.rki.coronawarnapp.ui.submission.testresult.pending.SubmissionTestResultPendingFragment$onResume$1.invoke(Unknown Source:2)
        at de.rki.coronawarnapp.ui.submission.testresult.pending.SubmissionTestResultPendingFragment$onResume$1.invoke(SubmissionTestResultPendingFragment.kt:27)
        at de.rki.coronawarnapp.util.ui.LiveDataExtensionsKt$observeOnce$internalObserver$1.onChanged(LiveDataExtensions.kt:17)
        at androidx.lifecycle.LiveData.considerNotify(LiveData.java:131)
        at androidx.lifecycle.LiveData.dispatchingValue(LiveData.java:149)
        at androidx.lifecycle.LiveData.setValue(LiveData.java:307)
        at androidx.lifecycle.MutableLiveData.setValue(MutableLiveData.java:50)
        at androidx.lifecycle.LiveDataScopeImpl$emit$2.invokeSuspend(CoroutineLiveData.kt:99)
        at androidx.lifecycle.LiveDataScopeImpl$emit$2.invoke(Unknown Source:10)
        at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:91)
        at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:165)
        at kotlinx.coroutines.BuildersKt.withContext(Unknown Source:1)
        at androidx.lifecycle.LiveDataScopeImpl.emit(CoroutineLiveData.kt:97)
        at androidx.lifecycle.FlowLiveDataConversions$asLiveData$1$invokeSuspend$$inlined$collect$1.emit(Collect.kt:136)
        at de.rki.coronawarnapp.ui.submission.testresult.pending.SubmissionTestResultPendingViewModel$$special$$inlined$map$1$2.emit(Collect.kt:135)
        at de.rki.coronawarnapp.ui.submission.testresult.pending.SubmissionTestResultPendingViewModel$$special$$inlined$filterIsInstance$1$2.emit(Collect.kt:135)
        at kotlinx.coroutines.flow.FlowKt__BuildersKt$flowOf$$inlined$unsafeFlow$2.collect(SafeCollector.common.kt:113)
        at de.rki.coronawarnapp.ui.submission.testresult.pending.SubmissionTestResultPendingViewModel$$special$$inlined$filterIsInstance$1.collect(SafeCollector.common.kt:114)
        at de.rki.coronawarnapp.ui.submission.testresult.pending.SubmissionTestResultPendingViewModel$$special$$inlined$map$1.collect(SafeCollector.common.kt:114)
        at androidx.lifecycle.FlowLiveDataConversions$asLiveData$1.invokeSuspend(FlowLiveData.kt:139)
        at androidx.lifecycle.FlowLiveDataConversions$asLiveData$1.invoke(Unknown Source:10)
        at androidx.lifecycle.BlockRunner$maybeRun$1.invokeSuspend(CoroutineLiveData.kt:176)
        (Coroutine boundary)
        at androidx.lifecycle.FlowLiveDataConversions$asLiveData$1$invokeSuspend$$inlined$collect$1.emit(FlowLiveData.kt:136)
        at de.rki.coronawarnapp.ui.submission.testresult.pending.SubmissionTestResultPendingViewModel$$special$$inlined$map$1$2.emit(SubmissionTestResultPendingViewModel.kt:135)
        at de.rki.coronawarnapp.ui.submission.testresult.pending.SubmissionTestResultPendingViewModel$$special$$inlined$filterIsInstance$1$2.emit(SubmissionTestResultPendingViewModel.kt:135)
        at androidx.lifecycle.FlowLiveDataConversions$asLiveData$1.invokeSuspend(FlowLiveData.kt:139)
        at androidx.lifecycle.BlockRunner$maybeRun$1.invokeSuspend(CoroutineLiveData.kt:176)
     Caused by: java.lang.NullPointerException: Parameter specified as non-null is null: method kotlin.jvm.internal.Intrinsics.checkNotNullParameter, parameter exception
        at de.rki.coronawarnapp.ui.submission.testresult.pending.SubmissionTestResultPendingFragment$onResume$1.invoke(Unknown Source:2)
        at de.rki.coronawarnapp.ui.submission.testresult.pending.SubmissionTestResultPendingFragment$onResume$1.invoke(SubmissionTestResultPendingFragment.kt:27)
        at de.rki.coronawarnapp.util.ui.LiveDataExtensionsKt$observeOnce$internalObserver$1.onChanged(LiveDataExtensions.kt:17)
        at androidx.lifecycle.LiveData.considerNotify(LiveData.java:131)
        at androidx.lifecycle.LiveData.dispatchingValue(LiveData.java:149)
        at androidx.lifecycle.LiveData.setValue(LiveData.java:307)
2021-02-01 12:25:43.342 30834-30834/de.rki.coronawarnapp.test E/AndroidRuntime:     at androidx.lifecycle.MutableLiveData.setValue(MutableLiveData.java:50)
        at androidx.lifecycle.LiveDataScopeImpl$emit$2.invokeSuspend(CoroutineLiveData.kt:99)
        at androidx.lifecycle.LiveDataScopeImpl$emit$2.invoke(Unknown Source:10)
        at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:91)
        at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:165)
        at kotlinx.coroutines.BuildersKt.withContext(Unknown Source:1)
        at androidx.lifecycle.LiveDataScopeImpl.emit(CoroutineLiveData.kt:97)
        at androidx.lifecycle.FlowLiveDataConversions$asLiveData$1$invokeSuspend$$inlined$collect$1.emit(Collect.kt:136)
        at de.rki.coronawarnapp.ui.submission.testresult.pending.SubmissionTestResultPendingViewModel$$special$$inlined$map$1$2.emit(Collect.kt:135)
        at de.rki.coronawarnapp.ui.submission.testresult.pending.SubmissionTestResultPendingViewModel$$special$$inlined$filterIsInstance$1$2.emit(Collect.kt:135)
        at kotlinx.coroutines.flow.FlowKt__BuildersKt$flowOf$$inlined$unsafeFlow$2.collect(SafeCollector.common.kt:113)
        at de.rki.coronawarnapp.ui.submission.testresult.pending.SubmissionTestResultPendingViewModel$$special$$inlined$filterIsInstance$1.collect(SafeCollector.common.kt:114)
        at de.rki.coronawarnapp.ui.submission.testresult.pending.SubmissionTestResultPendingViewModel$$special$$inlined$map$1.collect(SafeCollector.common.kt:114)
        at androidx.lifecycle.FlowLiveDataConversions$asLiveData$1.invokeSuspend(FlowLiveData.kt:139)
        at androidx.lifecycle.FlowLiveDataConversions$asLiveData$1.invoke(Unknown Source:10)
        at androidx.lifecycle.BlockRunner$maybeRun$1.invokeSuspend(CoroutineLiveData.kt:176)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.internal.DispatchedContinuationKt.resumeCancellableWith(DispatchedContinuation.kt:342)
        at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:30)
        at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable$default(Cancellable.kt:27)
        at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:109)
        at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:158)
        at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch(Builders.common.kt:56)
        at kotlinx.coroutines.BuildersKt.launch(Unknown Source:1)
        at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch$default(Builders.common.kt:49)
        at kotlinx.coroutines.BuildersKt.launch$default(Unknown Source:1)
        at androidx.lifecycle.BlockRunner.maybeRun(CoroutineLiveData.kt:174)
        at androidx.lifecycle.CoroutineLiveData.onActive(CoroutineLiveData.kt:240)
        at androidx.lifecycle.LiveData$ObserverWrapper.activeStateChanged(LiveData.java:437)
        at androidx.lifecycle.LiveData$LifecycleBoundObserver.onStateChanged(LiveData.java:395)
        at androidx.lifecycle.LifecycleRegistry$ObserverWithState.dispatchEvent(LifecycleRegistry.java:361)
        at androidx.lifecycle.LifecycleRegistry.addObserver(LifecycleRegistry.java:188)
        at androidx.lifecycle.LiveData.observe(LiveData.java:203)
        at de.rki.coronawarnapp.util.ui.LiveDataExtensionsKt.observeOnce(LiveDataExtensions.kt:24)
        at de.rki.coronawarnapp.ui.submission.testresult.pending.SubmissionTestResultPendingFragment.onResume(SubmissionTestResultPendingFragment.kt:95)
        at androidx.fragment.app.Fragment.performResume(Fragment.java:2748)
        at androidx.fragment.app.FragmentStateManager.resume(FragmentStateManager.java:373)
        at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1211)
        at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1368)
        at androidx.fragment.app.FragmentManager.moveFragmentToExpectedState(FragmentManager.java:1446)
        at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1509)
        at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:2019)
        at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:1965)
2021-02-01 12:25:43.342 30834-30834/de.rki.coronawarnapp.test E/AndroidRuntime:     at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:1861)
        at androidx.fragment.app.FragmentManager$4.run(FragmentManager.java:413)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:223)
        at android.app.ActivityThread.main(ActivityThread.java:7656)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
```
</details>

to prevent any future issues there I've adjusted the wrapper class to have stronger typing, i.e.:

`NetworkRequestWrapper<out T : Any, out U : Any> ` to prevent null arguments,
and `RequestFailed<T : Any, U : Throwable>` to enforce that the second, error parameter is actually a `Throwable`.

### Testing
* Review code and produce various exceptions on the pending test screen
* Complete a submission using TAN and QR code in `deviceForTestersRelease`