### PR TITLE
Accessibility: Text in Symptoms not in explore by touch sequence (EXPOSUREAPP-4102)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_symptom_intro.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_symptom_intro.xml
@@ -36,7 +36,6 @@
                 android:layout_marginStart="@dimen/spacing_normal"
                 android:layout_marginEnd="@dimen/spacing_normal"
                 android:fillViewport="true"
-                android:focusable="true"
                 android:orientation="vertical">
 
                 <TextView
@@ -62,6 +61,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_normal"
+                    android:focusable="true"
                     android:text="@string/submission_symptom_initial_explanation" />
 
 


### PR DESCRIPTION
Small PR that improves the TalkBack output on Symptoms Screen. Different parts are now announced individually. 

Steps to test:
- Scan Positive Test Result (by TAN etc.)
- Sharing Symptoms
- Invoke "Symptoms" screen
- Explore by touch the content (touch content sequentially or swipe right)