### PR TITLE
Add styles for diary circumstances text field (EXPOSUREAPP-5161)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/day/tabs/common/DiaryCircumstancesTextView.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/day/tabs/common/DiaryCircumstancesTextView.kt
@@ -1,8 +1,10 @@
 package de.rki.coronawarnapp.contactdiary.ui.day.tabs.common
 
 import android.content.Context
+import android.text.InputType
 import android.util.AttributeSet
 import android.view.LayoutInflater
+import android.view.inputmethod.EditorInfo
 import android.widget.EditText
 import android.widget.ImageView
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -29,9 +31,11 @@ class DiaryCircumstancesTextView @JvmOverloads constructor(
                     Timber.v("Focused on %s", v)
                 } else {
                     Timber.v("Lost focus on %s", v)
-                    afterTextChangedListener?.invoke(text.toString())
+                    notifyTextChanged(text.toString())
                 }
             }
+            imeOptions = EditorInfo.IME_ACTION_DONE
+            setRawInputType(InputType.TYPE_CLASS_TEXT)
         }
         infoButton = findViewById(R.id.info_button)
     }
@@ -39,6 +43,11 @@ class DiaryCircumstancesTextView @JvmOverloads constructor(
     override fun onFinishInflate() {
         input.clearFocus()
         super.onFinishInflate()
+    }
+
+    private fun notifyTextChanged(text: String) {
+        // Prevent Copy&Paste inserting new lines.
+        afterTextChangedListener?.invoke(text.trim().replace("\n", ""))
     }
 
     fun setInfoButtonClickListener(listener: () -> Unit) {

--- a/Corona-Warn-App/src/main/res/layout/view_diary_circumstances_textview.xml
+++ b/Corona-Warn-App/src/main/res/layout/view_diary_circumstances_textview.xml
@@ -12,10 +12,8 @@
         style="@style/ContactDiaryCircumstancesTextInputLayout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:hint="@string/contact_diary_person_encounter_circumstances_hint"
         android:scrollHorizontally="false"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:hintEnabled="false"
         app:layout_constraintEnd_toStartOf="@id/info_button"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/environment_group">
@@ -24,23 +22,19 @@
             android:id="@+id/input"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:padding="@dimen/spacing_tiny"
             android:maxLength="250"
+            android:hint="@string/contact_diary_person_encounter_circumstances_hint"
             tools:text="This was a triumph. I'm making a note here; 'Huge success'. It's hard to overstate my satisfaction. We do what we must, because we can." />
 
     </com.google.android.material.textfield.TextInputLayout>
 
-    <ImageView
+    <ImageButton
         android:id="@+id/info_button"
-        android:layout_width="@dimen/button_icon"
-        android:layout_height="@dimen/button_icon"
-        android:layout_marginTop="2dp"
-        android:background="?selectableItemBackground"
-        android:contentDescription="@string/statistics_info_button"
-        android:padding="10dp"
-        android:src="@drawable/ic_info"
+        style="@style/ContactDiaryInfoButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/input_layout"
-        app:layout_constraintTop_toTopOf="@id/input_layout"
-        app:tint="@color/colorAccent" />
+        app:layout_constraintTop_toBottomOf="@id/environment_group" />
 
 </merge>

--- a/Corona-Warn-App/src/main/res/layout/view_diary_circumstances_textview.xml
+++ b/Corona-Warn-App/src/main/res/layout/view_diary_circumstances_textview.xml
@@ -9,7 +9,7 @@
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/input_layout"
-        style="@style/Widget.MaterialComponents.TextInputLayout.FilledBox.Dense"
+        style="@style/ContactDiaryCircumstancesTextInputLayout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"

--- a/Corona-Warn-App/src/main/res/layout/view_diary_circumstances_textview.xml
+++ b/Corona-Warn-App/src/main/res/layout/view_diary_circumstances_textview.xml
@@ -12,7 +12,6 @@
         style="@style/ContactDiaryCircumstancesTextInputLayout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:scrollHorizontally="false"
         app:hintEnabled="false"
         app:layout_constraintEnd_toStartOf="@id/info_button"
         app:layout_constraintStart_toStartOf="parent"
@@ -22,9 +21,10 @@
             android:id="@+id/input"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:padding="@dimen/spacing_tiny"
-            android:maxLength="250"
             android:hint="@string/contact_diary_person_encounter_circumstances_hint"
+            android:inputType="textMultiLine"
+            android:maxLength="250"
+            android:padding="@dimen/spacing_tiny"
             tools:text="This was a triumph. I'm making a note here; 'Huge success'. It's hard to overstate my satisfaction. We do what we must, because we can." />
 
     </com.google.android.material.textfield.TextInputLayout>

--- a/Corona-Warn-App/src/main/res/values/styles.xml
+++ b/Corona-Warn-App/src/main/res/values/styles.xml
@@ -404,9 +404,10 @@
         <item name="android:background">@drawable/contact_diary_card_ripple</item>
     </style>
 
-    <style name="ContactDiaryCircumstancesTextInputLayout" parent="Widget.MaterialComponents.TextInputLayout.FilledBox">
+    <style name="ContactDiaryCircumstancesTextInputLayout" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense">
         <item name="boxBackgroundColor">@color/colorBackground</item>
         <item name="android:textColorHint">@color/colorTextPrimary2</item>
+        <item name="android:textSize">@dimen/font_small</item>
         <item name="hintTextColor">@color/colorTextPrimary2</item>
         <item name="boxCornerRadiusBottomEnd">@dimen/spacing_mega_tiny</item>
         <item name="boxCornerRadiusBottomStart">@dimen/spacing_mega_tiny</item>
@@ -414,6 +415,18 @@
         <item name="boxCornerRadiusTopStart">@dimen/spacing_mega_tiny</item>
         <item name="boxStrokeWidth">0dp</item>
         <item name="boxStrokeWidthFocused">0dp</item>
+    </style>
+
+    <style name="ContactDiaryInfoButton" parent="buttonIcon">
+        <item name="android:height">@dimen/button_icon</item>
+        <item name="android:width">@dimen/button_icon</item>
+        <item name="android:src">@drawable/ic_info</item>
+        <item name="android:paddingStart">12dp</item>
+        <item name="android:paddingEnd">12dp</item>
+        <item name="android:paddingTop">7dp</item>
+        <item name="android:paddingBottom">7dp</item>
+        <item name="android:contentDescription">@string/statistics_info_button</item>
+        <item name="android:tint">@color/colorAccent</item>
     </style>
 
     <style name="StatisticsCardInfoButton" parent="buttonIcon">

--- a/Corona-Warn-App/src/main/res/values/styles.xml
+++ b/Corona-Warn-App/src/main/res/values/styles.xml
@@ -404,6 +404,18 @@
         <item name="android:background">@drawable/contact_diary_card_ripple</item>
     </style>
 
+    <style name="ContactDiaryCircumstancesTextInputLayout" parent="Widget.MaterialComponents.TextInputLayout.FilledBox">
+        <item name="boxBackgroundColor">@color/colorBackground</item>
+        <item name="android:textColorHint">@color/colorTextPrimary2</item>
+        <item name="hintTextColor">@color/colorTextPrimary2</item>
+        <item name="boxCornerRadiusBottomEnd">@dimen/spacing_mega_tiny</item>
+        <item name="boxCornerRadiusBottomStart">@dimen/spacing_mega_tiny</item>
+        <item name="boxCornerRadiusTopEnd">@dimen/spacing_mega_tiny</item>
+        <item name="boxCornerRadiusTopStart">@dimen/spacing_mega_tiny</item>
+        <item name="boxStrokeWidth">0dp</item>
+        <item name="boxStrokeWidthFocused">0dp</item>
+    </style>
+
     <style name="StatisticsCardInfoButton" parent="buttonIcon">
         <item name="android:height">@dimen/button_icon</item>
         <item name="android:width">@dimen/button_icon</item>


### PR DESCRIPTION
This PR styles the "circumstances" text field of the contact journal extension. 

Remarks: 
- Although not in the design, we (@SamuraiKek has also implemented them this way in the screen to enter a person/location) decided to show the label when text is entered. This is also according to the material design guidelines ("label should always be visible")

![image](https://user-images.githubusercontent.com/10398034/108325482-66ae5b80-71c9-11eb-8092-11e30af946db.png)
