### PR TITLE
Make whole high risk survey card clickable (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/details/items/survey/UserSurveyBox.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/details/items/survey/UserSurveyBox.kt
@@ -29,6 +29,7 @@ class UserSurveyBox(
         item: Item,
         payloads: List<Any>
     ) -> Unit = { item, _ ->
+        itemView.setOnClickListener { onItemClickListener(item) }
         tracingDetailsSurveyCardButton.setOnClickListener { onItemClickListener(item) }
     }
 


### PR DESCRIPTION
Makes the whole high-risk survey card clickable, not just the Button with the Label "ZUR BEFRAGUNG".

This behavior is now consistent with other cards in our app. 

![Screenshot 2021-02-11 at 14 55 18](https://user-images.githubusercontent.com/10398034/107645599-2b67d600-6c79-11eb-8394-52156bc1d7d0.png)
