### PR TITLE
Add network connected constraint to DataDonationAnalyticsWorker (EXPOSUREAPP-5286)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/worker/DataDonationAnalyticsWorkBuilder.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/worker/DataDonationAnalyticsWorkBuilder.kt
@@ -1,6 +1,8 @@
 package de.rki.coronawarnapp.datadonation.analytics.worker
 
 import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequest
 import androidx.work.PeriodicWorkRequestBuilder
 import dagger.Reusable
@@ -25,5 +27,11 @@ class DataDonationAnalyticsWorkBuilder @Inject constructor() {
                 BackgroundConstants.BACKOFF_INITIAL_DELAY,
                 TimeUnit.MINUTES
             )
+            .setConstraints(buildConstraints())
+            .build()
+
+    private fun buildConstraints() =
+        Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
             .build()
 }


### PR DESCRIPTION
### Description
This PR adds a network connected constraint to the work builder of the DataDonationAnalyticsWorker as we cannot proceed with analytics donation without a network connection there is no need to enqueue work in that case

### Steps to reproduce
<!--
How can your changes be tested?
1. First step
2. Second step
 -->
