### PR TITLE
Pull firebase results anyways (Dev)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -493,11 +493,13 @@ jobs:
       - run:
           name: Create directory to store test results
           command: mkdir firebase-results
+          when: always
       - run:
           name: Install gsutil dependency and copy test results data
           command: |
             sudo pip install -U crcmod
             sudo gsutil -m cp -R -U gs://${GOOGLE_PROJECT_ID}-circleci-android/${BUCKETDIR}/flame* firebase-results
+          when: always
       - store_test_results:
           path: ./firebase-results/flame-29-de_DE-portrait
       - compress-path:


### PR DESCRIPTION
Run pulling results always regardless of the result of previous steps.
- Suppressing the error only did allow to grab the report ,but it gave false impression that the job succeeded.
- Verified in this build: https://app.circleci.com/pipelines/github/corona-warn-app/cwa-app-android/9145/workflows/736a7a5f-7c26-4978-af97-98f16443d6f5/jobs/50356