### PR TITLE
Don't close survey consent screen on errors (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/survey/consent/SurveyConsentFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/survey/consent/SurveyConsentFragment.kt
@@ -84,7 +84,6 @@ class SurveyConsentFragment : Fragment(R.layout.survey_consent_fragment), AutoIn
                 title = R.string.datadonation_details_survey_consent_error_dialog_title,
                 message = stringRes,
                 positiveButton = R.string.datadonation_details_survey_consent_error_dialog_pos_button,
-                positiveButtonFunction = { vm.onBackButtonPressed() },
                 cancelable = false
             )
             DialogHelper.showDialog(dialog)


### PR DESCRIPTION
It is a requirement that the survey consent screen should close automatically before the user is taken to the survey in the browser. 

However, this screen got also closed when there was an exception due to 
- a failure of one of our checks (device time, >24 after installation, ...)
- issues with the SafetyNet Attestation
- problems with the authentication of the one time password. 

In this case, the error dialog showed up and after clicking "Ok", the consent screen was closed automatically. 
This PR fixes this so the user stays on the consent screen after an error. 