### PR TITLE
Fix autoLink being too aggressive on some devices (closes #2275) (EXPOSUREAPP-4992)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/information/InformationContactFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/information/InformationContactFragment.kt
@@ -8,6 +8,7 @@ import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.FragmentInformationContactBinding
 import de.rki.coronawarnapp.ui.main.MainActivity
 import de.rki.coronawarnapp.util.ExternalActionHelper
+import de.rki.coronawarnapp.util.linkifyPhoneNumbers
 import de.rki.coronawarnapp.util.ui.viewBindingLazy
 
 /**
@@ -20,6 +21,8 @@ class InformationContactFragment : Fragment(R.layout.fragment_information_contac
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setButtonOnClickListener()
+
+        binding.informationContactBodyOther.linkifyPhoneNumbers()
     }
 
     override fun onResume() {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/fragment/SubmissionContactFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/fragment/SubmissionContactFragment.kt
@@ -11,6 +11,7 @@ import de.rki.coronawarnapp.ui.submission.viewmodel.SubmissionContactViewModel
 import de.rki.coronawarnapp.ui.submission.viewmodel.SubmissionNavigationEvents
 import de.rki.coronawarnapp.util.ExternalActionHelper
 import de.rki.coronawarnapp.util.di.AutoInject
+import de.rki.coronawarnapp.util.linkifyPhoneNumbers
 import de.rki.coronawarnapp.util.ui.doNavigate
 import de.rki.coronawarnapp.util.ui.observe2
 import de.rki.coronawarnapp.util.ui.viewBindingLazy
@@ -31,6 +32,8 @@ class SubmissionContactFragment : Fragment(R.layout.fragment_submission_contact)
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setButtonOnClickListener()
+
+        binding.includeSubmissionContact.submissionContactBodyOther.linkifyPhoneNumbers()
 
         viewModel.routeToScreen.observe2(this) {
             when (it) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/Views.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/Views.kt
@@ -5,8 +5,13 @@ import android.text.SpannableStringBuilder
 import android.text.Spanned
 import android.text.method.LinkMovementMethod
 import android.text.style.URLSpan
+import android.text.util.Linkify
+import android.util.Patterns
 import android.widget.TextView
 import androidx.annotation.StringRes
+import androidx.core.text.util.LinkifyCompat
+import de.rki.coronawarnapp.R
+import de.rki.coronawarnapp.util.ContextExtensions.getColorCompat
 
 fun TextView.convertToHyperlink(url: String) {
     setText(
@@ -71,4 +76,16 @@ fun TextView.setUrl(@StringRes textRes: Int, @StringRes labelRes: Int, @StringRe
             text = it
         }
     }
+}
+
+fun TextView.linkifyPhoneNumbers(){
+    LinkifyCompat.addLinks(
+        this,
+        Patterns.PHONE,
+        "tel:",
+        Linkify.sPhoneNumberMatchFilter,
+        Linkify.sPhoneNumberTransformFilter
+    )
+    movementMethod = LinkMovementMethod.getInstance()
+    setLinkTextColor(context.getColorCompat(R.color.colorTextTint))
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/Views.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/Views.kt
@@ -78,7 +78,7 @@ fun TextView.setUrl(@StringRes textRes: Int, @StringRes labelRes: Int, @StringRe
     }
 }
 
-fun TextView.linkifyPhoneNumbers(){
+fun TextView.linkifyPhoneNumbers() {
     LinkifyCompat.addLinks(
         this,
         Patterns.PHONE,

--- a/Corona-Warn-App/src/main/res/layout/fragment_information_contact.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_information_contact.xml
@@ -110,7 +110,6 @@
                     android:layout_marginTop="@dimen/spacing_normal"
                     android:text="@string/information_contact_body_other"
                     android:focusable="true"
-                    android:autoLink="phone"
                     android:textColorLink="@color/colorTextTint"
                     app:layout_constraintEnd_toEndOf="@+id/guideline_end"
                     app:layout_constraintStart_toStartOf="@+id/guideline_start"

--- a/Corona-Warn-App/src/main/res/layout/fragment_information_legal.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_information_legal.xml
@@ -99,7 +99,7 @@
                     android:layout_marginTop="@dimen/spacing_tiny"
                     android:text="@string/information_legal_subtitle_contact"
                     android:focusable="true"
-                    android:autoLink="all"
+                    android:autoLink="email"
                     android:textColorLink="@color/colorTextTint"
                     app:layout_constraintEnd_toStartOf="@+id/guideline_end"
                     app:layout_constraintStart_toEndOf="@+id/guideline_start"

--- a/Corona-Warn-App/src/main/res/layout/include_information_details.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_information_details.xml
@@ -64,7 +64,7 @@
             android:layout_marginStart="@dimen/spacing_normal"
             android:layout_marginTop="@dimen/spacing_medium"
             android:layout_marginEnd="@dimen/spacing_normal"
-            android:autoLink="all"
+            android:autoLink="web|email"
             android:focusable="true"
             android:text="@{body}"
             android:textColorLink="@color/colorTextTint"

--- a/Corona-Warn-App/src/main/res/layout/include_onboarding.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_onboarding.xml
@@ -124,6 +124,7 @@
                 android:autoLink="web|email"
                 android:focusable="true"
                 android:text="@{body}"
+                android:textColorLink="@color/colorTextTint"
                 app:layout_constraintEnd_toEndOf="@id/guideline_end"
                 app:layout_constraintStart_toStartOf="@id/guideline_start"
                 app:layout_constraintTop_toBottomOf="@+id/onboarding_subtitle"

--- a/Corona-Warn-App/src/main/res/layout/include_onboarding.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_onboarding.xml
@@ -121,6 +121,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_normal"
+                android:autoLink="web|email"
                 android:focusable="true"
                 android:text="@{body}"
                 app:layout_constraintEnd_toEndOf="@id/guideline_end"


### PR DESCRIPTION
### Description

As written in #2275 some TextViews with `android:autoLink="all"` also mark simple numbers as links on some devices.
I could reproduce it on a Pixel 4 XL, other devices are mentioned in the issue.

The fix changes the value `all` to `web|email` for the information details. I could not find any phone number in the terms so I didn't add `phone` at this point. In addition I also changed the `all` of the `information_legal_subtitle_contact` TextView to `email` because it only contains a mail address. 

### Screenshots

#### Before (taken from the issue)

![image](https://user-images.githubusercontent.com/10376534/106812759-631ac080-6670-11eb-86fb-0e0218ec85bc.png)

#### After (with fix applied on Pixel 4 XL)

![2275_fix](https://user-images.githubusercontent.com/10376534/106812734-5bf3b280-6670-11eb-8924-f5c2f0080b5f.png)


### Steps to reproduce

1. Go to App information -> Terms of Use
2. See for example postal code of Berlin being highlighted as a link

---
Internal tracking ID: [EXPOSUREAPP-4992](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4992)