### PR TITLE
Add autoLink to phone number 116 117 in Request TAN (EXPOSUREAPP-5007) (closes #2291)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/include_submission_contact.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_submission_contact.xml
@@ -109,6 +109,8 @@
                         android:layout_height="wrap_content"
                         android:layout_marginTop="@dimen/spacing_small"
                         android:text="@string/submission_contact_body_other"
+                        android:autoLink="phone"
+                        android:textColorLink="@color/colorTextTint"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/submission_contact_operating_hours_body" />


### PR DESCRIPTION
### Description

This PR links the Medical Emergency Service Hotline 116 117 in the Request TAN view so that tapping it will bring up the Phone app. This aligns the view with the presentation of the same phone number in the Technical Hotline view.

Issue #2291 describes the problem with screen shots.

### Steps to reproduce

After applying the fix:

1. Under "Have you been tested?" tap "NEXT STEPS"
2. Scroll down to "No TAN yet?" and tap
3. Scroll down to the paragraph "If you have any health-related questions, please contact your general practitioner or the medical emergency service hotline, telephone: 116 117."
4. Note that the phone number 116 117 is shown in the accent color and is underlined
5. Tap on the phone number 116 117 and the phone number is now showing in the Phone app ready to dial 116117.

![Request TAN with autoLink](https://user-images.githubusercontent.com/66998419/107018496-cad02900-67a0-11eb-896d-1b4eb6fbfa8c.jpg)

---
Internal tracking ID: [EXPOSUREAPP-5007](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5007)