### PR TITLE
Fix invisible close icon in survey consent detail view (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/survey/consent/SurveyConsentDetailFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/survey/consent/SurveyConsentDetailFragment.kt
@@ -13,6 +13,8 @@ class SurveyConsentDetailFragment : Fragment(R.layout.survey_consent_detail_frag
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding.toolbar.setNavigationOnClickListener { activity?.onBackPressed() }
+        binding.toolbar.headerButtonBack.buttonIcon.setOnClickListener {
+            activity?.onBackPressed()
+        }
     }
 }

--- a/Corona-Warn-App/src/main/res/layout/survey_consent_detail_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/survey_consent_detail_fragment.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/content_container"
@@ -10,11 +9,13 @@
         android:background="@drawable/contact_diary_onboarding_background"
         android:focusable="true">
 
-        <androidx.appcompat.widget.Toolbar
+        <include
             android:id="@+id/toolbar"
-            style="@style/CWAToolbar.Close"
+            layout="@layout/include_header"
             android:layout_width="0dp"
+            android:focusable="true"
             android:layout_height="wrap_content"
+            app:icon="@{@drawable/ic_close}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
@@ -36,7 +37,7 @@
                     style="@style/headline4"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/spacing_small"
+                    android:layout_marginTop="@dimen/spacing_tiny"
                     android:accessibilityHeading="true"
                     android:focusable="true"
                     android:text="@string/datadonation_details_survey_consent_details_title"


### PR DESCRIPTION
This fixes the invisible close icon in the survey consent detail view. 

How to access it
- Environment: Int
- Trigger high-risk card (Test Menu => ENF v2 Calculation => INCREASED_RISK_DEFAULT => Calculate Risk Level)
- See high-risk card appear in Home Screen
- Click Risk Card to go to the detail screen
- Click "Zur Befragung"
- Scroll down and click "Ausführliche Informationen zur Datenverarbeitung und Ihrem Einverständnis."

![image](https://user-images.githubusercontent.com/10398034/107954589-eb686200-6f9c-11eb-94f8-3910df664b7b.png)
