### PR TITLE
Accessibility: Image not announces in Submission Consent Screen (EXPOSUREAPP-4098)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_consent.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_consent.xml
@@ -51,7 +51,7 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     android:focusable="true"
-                    android:contentDescription="Eine Frau schaut auf ihr Smartphone. Daneben sieht man das Symbol für das Scannen eines QR-Codes." />
+                    android:contentDescription="@string/submission_consent_main_illustration_description" />
 
                 <include layout="@layout/include_submission_consent_intro"
                     android:id="@+id/include_submission_consent_intro"

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_consent.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_consent.xml
@@ -50,7 +50,8 @@
                     app:layout_constraintTop_toTopOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
-                    android:importantForAccessibility="no"/>
+                    android:focusable="true"
+                    android:contentDescription="Eine Frau schaut auf ihr Smartphone. Daneben sieht man das Symbol für das Scannen eines QR-Codes." />
 
                 <include layout="@layout/include_submission_consent_intro"
                     android:id="@+id/include_submission_consent_intro"

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -903,6 +903,8 @@
     <string name="submission_consent_main_third_point">"Ihre Identität bleibt geheim. Andere Nutzer erfahren nicht, wer sein Testergebnis geteilt hat."</string>
     <!-- YTXT: Body for consent main section fourth point  -->
     <string name="submission_consent_main_fourth_point">"Sie können Ihr Einverständnis abgeben, wenn Sie mindestens 16 Jahre alt sind."</string>
+    <!-- YTXT: Content Description for the illustration  -->
+    <string name="submission_consent_main_illustration_description">"Eine Person hält ein Smartphone. Ein QR-Code auf einem Test symbolisiert den zu scannenden Code."</string>
 
     <!-- Submission Test Result -->
     <!-- XHED: Page headline for test result  -->

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -918,6 +918,8 @@
     <string name="submission_consent_main_third_point">"Your identity will remain secret. Other users will not find out who has shared a test result."</string>
     <!-- YTXT: Body for consent main section fourth point  -->
     <string name="submission_consent_main_fourth_point">"You must be at least 16 years old to grant your consent."</string>
+    <!-- YTXT: Content Description for the illustration  -->
+    <string name="submission_consent_main_illustration_description"></string>
 
     <!-- Submission Test Result -->
     <!-- XHED: Page headline for test result  -->


### PR DESCRIPTION
Small PR that adds a content description to the illustration on the submission consent screen. 

To test the changes: Activate TalkBack -> Select Card "Wurden Sie getestet?" -> Select "Test mit QR-Code" -> Press on the illustration and listen to voice output 