### PR TITLE
Use last OTP auth result to check month on client side (EXPOSUREAPP-5246)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/OTPAuthorizationResult.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/OTPAuthorizationResult.kt
@@ -12,5 +12,10 @@ data class OTPAuthorizationResult(
     @SerializedName("authorized")
     val authorized: Boolean,
     @SerializedName("redeemedAt")
-    val redeemedAt: Instant
-)
+    val redeemedAt: Instant,
+    @SerializedName("invalidated")
+    val invalidated: Boolean
+) {
+
+    fun toInvalidatedInstance() = OTPAuthorizationResult(uuid, authorized, redeemedAt, true)
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/survey/SurveySettings.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/survey/SurveySettings.kt
@@ -52,6 +52,7 @@ class SurveySettings @Inject constructor(
                     requireNotNull(result.uuid)
                     requireNotNull(result.authorized)
                     requireNotNull(result.redeemedAt)
+                    requireNotNull(result.invalidated)
                     return result
                 }
                 return null

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/datadonation/storage/OTPRepositoryTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/datadonation/storage/OTPRepositoryTest.kt
@@ -69,7 +69,8 @@ class OTPRepositoryTest : BaseTest() {
         settings.otpAuthorizationResult = OTPAuthorizationResult(
             UUID.randomUUID(),
             true,
-            Instant.now()
+            Instant.now(),
+            false
         )
 
         settings.otpAuthorizationResult shouldNotBe null
@@ -87,7 +88,8 @@ class OTPRepositoryTest : BaseTest() {
         OTPRepository(settings).otpAuthorizationResult = OTPAuthorizationResult(
             UUID.randomUUID(),
             true,
-            Instant.now()
+            Instant.now(),
+            false
         )
         settings.oneTimePassword shouldBe null
     }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/datadonation/survey/SurveySettingsTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/datadonation/survey/SurveySettingsTest.kt
@@ -101,7 +101,8 @@ class SurveySettingsTest : BaseTest() {
                 {
                     "uuid":"e103c755-0975-4588-a639-d0cd1ba421a1",
                     "authorized": true,
-                    "redeemedAt": 1612381217443
+                    "redeemedAt": 1612381217443,
+                    "invalidated": true
                 }
             """.trimIndent()
         ).apply()
@@ -111,6 +112,7 @@ class SurveySettingsTest : BaseTest() {
         value!!.uuid.toString() shouldBe "e103c755-0975-4588-a639-d0cd1ba421a1"
         value.authorized shouldBe true
         value.redeemedAt.millis shouldBe 1612381217443
+        value.invalidated shouldBe true
     }
 
     @Test
@@ -133,14 +135,15 @@ class SurveySettingsTest : BaseTest() {
         val redeemedAt = Instant.ofEpochMilli(1612381217445)
 
         val instance = SurveySettings(context, baseGson)
-        instance.otpAuthorizationResult = OTPAuthorizationResult(uuid, authorized, redeemedAt)
+        instance.otpAuthorizationResult = OTPAuthorizationResult(uuid, authorized, redeemedAt, false)
 
         val value = preferences.getString("otp_result", null)
         value shouldBe """
             {
               "uuid": "e103c755-0975-4588-a639-d0cd1ba421a0",
               "authorized": false,
-              "redeemedAt": 1612381217445
+              "redeemedAt": 1612381217445,
+              "invalidated": false
             }
         """.trimIndent()
     }


### PR DESCRIPTION
how to test:
1. take a survey (in month m)
2. make the card green, then red again
3. try to take the survey again (still in month m)
expected: app shows info (not: error) that you already took part this month