### PR TITLE
Optimized otp auth result entity (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/OTPAuthorizationResult.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/OTPAuthorizationResult.kt
@@ -14,8 +14,8 @@ data class OTPAuthorizationResult(
     @SerializedName("redeemedAt")
     val redeemedAt: Instant,
     @SerializedName("invalidated")
-    val invalidated: Boolean
+    val invalidated: Boolean = false
 ) {
 
-    fun toInvalidatedInstance() = OTPAuthorizationResult(uuid, authorized, redeemedAt, true)
+    fun toInvalidatedInstance() = copy(invalidated = true)
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/survey/Surveys.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/survey/Surveys.kt
@@ -63,8 +63,7 @@ class Surveys @Inject constructor(
         val result = OTPAuthorizationResult(
             uuid = oneTimePassword.uuid,
             authorized = errorCode == null,
-            redeemedAt = now,
-            invalidated = false
+            redeemedAt = now
         )
         oneTimePasswordRepo.otpAuthorizationResult = result
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/datadonation/storage/OTPRepositoryTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/datadonation/storage/OTPRepositoryTest.kt
@@ -69,8 +69,7 @@ class OTPRepositoryTest : BaseTest() {
         settings.otpAuthorizationResult = OTPAuthorizationResult(
             UUID.randomUUID(),
             true,
-            Instant.now(),
-            false
+            Instant.now()
         )
 
         settings.otpAuthorizationResult shouldNotBe null
@@ -88,8 +87,7 @@ class OTPRepositoryTest : BaseTest() {
         OTPRepository(settings).otpAuthorizationResult = OTPAuthorizationResult(
             UUID.randomUUID(),
             true,
-            Instant.now(),
-            false
+            Instant.now()
         )
         settings.oneTimePassword shouldBe null
     }


### PR DESCRIPTION
use copy constructor, made 'invalidated'-flag optional