### PR TITLE
Implement Donor for User Metadata (EXPOSUREAPP-4823)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/DonorModule.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/DonorModule.kt
@@ -21,7 +21,7 @@ interface DonorModule {
         /**
          * You will be passed a protobuf container where the module will add it's data
          */
-        suspend fun injectData(protobufContainer: PpaData.PPADataAndroid)
+        suspend fun injectData(protobufContainer: PpaData.PPADataAndroid.Builder)
 
         /**
          * This will be called with the submission result.

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/exposureriskmetadata/ExposureRiskMetadataDonor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/exposureriskmetadata/ExposureRiskMetadataDonor.kt
@@ -57,7 +57,7 @@ class ExposureRiskMetadataDonor @Inject constructor(
         val contributionProto: PpaData.ExposureRiskMetadata,
         val onContributionFinished: suspend (Boolean) -> Unit
     ) : DonorModule.Contribution {
-        override suspend fun injectData(protobufContainer: PpaData.PPADataAndroid) {
+        override suspend fun injectData(protobufContainer: PpaData.PPADataAndroid.Builder) {
             protobufContainer.exposureRiskMetadataSetList.add(contributionProto)
         }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/exposurewindows/NewExposureWindowsDonor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/exposurewindows/NewExposureWindowsDonor.kt
@@ -21,7 +21,7 @@ class NewExposureWindowsDonor @Inject constructor() : DonorModule {
         val protobuf: Any,
         val onContributionFinished: suspend (Boolean) -> Unit
     ) : DonorModule.Contribution {
-        override suspend fun injectData(protobufContainer: PpaData.PPADataAndroid) {
+        override suspend fun injectData(protobufContainer: PpaData.PPADataAndroid.Builder) {
             // TODO "Add this specific protobuf to the top level protobuf container"
         }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/keysubmission/KeySubmissionStateDonor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/keysubmission/KeySubmissionStateDonor.kt
@@ -11,7 +11,7 @@ class KeySubmissionStateDonor @Inject constructor() : DonorModule {
     override suspend fun beginDonation(request: DonorModule.Request): DonorModule.Contribution {
         // TODO
         return object : DonorModule.Contribution {
-            override suspend fun injectData(protobufContainer: PpaData.PPADataAndroid) {
+            override suspend fun injectData(protobufContainer: PpaData.PPADataAndroid.Builder) {
                 // TODO
             }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/RegisteredTestDonor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/RegisteredTestDonor.kt
@@ -11,7 +11,7 @@ class RegisteredTestDonor @Inject constructor() : DonorModule {
     override suspend fun beginDonation(request: DonorModule.Request): DonorModule.Contribution {
         // TODO
         return object : DonorModule.Contribution {
-            override suspend fun injectData(protobufContainer: PpaData.PPADataAndroid) {
+            override suspend fun injectData(protobufContainer: PpaData.PPADataAndroid.Builder) {
                 // TODO
             }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/usermetadata/UserMetadataDonor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/usermetadata/UserMetadataDonor.kt
@@ -30,6 +30,8 @@ class UserMetadataDonor @Inject constructor(
             protobufContainer.userMetadata = contributionProto
         }
 
-        override suspend fun finishDonation(successful: Boolean) {}
+        override suspend fun finishDonation(successful: Boolean) {
+            // No post processing needed for User Metadata
+        }
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/usermetadata/UserMetadataDonor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/usermetadata/UserMetadataDonor.kt
@@ -1,0 +1,35 @@
+package de.rki.coronawarnapp.datadonation.analytics.modules.usermetadata
+
+import de.rki.coronawarnapp.datadonation.analytics.AnalyticsSettings
+import de.rki.coronawarnapp.datadonation.analytics.modules.DonorModule
+import de.rki.coronawarnapp.server.protocols.internal.ppdd.PpaData
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class UserMetadataDonor @Inject constructor(
+    private val analyticsSettings: AnalyticsSettings
+) : DonorModule {
+
+    override suspend fun beginDonation(request: DonorModule.Request): DonorModule.Contribution {
+        val userMetadata = PpaData.PPAUserMetadata.newBuilder()
+            .setAgeGroup(analyticsSettings.userInfoAgeGroup.value)
+            .setFederalState(analyticsSettings.userInfoFederalState.value)
+            .setAdministrativeUnit(analyticsSettings.userInfoDistrict.value)
+            .build()
+
+        return UserMetadataContribution(
+            contributionProto = userMetadata
+        )
+    }
+
+    data class UserMetadataContribution(
+        val contributionProto: PpaData.PPAUserMetadata
+    ) : DonorModule.Contribution {
+        override suspend fun injectData(protobufContainer: PpaData.PPADataAndroid.Builder) {
+            protobufContainer.userMetadata = contributionProto
+        }
+
+        override suspend fun finishDonation(successful: Boolean) {}
+    }
+}


### PR DESCRIPTION
### Description
This PR adds an analytics donor for the user metadata collected from the screens implemented by @d4rken
it also changes the Protobuf instances in the DonorModule interface to their respective builder which is also part of the 
Submit Analytics PR #2280 
