### PR TITLE
PPA Settings - Change default switch state (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/fragment_settings_privacy_preserving_analytics.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_settings_privacy_preserving_analytics.xml
@@ -90,7 +90,7 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/onboarding_body"
                     app:showDivider="@{true}"
-                    app:status="@{true}"
+                    app:status="@{false}"
                     app:statusText="@{@string/settings_on}"
                     app:subtitle="@{@string/settings_analytics_switch_subtitle}" />
 


### PR DESCRIPTION
Tiny PR that changes the default switch state from `true` to `false` - now aligned with the other settings switches.

**To test the behavior:** Go to settings and press on the entry "Datenspende". Check the default state of the switch before it adapts according to the users preferences.

![default_switch_state](https://user-images.githubusercontent.com/75120552/107950098-8d388080-6f96-11eb-8157-350fed873a90.png)


