### PR TITLE
Adapt 'fake correct device time' feature (DEV)

### DIFF
--- a/Corona-Warn-App/src/deviceForTesters/res/layout/fragment_test_appconfig.xml
+++ b/Corona-Warn-App/src/deviceForTesters/res/layout/fragment_test_appconfig.xml
@@ -90,6 +90,12 @@
                 android:layout_weight="1"
                 android:text="Fake correct device time" />
 
+            <TextView
+                style="@style/TextAppearance.AppCompat.Caption"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacing_tiny"
+                android:text="This sets the offset between server time and device time to 0 and therefore allows device time travelling while still getting positive device time checks." />
         </LinearLayout>
 
         <LinearLayout

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/appconfig/sources/remote/AppConfigServer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/appconfig/sources/remote/AppConfigServer.kt
@@ -66,8 +66,8 @@ class AppConfigServer @Inject constructor(
 
         val serverTime = response.getServerDate() ?: localTime
         val offset = if (CWADebug.isDeviceForTestersBuild && testSettings.fakeCorrectDeviceTime.value) {
-            Timber.tag(TAG).w("Test setting 'fakeCorrectDeviceTime' is active; time offset is now +90min.")
-            Duration.standardMinutes(90)
+            Timber.tag(TAG).w("Test setting 'fakeCorrectDeviceTime' is active; time offset is now 0")
+            Duration.ZERO
         } else {
             Duration(serverTime, localTime)
         }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/appconfig/sources/remote/AppConfigServerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/appconfig/sources/remote/AppConfigServerTest.kt
@@ -193,7 +193,7 @@ class AppConfigServerTest : BaseIOTest() {
         createInstance().downloadAppConfig() shouldBe InternalConfigData(
             rawData = APPCONFIG_RAW,
             serverTime = Instant.parse("2020-11-03T06:35:16.000Z"),
-            localOffset = Duration.standardMinutes(90),
+            localOffset = Duration.ZERO,
             etag = "I am an ETag :)!",
             cacheValidity = Duration.standardSeconds(300)
         )


### PR DESCRIPTION
This adjusts and extends the test menu feature from @d4rken => https://github.com/corona-warn-app/cwa-app-android/pull/2316

- Change the hardcoded offset from 90 to 0
- Add a description of the "Fake correct device time" in the Test Menu

![image](https://user-images.githubusercontent.com/10398034/107541069-09ae1680-6bc7-11eb-8b03-efee826a17cb.png)
