### PR TITLE
Fix PPA Submission Endpoint Return Type (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/server/DataDonationAnalyticsApiV1.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/server/DataDonationAnalyticsApiV1.kt
@@ -9,7 +9,7 @@ import retrofit2.http.POST
 interface DataDonationAnalyticsApiV1 {
 
     data class DataDonationAnalyticsResponse(
-        @SerializedName("errorState") val errorState: String?
+        @SerializedName("errorCode") val errorCode: String?
     )
 
     @POST("/version/v1/android/dat")

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/server/DataDonationAnalyticsServer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/server/DataDonationAnalyticsServer.kt
@@ -22,7 +22,7 @@ class DataDonationAnalyticsServer @Inject constructor(
         return when (code) {
             204 -> Timber.d("Analytics upload completed successfully")
             400, 401, 403 -> {
-                val explanation = response.body()?.errorState ?: "Unknown clientside error"
+                val explanation = response.body()?.errorCode ?: "Unknown clientside error"
                 throw AnalyticsException(message = explanation).also {
                     Timber.w(it, "Analytics upload failed with 40X")
                 }


### PR DESCRIPTION
### Description
This PR implements a change in the PPA Specs where the `/version/v1/android/dat` endpoint will now return an `errorCode` instead of an `errorState`
