### PR TITLE
Delta-Onboarding interoperability info not shown (EXPOSUREAPP-4910)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -488,7 +488,7 @@ jobs:
               --os-version-ids 29 \
               --locales de_DE \
               --orientations portrait \
-              --no-record-video
+              --no-record-video | true
           no_output_timeout: 30m
       - run:
           name: Create directory to store test results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -488,7 +488,7 @@ jobs:
               --os-version-ids 29 \
               --locales de_DE \
               --orientations portrait \
-              --no-record-video | true
+              --no-record-video
           no_output_timeout: 30m
       - run:
           name: Create directory to store test results

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/main/home/HomeFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/main/home/HomeFragmentTest.kt
@@ -86,6 +86,7 @@ class HomeFragmentTest : BaseUITest() {
             every { showLoweredRiskLevelDialog } returns MutableLiveData()
             every { homeItems } returns MutableLiveData(emptyList())
             every { popupEvents } returns SingleLiveEvent()
+            every { showPopUpsOrNavigate() } just Runs
         }
 
         setupMockViewModel(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragment.kt
@@ -115,6 +115,8 @@ class HomeFragment : Fragment(R.layout.home_fragment_layout), AutoInject {
             }
         }
 
+        vm.showPopUpsOrNavigate()
+
         vm.showLoweredRiskLevelDialog.observe2(this) {
             if (it) showRiskLevelLoweredDialog()
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragmentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragmentViewModel.kt
@@ -91,28 +91,27 @@ class HomeFragmentViewModel @AssistedInject constructor(
         .map { it.toHeaderState() }
         .asLiveData(dispatcherProvider.Default)
 
-    val popupEvents: SingleLiveEvent<HomeFragmentEvents> by lazy {
-        SingleLiveEvent<HomeFragmentEvents>().apply {
-            if (!LocalData.isInteroperabilityShownAtLeastOnce) {
-                postValue(ShowInteropDeltaOnboarding)
-            } else {
-                launch {
-                    if (!LocalData.tracingExplanationDialogWasShown()) {
-                        postValue(
-                            ShowTracingExplanation(
-                                TimeVariables.getActiveTracingDaysInRetentionPeriod()
-                            )
+    val popupEvents = SingleLiveEvent<HomeFragmentEvents>()
+
+    fun showPopUpsOrNavigate() {
+        if (!LocalData.isInteroperabilityShownAtLeastOnce) {
+            popupEvents.postValue(ShowInteropDeltaOnboarding)
+        } else if (cwaSettings.lastChangelogVersion.value < BuildConfigWrap.VERSION_CODE) {
+            popupEvents.postValue(HomeFragmentEvents.ShowNewReleaseFragment)
+        } else {
+            launch {
+                if (!LocalData.tracingExplanationDialogWasShown()) {
+                    popupEvents.postValue(
+                        ShowTracingExplanation(
+                            TimeVariables.getActiveTracingDaysInRetentionPeriod()
                         )
-                    }
-                }
-                launch {
-                    if (errorResetTool.isResetNoticeToBeShown) {
-                        postValue(ShowErrorResetDialog)
-                    }
+                    )
                 }
             }
-            if (cwaSettings.lastChangelogVersion.value < BuildConfigWrap.VERSION_CODE) {
-                postValue(HomeFragmentEvents.ShowNewReleaseFragment)
+            launch {
+                if (errorResetTool.isResetNoticeToBeShown) {
+                    popupEvents.postValue(ShowErrorResetDialog)
+                }
             }
         }
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragmentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragmentViewModel.kt
@@ -94,23 +94,27 @@ class HomeFragmentViewModel @AssistedInject constructor(
     val popupEvents = SingleLiveEvent<HomeFragmentEvents>()
 
     fun showPopUpsOrNavigate() {
-        if (!LocalData.isInteroperabilityShownAtLeastOnce) {
-            popupEvents.postValue(ShowInteropDeltaOnboarding)
-        } else if (cwaSettings.lastChangelogVersion.value < BuildConfigWrap.VERSION_CODE) {
-            popupEvents.postValue(HomeFragmentEvents.ShowNewReleaseFragment)
-        } else {
-            launch {
-                if (!LocalData.tracingExplanationDialogWasShown()) {
-                    popupEvents.postValue(
-                        ShowTracingExplanation(
-                            TimeVariables.getActiveTracingDaysInRetentionPeriod()
-                        )
-                    )
-                }
+        when {
+            !LocalData.isInteroperabilityShownAtLeastOnce -> {
+                popupEvents.postValue(ShowInteropDeltaOnboarding)
             }
-            launch {
-                if (errorResetTool.isResetNoticeToBeShown) {
-                    popupEvents.postValue(ShowErrorResetDialog)
+            cwaSettings.lastChangelogVersion.value < BuildConfigWrap.VERSION_CODE -> {
+                popupEvents.postValue(HomeFragmentEvents.ShowNewReleaseFragment)
+            }
+            else -> {
+                launch {
+                    if (!LocalData.tracingExplanationDialogWasShown()) {
+                        popupEvents.postValue(
+                            ShowTracingExplanation(
+                                TimeVariables.getActiveTracingDaysInRetentionPeriod()
+                            )
+                        )
+                    }
+                }
+                launch {
+                    if (errorResetTool.isResetNoticeToBeShown) {
+                        popupEvents.postValue(ShowErrorResetDialog)
+                    }
                 }
             }
         }


### PR DESCRIPTION
A description of how to test is in the Jira ticket description. 

The problem was, that in our `HomeFragmentViewModel` => `postValue(ShowInteropDeltaOnboarding)` and `postValue(HomeFragmentEvents.ShowNewReleaseFragment)` were both executed within a short timespan and our `HomeFragment` therefore only observed the later event - `HomeFragmentEvents.ShowNewReleaseFragment`.

My solution here is to not `post()` both `Events` as soon as the user sees our `HomeFragment`, but to at first do `postValue(ShowInteropDeltaOnboarding)` to navigate to the Delta Onboarding Screen and when the user returns to the `HomeFragment` again, `showPopupsOrNavigate()` is executed again and the other event `HomeFragmentEvents.ShowNewReleaseFragment` will be fired to trigger navigation to `NewReleaseInfoFragment`. 

I think this logic needs to be refactored at some point, but since we want to release this week, I wanted to be as minimal invasive as possible to not introduce new bugs. 

The small problem with this solution is that we access 2 values of our shared preferences whenever the user returns to the `HomeFragment`, which costs us a bit of performance. 
