### PR TITLE
Accessibility: Statistics Blocks Enhancements (EXPOSUREAPP-4845)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/IncidenceCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/IncidenceCard.kt
@@ -10,6 +10,8 @@ import de.rki.coronawarnapp.statistics.ui.homecards.StatisticsCardAdapter
 import de.rki.coronawarnapp.statistics.util.formatStatisticalValue
 import de.rki.coronawarnapp.statistics.util.getContentDescriptionForTrends
 import de.rki.coronawarnapp.statistics.util.getLocalizedSpannableString
+import de.rki.coronawarnapp.util.StringBuilderExtension.appendWithLineBreak
+import de.rki.coronawarnapp.util.StringBuilderExtension.appendWithWhiteSpace
 import de.rki.coronawarnapp.util.formatter.getPrimaryLabel
 
 class IncidenceCard(parent: ViewGroup) :
@@ -46,12 +48,9 @@ class IncidenceCard(parent: ViewGroup) :
             )
 
             primaryValue.contentDescription = StringBuilder()
-                .append(context.getString(R.string.statistics_explanation_seven_day_incidence_title))
-                .append(" ")
-                .append(getPrimaryLabel(context))
-                .append(" ")
-                .append(formatStatisticalValue(context, sevenDayIncidence.value, sevenDayIncidence.decimals))
-                .append(" ")
+                .appendWithWhiteSpace(context.getString(R.string.statistics_explanation_seven_day_incidence_title))
+                .appendWithWhiteSpace(getPrimaryLabel(context))
+                .appendWithWhiteSpace(formatStatisticalValue(context, sevenDayIncidence.value, sevenDayIncidence.decimals))
                 .append(getContentDescriptionForTrends(context, sevenDayIncidence.trend))
 
             trendArrow.setTrend(sevenDayIncidence.trend, sevenDayIncidence.trendSemantic)
@@ -64,18 +63,12 @@ class IncidenceCard(parent: ViewGroup) :
     ): StringBuilder {
 
         return StringBuilder()
-            .append(context.getString(R.string.accessibility_statistics_card_announcement))
-            .append(" ")
-            .append(context.getString(R.string.statistics_explanation_seven_day_incidence_title))
-            .append(" \n ")
-            .append(item.getPrimaryLabel(context))
-            .append(" ")
-            .append(formatStatisticalValue(context, sevenDayIncidence.value, sevenDayIncidence.decimals))
-            .append(" ")
-            .append(context.getString(R.string.statistics_card_incidence_value_description))
-            .append(" ")
-            .append(getContentDescriptionForTrends(context, sevenDayIncidence.trend))
-            .append(" \n ")
+            .appendWithWhiteSpace(context.getString(R.string.accessibility_statistics_card_announcement))
+            .appendWithLineBreak(context.getString(R.string.statistics_explanation_seven_day_incidence_title))
+            .appendWithWhiteSpace(item.getPrimaryLabel(context))
+            .appendWithWhiteSpace(formatStatisticalValue(context, sevenDayIncidence.value, sevenDayIncidence.decimals))
+            .appendWithWhiteSpace(context.getString(R.string.statistics_card_incidence_value_description))
+            .appendWithLineBreak(getContentDescriptionForTrends(context, sevenDayIncidence.trend))
             .append(context.getString(R.string.accessibility_statistics_card_navigation_information))
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/IncidenceCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/IncidenceCard.kt
@@ -56,8 +56,8 @@ class IncidenceCard(parent: ViewGroup) :
 
     private fun buildAccessibilityStringForIncidenceCard(
         item: StatsItem,
-        sevenDayIncidence: KeyFigureCardOuterClass.KeyFigure)
-    : String {
+        sevenDayIncidence: KeyFigureCardOuterClass.KeyFigure
+    ): String {
         return context.getString(R.string.accessibility_statistics_card_announcement) +
             context.getString(R.string.statistics_explanation_seven_day_incidence_title) + "\n" +
             item.getPrimaryLabel(context) +
@@ -67,4 +67,3 @@ class IncidenceCard(parent: ViewGroup) :
             context.getString(R.string.accessibility_statistics_card_navigation_information)
     }
 }
-

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/IncidenceCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/IncidenceCard.kt
@@ -44,4 +44,4 @@ class IncidenceCard(parent: ViewGroup) :
         }
     }
 }
-ß
+

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/IncidenceCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/IncidenceCard.kt
@@ -67,7 +67,8 @@ class IncidenceCard(parent: ViewGroup) :
             .appendWithTrailingSpace(context.getString(R.string.accessibility_statistics_card_announcement))
             .appendWithLineBreak(context.getString(R.string.statistics_explanation_seven_day_incidence_title))
             .appendWithTrailingSpace(item.getPrimaryLabel(context))
-            .appendWithTrailingSpace(formatStatisticalValue(context, sevenDayIncidence.value, sevenDayIncidence.decimals))
+            .appendWithTrailingSpace(formatStatisticalValue(context, sevenDayIncidence.value,
+                sevenDayIncidence.decimals))
             .appendWithTrailingSpace(context.getString(R.string.statistics_card_incidence_value_description))
             .appendWithLineBreak(getContentDescriptionForTrends(context, sevenDayIncidence.trend))
             .append(context.getString(R.string.accessibility_statistics_card_navigation_information))

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/IncidenceCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/IncidenceCard.kt
@@ -44,10 +44,11 @@ class IncidenceCard(parent: ViewGroup) :
                 context,
                 formatStatisticalValue(context, sevenDayIncidence.value, sevenDayIncidence.decimals)
             )
+
             primaryValue.contentDescription =
-                context.getString(R.string.statistics_explanation_seven_day_incidence_title) +
-                    getPrimaryLabel(context) +
-                    formatStatisticalValue(context, sevenDayIncidence.value, sevenDayIncidence.decimals) +
+                context.getString(R.string.statistics_explanation_seven_day_incidence_title) + " " +
+                    getPrimaryLabel(context) + " " +
+                    formatStatisticalValue(context, sevenDayIncidence.value, sevenDayIncidence.decimals) + " " +
                     getContentDescriptionForTrends(context, sevenDayIncidence.trend)
 
             trendArrow.setTrend(sevenDayIncidence.trend, sevenDayIncidence.trendSemantic)
@@ -58,12 +59,12 @@ class IncidenceCard(parent: ViewGroup) :
         item: StatsItem,
         sevenDayIncidence: KeyFigureCardOuterClass.KeyFigure
     ): String {
-        return context.getString(R.string.accessibility_statistics_card_announcement) +
-            context.getString(R.string.statistics_explanation_seven_day_incidence_title) + "\n" +
-            item.getPrimaryLabel(context) +
-            formatStatisticalValue(context, sevenDayIncidence.value, sevenDayIncidence.decimals) +
+        return context.getString(R.string.accessibility_statistics_card_announcement) + " " +
+            context.getString(R.string.statistics_explanation_seven_day_incidence_title) + " \n " +
+            item.getPrimaryLabel(context) + " " +
+            formatStatisticalValue(context, sevenDayIncidence.value, sevenDayIncidence.decimals) + " " +
             context.getString(R.string.statistics_card_incidence_value_description) + " " +
-            getContentDescriptionForTrends(context, sevenDayIncidence.trend) + "\n" +
+            getContentDescriptionForTrends(context, sevenDayIncidence.trend) + " \n " +
             context.getString(R.string.accessibility_statistics_card_navigation_information)
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/IncidenceCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/IncidenceCard.kt
@@ -50,7 +50,8 @@ class IncidenceCard(parent: ViewGroup) :
             primaryValue.contentDescription = StringBuilder()
                 .appendWithWhiteSpace(context.getString(R.string.statistics_explanation_seven_day_incidence_title))
                 .appendWithWhiteSpace(getPrimaryLabel(context))
-                .appendWithWhiteSpace(formatStatisticalValue(context, sevenDayIncidence.value, sevenDayIncidence.decimals))
+                .appendWithWhiteSpace(formatStatisticalValue(context, sevenDayIncidence.value,
+                    sevenDayIncidence.decimals))
                 .append(getContentDescriptionForTrends(context, sevenDayIncidence.trend))
 
             trendArrow.setTrend(sevenDayIncidence.trend, sevenDayIncidence.trendSemantic)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/IncidenceCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/IncidenceCard.kt
@@ -3,7 +3,9 @@ package de.rki.coronawarnapp.statistics.ui.homecards.cards
 import android.view.ViewGroup
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.HomeStatisticsCardsIncidenceLayoutBinding
+import de.rki.coronawarnapp.server.protocols.internal.stats.KeyFigureCardOuterClass
 import de.rki.coronawarnapp.statistics.IncidenceStats
+import de.rki.coronawarnapp.statistics.StatsItem
 import de.rki.coronawarnapp.statistics.ui.homecards.StatisticsCardAdapter
 import de.rki.coronawarnapp.statistics.util.formatStatisticalValue
 import de.rki.coronawarnapp.statistics.util.getContentDescriptionForTrends
@@ -33,15 +35,36 @@ class IncidenceCard(parent: ViewGroup) :
         }
 
         with(item.stats as IncidenceStats) {
+
+            incidenceContainer.contentDescription =
+                buildAccessibilityStringForIncidenceCard(item.stats, sevenDayIncidence)
+
             primaryLabel.text = getPrimaryLabel(context)
             primaryValue.text = getLocalizedSpannableString(
                 context,
                 formatStatisticalValue(context, sevenDayIncidence.value, sevenDayIncidence.decimals)
             )
+            primaryValue.contentDescription =
+                context.getString(R.string.statistics_explanation_seven_day_incidence_title) +
+                    getPrimaryLabel(context) +
+                    formatStatisticalValue(context, sevenDayIncidence.value, sevenDayIncidence.decimals) +
+                    getContentDescriptionForTrends(context, sevenDayIncidence.trend)
 
-            primaryValue.contentDescription = context.getString(R.string.statistics_explanation_seven_day_incidence_title) + getPrimaryLabel(context) + formatStatisticalValue(context, sevenDayIncidence.value, sevenDayIncidence.decimals) + getContentDescriptionForTrends(context, sevenDayIncidence.trend)
             trendArrow.setTrend(sevenDayIncidence.trend, sevenDayIncidence.trendSemantic)
         }
+    }
+
+    private fun buildAccessibilityStringForIncidenceCard(
+        item: StatsItem,
+        sevenDayIncidence: KeyFigureCardOuterClass.KeyFigure)
+    : String {
+        return context.getString(R.string.accessibility_statistics_card_announcement) +
+            context.getString(R.string.statistics_explanation_seven_day_incidence_title) + "\n" +
+            item.getPrimaryLabel(context) +
+            formatStatisticalValue(context, sevenDayIncidence.value, sevenDayIncidence.decimals) +
+            context.getString(R.string.statistics_card_incidence_value_description) + " " +
+            getContentDescriptionForTrends(context, sevenDayIncidence.trend) + "\n" +
+            context.getString(R.string.accessibility_statistics_card_navigation_information)
     }
 }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/IncidenceCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/IncidenceCard.kt
@@ -6,6 +6,7 @@ import de.rki.coronawarnapp.databinding.HomeStatisticsCardsIncidenceLayoutBindin
 import de.rki.coronawarnapp.statistics.IncidenceStats
 import de.rki.coronawarnapp.statistics.ui.homecards.StatisticsCardAdapter
 import de.rki.coronawarnapp.statistics.util.formatStatisticalValue
+import de.rki.coronawarnapp.statistics.util.getContentDescriptionForTrends
 import de.rki.coronawarnapp.statistics.util.getLocalizedSpannableString
 import de.rki.coronawarnapp.util.formatter.getPrimaryLabel
 
@@ -37,7 +38,10 @@ class IncidenceCard(parent: ViewGroup) :
                 context,
                 formatStatisticalValue(context, sevenDayIncidence.value, sevenDayIncidence.decimals)
             )
+
+            primaryValue.contentDescription = context.getString(R.string.statistics_explanation_seven_day_incidence_title) + getPrimaryLabel(context) + formatStatisticalValue(context, sevenDayIncidence.value, sevenDayIncidence.decimals) + getContentDescriptionForTrends(context, sevenDayIncidence.trend)
             trendArrow.setTrend(sevenDayIncidence.trend, sevenDayIncidence.trendSemantic)
         }
     }
 }
+ß

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/IncidenceCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/IncidenceCard.kt
@@ -11,7 +11,7 @@ import de.rki.coronawarnapp.statistics.util.formatStatisticalValue
 import de.rki.coronawarnapp.statistics.util.getContentDescriptionForTrends
 import de.rki.coronawarnapp.statistics.util.getLocalizedSpannableString
 import de.rki.coronawarnapp.util.StringBuilderExtension.appendWithLineBreak
-import de.rki.coronawarnapp.util.StringBuilderExtension.appendWithWhiteSpace
+import de.rki.coronawarnapp.util.StringBuilderExtension.appendWithTrailingSpace
 import de.rki.coronawarnapp.util.formatter.getPrimaryLabel
 
 class IncidenceCard(parent: ViewGroup) :
@@ -48,9 +48,9 @@ class IncidenceCard(parent: ViewGroup) :
             )
 
             primaryValue.contentDescription = StringBuilder()
-                .appendWithWhiteSpace(context.getString(R.string.statistics_explanation_seven_day_incidence_title))
-                .appendWithWhiteSpace(getPrimaryLabel(context))
-                .appendWithWhiteSpace(formatStatisticalValue(context, sevenDayIncidence.value,
+                .appendWithTrailingSpace(context.getString(R.string.statistics_explanation_seven_day_incidence_title))
+                .appendWithTrailingSpace(getPrimaryLabel(context))
+                .appendWithTrailingSpace(formatStatisticalValue(context, sevenDayIncidence.value,
                     sevenDayIncidence.decimals))
                 .append(getContentDescriptionForTrends(context, sevenDayIncidence.trend))
 
@@ -64,11 +64,11 @@ class IncidenceCard(parent: ViewGroup) :
     ): StringBuilder {
 
         return StringBuilder()
-            .appendWithWhiteSpace(context.getString(R.string.accessibility_statistics_card_announcement))
+            .appendWithTrailingSpace(context.getString(R.string.accessibility_statistics_card_announcement))
             .appendWithLineBreak(context.getString(R.string.statistics_explanation_seven_day_incidence_title))
-            .appendWithWhiteSpace(item.getPrimaryLabel(context))
-            .appendWithWhiteSpace(formatStatisticalValue(context, sevenDayIncidence.value, sevenDayIncidence.decimals))
-            .appendWithWhiteSpace(context.getString(R.string.statistics_card_incidence_value_description))
+            .appendWithTrailingSpace(item.getPrimaryLabel(context))
+            .appendWithTrailingSpace(formatStatisticalValue(context, sevenDayIncidence.value, sevenDayIncidence.decimals))
+            .appendWithTrailingSpace(context.getString(R.string.statistics_card_incidence_value_description))
             .appendWithLineBreak(getContentDescriptionForTrends(context, sevenDayIncidence.trend))
             .append(context.getString(R.string.accessibility_statistics_card_navigation_information))
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/IncidenceCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/IncidenceCard.kt
@@ -45,11 +45,14 @@ class IncidenceCard(parent: ViewGroup) :
                 formatStatisticalValue(context, sevenDayIncidence.value, sevenDayIncidence.decimals)
             )
 
-            primaryValue.contentDescription =
-                context.getString(R.string.statistics_explanation_seven_day_incidence_title) + " " +
-                    getPrimaryLabel(context) + " " +
-                    formatStatisticalValue(context, sevenDayIncidence.value, sevenDayIncidence.decimals) + " " +
-                    getContentDescriptionForTrends(context, sevenDayIncidence.trend)
+            primaryValue.contentDescription = StringBuilder()
+                .append(context.getString(R.string.statistics_explanation_seven_day_incidence_title))
+                .append(" ")
+                .append(getPrimaryLabel(context))
+                .append(" ")
+                .append(formatStatisticalValue(context, sevenDayIncidence.value, sevenDayIncidence.decimals))
+                .append(" ")
+                .append(getContentDescriptionForTrends(context, sevenDayIncidence.trend))
 
             trendArrow.setTrend(sevenDayIncidence.trend, sevenDayIncidence.trendSemantic)
         }
@@ -58,13 +61,21 @@ class IncidenceCard(parent: ViewGroup) :
     private fun buildAccessibilityStringForIncidenceCard(
         item: StatsItem,
         sevenDayIncidence: KeyFigureCardOuterClass.KeyFigure
-    ): String {
-        return context.getString(R.string.accessibility_statistics_card_announcement) + " " +
-            context.getString(R.string.statistics_explanation_seven_day_incidence_title) + " \n " +
-            item.getPrimaryLabel(context) + " " +
-            formatStatisticalValue(context, sevenDayIncidence.value, sevenDayIncidence.decimals) + " " +
-            context.getString(R.string.statistics_card_incidence_value_description) + " " +
-            getContentDescriptionForTrends(context, sevenDayIncidence.trend) + " \n " +
-            context.getString(R.string.accessibility_statistics_card_navigation_information)
+    ): StringBuilder {
+
+        return StringBuilder()
+            .append(context.getString(R.string.accessibility_statistics_card_announcement))
+            .append(" ")
+            .append(context.getString(R.string.statistics_explanation_seven_day_incidence_title))
+            .append(" \n ")
+            .append(item.getPrimaryLabel(context))
+            .append(" ")
+            .append(formatStatisticalValue(context, sevenDayIncidence.value, sevenDayIncidence.decimals))
+            .append(" ")
+            .append(context.getString(R.string.statistics_card_incidence_value_description))
+            .append(" ")
+            .append(getContentDescriptionForTrends(context, sevenDayIncidence.trend))
+            .append(" \n ")
+            .append(context.getString(R.string.accessibility_statistics_card_navigation_information))
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/InfectionsCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/InfectionsCard.kt
@@ -7,6 +7,8 @@ import de.rki.coronawarnapp.statistics.InfectionStats
 import de.rki.coronawarnapp.statistics.ui.homecards.StatisticsCardAdapter
 import de.rki.coronawarnapp.statistics.util.formatStatisticalValue
 import de.rki.coronawarnapp.util.formatter.getPrimaryLabel
+import de.rki.coronawarnapp.statistics.util.getContentDescriptionForTrends
+
 
 class InfectionsCard(parent: ViewGroup) :
     StatisticsCardAdapter.ItemVH<StatisticsCardItem, HomeStatisticsCardsInfectionsLayoutBinding>(
@@ -31,10 +33,20 @@ class InfectionsCard(parent: ViewGroup) :
         }
 
         with(item.stats as InfectionStats) {
+
+
+            infectionsContainer.contentDescription = "Statistics Card:" + context.getString(R.string.statistics_card_infections_title) + " One of 4 in the list: swipe horizontal to find more statistical information"
+
+
             primaryLabel.text = getPrimaryLabel(context)
             primaryValue.text = formatStatisticalValue(context, newInfections.value, newInfections.decimals)
+            primaryValue.contentDescription = getPrimaryLabel(context)+ ": " + formatStatisticalValue(context, newInfections.value, newInfections.decimals)
+
             secondaryValue.text = formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals)
+            secondaryValue.contentDescription = context.getString(R.string.statistics_card_infections_secondary_label )+ ": " + formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals) + getContentDescriptionForTrends(context, sevenDayAverage.trend)
+
             tertiaryValue.text = formatStatisticalValue(context, total.value, total.decimals)
+            tertiaryValue.contentDescription = context.getString(R.string.statistics_card_infections_tertiary_label) + ": " + formatStatisticalValue(context, total.value, total.decimals)
             trendArrow.setTrend(sevenDayAverage.trend, sevenDayAverage.trendSemantic)
         }
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/InfectionsCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/InfectionsCard.kt
@@ -10,6 +10,8 @@ import de.rki.coronawarnapp.statistics.ui.homecards.StatisticsCardAdapter
 import de.rki.coronawarnapp.statistics.util.formatStatisticalValue
 import de.rki.coronawarnapp.util.formatter.getPrimaryLabel
 import de.rki.coronawarnapp.statistics.util.getContentDescriptionForTrends
+import de.rki.coronawarnapp.util.StringBuilderExtension.appendWithLineBreak
+import de.rki.coronawarnapp.util.StringBuilderExtension.appendWithWhiteSpace
 
 class InfectionsCard(parent: ViewGroup) :
     StatisticsCardAdapter.ItemVH<StatisticsCardItem, HomeStatisticsCardsInfectionsLayoutBinding>(
@@ -41,28 +43,21 @@ class InfectionsCard(parent: ViewGroup) :
             primaryLabel.text = getPrimaryLabel(context)
             primaryValue.text = formatStatisticalValue(context, newInfections.value, newInfections.decimals)
             primaryValue.contentDescription = StringBuilder()
-                .append(getPrimaryLabel(context))
-                .append(" ")
-                .append(formatStatisticalValue(context, newInfections.value, newInfections.decimals))
-                .append(" ")
+                .appendWithWhiteSpace(getPrimaryLabel(context))
+                .appendWithWhiteSpace(formatStatisticalValue(context, newInfections.value, newInfections.decimals))
                 .append(context.getString(R.string.statistics_card_infections_title))
 
             secondaryValue.text = formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals)
             secondaryValue.contentDescription = StringBuilder()
-                .append(context.getString(R.string.statistics_card_infections_secondary_label))
-                .append(" ")
-                .append(formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals))
-                .append(" ")
-                .append(context.getString(R.string.statistics_card_infections_title))
-                .append(" ")
+                .appendWithWhiteSpace(context.getString(R.string.statistics_card_infections_secondary_label))
+                .appendWithWhiteSpace(formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals))
+                .appendWithWhiteSpace(context.getString(R.string.statistics_card_infections_title))
                 .append(getContentDescriptionForTrends(context, sevenDayAverage.trend))
 
             tertiaryValue.text = formatStatisticalValue(context, total.value, total.decimals)
             tertiaryValue.contentDescription = StringBuilder()
-                .append(context.getString(R.string.statistics_card_infections_tertiary_label))
-                .append(" ")
-                .append(formatStatisticalValue(context, total.value, total.decimals))
-                .append(" ")
+                .appendWithWhiteSpace(context.getString(R.string.statistics_card_infections_tertiary_label))
+                .appendWithWhiteSpace(formatStatisticalValue(context, total.value, total.decimals))
                 .append(context.getString(R.string.statistics_card_infections_title))
 
             trendArrow.setTrend(sevenDayAverage.trend, sevenDayAverage.trendSemantic)
@@ -77,24 +72,15 @@ class InfectionsCard(parent: ViewGroup) :
     ): StringBuilder {
 
         return StringBuilder()
-            .append(context.getString(R.string.accessibility_statistics_card_announcement))
-            .append(" ")
-            .append(context.getString(R.string.statistics_card_infections_title))
-            .append(" \n ")
-            .append(item.getPrimaryLabel(context))
-            .append(" ")
-            .append(formatStatisticalValue(context, newInfections.value, newInfections.decimals))
-            .append(" \n ")
-            .append(context.getString(R.string.statistics_card_infections_secondary_label))
-            .append(" ")
-            .append(formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals))
-            .append(" ")
-            .append(getContentDescriptionForTrends(context, sevenDayAverage.trend))
-            .append(" \n ")
-            .append(context.getString(R.string.statistics_card_infections_tertiary_label))
-            .append(" ")
-            .append(formatStatisticalValue(context, total.value, total.decimals))
-            .append(" \n ")
+            .appendWithWhiteSpace(context.getString(R.string.accessibility_statistics_card_announcement))
+            .appendWithLineBreak(context.getString(R.string.statistics_card_infections_title))
+            .appendWithWhiteSpace(item.getPrimaryLabel(context))
+            .appendWithLineBreak(formatStatisticalValue(context, newInfections.value, newInfections.decimals))
+            .appendWithWhiteSpace(context.getString(R.string.statistics_card_infections_secondary_label))
+            .appendWithWhiteSpace(formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals))
+            .appendWithLineBreak(getContentDescriptionForTrends(context, sevenDayAverage.trend))
+            .appendWithWhiteSpace(context.getString(R.string.statistics_card_infections_tertiary_label))
+            .appendWithLineBreak(formatStatisticalValue(context, total.value, total.decimals))
             .append(context.getString(R.string.accessibility_statistics_card_navigation_information))
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/InfectionsCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/InfectionsCard.kt
@@ -1,6 +1,5 @@
 package de.rki.coronawarnapp.statistics.ui.homecards.cards
 
-import android.util.Log
 import android.view.ViewGroup
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.HomeStatisticsCardsInfectionsLayoutBinding

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/InfectionsCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/InfectionsCard.kt
@@ -40,13 +40,13 @@ class InfectionsCard(parent: ViewGroup) :
 
             primaryLabel.text = getPrimaryLabel(context)
             primaryValue.text = formatStatisticalValue(context, newInfections.value, newInfections.decimals)
-            primaryValue.contentDescription = getPrimaryLabel(context)+ ": " + formatStatisticalValue(context, newInfections.value, newInfections.decimals)
+            primaryValue.contentDescription = getPrimaryLabel(context)+ ": " + formatStatisticalValue(context, newInfections.value, newInfections.decimals) + context.getString(R.string.statistics_card_infections_title)
 
             secondaryValue.text = formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals)
-            secondaryValue.contentDescription = context.getString(R.string.statistics_card_infections_secondary_label ) + formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals) + getContentDescriptionForTrends(context, sevenDayAverage.trend)
+            secondaryValue.contentDescription = context.getString(R.string.statistics_card_infections_secondary_label ) + formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals) + context.getString(R.string.statistics_card_infections_title) + " " + getContentDescriptionForTrends(context, sevenDayAverage.trend)
 
             tertiaryValue.text = formatStatisticalValue(context, total.value, total.decimals)
-            tertiaryValue.contentDescription = context.getString(R.string.statistics_card_infections_tertiary_label) + ": " + formatStatisticalValue(context, total.value, total.decimals)
+            tertiaryValue.contentDescription = context.getString(R.string.statistics_card_infections_tertiary_label) + ": " + formatStatisticalValue(context, total.value, total.decimals) + context.getString(R.string.statistics_card_infections_title)
             trendArrow.setTrend(sevenDayAverage.trend, sevenDayAverage.trendSemantic)
         }
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/InfectionsCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/InfectionsCard.kt
@@ -11,7 +11,6 @@ import de.rki.coronawarnapp.statistics.util.formatStatisticalValue
 import de.rki.coronawarnapp.util.formatter.getPrimaryLabel
 import de.rki.coronawarnapp.statistics.util.getContentDescriptionForTrends
 
-
 class InfectionsCard(parent: ViewGroup) :
     StatisticsCardAdapter.ItemVH<StatisticsCardItem, HomeStatisticsCardsInfectionsLayoutBinding>(
         R.layout.home_statistics_cards_basecard_layout, parent
@@ -37,17 +36,17 @@ class InfectionsCard(parent: ViewGroup) :
         with(item.stats as InfectionStats) {
 
             infectionsContainer.contentDescription =
-                buildAccessibilityStringForInfectionsCard(item.stats, newInfections, sevenDayAverage, total);
+                buildAccessibilityStringForInfectionsCard(item.stats, newInfections, sevenDayAverage, total)
 
             primaryLabel.text = getPrimaryLabel(context)
             primaryValue.text = formatStatisticalValue(context, newInfections.value, newInfections.decimals)
-            primaryValue.contentDescription = getPrimaryLabel(context)+ " " +
+            primaryValue.contentDescription = getPrimaryLabel(context) + " " +
                 formatStatisticalValue(context, newInfections.value, newInfections.decimals) +
                 context.getString(R.string.statistics_card_infections_title)
 
             secondaryValue.text = formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals)
             secondaryValue.contentDescription =
-                context.getString(R.string.statistics_card_infections_secondary_label ) +
+                context.getString(R.string.statistics_card_infections_secondary_label) +
                 formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals) +
                 context.getString(R.string.statistics_card_infections_title) + " " +
                     getContentDescriptionForTrends(context, sevenDayAverage.trend)
@@ -62,23 +61,21 @@ class InfectionsCard(parent: ViewGroup) :
         }
     }
 
-
     private fun buildAccessibilityStringForInfectionsCard(
         item: StatsItem,
         newInfections: KeyFigureCardOuterClass.KeyFigure,
         sevenDayAverage: KeyFigureCardOuterClass.KeyFigure,
-        total: KeyFigureCardOuterClass.KeyFigure)
-    : String {
+        total: KeyFigureCardOuterClass.KeyFigure
+    ): String {
         return context.getString(R.string.accessibility_statistics_card_announcement) +
             context.getString(R.string.statistics_card_infections_title) + "\n" +
-            item.getPrimaryLabel(context)+
+            item.getPrimaryLabel(context) +
             formatStatisticalValue(context, newInfections.value, newInfections.decimals) + "\n" +
-            context.getString(R.string.statistics_card_infections_secondary_label ) +
+            context.getString(R.string.statistics_card_infections_secondary_label) +
             formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals) +
             getContentDescriptionForTrends(context, sevenDayAverage.trend) + "\n" +
             context.getString(R.string.statistics_card_infections_tertiary_label) +
             formatStatisticalValue(context, total.value, total.decimals) + "\n" +
             context.getString(R.string.accessibility_statistics_card_navigation_information)
     }
-
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/InfectionsCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/InfectionsCard.kt
@@ -3,7 +3,9 @@ package de.rki.coronawarnapp.statistics.ui.homecards.cards
 import android.view.ViewGroup
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.HomeStatisticsCardsInfectionsLayoutBinding
+import de.rki.coronawarnapp.server.protocols.internal.stats.KeyFigureCardOuterClass
 import de.rki.coronawarnapp.statistics.InfectionStats
+import de.rki.coronawarnapp.statistics.StatsItem
 import de.rki.coronawarnapp.statistics.ui.homecards.StatisticsCardAdapter
 import de.rki.coronawarnapp.statistics.util.formatStatisticalValue
 import de.rki.coronawarnapp.util.formatter.getPrimaryLabel
@@ -34,20 +36,49 @@ class InfectionsCard(parent: ViewGroup) :
 
         with(item.stats as InfectionStats) {
 
-
-            infectionsContainer.contentDescription = "Statistikkarte: " + context.getString(R.string.statistics_card_infections_title) + ".  Wische horizontal zwischen den Items"
-
+            infectionsContainer.contentDescription =
+                buildAccessibilityStringForInfectionsCard(item.stats, newInfections, sevenDayAverage, total);
 
             primaryLabel.text = getPrimaryLabel(context)
             primaryValue.text = formatStatisticalValue(context, newInfections.value, newInfections.decimals)
-            primaryValue.contentDescription = getPrimaryLabel(context)+ ": " + formatStatisticalValue(context, newInfections.value, newInfections.decimals) + context.getString(R.string.statistics_card_infections_title)
+            primaryValue.contentDescription = getPrimaryLabel(context)+ " " +
+                formatStatisticalValue(context, newInfections.value, newInfections.decimals) +
+                context.getString(R.string.statistics_card_infections_title)
 
             secondaryValue.text = formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals)
-            secondaryValue.contentDescription = context.getString(R.string.statistics_card_infections_secondary_label ) + formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals) + context.getString(R.string.statistics_card_infections_title) + " " + getContentDescriptionForTrends(context, sevenDayAverage.trend)
+            secondaryValue.contentDescription =
+                context.getString(R.string.statistics_card_infections_secondary_label ) +
+                formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals) +
+                context.getString(R.string.statistics_card_infections_title) + " " +
+                    getContentDescriptionForTrends(context, sevenDayAverage.trend)
 
             tertiaryValue.text = formatStatisticalValue(context, total.value, total.decimals)
-            tertiaryValue.contentDescription = context.getString(R.string.statistics_card_infections_tertiary_label) + ": " + formatStatisticalValue(context, total.value, total.decimals) + context.getString(R.string.statistics_card_infections_title)
+            tertiaryValue.contentDescription =
+                context.getString(R.string.statistics_card_infections_tertiary_label) + " " +
+                    formatStatisticalValue(context, total.value, total.decimals) +
+                    context.getString(R.string.statistics_card_infections_title)
+
             trendArrow.setTrend(sevenDayAverage.trend, sevenDayAverage.trendSemantic)
         }
     }
+
+
+    private fun buildAccessibilityStringForInfectionsCard(
+        item: StatsItem,
+        newInfections: KeyFigureCardOuterClass.KeyFigure,
+        sevenDayAverage: KeyFigureCardOuterClass.KeyFigure,
+        total: KeyFigureCardOuterClass.KeyFigure)
+    : String {
+        return context.getString(R.string.accessibility_statistics_card_announcement) +
+            context.getString(R.string.statistics_card_infections_title) + "\n" +
+            item.getPrimaryLabel(context)+
+            formatStatisticalValue(context, newInfections.value, newInfections.decimals) + "\n" +
+            context.getString(R.string.statistics_card_infections_secondary_label ) +
+            formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals) +
+            getContentDescriptionForTrends(context, sevenDayAverage.trend) + "\n" +
+            context.getString(R.string.statistics_card_infections_tertiary_label) +
+            formatStatisticalValue(context, total.value, total.decimals) + "\n" +
+            context.getString(R.string.accessibility_statistics_card_navigation_information)
+    }
+
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/InfectionsCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/InfectionsCard.kt
@@ -50,7 +50,8 @@ class InfectionsCard(parent: ViewGroup) :
             secondaryValue.text = formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals)
             secondaryValue.contentDescription = StringBuilder()
                 .appendWithTrailingSpace(context.getString(R.string.statistics_card_infections_secondary_label))
-                .appendWithTrailingSpace(formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals))
+                .appendWithTrailingSpace(formatStatisticalValue(context, sevenDayAverage.value,
+                    sevenDayAverage.decimals))
                 .appendWithTrailingSpace(context.getString(R.string.statistics_card_infections_title))
                 .append(getContentDescriptionForTrends(context, sevenDayAverage.trend))
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/InfectionsCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/InfectionsCard.kt
@@ -35,7 +35,7 @@ class InfectionsCard(parent: ViewGroup) :
         with(item.stats as InfectionStats) {
 
 
-            infectionsContainer.contentDescription = "Statistics Card:" + context.getString(R.string.statistics_card_infections_title) + " One of 4 in the list: swipe horizontal to find more statistical information"
+            infectionsContainer.contentDescription = "Statistikkarte: " + context.getString(R.string.statistics_card_infections_title) + ".  Wische horizontal zwischen den Items"
 
 
             primaryLabel.text = getPrimaryLabel(context)
@@ -43,7 +43,7 @@ class InfectionsCard(parent: ViewGroup) :
             primaryValue.contentDescription = getPrimaryLabel(context)+ ": " + formatStatisticalValue(context, newInfections.value, newInfections.decimals)
 
             secondaryValue.text = formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals)
-            secondaryValue.contentDescription = context.getString(R.string.statistics_card_infections_secondary_label )+ ": " + formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals) + getContentDescriptionForTrends(context, sevenDayAverage.trend)
+            secondaryValue.contentDescription = context.getString(R.string.statistics_card_infections_secondary_label ) + formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals) + getContentDescriptionForTrends(context, sevenDayAverage.trend)
 
             tertiaryValue.text = formatStatisticalValue(context, total.value, total.decimals)
             tertiaryValue.contentDescription = context.getString(R.string.statistics_card_infections_tertiary_label) + ": " + formatStatisticalValue(context, total.value, total.decimals)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/InfectionsCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/InfectionsCard.kt
@@ -1,5 +1,6 @@
 package de.rki.coronawarnapp.statistics.ui.homecards.cards
 
+import android.util.Log
 import android.view.ViewGroup
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.HomeStatisticsCardsInfectionsLayoutBinding
@@ -41,20 +42,20 @@ class InfectionsCard(parent: ViewGroup) :
             primaryLabel.text = getPrimaryLabel(context)
             primaryValue.text = formatStatisticalValue(context, newInfections.value, newInfections.decimals)
             primaryValue.contentDescription = getPrimaryLabel(context) + " " +
-                formatStatisticalValue(context, newInfections.value, newInfections.decimals) +
+                formatStatisticalValue(context, newInfections.value, newInfections.decimals) + " " +
                 context.getString(R.string.statistics_card_infections_title)
 
             secondaryValue.text = formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals)
             secondaryValue.contentDescription =
-                context.getString(R.string.statistics_card_infections_secondary_label) +
-                formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals) +
-                context.getString(R.string.statistics_card_infections_title) + " " +
+                context.getString(R.string.statistics_card_infections_secondary_label) + " " +
+                    formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals).toString() + " " +
+                    context.getString(R.string.statistics_card_infections_title) + " " +
                     getContentDescriptionForTrends(context, sevenDayAverage.trend)
 
             tertiaryValue.text = formatStatisticalValue(context, total.value, total.decimals)
             tertiaryValue.contentDescription =
                 context.getString(R.string.statistics_card_infections_tertiary_label) + " " +
-                    formatStatisticalValue(context, total.value, total.decimals) +
+                    formatStatisticalValue(context, total.value, total.decimals) + " " +
                     context.getString(R.string.statistics_card_infections_title)
 
             trendArrow.setTrend(sevenDayAverage.trend, sevenDayAverage.trendSemantic)
@@ -67,15 +68,15 @@ class InfectionsCard(parent: ViewGroup) :
         sevenDayAverage: KeyFigureCardOuterClass.KeyFigure,
         total: KeyFigureCardOuterClass.KeyFigure
     ): String {
-        return context.getString(R.string.accessibility_statistics_card_announcement) +
-            context.getString(R.string.statistics_card_infections_title) + "\n" +
-            item.getPrimaryLabel(context) +
-            formatStatisticalValue(context, newInfections.value, newInfections.decimals) + "\n" +
-            context.getString(R.string.statistics_card_infections_secondary_label) +
-            formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals) +
-            getContentDescriptionForTrends(context, sevenDayAverage.trend) + "\n" +
-            context.getString(R.string.statistics_card_infections_tertiary_label) +
-            formatStatisticalValue(context, total.value, total.decimals) + "\n" +
+        return context.getString(R.string.accessibility_statistics_card_announcement) + " " +
+            context.getString(R.string.statistics_card_infections_title) + " \n " +
+            item.getPrimaryLabel(context) + " " +
+            formatStatisticalValue(context, newInfections.value, newInfections.decimals) + " \n " +
+            context.getString(R.string.statistics_card_infections_secondary_label) + " " +
+            formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals) + " " +
+            getContentDescriptionForTrends(context, sevenDayAverage.trend) + " \n " +
+            context.getString(R.string.statistics_card_infections_tertiary_label) + " " +
+            formatStatisticalValue(context, total.value, total.decimals) + " \n " +
             context.getString(R.string.accessibility_statistics_card_navigation_information)
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/InfectionsCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/InfectionsCard.kt
@@ -11,7 +11,7 @@ import de.rki.coronawarnapp.statistics.util.formatStatisticalValue
 import de.rki.coronawarnapp.util.formatter.getPrimaryLabel
 import de.rki.coronawarnapp.statistics.util.getContentDescriptionForTrends
 import de.rki.coronawarnapp.util.StringBuilderExtension.appendWithLineBreak
-import de.rki.coronawarnapp.util.StringBuilderExtension.appendWithWhiteSpace
+import de.rki.coronawarnapp.util.StringBuilderExtension.appendWithTrailingSpace
 
 class InfectionsCard(parent: ViewGroup) :
     StatisticsCardAdapter.ItemVH<StatisticsCardItem, HomeStatisticsCardsInfectionsLayoutBinding>(
@@ -43,21 +43,21 @@ class InfectionsCard(parent: ViewGroup) :
             primaryLabel.text = getPrimaryLabel(context)
             primaryValue.text = formatStatisticalValue(context, newInfections.value, newInfections.decimals)
             primaryValue.contentDescription = StringBuilder()
-                .appendWithWhiteSpace(getPrimaryLabel(context))
-                .appendWithWhiteSpace(formatStatisticalValue(context, newInfections.value, newInfections.decimals))
+                .appendWithTrailingSpace(getPrimaryLabel(context))
+                .appendWithTrailingSpace(formatStatisticalValue(context, newInfections.value, newInfections.decimals))
                 .append(context.getString(R.string.statistics_card_infections_title))
 
             secondaryValue.text = formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals)
             secondaryValue.contentDescription = StringBuilder()
-                .appendWithWhiteSpace(context.getString(R.string.statistics_card_infections_secondary_label))
-                .appendWithWhiteSpace(formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals))
-                .appendWithWhiteSpace(context.getString(R.string.statistics_card_infections_title))
+                .appendWithTrailingSpace(context.getString(R.string.statistics_card_infections_secondary_label))
+                .appendWithTrailingSpace(formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals))
+                .appendWithTrailingSpace(context.getString(R.string.statistics_card_infections_title))
                 .append(getContentDescriptionForTrends(context, sevenDayAverage.trend))
 
             tertiaryValue.text = formatStatisticalValue(context, total.value, total.decimals)
             tertiaryValue.contentDescription = StringBuilder()
-                .appendWithWhiteSpace(context.getString(R.string.statistics_card_infections_tertiary_label))
-                .appendWithWhiteSpace(formatStatisticalValue(context, total.value, total.decimals))
+                .appendWithTrailingSpace(context.getString(R.string.statistics_card_infections_tertiary_label))
+                .appendWithTrailingSpace(formatStatisticalValue(context, total.value, total.decimals))
                 .append(context.getString(R.string.statistics_card_infections_title))
 
             trendArrow.setTrend(sevenDayAverage.trend, sevenDayAverage.trendSemantic)
@@ -72,14 +72,14 @@ class InfectionsCard(parent: ViewGroup) :
     ): StringBuilder {
 
         return StringBuilder()
-            .appendWithWhiteSpace(context.getString(R.string.accessibility_statistics_card_announcement))
+            .appendWithTrailingSpace(context.getString(R.string.accessibility_statistics_card_announcement))
             .appendWithLineBreak(context.getString(R.string.statistics_card_infections_title))
-            .appendWithWhiteSpace(item.getPrimaryLabel(context))
+            .appendWithTrailingSpace(item.getPrimaryLabel(context))
             .appendWithLineBreak(formatStatisticalValue(context, newInfections.value, newInfections.decimals))
-            .appendWithWhiteSpace(context.getString(R.string.statistics_card_infections_secondary_label))
-            .appendWithWhiteSpace(formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals))
+            .appendWithTrailingSpace(context.getString(R.string.statistics_card_infections_secondary_label))
+            .appendWithTrailingSpace(formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals))
             .appendWithLineBreak(getContentDescriptionForTrends(context, sevenDayAverage.trend))
-            .appendWithWhiteSpace(context.getString(R.string.statistics_card_infections_tertiary_label))
+            .appendWithTrailingSpace(context.getString(R.string.statistics_card_infections_tertiary_label))
             .appendWithLineBreak(formatStatisticalValue(context, total.value, total.decimals))
             .append(context.getString(R.string.accessibility_statistics_card_navigation_information))
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/InfectionsCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/InfectionsCard.kt
@@ -40,22 +40,30 @@ class InfectionsCard(parent: ViewGroup) :
 
             primaryLabel.text = getPrimaryLabel(context)
             primaryValue.text = formatStatisticalValue(context, newInfections.value, newInfections.decimals)
-            primaryValue.contentDescription = getPrimaryLabel(context) + " " +
-                formatStatisticalValue(context, newInfections.value, newInfections.decimals) + " " +
-                context.getString(R.string.statistics_card_infections_title)
+            primaryValue.contentDescription = StringBuilder()
+                .append(getPrimaryLabel(context))
+                .append(" ")
+                .append(formatStatisticalValue(context, newInfections.value, newInfections.decimals))
+                .append(" ")
+                .append(context.getString(R.string.statistics_card_infections_title))
 
             secondaryValue.text = formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals)
-            secondaryValue.contentDescription =
-                context.getString(R.string.statistics_card_infections_secondary_label) + " " +
-                    formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals).toString() + " " +
-                    context.getString(R.string.statistics_card_infections_title) + " " +
-                    getContentDescriptionForTrends(context, sevenDayAverage.trend)
+            secondaryValue.contentDescription = StringBuilder()
+                .append(context.getString(R.string.statistics_card_infections_secondary_label))
+                .append(" ")
+                .append(formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals))
+                .append(" ")
+                .append(context.getString(R.string.statistics_card_infections_title))
+                .append(" ")
+                .append(getContentDescriptionForTrends(context, sevenDayAverage.trend))
 
             tertiaryValue.text = formatStatisticalValue(context, total.value, total.decimals)
-            tertiaryValue.contentDescription =
-                context.getString(R.string.statistics_card_infections_tertiary_label) + " " +
-                    formatStatisticalValue(context, total.value, total.decimals) + " " +
-                    context.getString(R.string.statistics_card_infections_title)
+            tertiaryValue.contentDescription = StringBuilder()
+                .append(context.getString(R.string.statistics_card_infections_tertiary_label))
+                .append(" ")
+                .append(formatStatisticalValue(context, total.value, total.decimals))
+                .append(" ")
+                .append(context.getString(R.string.statistics_card_infections_title))
 
             trendArrow.setTrend(sevenDayAverage.trend, sevenDayAverage.trendSemantic)
         }
@@ -66,16 +74,27 @@ class InfectionsCard(parent: ViewGroup) :
         newInfections: KeyFigureCardOuterClass.KeyFigure,
         sevenDayAverage: KeyFigureCardOuterClass.KeyFigure,
         total: KeyFigureCardOuterClass.KeyFigure
-    ): String {
-        return context.getString(R.string.accessibility_statistics_card_announcement) + " " +
-            context.getString(R.string.statistics_card_infections_title) + " \n " +
-            item.getPrimaryLabel(context) + " " +
-            formatStatisticalValue(context, newInfections.value, newInfections.decimals) + " \n " +
-            context.getString(R.string.statistics_card_infections_secondary_label) + " " +
-            formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals) + " " +
-            getContentDescriptionForTrends(context, sevenDayAverage.trend) + " \n " +
-            context.getString(R.string.statistics_card_infections_tertiary_label) + " " +
-            formatStatisticalValue(context, total.value, total.decimals) + " \n " +
-            context.getString(R.string.accessibility_statistics_card_navigation_information)
+    ): StringBuilder {
+
+        return StringBuilder()
+            .append(context.getString(R.string.accessibility_statistics_card_announcement))
+            .append(" ")
+            .append(context.getString(R.string.statistics_card_infections_title))
+            .append(" \n ")
+            .append(item.getPrimaryLabel(context))
+            .append(" ")
+            .append(formatStatisticalValue(context, newInfections.value, newInfections.decimals))
+            .append(" \n ")
+            .append(context.getString(R.string.statistics_card_infections_secondary_label))
+            .append(" ")
+            .append(formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals))
+            .append(" ")
+            .append(getContentDescriptionForTrends(context, sevenDayAverage.trend))
+            .append(" \n ")
+            .append(context.getString(R.string.statistics_card_infections_tertiary_label))
+            .append(" ")
+            .append(formatStatisticalValue(context, total.value, total.decimals))
+            .append(" \n ")
+            .append(context.getString(R.string.accessibility_statistics_card_navigation_information))
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/KeySubmissionsCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/KeySubmissionsCard.kt
@@ -1,5 +1,6 @@
 package de.rki.coronawarnapp.statistics.ui.homecards.cards
 
+import android.util.Log
 import android.view.ViewGroup
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.HomeStatisticsCardsKeysubmissionsLayoutBinding
@@ -41,21 +42,21 @@ class KeySubmissionsCard(parent: ViewGroup) :
             primaryLabel.text = getPrimaryLabel(context)
             primaryValue.text = formatStatisticalValue(context, keySubmissions.value, keySubmissions.decimals)
             primaryValue.contentDescription =
-                getPrimaryLabel(context) +
-                    formatStatisticalValue(context, keySubmissions.value, keySubmissions.decimals) +
+                getPrimaryLabel(context) + " " +
+                    formatStatisticalValue(context, keySubmissions.value, keySubmissions.decimals) + " " +
                     context.getString(R.string.statistics_card_submission_title)
 
             secondaryValue.text = formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals)
             secondaryValue.contentDescription =
-                context.getString(R.string.statistics_card_infections_secondary_label) +
-                    formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals) +
+                context.getString(R.string.statistics_card_infections_secondary_label) + " " +
+                    formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals) + " " +
                     context.getString(R.string.statistics_card_submission_title) + " " +
                     getContentDescriptionForTrends(context, sevenDayAverage.trend)
 
             tertiaryValue.text = formatStatisticalValue(context, total.value, total.decimals)
             tertiaryValue.contentDescription =
-                context.getString(R.string.statistics_card_infections_tertiary_label) +
-                    formatStatisticalValue(context, total.value, total.decimals) +
+                context.getString(R.string.statistics_card_infections_tertiary_label) + " " +
+                    formatStatisticalValue(context, total.value, total.decimals) + " " +
                     context.getString(R.string.statistics_card_submission_title)
 
             trendArrow.setTrend(sevenDayAverage.trend, sevenDayAverage.trendSemantic)
@@ -68,16 +69,16 @@ class KeySubmissionsCard(parent: ViewGroup) :
         sevenDayAverage: KeyFigureCardOuterClass.KeyFigure,
         total: KeyFigureCardOuterClass.KeyFigure
     ): String {
-        return context.getString(R.string.accessibility_statistics_card_announcement) +
-            context.getString(R.string.statistics_card_submission_title) + "\n" +
-            item.getPrimaryLabel(context) +
-            formatStatisticalValue(context, keySubmissions.value, keySubmissions.decimals) + "\n" +
-            context.getString(R.string.statistics_card_infections_secondary_label) +
-            formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals) +
-            getContentDescriptionForTrends(context, sevenDayAverage.trend) + "\n" +
-            context.getString(R.string.statistics_card_infections_tertiary_label) +
-            formatStatisticalValue(context, total.value, total.decimals) +
-            context.getString(R.string.statistics_card_submission_bottom_text) + "\n" +
+        return context.getString(R.string.accessibility_statistics_card_announcement) + " " +
+            context.getString(R.string.statistics_card_submission_title) + " \n " +
+            item.getPrimaryLabel(context) + " " +
+            formatStatisticalValue(context, keySubmissions.value, keySubmissions.decimals) + " \n " +
+            context.getString(R.string.statistics_card_infections_secondary_label) + " " +
+            formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals) + " " +
+            getContentDescriptionForTrends(context, sevenDayAverage.trend) + " \n " +
+            context.getString(R.string.statistics_card_infections_tertiary_label) + " " +
+            formatStatisticalValue(context, total.value, total.decimals) + " " +
+            context.getString(R.string.statistics_card_submission_bottom_text) + " \n " +
             context.getString(R.string.accessibility_statistics_card_navigation_information)
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/KeySubmissionsCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/KeySubmissionsCard.kt
@@ -3,7 +3,9 @@ package de.rki.coronawarnapp.statistics.ui.homecards.cards
 import android.view.ViewGroup
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.HomeStatisticsCardsKeysubmissionsLayoutBinding
+import de.rki.coronawarnapp.server.protocols.internal.stats.KeyFigureCardOuterClass
 import de.rki.coronawarnapp.statistics.KeySubmissionsStats
+import de.rki.coronawarnapp.statistics.StatsItem
 import de.rki.coronawarnapp.statistics.ui.homecards.StatisticsCardAdapter
 import de.rki.coronawarnapp.statistics.util.formatStatisticalValue
 import de.rki.coronawarnapp.statistics.util.getContentDescriptionForTrends
@@ -32,17 +34,51 @@ class KeySubmissionsCard(parent: ViewGroup) :
         }
 
         with(item.stats as KeySubmissionsStats) {
+
+            keysubmissionsContainer.contentDescription =
+                buildAccessibilityStringForKeySubmissionsCard(item.stats, keySubmissions, sevenDayAverage, total);
+
             primaryLabel.text = getPrimaryLabel(context)
             primaryValue.text = formatStatisticalValue(context, keySubmissions.value, keySubmissions.decimals)
-            primaryValue.contentDescription = getPrimaryLabel(context) + formatStatisticalValue(context, keySubmissions.value, keySubmissions.decimals) + context.getString(R.string.statistics_card_submission_title)
+            primaryValue.contentDescription =
+                getPrimaryLabel(context) +
+                    formatStatisticalValue(context, keySubmissions.value, keySubmissions.decimals) +
+                    context.getString(R.string.statistics_card_submission_title)
 
             secondaryValue.text = formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals)
-            secondaryValue.contentDescription = context.getString(R.string.statistics_card_infections_secondary_label ) + formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals) + context.getString(R.string.statistics_card_submission_title) + " " + getContentDescriptionForTrends(context, sevenDayAverage.trend)
+            secondaryValue.contentDescription =
+                context.getString(R.string.statistics_card_infections_secondary_label ) +
+                    formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals) +
+                    context.getString(R.string.statistics_card_submission_title) + " " +
+                    getContentDescriptionForTrends(context, sevenDayAverage.trend)
 
 
             tertiaryValue.text = formatStatisticalValue(context, total.value, total.decimals)
-            tertiaryValue.contentDescription = context.getString(R.string.statistics_card_infections_tertiary_label) + formatStatisticalValue(context, total.value, total.decimals) + context.getString(R.string.statistics_card_submission_title)
+            tertiaryValue.contentDescription =
+                context.getString(R.string.statistics_card_infections_tertiary_label) +
+                    formatStatisticalValue(context, total.value, total.decimals) +
+                    context.getString(R.string.statistics_card_submission_title)
+
             trendArrow.setTrend(sevenDayAverage.trend, sevenDayAverage.trendSemantic)
         }
+    }
+
+    private fun buildAccessibilityStringForKeySubmissionsCard(
+        item: StatsItem,
+        keySubmissions: KeyFigureCardOuterClass.KeyFigure,
+        sevenDayAverage: KeyFigureCardOuterClass.KeyFigure,
+        total: KeyFigureCardOuterClass.KeyFigure)
+        : String {
+        return context.getString(R.string.accessibility_statistics_card_announcement) +
+            context.getString(R.string.statistics_card_submission_title) + "\n" +
+            item.getPrimaryLabel(context)+
+            formatStatisticalValue(context, keySubmissions.value, keySubmissions.decimals) + "\n" +
+            context.getString(R.string.statistics_card_infections_secondary_label ) +
+            formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals) +
+            getContentDescriptionForTrends(context, sevenDayAverage.trend) + "\n" +
+            context.getString(R.string.statistics_card_infections_tertiary_label) +
+            formatStatisticalValue(context, total.value, total.decimals) +
+            context.getString(R.string.statistics_card_submission_bottom_text) + "\n" +
+            context.getString(R.string.accessibility_statistics_card_navigation_information)
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/KeySubmissionsCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/KeySubmissionsCard.kt
@@ -50,7 +50,8 @@ class KeySubmissionsCard(parent: ViewGroup) :
             secondaryValue.text = formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals)
             secondaryValue.contentDescription = StringBuilder()
                 .appendWithTrailingSpace(context.getString(R.string.statistics_card_infections_secondary_label))
-                .appendWithTrailingSpace(formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals))
+                .appendWithTrailingSpace(formatStatisticalValue(context, sevenDayAverage.value,
+                    sevenDayAverage.decimals))
                 .appendWithTrailingSpace(context.getString(R.string.statistics_card_submission_title))
                 .append(getContentDescriptionForTrends(context, sevenDayAverage.trend))
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/KeySubmissionsCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/KeySubmissionsCard.kt
@@ -6,6 +6,7 @@ import de.rki.coronawarnapp.databinding.HomeStatisticsCardsKeysubmissionsLayoutB
 import de.rki.coronawarnapp.statistics.KeySubmissionsStats
 import de.rki.coronawarnapp.statistics.ui.homecards.StatisticsCardAdapter
 import de.rki.coronawarnapp.statistics.util.formatStatisticalValue
+import de.rki.coronawarnapp.statistics.util.getContentDescriptionForTrends
 import de.rki.coronawarnapp.util.formatter.getPrimaryLabel
 
 class KeySubmissionsCard(parent: ViewGroup) :
@@ -33,8 +34,14 @@ class KeySubmissionsCard(parent: ViewGroup) :
         with(item.stats as KeySubmissionsStats) {
             primaryLabel.text = getPrimaryLabel(context)
             primaryValue.text = formatStatisticalValue(context, keySubmissions.value, keySubmissions.decimals)
+            primaryValue.contentDescription = getPrimaryLabel(context) + formatStatisticalValue(context, keySubmissions.value, keySubmissions.decimals) + context.getString(R.string.statistics_card_submission_title)
+
             secondaryValue.text = formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals)
+            secondaryValue.contentDescription = context.getString(R.string.statistics_card_infections_secondary_label ) + formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals) + context.getString(R.string.statistics_card_submission_title) + " " + getContentDescriptionForTrends(context, sevenDayAverage.trend)
+
+
             tertiaryValue.text = formatStatisticalValue(context, total.value, total.decimals)
+            tertiaryValue.contentDescription = context.getString(R.string.statistics_card_infections_tertiary_label) + formatStatisticalValue(context, total.value, total.decimals) + context.getString(R.string.statistics_card_submission_title)
             trendArrow.setTrend(sevenDayAverage.trend, sevenDayAverage.trendSemantic)
         }
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/KeySubmissionsCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/KeySubmissionsCard.kt
@@ -9,6 +9,8 @@ import de.rki.coronawarnapp.statistics.StatsItem
 import de.rki.coronawarnapp.statistics.ui.homecards.StatisticsCardAdapter
 import de.rki.coronawarnapp.statistics.util.formatStatisticalValue
 import de.rki.coronawarnapp.statistics.util.getContentDescriptionForTrends
+import de.rki.coronawarnapp.util.StringBuilderExtension.appendWithLineBreak
+import de.rki.coronawarnapp.util.StringBuilderExtension.appendWithWhiteSpace
 import de.rki.coronawarnapp.util.formatter.getPrimaryLabel
 
 class KeySubmissionsCard(parent: ViewGroup) :
@@ -41,28 +43,21 @@ class KeySubmissionsCard(parent: ViewGroup) :
             primaryLabel.text = getPrimaryLabel(context)
             primaryValue.text = formatStatisticalValue(context, keySubmissions.value, keySubmissions.decimals)
             primaryValue.contentDescription = StringBuilder()
-                .append(getPrimaryLabel(context))
-                .append(" ")
-                .append(formatStatisticalValue(context, keySubmissions.value, keySubmissions.decimals))
-                .append(" ")
+                .appendWithWhiteSpace(getPrimaryLabel(context))
+                .appendWithWhiteSpace(formatStatisticalValue(context, keySubmissions.value, keySubmissions.decimals))
                 .append(context.getString(R.string.statistics_card_submission_title))
 
             secondaryValue.text = formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals)
             secondaryValue.contentDescription = StringBuilder()
-                .append(context.getString(R.string.statistics_card_infections_secondary_label))
-                .append(" ")
-                .append(formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals))
-                .append(" ")
-                .append(context.getString(R.string.statistics_card_submission_title))
-                .append(" ")
+                .appendWithWhiteSpace(context.getString(R.string.statistics_card_infections_secondary_label))
+                .appendWithWhiteSpace(formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals))
+                .appendWithWhiteSpace(context.getString(R.string.statistics_card_submission_title))
                 .append(getContentDescriptionForTrends(context, sevenDayAverage.trend))
 
             tertiaryValue.text = formatStatisticalValue(context, total.value, total.decimals)
             tertiaryValue.contentDescription = StringBuilder()
-                .append(context.getString(R.string.statistics_card_infections_tertiary_label))
-                .append(" ")
-                .append(formatStatisticalValue(context, total.value, total.decimals))
-                .append(" ")
+                .appendWithWhiteSpace(context.getString(R.string.statistics_card_infections_tertiary_label))
+                .appendWithWhiteSpace(formatStatisticalValue(context, total.value, total.decimals))
                 .append(context.getString(R.string.statistics_card_submission_title))
 
             trendArrow.setTrend(sevenDayAverage.trend, sevenDayAverage.trendSemantic)
@@ -77,26 +72,16 @@ class KeySubmissionsCard(parent: ViewGroup) :
     ): StringBuilder {
 
         return StringBuilder()
-            .append(context.getString(R.string.accessibility_statistics_card_announcement))
-            .append(" ")
-            .append(context.getString(R.string.statistics_card_submission_title))
-            .append(" \n ")
-            .append(item.getPrimaryLabel(context))
-            .append(" ")
-            .append(formatStatisticalValue(context, keySubmissions.value, keySubmissions.decimals))
-            .append(" \n ")
-            .append(context.getString(R.string.statistics_card_infections_secondary_label))
-            .append(" ")
-            .append(formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals))
-            .append(" ")
-            .append(getContentDescriptionForTrends(context, sevenDayAverage.trend))
-            .append(" \n ")
-            .append(context.getString(R.string.statistics_card_infections_tertiary_label))
-            .append(" ")
-            .append(formatStatisticalValue(context, total.value, total.decimals))
-            .append(" ")
-            .append(context.getString(R.string.statistics_card_submission_bottom_text))
-            .append(" \n ")
+            .appendWithWhiteSpace(context.getString(R.string.accessibility_statistics_card_announcement))
+            .appendWithLineBreak(context.getString(R.string.statistics_card_submission_title))
+            .appendWithWhiteSpace(item.getPrimaryLabel(context))
+            .appendWithLineBreak(formatStatisticalValue(context, keySubmissions.value, keySubmissions.decimals))
+            .appendWithWhiteSpace(context.getString(R.string.statistics_card_infections_secondary_label))
+            .appendWithWhiteSpace(formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals))
+            .appendWithLineBreak(getContentDescriptionForTrends(context, sevenDayAverage.trend))
+            .appendWithWhiteSpace(context.getString(R.string.statistics_card_infections_tertiary_label))
+            .appendWithWhiteSpace(formatStatisticalValue(context, total.value, total.decimals))
+            .appendWithLineBreak(context.getString(R.string.statistics_card_submission_bottom_text))
             .append(context.getString(R.string.accessibility_statistics_card_navigation_information))
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/KeySubmissionsCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/KeySubmissionsCard.kt
@@ -1,6 +1,5 @@
 package de.rki.coronawarnapp.statistics.ui.homecards.cards
 
-import android.util.Log
 import android.view.ViewGroup
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.HomeStatisticsCardsKeysubmissionsLayoutBinding

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/KeySubmissionsCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/KeySubmissionsCard.kt
@@ -10,7 +10,7 @@ import de.rki.coronawarnapp.statistics.ui.homecards.StatisticsCardAdapter
 import de.rki.coronawarnapp.statistics.util.formatStatisticalValue
 import de.rki.coronawarnapp.statistics.util.getContentDescriptionForTrends
 import de.rki.coronawarnapp.util.StringBuilderExtension.appendWithLineBreak
-import de.rki.coronawarnapp.util.StringBuilderExtension.appendWithWhiteSpace
+import de.rki.coronawarnapp.util.StringBuilderExtension.appendWithTrailingSpace
 import de.rki.coronawarnapp.util.formatter.getPrimaryLabel
 
 class KeySubmissionsCard(parent: ViewGroup) :
@@ -43,21 +43,21 @@ class KeySubmissionsCard(parent: ViewGroup) :
             primaryLabel.text = getPrimaryLabel(context)
             primaryValue.text = formatStatisticalValue(context, keySubmissions.value, keySubmissions.decimals)
             primaryValue.contentDescription = StringBuilder()
-                .appendWithWhiteSpace(getPrimaryLabel(context))
-                .appendWithWhiteSpace(formatStatisticalValue(context, keySubmissions.value, keySubmissions.decimals))
+                .appendWithTrailingSpace(getPrimaryLabel(context))
+                .appendWithTrailingSpace(formatStatisticalValue(context, keySubmissions.value, keySubmissions.decimals))
                 .append(context.getString(R.string.statistics_card_submission_title))
 
             secondaryValue.text = formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals)
             secondaryValue.contentDescription = StringBuilder()
-                .appendWithWhiteSpace(context.getString(R.string.statistics_card_infections_secondary_label))
-                .appendWithWhiteSpace(formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals))
-                .appendWithWhiteSpace(context.getString(R.string.statistics_card_submission_title))
+                .appendWithTrailingSpace(context.getString(R.string.statistics_card_infections_secondary_label))
+                .appendWithTrailingSpace(formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals))
+                .appendWithTrailingSpace(context.getString(R.string.statistics_card_submission_title))
                 .append(getContentDescriptionForTrends(context, sevenDayAverage.trend))
 
             tertiaryValue.text = formatStatisticalValue(context, total.value, total.decimals)
             tertiaryValue.contentDescription = StringBuilder()
-                .appendWithWhiteSpace(context.getString(R.string.statistics_card_infections_tertiary_label))
-                .appendWithWhiteSpace(formatStatisticalValue(context, total.value, total.decimals))
+                .appendWithTrailingSpace(context.getString(R.string.statistics_card_infections_tertiary_label))
+                .appendWithTrailingSpace(formatStatisticalValue(context, total.value, total.decimals))
                 .append(context.getString(R.string.statistics_card_submission_title))
 
             trendArrow.setTrend(sevenDayAverage.trend, sevenDayAverage.trendSemantic)
@@ -72,15 +72,15 @@ class KeySubmissionsCard(parent: ViewGroup) :
     ): StringBuilder {
 
         return StringBuilder()
-            .appendWithWhiteSpace(context.getString(R.string.accessibility_statistics_card_announcement))
+            .appendWithTrailingSpace(context.getString(R.string.accessibility_statistics_card_announcement))
             .appendWithLineBreak(context.getString(R.string.statistics_card_submission_title))
-            .appendWithWhiteSpace(item.getPrimaryLabel(context))
+            .appendWithTrailingSpace(item.getPrimaryLabel(context))
             .appendWithLineBreak(formatStatisticalValue(context, keySubmissions.value, keySubmissions.decimals))
-            .appendWithWhiteSpace(context.getString(R.string.statistics_card_infections_secondary_label))
-            .appendWithWhiteSpace(formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals))
+            .appendWithTrailingSpace(context.getString(R.string.statistics_card_infections_secondary_label))
+            .appendWithTrailingSpace(formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals))
             .appendWithLineBreak(getContentDescriptionForTrends(context, sevenDayAverage.trend))
-            .appendWithWhiteSpace(context.getString(R.string.statistics_card_infections_tertiary_label))
-            .appendWithWhiteSpace(formatStatisticalValue(context, total.value, total.decimals))
+            .appendWithTrailingSpace(context.getString(R.string.statistics_card_infections_tertiary_label))
+            .appendWithTrailingSpace(formatStatisticalValue(context, total.value, total.decimals))
             .appendWithLineBreak(context.getString(R.string.statistics_card_submission_bottom_text))
             .append(context.getString(R.string.accessibility_statistics_card_navigation_information))
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/KeySubmissionsCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/KeySubmissionsCard.kt
@@ -36,7 +36,7 @@ class KeySubmissionsCard(parent: ViewGroup) :
         with(item.stats as KeySubmissionsStats) {
 
             keysubmissionsContainer.contentDescription =
-                buildAccessibilityStringForKeySubmissionsCard(item.stats, keySubmissions, sevenDayAverage, total);
+                buildAccessibilityStringForKeySubmissionsCard(item.stats, keySubmissions, sevenDayAverage, total)
 
             primaryLabel.text = getPrimaryLabel(context)
             primaryValue.text = formatStatisticalValue(context, keySubmissions.value, keySubmissions.decimals)
@@ -47,11 +47,10 @@ class KeySubmissionsCard(parent: ViewGroup) :
 
             secondaryValue.text = formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals)
             secondaryValue.contentDescription =
-                context.getString(R.string.statistics_card_infections_secondary_label ) +
+                context.getString(R.string.statistics_card_infections_secondary_label) +
                     formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals) +
                     context.getString(R.string.statistics_card_submission_title) + " " +
                     getContentDescriptionForTrends(context, sevenDayAverage.trend)
-
 
             tertiaryValue.text = formatStatisticalValue(context, total.value, total.decimals)
             tertiaryValue.contentDescription =
@@ -67,13 +66,13 @@ class KeySubmissionsCard(parent: ViewGroup) :
         item: StatsItem,
         keySubmissions: KeyFigureCardOuterClass.KeyFigure,
         sevenDayAverage: KeyFigureCardOuterClass.KeyFigure,
-        total: KeyFigureCardOuterClass.KeyFigure)
-        : String {
+        total: KeyFigureCardOuterClass.KeyFigure
+    ): String {
         return context.getString(R.string.accessibility_statistics_card_announcement) +
             context.getString(R.string.statistics_card_submission_title) + "\n" +
-            item.getPrimaryLabel(context)+
+            item.getPrimaryLabel(context) +
             formatStatisticalValue(context, keySubmissions.value, keySubmissions.decimals) + "\n" +
-            context.getString(R.string.statistics_card_infections_secondary_label ) +
+            context.getString(R.string.statistics_card_infections_secondary_label) +
             formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals) +
             getContentDescriptionForTrends(context, sevenDayAverage.trend) + "\n" +
             context.getString(R.string.statistics_card_infections_tertiary_label) +

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/KeySubmissionsCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/KeySubmissionsCard.kt
@@ -40,23 +40,30 @@ class KeySubmissionsCard(parent: ViewGroup) :
 
             primaryLabel.text = getPrimaryLabel(context)
             primaryValue.text = formatStatisticalValue(context, keySubmissions.value, keySubmissions.decimals)
-            primaryValue.contentDescription =
-                getPrimaryLabel(context) + " " +
-                    formatStatisticalValue(context, keySubmissions.value, keySubmissions.decimals) + " " +
-                    context.getString(R.string.statistics_card_submission_title)
+            primaryValue.contentDescription = StringBuilder()
+                .append(getPrimaryLabel(context))
+                .append(" ")
+                .append(formatStatisticalValue(context, keySubmissions.value, keySubmissions.decimals))
+                .append(" ")
+                .append(context.getString(R.string.statistics_card_submission_title))
 
             secondaryValue.text = formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals)
-            secondaryValue.contentDescription =
-                context.getString(R.string.statistics_card_infections_secondary_label) + " " +
-                    formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals) + " " +
-                    context.getString(R.string.statistics_card_submission_title) + " " +
-                    getContentDescriptionForTrends(context, sevenDayAverage.trend)
+            secondaryValue.contentDescription = StringBuilder()
+                .append(context.getString(R.string.statistics_card_infections_secondary_label))
+                .append(" ")
+                .append(formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals))
+                .append(" ")
+                .append(context.getString(R.string.statistics_card_submission_title))
+                .append(" ")
+                .append(getContentDescriptionForTrends(context, sevenDayAverage.trend))
 
             tertiaryValue.text = formatStatisticalValue(context, total.value, total.decimals)
-            tertiaryValue.contentDescription =
-                context.getString(R.string.statistics_card_infections_tertiary_label) + " " +
-                    formatStatisticalValue(context, total.value, total.decimals) + " " +
-                    context.getString(R.string.statistics_card_submission_title)
+            tertiaryValue.contentDescription = StringBuilder()
+                .append(context.getString(R.string.statistics_card_infections_tertiary_label))
+                .append(" ")
+                .append(formatStatisticalValue(context, total.value, total.decimals))
+                .append(" ")
+                .append(context.getString(R.string.statistics_card_submission_title))
 
             trendArrow.setTrend(sevenDayAverage.trend, sevenDayAverage.trendSemantic)
         }
@@ -67,17 +74,29 @@ class KeySubmissionsCard(parent: ViewGroup) :
         keySubmissions: KeyFigureCardOuterClass.KeyFigure,
         sevenDayAverage: KeyFigureCardOuterClass.KeyFigure,
         total: KeyFigureCardOuterClass.KeyFigure
-    ): String {
-        return context.getString(R.string.accessibility_statistics_card_announcement) + " " +
-            context.getString(R.string.statistics_card_submission_title) + " \n " +
-            item.getPrimaryLabel(context) + " " +
-            formatStatisticalValue(context, keySubmissions.value, keySubmissions.decimals) + " \n " +
-            context.getString(R.string.statistics_card_infections_secondary_label) + " " +
-            formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals) + " " +
-            getContentDescriptionForTrends(context, sevenDayAverage.trend) + " \n " +
-            context.getString(R.string.statistics_card_infections_tertiary_label) + " " +
-            formatStatisticalValue(context, total.value, total.decimals) + " " +
-            context.getString(R.string.statistics_card_submission_bottom_text) + " \n " +
-            context.getString(R.string.accessibility_statistics_card_navigation_information)
+    ): StringBuilder {
+
+        return StringBuilder()
+            .append(context.getString(R.string.accessibility_statistics_card_announcement))
+            .append(" ")
+            .append(context.getString(R.string.statistics_card_submission_title))
+            .append(" \n ")
+            .append(item.getPrimaryLabel(context))
+            .append(" ")
+            .append(formatStatisticalValue(context, keySubmissions.value, keySubmissions.decimals))
+            .append(" \n ")
+            .append(context.getString(R.string.statistics_card_infections_secondary_label))
+            .append(" ")
+            .append(formatStatisticalValue(context, sevenDayAverage.value, sevenDayAverage.decimals))
+            .append(" ")
+            .append(getContentDescriptionForTrends(context, sevenDayAverage.trend))
+            .append(" \n ")
+            .append(context.getString(R.string.statistics_card_infections_tertiary_label))
+            .append(" ")
+            .append(formatStatisticalValue(context, total.value, total.decimals))
+            .append(" ")
+            .append(context.getString(R.string.statistics_card_submission_bottom_text))
+            .append(" \n ")
+            .append(context.getString(R.string.accessibility_statistics_card_navigation_information))
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/SevenDayRValueCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/SevenDayRValueCard.kt
@@ -1,7 +1,6 @@
 package de.rki.coronawarnapp.statistics.ui.homecards.cards
 
 import android.view.ViewGroup
-import androidx.core.view.contains
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.HomeStatisticsCardsSevendayrvalueLayoutBinding
 import de.rki.coronawarnapp.server.protocols.internal.stats.KeyFigureCardOuterClass
@@ -12,7 +11,7 @@ import de.rki.coronawarnapp.statistics.util.formatStatisticalValue
 import de.rki.coronawarnapp.statistics.util.getContentDescriptionForTrends
 import de.rki.coronawarnapp.statistics.util.getLocalizedSpannableString
 import de.rki.coronawarnapp.util.StringBuilderExtension.appendWithLineBreak
-import de.rki.coronawarnapp.util.StringBuilderExtension.appendWithWhiteSpace
+import de.rki.coronawarnapp.util.StringBuilderExtension.appendWithTrailingSpace
 import de.rki.coronawarnapp.util.formatter.getPrimaryLabel
 
 class SevenDayRValueCard(parent: ViewGroup) :
@@ -49,9 +48,9 @@ class SevenDayRValueCard(parent: ViewGroup) :
             )
 
             primaryValue.contentDescription = StringBuilder()
-                .appendWithWhiteSpace(context.getString(R.string.statistics_title_reproduction))
-                .appendWithWhiteSpace(getPrimaryLabel(context))
-                .appendWithWhiteSpace(formatStatisticalValue(context, reproductionNumber.value,
+                .appendWithTrailingSpace(context.getString(R.string.statistics_title_reproduction))
+                .appendWithTrailingSpace(getPrimaryLabel(context))
+                .appendWithTrailingSpace(formatStatisticalValue(context, reproductionNumber.value,
                     reproductionNumber.decimals))
                 .append(getContentDescriptionForTrends(context, reproductionNumber.trend))
 
@@ -65,12 +64,12 @@ class SevenDayRValueCard(parent: ViewGroup) :
     ): StringBuilder {
 
         return StringBuilder()
-            .appendWithWhiteSpace(context.getString(R.string.accessibility_statistics_card_announcement))
+            .appendWithTrailingSpace(context.getString(R.string.accessibility_statistics_card_announcement))
             .appendWithLineBreak(context.getString(R.string.statistics_title_reproduction))
-            .appendWithWhiteSpace(item.getPrimaryLabel(context))
-            .appendWithWhiteSpace(formatStatisticalValue(context, reproductionNumber.value,
+            .appendWithTrailingSpace(item.getPrimaryLabel(context))
+            .appendWithTrailingSpace(formatStatisticalValue(context, reproductionNumber.value,
                 reproductionNumber.decimals))
-            .appendWithWhiteSpace(context.getString(R.string.statistics_reproduction_average))
+            .appendWithTrailingSpace(context.getString(R.string.statistics_reproduction_average))
             .appendWithLineBreak(getContentDescriptionForTrends(context, reproductionNumber.trend))
             .append(context.getString(R.string.accessibility_statistics_card_navigation_information))
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/SevenDayRValueCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/SevenDayRValueCard.kt
@@ -11,6 +11,8 @@ import de.rki.coronawarnapp.statistics.ui.homecards.StatisticsCardAdapter
 import de.rki.coronawarnapp.statistics.util.formatStatisticalValue
 import de.rki.coronawarnapp.statistics.util.getContentDescriptionForTrends
 import de.rki.coronawarnapp.statistics.util.getLocalizedSpannableString
+import de.rki.coronawarnapp.util.StringBuilderExtension.appendWithLineBreak
+import de.rki.coronawarnapp.util.StringBuilderExtension.appendWithWhiteSpace
 import de.rki.coronawarnapp.util.formatter.getPrimaryLabel
 
 class SevenDayRValueCard(parent: ViewGroup) :
@@ -47,12 +49,9 @@ class SevenDayRValueCard(parent: ViewGroup) :
             )
 
             primaryValue.contentDescription = StringBuilder()
-                .append(context.getString(R.string.statistics_title_reproduction))
-                .append(" ")
-                .append(getPrimaryLabel(context))
-                .append(" ")
-                .append(formatStatisticalValue(context, reproductionNumber.value, reproductionNumber.decimals))
-                .append(" ")
+                .appendWithWhiteSpace(context.getString(R.string.statistics_title_reproduction))
+                .appendWithWhiteSpace(getPrimaryLabel(context))
+                .appendWithWhiteSpace(formatStatisticalValue(context, reproductionNumber.value, reproductionNumber.decimals))
                 .append(getContentDescriptionForTrends(context, reproductionNumber.trend))
 
             trendArrow.setTrend(reproductionNumber.trend, reproductionNumber.trendSemantic)
@@ -65,18 +64,12 @@ class SevenDayRValueCard(parent: ViewGroup) :
     ): StringBuilder {
 
         return StringBuilder()
-            .append(context.getString(R.string.accessibility_statistics_card_announcement))
-            .append(" ")
-            .append(context.getString(R.string.statistics_title_reproduction))
-            .append(" \n ")
-            .append(item.getPrimaryLabel(context))
-            .append(" ")
-            .append(formatStatisticalValue(context, reproductionNumber.value, reproductionNumber.decimals))
-            .append(" ")
-            .append(context.getString(R.string.statistics_card_incidence_value_description))
-            .append(" ")
-            .append(getContentDescriptionForTrends(context, reproductionNumber.trend))
-            .append(" \n ")
+            .appendWithWhiteSpace(context.getString(R.string.accessibility_statistics_card_announcement))
+            .appendWithLineBreak(context.getString(R.string.statistics_title_reproduction))
+            .appendWithWhiteSpace(item.getPrimaryLabel(context))
+            .appendWithWhiteSpace(formatStatisticalValue(context, reproductionNumber.value, reproductionNumber.decimals))
+            .appendWithWhiteSpace(context.getString(R.string.statistics_card_incidence_value_description))
+            .appendWithLineBreak(getContentDescriptionForTrends(context, reproductionNumber.trend))
             .append(context.getString(R.string.accessibility_statistics_card_navigation_information))
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/SevenDayRValueCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/SevenDayRValueCard.kt
@@ -1,9 +1,12 @@
 package de.rki.coronawarnapp.statistics.ui.homecards.cards
 
 import android.view.ViewGroup
+import androidx.core.view.contains
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.HomeStatisticsCardsSevendayrvalueLayoutBinding
+import de.rki.coronawarnapp.server.protocols.internal.stats.KeyFigureCardOuterClass
 import de.rki.coronawarnapp.statistics.SevenDayRValue
+import de.rki.coronawarnapp.statistics.StatsItem
 import de.rki.coronawarnapp.statistics.ui.homecards.StatisticsCardAdapter
 import de.rki.coronawarnapp.statistics.util.formatStatisticalValue
 import de.rki.coronawarnapp.statistics.util.getContentDescriptionForTrends
@@ -33,15 +36,37 @@ class SevenDayRValueCard(parent: ViewGroup) :
         }
 
         with(item.stats as SevenDayRValue) {
+
+            sevenDayRValueContainer.contentDescription =
+                buildAccessibilityStringForSevenDayRValueCard(item.stats, reproductionNumber)
+
             primaryLabel.text = getPrimaryLabel(context)
             primaryValue.text = getLocalizedSpannableString(
                 context,
                 formatStatisticalValue(context, reproductionNumber.value, reproductionNumber.decimals)
             )
 
-            primaryValue.contentDescription = context.getString(R.string.statistics_title_reproduction) + " " + getPrimaryLabel(context) + " " + formatStatisticalValue(context, reproductionNumber.value, reproductionNumber.decimals) + getContentDescriptionForTrends(context, reproductionNumber.trend)
+            primaryValue.contentDescription =
+                context.getString(R.string.statistics_title_reproduction) + " " +
+                    getPrimaryLabel(context) + " " +
+                    formatStatisticalValue(context, reproductionNumber.value, reproductionNumber.decimals) +
+                    getContentDescriptionForTrends(context, reproductionNumber.trend)
+
             trendArrow.setTrend(reproductionNumber.trend, reproductionNumber.trendSemantic)
         }
+    }
+
+    private fun buildAccessibilityStringForSevenDayRValueCard(
+        item: StatsItem,
+        reproductionNumber: KeyFigureCardOuterClass.KeyFigure)
+    : String {
+        return context.getString(R.string.accessibility_statistics_card_announcement) +
+            context.getString(R.string.statistics_title_reproduction) + "\n" +
+            item.getPrimaryLabel(context) + " " +
+            formatStatisticalValue(context, reproductionNumber.value, reproductionNumber.decimals) +
+            context.getString(R.string.statistics_card_incidence_value_description) + " " +
+            getContentDescriptionForTrends(context, reproductionNumber.trend) + "\n" +
+            context.getString(R.string.accessibility_statistics_card_navigation_information)
     }
     
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/SevenDayRValueCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/SevenDayRValueCard.kt
@@ -49,7 +49,7 @@ class SevenDayRValueCard(parent: ViewGroup) :
             primaryValue.contentDescription =
                 context.getString(R.string.statistics_title_reproduction) + " " +
                     getPrimaryLabel(context) + " " +
-                    formatStatisticalValue(context, reproductionNumber.value, reproductionNumber.decimals) +
+                    formatStatisticalValue(context, reproductionNumber.value, reproductionNumber.decimals) + " " +
                     getContentDescriptionForTrends(context, reproductionNumber.trend)
 
             trendArrow.setTrend(reproductionNumber.trend, reproductionNumber.trendSemantic)
@@ -60,10 +60,10 @@ class SevenDayRValueCard(parent: ViewGroup) :
         item: StatsItem,
         reproductionNumber: KeyFigureCardOuterClass.KeyFigure
     ): String {
-        return context.getString(R.string.accessibility_statistics_card_announcement) +
+        return context.getString(R.string.accessibility_statistics_card_announcement) + " " +
             context.getString(R.string.statistics_title_reproduction) + "\n" +
             item.getPrimaryLabel(context) + " " +
-            formatStatisticalValue(context, reproductionNumber.value, reproductionNumber.decimals) +
+            formatStatisticalValue(context, reproductionNumber.value, reproductionNumber.decimals) + " " +
             context.getString(R.string.statistics_card_incidence_value_description) + " " +
             getContentDescriptionForTrends(context, reproductionNumber.trend) + "\n" +
             context.getString(R.string.accessibility_statistics_card_navigation_information)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/SevenDayRValueCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/SevenDayRValueCard.kt
@@ -58,8 +58,8 @@ class SevenDayRValueCard(parent: ViewGroup) :
 
     private fun buildAccessibilityStringForSevenDayRValueCard(
         item: StatsItem,
-        reproductionNumber: KeyFigureCardOuterClass.KeyFigure)
-    : String {
+        reproductionNumber: KeyFigureCardOuterClass.KeyFigure
+    ): String {
         return context.getString(R.string.accessibility_statistics_card_announcement) +
             context.getString(R.string.statistics_title_reproduction) + "\n" +
             item.getPrimaryLabel(context) + " " +
@@ -68,5 +68,4 @@ class SevenDayRValueCard(parent: ViewGroup) :
             getContentDescriptionForTrends(context, reproductionNumber.trend) + "\n" +
             context.getString(R.string.accessibility_statistics_card_navigation_information)
     }
-    
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/SevenDayRValueCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/SevenDayRValueCard.kt
@@ -46,11 +46,14 @@ class SevenDayRValueCard(parent: ViewGroup) :
                 formatStatisticalValue(context, reproductionNumber.value, reproductionNumber.decimals)
             )
 
-            primaryValue.contentDescription =
-                context.getString(R.string.statistics_title_reproduction) + " " +
-                    getPrimaryLabel(context) + " " +
-                    formatStatisticalValue(context, reproductionNumber.value, reproductionNumber.decimals) + " " +
-                    getContentDescriptionForTrends(context, reproductionNumber.trend)
+            primaryValue.contentDescription = StringBuilder()
+                .append(context.getString(R.string.statistics_title_reproduction))
+                .append(" ")
+                .append(getPrimaryLabel(context))
+                .append(" ")
+                .append(formatStatisticalValue(context, reproductionNumber.value, reproductionNumber.decimals))
+                .append(" ")
+                .append(getContentDescriptionForTrends(context, reproductionNumber.trend))
 
             trendArrow.setTrend(reproductionNumber.trend, reproductionNumber.trendSemantic)
         }
@@ -59,13 +62,21 @@ class SevenDayRValueCard(parent: ViewGroup) :
     private fun buildAccessibilityStringForSevenDayRValueCard(
         item: StatsItem,
         reproductionNumber: KeyFigureCardOuterClass.KeyFigure
-    ): String {
-        return context.getString(R.string.accessibility_statistics_card_announcement) + " " +
-            context.getString(R.string.statistics_title_reproduction) + "\n" +
-            item.getPrimaryLabel(context) + " " +
-            formatStatisticalValue(context, reproductionNumber.value, reproductionNumber.decimals) + " " +
-            context.getString(R.string.statistics_card_incidence_value_description) + " " +
-            getContentDescriptionForTrends(context, reproductionNumber.trend) + "\n" +
-            context.getString(R.string.accessibility_statistics_card_navigation_information)
+    ): StringBuilder {
+
+        return StringBuilder()
+            .append(context.getString(R.string.accessibility_statistics_card_announcement))
+            .append(" ")
+            .append(context.getString(R.string.statistics_title_reproduction))
+            .append(" \n ")
+            .append(item.getPrimaryLabel(context))
+            .append(" ")
+            .append(formatStatisticalValue(context, reproductionNumber.value, reproductionNumber.decimals))
+            .append(" ")
+            .append(context.getString(R.string.statistics_card_incidence_value_description))
+            .append(" ")
+            .append(getContentDescriptionForTrends(context, reproductionNumber.trend))
+            .append(" \n ")
+            .append(context.getString(R.string.accessibility_statistics_card_navigation_information))
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/SevenDayRValueCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/SevenDayRValueCard.kt
@@ -70,7 +70,7 @@ class SevenDayRValueCard(parent: ViewGroup) :
             .appendWithWhiteSpace(item.getPrimaryLabel(context))
             .appendWithWhiteSpace(formatStatisticalValue(context, reproductionNumber.value,
                 reproductionNumber.decimals))
-            .appendWithWhiteSpace(context.getString(R.string.statistics_card_incidence_value_description))
+            .appendWithWhiteSpace(context.getString(R.string.statistics_reproduction_average))
             .appendWithLineBreak(getContentDescriptionForTrends(context, reproductionNumber.trend))
             .append(context.getString(R.string.accessibility_statistics_card_navigation_information))
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/SevenDayRValueCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/SevenDayRValueCard.kt
@@ -6,6 +6,7 @@ import de.rki.coronawarnapp.databinding.HomeStatisticsCardsSevendayrvalueLayoutB
 import de.rki.coronawarnapp.statistics.SevenDayRValue
 import de.rki.coronawarnapp.statistics.ui.homecards.StatisticsCardAdapter
 import de.rki.coronawarnapp.statistics.util.formatStatisticalValue
+import de.rki.coronawarnapp.statistics.util.getContentDescriptionForTrends
 import de.rki.coronawarnapp.statistics.util.getLocalizedSpannableString
 import de.rki.coronawarnapp.util.formatter.getPrimaryLabel
 
@@ -37,7 +38,10 @@ class SevenDayRValueCard(parent: ViewGroup) :
                 context,
                 formatStatisticalValue(context, reproductionNumber.value, reproductionNumber.decimals)
             )
+
+            primaryValue.contentDescription = context.getString(R.string.statistics_title_reproduction) + " " + getPrimaryLabel(context) + " " + formatStatisticalValue(context, reproductionNumber.value, reproductionNumber.decimals) + getContentDescriptionForTrends(context, reproductionNumber.trend)
             trendArrow.setTrend(reproductionNumber.trend, reproductionNumber.trendSemantic)
         }
     }
+    
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/SevenDayRValueCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/SevenDayRValueCard.kt
@@ -51,7 +51,8 @@ class SevenDayRValueCard(parent: ViewGroup) :
             primaryValue.contentDescription = StringBuilder()
                 .appendWithWhiteSpace(context.getString(R.string.statistics_title_reproduction))
                 .appendWithWhiteSpace(getPrimaryLabel(context))
-                .appendWithWhiteSpace(formatStatisticalValue(context, reproductionNumber.value, reproductionNumber.decimals))
+                .appendWithWhiteSpace(formatStatisticalValue(context, reproductionNumber.value,
+                    reproductionNumber.decimals))
                 .append(getContentDescriptionForTrends(context, reproductionNumber.trend))
 
             trendArrow.setTrend(reproductionNumber.trend, reproductionNumber.trendSemantic)
@@ -67,7 +68,8 @@ class SevenDayRValueCard(parent: ViewGroup) :
             .appendWithWhiteSpace(context.getString(R.string.accessibility_statistics_card_announcement))
             .appendWithLineBreak(context.getString(R.string.statistics_title_reproduction))
             .appendWithWhiteSpace(item.getPrimaryLabel(context))
-            .appendWithWhiteSpace(formatStatisticalValue(context, reproductionNumber.value, reproductionNumber.decimals))
+            .appendWithWhiteSpace(formatStatisticalValue(context, reproductionNumber.value,
+                reproductionNumber.decimals))
             .appendWithWhiteSpace(context.getString(R.string.statistics_card_incidence_value_description))
             .appendWithLineBreak(getContentDescriptionForTrends(context, reproductionNumber.trend))
             .append(context.getString(R.string.accessibility_statistics_card_navigation_information))

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/util/AccessibilityHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/util/AccessibilityHelper.kt
@@ -3,11 +3,26 @@ package de.rki.coronawarnapp.statistics.util
 import android.content.Context
 import android.text.SpannableString
 import android.text.style.LocaleSpan
+import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.contactdiary.util.getLocale
+import de.rki.coronawarnapp.server.protocols.internal.stats.KeyFigureCardOuterClass
 
 /**
  * returns localized spannable string so that screen readers read out decimal values appropriately
  */
 fun getLocalizedSpannableString(context: Context, source: String) = SpannableString(source).apply {
     setSpan(LocaleSpan(context.getLocale()), 0, this.length, 0)
+}
+
+fun getContentDescriptionForTrends(
+    context: Context,
+    trend: KeyFigureCardOuterClass.KeyFigure.Trend
+):String {
+    return context.getString(
+        when (trend) {
+            KeyFigureCardOuterClass.KeyFigure.Trend.INCREASING -> R.string.statistics_trend_increasing
+            KeyFigureCardOuterClass.KeyFigure.Trend.DECREASING -> R.string.statistics_trend_decreasing
+            else -> R.string.statistics_trend_stable
+        }
+    )
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/util/AccessibilityHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/util/AccessibilityHelper.kt
@@ -17,7 +17,7 @@ fun getLocalizedSpannableString(context: Context, source: String) = SpannableStr
 fun getContentDescriptionForTrends(
     context: Context,
     trend: KeyFigureCardOuterClass.KeyFigure.Trend
-):String {
+): String {
     return context.getString(
         when (trend) {
             KeyFigureCardOuterClass.KeyFigure.Trend.INCREASING -> R.string.statistics_trend_increasing

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/StringBuilderExtension.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/StringBuilderExtension.kt
@@ -4,6 +4,6 @@ import kotlin.text.StringBuilder
 
 object StringBuilderExtension {
 
-    fun StringBuilder.appendWithWhiteSpace(str: String): StringBuilder = this.append(str).append(" ")
+    fun StringBuilder.appendWithTrailingSpace(str: String): StringBuilder = this.append(str).append(" ")
     fun StringBuilder.appendWithLineBreak(str: String): StringBuilder = this.append(str).append(" \n ")
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/StringBuilderExtension.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/StringBuilderExtension.kt
@@ -1,0 +1,9 @@
+package de.rki.coronawarnapp.util
+
+import kotlin.text.StringBuilder
+
+object StringBuilderExtension {
+
+    fun StringBuilder.appendWithWhiteSpace(str: String): StringBuilder = this.append(str).append(" ")
+    fun StringBuilder.appendWithLineBreak(str: String): StringBuilder = this.append(str).append(" \n ")
+}

--- a/Corona-Warn-App/src/main/res/layout/home_statistics_cards_incidence_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_statistics_cards_incidence_layout.xml
@@ -26,6 +26,7 @@
             android:id="@+id/title"
             style="@style/headline5"
             android:layout_width="0dp"
+            android:focusable="true"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/spacing_normal"
             android:layout_marginTop="@dimen/spacing_normal"

--- a/Corona-Warn-App/src/main/res/layout/home_statistics_cards_incidence_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_statistics_cards_incidence_layout.xml
@@ -16,6 +16,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:importantForAccessibility="no"
+            android:contentDescription="@null"
             android:src="@drawable/ic_statistics_incidence"
             android:paddingStart="0dp"
             android:paddingEnd="@dimen/spacing_small"
@@ -48,6 +49,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:includeFontPadding="false"
+            android:focusable="true"
             tools:text="98,9" />
 
         <TextView

--- a/Corona-Warn-App/src/main/res/layout/home_statistics_cards_incidence_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_statistics_cards_incidence_layout.xml
@@ -9,6 +9,7 @@
         android:layout_height="wrap_content"
         tools:layout_height="wrap_content"
         tools:layout_width="@dimen/statistics_card_width"
+        android:id="@+id/incidence_container"
         tools:showIn="@layout/home_statistics_cards_basecard_layout">
 
         <androidx.appcompat.widget.AppCompatImageView
@@ -27,7 +28,6 @@
             android:id="@+id/title"
             style="@style/headline5"
             android:layout_width="0dp"
-            android:focusable="true"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/spacing_normal"
             android:layout_marginTop="@dimen/spacing_normal"

--- a/Corona-Warn-App/src/main/res/layout/home_statistics_cards_infections_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_statistics_cards_infections_layout.xml
@@ -9,6 +9,7 @@
         android:layout_height="wrap_content"
         tools:layout_height="wrap_content"
         tools:layout_width="@dimen/statistics_card_width"
+        android:id="@+id/infections_container"
         tools:showIn="@layout/home_statistics_cards_basecard_layout">
 
         <androidx.appcompat.widget.AppCompatImageView
@@ -16,6 +17,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:importantForAccessibility="no"
+            android:contentDescription="@null"
             android:src="@drawable/ic_main_illustration_infection"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@id/flow_layout" />
@@ -23,6 +25,7 @@
         <TextView
             android:id="@+id/title"
             style="@style/headline5"
+            android:focusable="true"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/spacing_normal"
@@ -42,6 +45,7 @@
         <TextView
             android:id="@+id/primary_value"
             style="@style/StatisticsCardPrimaryValue"
+            android:focusable="true"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:includeFontPadding="false"
@@ -58,6 +62,7 @@
         <TextView
             android:id="@+id/secondary_value"
             style="@style/StatisticsCardSecondaryValue"
+            android:focusable="true"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             tools:text="11.981" />
@@ -81,6 +86,7 @@
 
         <TextView
             android:id="@+id/tertiary_value"
+            android:focusable="true"
             style="@style/StatisticsCardSecondaryValue"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/Corona-Warn-App/src/main/res/layout/home_statistics_cards_infections_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_statistics_cards_infections_layout.xml
@@ -25,7 +25,6 @@
         <TextView
             android:id="@+id/title"
             style="@style/headline5"
-            android:focusable="true"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/spacing_normal"

--- a/Corona-Warn-App/src/main/res/layout/home_statistics_cards_keysubmissions_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_statistics_cards_keysubmissions_layout.xml
@@ -16,6 +16,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:importantForAccessibility="no"
+            android:contentDescription="@null"
             android:src="@drawable/ic_main_illustration_warnende_personen"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@id/flow_layout" />
@@ -42,6 +43,7 @@
         <TextView
             android:id="@+id/primary_value"
             style="@style/StatisticsCardPrimaryValue"
+            android:focusable="true"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:includeFontPadding="false"
@@ -58,6 +60,7 @@
         <TextView
             android:id="@+id/secondary_value"
             style="@style/StatisticsCardSecondaryValue"
+            android:focusable="true"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             tools:text="1.812" />
@@ -83,6 +86,7 @@
             android:id="@+id/tertiary_value"
             style="@style/StatisticsCardSecondaryValue"
             android:layout_width="wrap_content"
+            android:focusable="true"
             android:layout_height="wrap_content"
             tools:text="20.922" />
 

--- a/Corona-Warn-App/src/main/res/layout/home_statistics_cards_keysubmissions_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_statistics_cards_keysubmissions_layout.xml
@@ -9,6 +9,7 @@
         android:layout_height="wrap_content"
         tools:layout_height="wrap_content"
         tools:layout_width="@dimen/statistics_card_width"
+        android:id="@+id/keysubmissions_container"
         tools:showIn="@layout/home_statistics_cards_basecard_layout">
 
         <androidx.appcompat.widget.AppCompatImageView

--- a/Corona-Warn-App/src/main/res/layout/home_statistics_cards_sevendayrvalue_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_statistics_cards_sevendayrvalue_layout.xml
@@ -55,7 +55,6 @@
             android:id="@+id/secondary_label"
             style="@style/StatisticsCardValueLabel"
             android:layout_width="0dp"
-            android:focusable="true"
             android:layout_height="wrap_content"
             android:paddingTop="@dimen/spacing_normal"
             android:text="@string/statistics_reproduction_average" />

--- a/Corona-Warn-App/src/main/res/layout/home_statistics_cards_sevendayrvalue_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_statistics_cards_sevendayrvalue_layout.xml
@@ -9,6 +9,7 @@
         android:layout_height="wrap_content"
         tools:layout_height="wrap_content"
         tools:layout_width="@dimen/statistics_card_width"
+        android:id="@+id/seven_day_r_value_container"
         tools:showIn="@layout/home_statistics_cards_basecard_layout">
 
         <androidx.appcompat.widget.AppCompatImageView

--- a/Corona-Warn-App/src/main/res/layout/home_statistics_cards_sevendayrvalue_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_statistics_cards_sevendayrvalue_layout.xml
@@ -44,6 +44,7 @@
         <TextView
             android:id="@+id/primary_value"
             style="@style/StatisticsCardPrimaryValue"
+            android:focusable="true"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:includeFontPadding="false"
@@ -53,6 +54,7 @@
             android:id="@+id/secondary_label"
             style="@style/StatisticsCardValueLabel"
             android:layout_width="0dp"
+            android:focusable="true"
             android:layout_height="wrap_content"
             android:paddingTop="@dimen/spacing_normal"
             android:text="@string/statistics_reproduction_average" />

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -1371,7 +1371,7 @@
     <!-- XTXT: Statistics Card Announcement -->
     <string name="accessibility_statistics_card_announcement">"Statistikkarte"</string>
     <!-- XTXT: Statistics Card Navigation Announcement -->
-    <string name="accessibility_statistics_card_navigation_information">"Wische horizontal zwischen den Items für weitere Statistiken"</string>
+    <string name="accessibility_statistics_card_navigation_information">"Wische horizontal zwischen den Karten für weitere Statistiken"</string>
 
     <!-- ####################################
           Button Tooltips for Accessibility

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -1368,6 +1368,11 @@
     <!-- XACT: Statistics explanation illustration description -->
     <string name="statistics_explanation_illustration_description">"Abstrakte Darstellung eines Smartphones mit vier Platzhaltern für Informationen"</string>
 
+    <!-- XTXT: Statistics Card Announcement -->
+    <string name="accessibility_statistics_card_announcement">"Statistikkarte"</string>
+    <!-- XTXT: Statistics Card Navigation Announcement -->
+    <string name="accessibility_statistics_card_navigation_information">"Wische horizontal zwischen den Items für weitere Statistiken"</string>
+
     <!-- ####################################
           Button Tooltips for Accessibility
     ###################################### -->

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -1382,6 +1382,11 @@
     <!-- XACT: Statistics explanation illustration description -->
     <string name="statistics_explanation_illustration_description">"Abstract picture of a smartphone with four placeholders for information"</string>
 
+    <!-- XTXT: Statistics Card Announcement -->
+    <string name="accessibility_statistics_card_announcement">""</string>
+    <!-- XTXT: Statistics Card Navigation Announcement -->
+    <string name="accessibility_statistics_card_navigation_information">""</string>
+
 
     <!-- ####################################
           Button Tooltips for Accessibility

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -1377,15 +1377,15 @@
     <string name="statistics_explanation_trend_stable_title">"Trend: Steady"</string>
     <!-- XHED: Explanation screen trend description -->
     <string name="statistics_explanation_trend_description">"The assessment of the trend for warnings by app users changes depending on current infection levels, which is why this trend is always displayed as neutral."</string>
-    <!-- XTXT: Explains user about statistics: URL, has to be "translated" into english (relevant for all languages except german) - https://www.coronawarn.app/en/faq/#further_details -->
+    <!-- XTXT: Explains user about statistics: URL, has to be "translated" into english (relevant for all languages except german)0 - https://www.coronawarn.app/en/faq/#further_details -->
     <string name="statistics_explanation_faq_url">"https://www.coronawarn.app/en/faq/#further_details"</string>
     <!-- XACT: Statistics explanation illustration description -->
     <string name="statistics_explanation_illustration_description">"Abstract picture of a smartphone with four placeholders for information"</string>
 
     <!-- XTXT: Statistics Card Announcement -->
-    <string name="accessibility_statistics_card_announcement">""</string>
+    <string name="accessibility_statistics_card_announcement">"Statistics Card"</string>
     <!-- XTXT: Statistics Card Navigation Announcement -->
-    <string name="accessibility_statistics_card_navigation_information">""</string>
+    <string name="accessibility_statistics_card_navigation_information">"Swipe horizontal between items"</string>
 
 
     <!-- ####################################

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -1383,9 +1383,9 @@
     <string name="statistics_explanation_illustration_description">"Abstract picture of a smartphone with four placeholders for information"</string>
 
     <!-- XTXT: Statistics Card Announcement -->
-    <string name="accessibility_statistics_card_announcement">"Statistics Card"</string>
+    <string name="accessibility_statistics_card_announcement">""</string>
     <!-- XTXT: Statistics Card Navigation Announcement -->
-    <string name="accessibility_statistics_card_navigation_information">"Swipe horizontal between items"</string>
+    <string name="accessibility_statistics_card_navigation_information">""</string>
 
 
     <!-- ####################################


### PR DESCRIPTION
This PR enhanced the Screen Reader capabilities for the statistics card.

- When focusing a specific statistics card, the card is announced with "Statistics Card" + Title and is then reading all the content. In addition, "Swipe horizontal between cards for more statistical information" is announced to let the user know how to navigate.

- When exploring a specific KPI within a card, the label is announced as well + some additional information like trends in a semantical correct order. 

To test the changes, activate TalkBack in the settings of your mobile phone. Currently only German contains all the strings since the translation isn't ready by now.