### PR TITLE
Change escaping of percentage sign (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/StatisticsExplanationFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/StatisticsExplanationFragment.kt
@@ -28,9 +28,11 @@ class StatisticsExplanationFragment : Fragment(R.layout.fragment_statistics_expl
             R.string.statistics_explanation_seven_day_r_link_label,
             R.string.statistics_explanation_faq_url
         )
+
         binding.statisticsExplanationTrendText.apply {
-            text = String.format(getString(R.string.statistics_explanation_trend_text))
-            contentDescription = String.format(getString(R.string.statistics_explanation_trend_text))
+            val label = String.format(getString(R.string.statistics_explanation_trend_text))
+            text = label
+            contentDescription = label
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/StatisticsExplanationFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/StatisticsExplanationFragment.kt
@@ -28,6 +28,10 @@ class StatisticsExplanationFragment : Fragment(R.layout.fragment_statistics_expl
             R.string.statistics_explanation_seven_day_r_link_label,
             R.string.statistics_explanation_faq_url
         )
+        binding.statisticsExplanationTrendText.apply {
+            text = String.format(getString(R.string.statistics_explanation_trend_text))
+            contentDescription = String.format(getString(R.string.statistics_explanation_trend_text))
+        }
     }
 
     override fun onResume() {

--- a/Corona-Warn-App/src/main/res/layout/fragment_statistics_explanation.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_statistics_explanation.xml
@@ -314,15 +314,15 @@
                     android:text="@string/statistics_explanation_trend_title" />
 
                 <TextView
+                    android:id="@+id/statistics_explanation_trend_text"
                     style="@style/body2"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="@dimen/guideline_start"
                     android:layout_marginTop="14dp"
                     android:layout_marginEnd="@dimen/guideline_end"
-                    android:contentDescription="@string/statistics_explanation_trend_text"
                     android:focusable="true"
-                    android:text="@string/statistics_explanation_trend_text" />
+                    tools:text="@string/statistics_explanation_trend_text" />
 
                 <TextView
                     style="@style/headline6"

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -1352,7 +1352,7 @@
     <!-- XHED: Explanation screen trend title -->
     <string name="statistics_explanation_trend_title">"Trend"</string>
     <!-- YTXT: Explanation screen trend text -->
-    <string name="statistics_explanation_trend_text">"Die Pfeilrichtung zeigt an, ob der Trend nach oben oder nach unten geht oder relativ stabil ist, d.h. eine Abweichung von weniger als 1&#37; im Vortagesvergleich bzw. 5&#37; im Vorwochenvergleich aufweist. Die Farbe bewertet diesen Trend als positiv (grün), negativ (rot) oder neutral (grau). Der Trend vergleicht den Wert vom Vortag mit dem Wert von vor zwei Tagen bzw. für die 7-Tage-Trends den Mittelwert der letzten 7 Tage mit dem der vorausgegangenen 7 Tage."</string>
+    <string name="statistics_explanation_trend_text">"Die Pfeilrichtung zeigt an, ob der Trend nach oben oder nach unten geht oder relativ stabil ist, d.h. eine Abweichung von weniger als 1%% im Vortagesvergleich bzw. 5%% im Vorwochenvergleich aufweist. Die Farbe bewertet diesen Trend als positiv (grün), negativ (rot) oder neutral (grau). Der Trend vergleicht den Wert vom Vortag mit dem Wert von vor zwei Tagen bzw. für die 7-Tage-Trends den Mittelwert der letzten 7 Tage mit dem der vorausgegangenen 7 Tage."</string>
     <!-- XHED: Explanation screen trend icons title -->
     <string name="statistics_explanation_trend_icons_title">"Folgende Trends können angezeigt werden:"</string>
     <!-- XHED: Explanation screen trend increasing title -->


### PR DESCRIPTION
All other options did not work well with the internal translation tool.

TEST:
- Check the statistics info screen.
- Scroll to Legend
- See Trend
- Check the description and make sure it says "...1%..."  and "...5%..."