### PR TITLE
FIX: No PPA submission in background over 36+ hours (EXPOSUREAPP-5286)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/main/MainActivityTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/main/MainActivityTest.kt
@@ -17,6 +17,7 @@ import de.rki.coronawarnapp.contactdiary.ui.ContactDiarySettings
 import de.rki.coronawarnapp.contactdiary.ui.overview.ContactDiaryOverviewFragment
 import de.rki.coronawarnapp.contactdiary.ui.overview.ContactDiaryOverviewViewModel
 import de.rki.coronawarnapp.contactdiary.ui.overview.adapter.ListItem
+import de.rki.coronawarnapp.datadonation.analytics.worker.DataDonationAnalyticsScheduler
 import de.rki.coronawarnapp.deadman.DeadmanNotificationScheduler
 import de.rki.coronawarnapp.environment.EnvironmentSetup
 import de.rki.coronawarnapp.main.CWASettings
@@ -438,6 +439,12 @@ class MainProviderModule {
     @Provides
     fun contactDiaryWorkScheduler(): ContactDiaryWorkScheduler =
         mockk<ContactDiaryWorkScheduler>(relaxed = true).apply {
+            every { schedulePeriodic() } just Runs
+        }
+
+    @Provides
+    fun dataDonationAnalyticsScheduler(): DataDonationAnalyticsScheduler =
+        mockk<DataDonationAnalyticsScheduler>(relaxed = true).apply {
             every { schedulePeriodic() } just Runs
         }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/CoronaWarnApplication.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/CoronaWarnApplication.kt
@@ -92,7 +92,6 @@ class CoronaWarnApplication : Application(), HasAndroidInjector {
                 deadmanNotificationScheduler.schedulePeriodic()
             }
             contactDiaryWorkScheduler.schedulePeriodic()
-            dataDonationAnalyticsScheduler.schedulePeriodic()
         }
 
         deviceTimeHandler.launch()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/worker/DataDonationAnalyticsScheduler.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/worker/DataDonationAnalyticsScheduler.kt
@@ -3,6 +3,7 @@ package de.rki.coronawarnapp.datadonation.analytics.worker
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.WorkManager
 import dagger.Reusable
+import timber.log.Timber
 import javax.inject.Inject
 
 /**
@@ -22,12 +23,18 @@ class DataDonationAnalyticsScheduler @Inject constructor(
      * Enqueue background analytics submission periodic work
      */
     fun schedulePeriodic() {
-        val additionalDelay = timeCalculation.getDelay()
+        val initialDelay = timeCalculation.getDelay()
+
+        Timber.d(
+            "scheduling Analytics job for %s Hours in the future, will repeat every 24 Hours from there",
+            initialDelay.standardHours
+        )
+
         // Create unique work and enqueue
         workManager.enqueueUniquePeriodicWork(
             PERIODIC_WORK_NAME,
             ExistingPeriodicWorkPolicy.KEEP,
-            workBuilder.buildPeriodicWork(additionalDelay)
+            workBuilder.buildPeriodicWork(initialDelay)
         )
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/worker/DataDonationAnalyticsScheduler.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/worker/DataDonationAnalyticsScheduler.kt
@@ -3,7 +3,6 @@ package de.rki.coronawarnapp.datadonation.analytics.worker
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.WorkManager
 import dagger.Reusable
-import timber.log.Timber
 import javax.inject.Inject
 
 /**

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/worker/DataDonationAnalyticsScheduler.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/worker/DataDonationAnalyticsScheduler.kt
@@ -25,11 +25,6 @@ class DataDonationAnalyticsScheduler @Inject constructor(
     fun schedulePeriodic() {
         val initialDelay = timeCalculation.getDelay()
 
-        Timber.d(
-            "scheduling Analytics job for %s Hours in the future, will repeat every 24 Hours from there",
-            initialDelay.standardHours
-        )
-
         // Create unique work and enqueue
         workManager.enqueueUniquePeriodicWork(
             PERIODIC_WORK_NAME,

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/worker/DataDonationAnalyticsWorkBuilder.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/worker/DataDonationAnalyticsWorkBuilder.kt
@@ -12,12 +12,12 @@ import javax.inject.Inject
 
 @Reusable
 class DataDonationAnalyticsWorkBuilder @Inject constructor() {
-    fun buildPeriodicWork(additionalDelay: Duration): PeriodicWorkRequest =
+    fun buildPeriodicWork(initialDelay: Duration): PeriodicWorkRequest =
         PeriodicWorkRequestBuilder<DataDonationAnalyticsPeriodicWorker>(
             DateTimeConstants.HOURS_PER_DAY.toLong(), TimeUnit.HOURS
         )
             .setInitialDelay(
-                DateTimeConstants.HOURS_PER_DAY.toLong() + additionalDelay.standardHours,
+                initialDelay.standardHours,
                 TimeUnit.HOURS
             )
             .setBackoffCriteria(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainActivity.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainActivity.kt
@@ -17,6 +17,7 @@ import dagger.android.HasAndroidInjector
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.contactdiary.retention.ContactDiaryWorkScheduler
 import de.rki.coronawarnapp.databinding.ActivityMainBinding
+import de.rki.coronawarnapp.datadonation.analytics.worker.DataDonationAnalyticsScheduler
 import de.rki.coronawarnapp.deadman.DeadmanNotificationScheduler
 import de.rki.coronawarnapp.storage.LocalData
 import de.rki.coronawarnapp.ui.base.startActivitySafely
@@ -61,6 +62,7 @@ class MainActivity : AppCompatActivity(), HasAndroidInjector {
     @Inject lateinit var powerManagement: PowerManagement
     @Inject lateinit var deadmanScheduler: DeadmanNotificationScheduler
     @Inject lateinit var contactDiaryWorkScheduler: ContactDiaryWorkScheduler
+    @Inject lateinit var dataDonationAnalyticsScheduler: DataDonationAnalyticsScheduler
 
     override fun onCreate(savedInstanceState: Bundle?) {
         AppInjector.setup(this)
@@ -108,6 +110,7 @@ class MainActivity : AppCompatActivity(), HasAndroidInjector {
         scheduleWork()
         vm.doBackgroundNoiseCheck()
         contactDiaryWorkScheduler.schedulePeriodic()
+        dataDonationAnalyticsScheduler.schedulePeriodic()
         if (!LocalData.isAllowedToSubmitDiagnosisKeys()) {
             deadmanScheduler.schedulePeriodic()
         }


### PR DESCRIPTION
### Description

This PR changes a few values in the PPA Worker Scheduling logic to combat huge initial execution delays and provide a more testable experience

Note that this does not influence the repeat of submissions every 24Hours afterwards, these should still happen as usual.

### Steps to reproduce
1. Install App and consent to analytics donation
2. Wait 24 Hours (or check logcat for actual analytics scheduling delay)
3. An Analytics donation should have been triggered in the background
