### PR TITLE
Enhance screenshots-FTL(EXPOSUREAPP-5250)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -601,9 +601,7 @@ jobs:
             sudo gsutil -m cp -R -U gs://${GOOGLE_PROJECT_ID}-circleci-android/${BUCKETDIR}/flame* firebase-screenshots
           when: always
       - store_test_results:
-          path: ./firebase-screenshots/flame-29-en_US-portrait/*.xml
-      - store_test_results:
-          path: ./firebase-screenshots/flame-29-de_DE-portrait/*.xml
+          path: ./firebase-screenshots
       - compress-path:
           input: ./firebase-screenshots
           output: /tmp/screenshots.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -550,6 +550,65 @@ jobs:
           path: /tmp/device_screenshots.zip
           destination: zips/device_screenshots.zip
 
+  firebase_screenshots:
+    resource_class: xlarge
+      docker:
+          - image: circleci/android:api-28
+    steps:
+      - skip-for-external-pull-requests
+        - setup-google-cloud
+        - checkout
+        - restore-gradle-cache
+        - restore-android-build-cache
+      - run-gradle-cmd:
+          desc: Build APKs for screenshots
+          cmd: >
+            :Corona-Warn-App:assembleDebug
+            :Corona-Warn-App:assembleAndroidTest
+      - run:
+          name: Setup Testlab environment
+            command: |
+              echo "export BUCKETDIR=\"`date "+%Y-%m-%d-%H:%M:%S:%3N"`-${RANDOM}\"" >> $BASH_ENV
+              source $BASH_ENV
+              echo "$BUCKETDIR is setup."
+      - run:
+          name: Test with Firebase Test Lab
+          command: |
+            echo "Using bucketdir $BUCKETDIR"
+            sudo gcloud firebase test android run \
+              --type instrumentation \
+              --app Corona-Warn-App/build/outputs/apk/deviceForTesters/debug/*.apk \
+              --test Corona-Warn-App/build/outputs/apk/androidTest/deviceForTesters/debug/*.apk \
+              --results-dir ${BUCKETDIR} \
+              --results-bucket ${GOOGLE_PROJECT_ID}-circleci-android \
+              --environment-variables clearPackageData=true \
+              --test-targets "notAnnotation testhelpers.Screenshot" \
+              --timeout 20m \
+              --device-ids flame \
+              --os-version-ids 29 \
+              --locales de_DE,en_US \
+              --orientations portrait \
+              --no-record-video
+          no_output_timeout: 30m
+      - run:
+          name: Create directory to store test results
+          command: mkdir firebase-screenshots
+          when: always
+      - run:
+          name: Install gsutil dependency and copy test results data
+          command: |
+            sudo pip install -U crcmod
+            sudo gsutil -m cp -R -U gs://${GOOGLE_PROJECT_ID}-circleci-android/${BUCKETDIR}/flame* firebase-screenshots
+          when: always
+      - store_test_results:
+          path: ./firebase-screenshots
+      - compress-path:
+          input: ./firebase-results/*.xml
+          output: /tmp/screenshots.zip
+      - store_artifacts:
+          path: /tmp/screenshots.zip
+          destination: zips/screenshots.zip
+
 #######################
 # Workflow section
 # Job execution orders

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -601,9 +601,9 @@ jobs:
             sudo gsutil -m cp -R -U gs://${GOOGLE_PROJECT_ID}-circleci-android/${BUCKETDIR}/flame* firebase-screenshots
           when: always
       - store_test_results:
-          path: ./firebase-screenshots
+          path: ./firebase-screenshots/flame-*/*.xml
       - compress-path:
-          input: ./firebase-results/*.xml
+          input: ./firebase-screenshots
           output: /tmp/screenshots.zip
       - store_artifacts:
           path: /tmp/screenshots.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -629,7 +629,10 @@ workflows:
           requires:
             - ktlint_device_release_check
             - detekt
-
+      - firebase_screenshots:
+          requires:
+            - ktlint_device_release_check
+            - detekt
   check_buildtype_device_for_testers:
     jobs:
       - detekt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -552,8 +552,8 @@ jobs:
 
   firebase_screenshots:
     resource_class: xlarge
-      docker:
-          - image: circleci/android:api-28
+    docker:
+        - image: circleci/android:api-28
     steps:
       - skip-for-external-pull-requests
       - setup-google-cloud
@@ -566,8 +566,8 @@ jobs:
             :Corona-Warn-App:assembleDebug
             :Corona-Warn-App:assembleAndroidTest
       - run:
-          name: Setup Testlab environment
-            command: |
+         name: Setup Testlab environment
+         command: |
               echo "export BUCKETDIR=\"`date "+%Y-%m-%d-%H:%M:%S:%3N"`-${RANDOM}\"" >> $BASH_ENV
               source $BASH_ENV
               echo "$BUCKETDIR is setup."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -588,6 +588,7 @@ jobs:
               --os-version-ids 29 \
               --locales de_DE,en_US \
               --orientations portrait \
+              --directories-to-pull /sdcard/screenshots \
               --no-record-video
           no_output_timeout: 30m
       - run:
@@ -626,6 +627,10 @@ workflows:
           requires:
             - unit_tests_device_release
       - instrumentation_tests_device:
+          requires:
+            - ktlint_device_release_check
+            - detekt
+      - firebase_screenshots:
           requires:
             - ktlint_device_release_check
             - detekt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -553,7 +553,7 @@ jobs:
   firebase_screenshots:
     resource_class: xlarge
     docker:
-        - image: circleci/android:api-28
+      - image: circleci/android:api-28
     steps:
       - skip-for-external-pull-requests
       - setup-google-cloud
@@ -566,11 +566,11 @@ jobs:
             :Corona-Warn-App:assembleDebug
             :Corona-Warn-App:assembleAndroidTest
       - run:
-         name: Setup Testlab environment
-         command: |
-              echo "export BUCKETDIR=\"`date "+%Y-%m-%d-%H:%M:%S:%3N"`-${RANDOM}\"" >> $BASH_ENV
-              source $BASH_ENV
-              echo "$BUCKETDIR is setup."
+          name: Setup Testlab environment
+          command: |
+            echo "export BUCKETDIR=\"`date "+%Y-%m-%d-%H:%M:%S:%3N"`-${RANDOM}\"" >> $BASH_ENV
+            source $BASH_ENV
+            echo "$BUCKETDIR is setup."
       - run:
           name: Test with Firebase Test Lab
           command: |
@@ -601,7 +601,9 @@ jobs:
             sudo gsutil -m cp -R -U gs://${GOOGLE_PROJECT_ID}-circleci-android/${BUCKETDIR}/flame* firebase-screenshots
           when: always
       - store_test_results:
-          path: ./firebase-screenshots/flame-*/*.xml
+          path: ./firebase-screenshots/flame-29-en_US-portrait/*.xml
+      - store_test_results:
+          path: ./firebase-screenshots/flame-29-de_DE-portrait/*.xml
       - compress-path:
           input: ./firebase-screenshots
           output: /tmp/screenshots.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -508,7 +508,7 @@ jobs:
       - store_artifacts:
           path: /tmp/instrumentation_tests_device.zip
           destination: zips/instrumentation_tests_device.zip
-
+  # Keep it until Firebase Test Lab proves reliability
   device_screenshots:
     macos:
       xcode: "12.3.0"
@@ -629,10 +629,7 @@ workflows:
           requires:
             - ktlint_device_release_check
             - detekt
-      - firebase_screenshots:
-          requires:
-            - ktlint_device_release_check
-            - detekt
+
   check_buildtype_device_for_testers:
     jobs:
       - detekt
@@ -650,7 +647,7 @@ workflows:
                 - /^v.*/
             branches:
               ignore: /.*/
-      - device_screenshots:
+      - firebase_screenshots:
           filters:
             tags:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -588,7 +588,6 @@ jobs:
               --os-version-ids 29 \
               --locales de_DE,en_US \
               --orientations portrait \
-              --directories-to-pull /sdcard/screenshots \
               --no-record-video
           no_output_timeout: 30m
       - run:
@@ -627,10 +626,6 @@ workflows:
           requires:
             - unit_tests_device_release
       - instrumentation_tests_device:
-          requires:
-            - ktlint_device_release_check
-            - detekt
-      - firebase_screenshots:
           requires:
             - ktlint_device_release_check
             - detekt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -556,10 +556,10 @@ jobs:
           - image: circleci/android:api-28
     steps:
       - skip-for-external-pull-requests
-        - setup-google-cloud
-        - checkout
-        - restore-gradle-cache
-        - restore-android-build-cache
+      - setup-google-cloud
+      - checkout
+      - restore-gradle-cache
+      - restore-android-build-cache
       - run-gradle-cmd:
           desc: Build APKs for screenshots
           cmd: >

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -582,7 +582,7 @@ jobs:
               --results-dir ${BUCKETDIR} \
               --results-bucket ${GOOGLE_PROJECT_ID}-circleci-android \
               --environment-variables clearPackageData=true \
-              --test-targets "notAnnotation testhelpers.Screenshot" \
+              --test-targets "annotation testhelpers.Screenshot" \
               --timeout 20m \
               --device-ids flame \
               --os-version-ids 29 \

--- a/Corona-Warn-App/src/androidTest/java/testhelpers/BaseUITest.kt
+++ b/Corona-Warn-App/src/androidTest/java/testhelpers/BaseUITest.kt
@@ -1,10 +1,19 @@
 package testhelpers
 
+import android.Manifest
+import androidx.test.rule.GrantPermissionRule
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactory
+import org.junit.Rule
 import testhelpers.viewmodels.MockViewModelModule
 
 abstract class BaseUITest : BaseTest() {
+
+    @get:Rule
+    val permissionRule: GrantPermissionRule = GrantPermissionRule.grant(
+        Manifest.permission.READ_EXTERNAL_STORAGE,
+        Manifest.permission.WRITE_EXTERNAL_STORAGE
+    )
 
     inline fun <reified T : CWAViewModel> setupMockViewModel(factory: CWAViewModelFactory<T>) {
         MockViewModelModule.CREATORS[T::class.java] = factory

--- a/Corona-Warn-App/src/androidTest/java/testhelpers/ScreenShotter.kt
+++ b/Corona-Warn-App/src/androidTest/java/testhelpers/ScreenShotter.kt
@@ -1,13 +1,23 @@
 package testhelpers
 
 import android.app.Activity
+import android.graphics.Bitmap
 import android.os.Bundle
+import android.provider.Settings
+import android.util.Log
 import androidx.annotation.StyleRes
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentFactory
 import androidx.test.espresso.ViewAction
+import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import de.rki.coronawarnapp.R
 import tools.fastlane.screengrab.Screengrab
+import tools.fastlane.screengrab.ScreenshotCallback
+import tools.fastlane.screengrab.UiAutomatorScreenshotStrategy
+import tools.fastlane.screengrab.file.Chmod
+import java.io.BufferedOutputStream
+import java.io.File
+import java.io.FileOutputStream
 
 /**
  * Waits for 2 sec and captures a screenshot
@@ -18,7 +28,18 @@ inline fun <reified T> takeScreenshot(suffix: String = "", delay: Long = SCREENS
     Thread.sleep(delay)
     val simpleName = T::class.simpleName
     val name = if (suffix.isEmpty()) simpleName else simpleName.plus("_$suffix")
-    Screengrab.screenshot(name)
+
+    val contentResolver = getInstrumentation().targetContext.contentResolver
+    val testLabSetting = Settings.System.getString(contentResolver, "firebase.test.lab")
+    if ("true" == testLabSetting) {
+        Screengrab.screenshot(
+            name,
+            UiAutomatorScreenshotStrategy(),
+            SDCardCallback
+        )
+    } else {
+        Screengrab.screenshot(name)
+    }
 }
 
 /**
@@ -35,4 +56,36 @@ inline fun <reified F : Fragment> captureScreenshot(
 ) {
     launchFragmentInContainer2<F>(fragmentArgs, themeResId, factory)
     takeScreenshot<F>(suffix)
+}
+
+/**
+ * Saves screenshots on the device's sdcard
+ */
+object SDCardCallback : ScreenshotCallback {
+    private const val ROOT_DIRECTORY = "/sdcard"
+    private const val SCREENSHOTS_DIRECTORY = "screenshots"
+    private const val SCREENSHOT_FORMAT = ".png"
+    private const val IMAGE_QUALITY = 100
+
+    override fun screenshotCaptured(screenshotName: String, screenshot: Bitmap) {
+        try {
+            val directory = File(ROOT_DIRECTORY, SCREENSHOTS_DIRECTORY)
+            if (!directory.exists()) {
+                directory.mkdirs()
+            }
+            val screenshotFile = File(directory, screenshotName + SCREENSHOT_FORMAT)
+            if (!screenshotFile.exists()) {
+                screenshotFile.createNewFile()
+            }
+
+            BufferedOutputStream(FileOutputStream(screenshotFile)).use {
+                screenshot.compress(Bitmap.CompressFormat.PNG, IMAGE_QUALITY, it)
+                Chmod.chmodPlusR(screenshotFile)
+                screenshot.recycle()
+            }
+            Log.d("Screengrab", "Captured screenshot \"${screenshotFile.name}\"")
+        } catch (e: Exception) {
+            throw RuntimeException("Unable to capture screenshot.", e)
+        }
+    }
 }

--- a/Corona-Warn-App/src/debug/AndroidManifest.xml
+++ b/Corona-Warn-App/src/debug/AndroidManifest.xml
@@ -15,4 +15,8 @@
         android:name="android.permission.CHANGE_CONFIGURATION"
         tools:ignore="ProtectedPermissions" />
 
+    <application
+        android:requestLegacyExternalStorage="true"
+        tools:node="merge" />
+
 </manifest>

--- a/fastlane/Screengrabfile
+++ b/fastlane/Screengrabfile
@@ -1,4 +1,4 @@
-locales ['de-DE', 'en-US', 'tr-TR', 'bg-BG', 'pl-PL', 'ro-RO']
+locales ['de-DE', 'en-US']
 use_adb_root true
 clear_previous_screenshots true
 app_package_name 'de.rki.coronawarnapp.test'


### PR DESCRIPTION
- Run screenshots 📸 tests on Firebase Test Lab
- Refactor screenshots logic to work with both fastlane (locally) and Firebase Test Lab
- We can always switch at anytime with less effort

## Outcome
- Quick and reliable screenshots job
- High quality screenshots (No blank anymore)

## Changes
- No html file to display the results 🧾 
- Tests tab shows number of tests combined for both locales (DE, EN) = `96` Tests (In case. something went wrong, you would still know)
- Screenshots 🖼  and other artifacts (Logs + test_result) are zipped together.

[Build Link](https://app.circleci.com/pipelines/github/corona-warn-app/cwa-app-android/10132/workflows/a6bdbfc1-1250-4776-80ed-1c8b54131c49/jobs/61908/steps)

Enjoy 😉 release builds 🏭  🚀