### PR TITLE
Skip consent screen on subsequent survey participations (EXPOSUREAPP-5278)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/tracing/TracingDetailsFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/tracing/TracingDetailsFragmentTest.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import dagger.Module
 import dagger.android.ContributesAndroidInjector
+import de.rki.coronawarnapp.datadonation.survey.Surveys
 import de.rki.coronawarnapp.risk.storage.RiskLevelStorage
 import de.rki.coronawarnapp.storage.TracingRepository
 import de.rki.coronawarnapp.tracing.GeneralTracingStatus
@@ -24,12 +25,12 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import testhelpers.BaseUITest
-import testhelpers.takeScreenshot
 import testhelpers.Screenshot
 import testhelpers.SystemUIDemoModeRule
 import testhelpers.TestDispatcherProvider
 import testhelpers.launchFragment2
 import testhelpers.launchFragmentInContainer2
+import testhelpers.takeScreenshot
 import tools.fastlane.screengrab.locale.LocaleTestRule
 
 @RunWith(AndroidJUnit4::class)
@@ -41,6 +42,7 @@ class TracingDetailsFragmentTest : BaseUITest() {
     @MockK lateinit var tracingDetailsItemProvider: TracingDetailsItemProvider
     @MockK lateinit var tracingStateProviderFactory: TracingStateProvider.Factory
     @MockK lateinit var tracingRepository: TracingRepository
+    @MockK lateinit var surveys: Surveys
 
     private lateinit var viewModel: TracingDetailsFragmentViewModel
 
@@ -63,7 +65,8 @@ class TracingDetailsFragmentTest : BaseUITest() {
                 riskLevelStorage = riskLevelStorage,
                 tracingDetailsItemProvider = tracingDetailsItemProvider,
                 tracingStateProviderFactory = tracingStateProviderFactory,
-                tracingRepository = tracingRepository
+                tracingRepository = tracingRepository,
+                surveys = surveys
             )
         )
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/survey/Surveys.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/survey/Surveys.kt
@@ -37,6 +37,36 @@ class Surveys @Inject constructor(
             }
     }
 
+    suspend fun isConsentNeeded(type: Type): ConsentResult {
+
+        when (type) {
+            Type.HIGH_RISK_ENCOUNTER -> {
+
+                // If no OTP was ever authorized, we need a consent.
+                val authResult = oneTimePasswordRepo.otpAuthorizationResult ?: return ConsentResult.Needed
+
+                // If we already have an authorized OTP for this high-risk state
+                // we can skip the consent and directly show the url in the browser.
+                // We know that the otp belongs to the current high-risk state, because the authResult gets
+                // invalidated on high to low risk state transitions.
+                if (authResult.authorized && !authResult.invalidated) {
+                    val surveyLink = urlProvider.provideUrl(type, authResult.uuid)
+                    return ConsentResult.NotNeeded(surveyLink)
+                }
+
+                // Finally, we need a consent for stored OTPs where the authorization failed (authorized == false)
+                // or when the app shows a new high-risk card (and therefore authResult was previously invalidated when the
+                // risk changed from high to low)
+                return ConsentResult.Needed
+            }
+        }
+    }
+
+    sealed class ConsentResult {
+        object Needed : ConsentResult()
+        data class NotNeeded(val surveyLink: String) : ConsentResult()
+    }
+
     suspend fun requestDetails(type: Type): Survey {
         val config = appConfigProvider.getAppConfig().survey
         Timber.v("Requested survey: %s", config)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/survey/Surveys.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/survey/Surveys.kt
@@ -51,7 +51,7 @@ class Surveys @Inject constructor(
                 // invalidated on high to low risk state transitions.
                 if (authResult.authorized && !authResult.invalidated) {
                     val surveyLink = urlProvider.provideUrl(type, authResult.uuid)
-                    return ConsentResult.NotNeeded(surveyLink)
+                    return ConsentResult.AlreadyGiven(surveyLink)
                 }
 
                 // Finally, we need a consent for stored OTPs where the authorization failed (authorized == false)
@@ -64,7 +64,7 @@ class Surveys @Inject constructor(
 
     sealed class ConsentResult {
         object Needed : ConsentResult()
-        data class NotNeeded(val surveyLink: String) : ConsentResult()
+        data class AlreadyGiven(val surveyLink: String) : ConsentResult()
     }
 
     suspend fun requestDetails(type: Type): Survey {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/details/TracingDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/details/TracingDetailsFragment.kt
@@ -8,6 +8,7 @@ import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.LinearLayoutManager
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.TracingDetailsFragmentLayoutBinding
+import de.rki.coronawarnapp.util.ExternalActionHelper
 import de.rki.coronawarnapp.util.di.AutoInject
 import de.rki.coronawarnapp.util.lists.diffutil.update
 import de.rki.coronawarnapp.util.ui.doNavigate
@@ -54,6 +55,10 @@ class TracingDetailsFragment : Fragment(R.layout.tracing_details_fragment_layout
             when (it) {
                 is TracingDetailsNavigationEvents.NavigateToSurveyConsentFragment -> doNavigate(
                     TracingDetailsFragmentDirections.actionRiskDetailsFragmentToSurveyConsentFragment(it.type)
+                )
+                is TracingDetailsNavigationEvents.NavigateToSurveyUrlInBrowser -> ExternalActionHelper.openUrl(
+                    this,
+                    it.url
                 )
             }
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/details/TracingDetailsFragmentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/details/TracingDetailsFragmentViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.asLiveData
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import de.rki.coronawarnapp.datadonation.survey.Surveys
+import de.rki.coronawarnapp.datadonation.survey.Surveys.ConsentResult.Needed
+import de.rki.coronawarnapp.datadonation.survey.Surveys.ConsentResult.NotNeeded
 import de.rki.coronawarnapp.risk.RiskState
 import de.rki.coronawarnapp.risk.storage.RiskLevelStorage
 import de.rki.coronawarnapp.risk.tryLatestResultsWithDefaults
@@ -112,12 +114,12 @@ class TracingDetailsFragmentViewModel @AssistedInject constructor(
             is UserSurveyBox.Item ->
                 launch {
                     when (val consentResult = surveys.isConsentNeeded(Surveys.Type.HIGH_RISK_ENCOUNTER)) {
-                        is Surveys.ConsentResult.Needed -> routeToScreen.postValue(
+                        is Needed -> routeToScreen.postValue(
                             TracingDetailsNavigationEvents.NavigateToSurveyConsentFragment(
                                 item.type
                             )
                         )
-                        is Surveys.ConsentResult.NotNeeded -> routeToScreen.postValue(
+                        is NotNeeded -> routeToScreen.postValue(
                             TracingDetailsNavigationEvents.NavigateToSurveyUrlInBrowser(
                                 consentResult.surveyLink
                             )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/details/TracingDetailsFragmentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/details/TracingDetailsFragmentViewModel.kt
@@ -5,8 +5,8 @@ import androidx.lifecycle.asLiveData
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import de.rki.coronawarnapp.datadonation.survey.Surveys
+import de.rki.coronawarnapp.datadonation.survey.Surveys.ConsentResult.AlreadyGiven
 import de.rki.coronawarnapp.datadonation.survey.Surveys.ConsentResult.Needed
-import de.rki.coronawarnapp.datadonation.survey.Surveys.ConsentResult.NotNeeded
 import de.rki.coronawarnapp.risk.RiskState
 import de.rki.coronawarnapp.risk.storage.RiskLevelStorage
 import de.rki.coronawarnapp.risk.tryLatestResultsWithDefaults
@@ -119,7 +119,7 @@ class TracingDetailsFragmentViewModel @AssistedInject constructor(
                                 item.type
                             )
                         )
-                        is NotNeeded -> routeToScreen.postValue(
+                        is AlreadyGiven -> routeToScreen.postValue(
                             TracingDetailsNavigationEvents.NavigateToSurveyUrlInBrowser(
                                 consentResult.surveyLink
                             )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/details/TracingDetailsFragmentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/details/TracingDetailsFragmentViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.asLiveData
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import de.rki.coronawarnapp.datadonation.survey.Surveys
 import de.rki.coronawarnapp.risk.RiskState
 import de.rki.coronawarnapp.risk.storage.RiskLevelStorage
 import de.rki.coronawarnapp.risk.tryLatestResultsWithDefaults
@@ -42,7 +43,8 @@ class TracingDetailsFragmentViewModel @AssistedInject constructor(
     riskLevelStorage: RiskLevelStorage,
     tracingDetailsItemProvider: TracingDetailsItemProvider,
     tracingStateProviderFactory: TracingStateProvider.Factory,
-    private val tracingRepository: TracingRepository
+    private val tracingRepository: TracingRepository,
+    private val surveys: Surveys
 ) : CWAViewModel(dispatcherProvider = dispatcherProvider) {
 
     private val tracingStateProvider by lazy { tracingStateProviderFactory.create(isDetailsMode = true) }
@@ -108,7 +110,20 @@ class TracingDetailsFragmentViewModel @AssistedInject constructor(
     fun onItemClicked(item: DetailsItem) {
         when (item) {
             is UserSurveyBox.Item ->
-                routeToScreen.postValue(TracingDetailsNavigationEvents.NavigateToSurveyConsentFragment(item.type))
+                launch {
+                    when (val consentResult = surveys.isConsentNeeded(Surveys.Type.HIGH_RISK_ENCOUNTER)) {
+                        is Surveys.ConsentResult.Needed -> routeToScreen.postValue(
+                            TracingDetailsNavigationEvents.NavigateToSurveyConsentFragment(
+                                item.type
+                            )
+                        )
+                        is Surveys.ConsentResult.NotNeeded -> routeToScreen.postValue(
+                            TracingDetailsNavigationEvents.NavigateToSurveyUrlInBrowser(
+                                consentResult.surveyLink
+                            )
+                        )
+                    }
+                }
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/details/TracingDetailsNavigationEvents.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/details/TracingDetailsNavigationEvents.kt
@@ -3,5 +3,6 @@ package de.rki.coronawarnapp.tracing.ui.details
 import de.rki.coronawarnapp.datadonation.survey.Surveys
 
 sealed class TracingDetailsNavigationEvents {
-    class NavigateToSurveyConsentFragment(val type: Surveys.Type) : TracingDetailsNavigationEvents()
+    data class NavigateToSurveyConsentFragment(val type: Surveys.Type) : TracingDetailsNavigationEvents()
+    data class NavigateToSurveyUrlInBrowser(val url: String) : TracingDetailsNavigationEvents()
 }


### PR DESCRIPTION
When the user has already granted his consent to participate in the survey for his current high-risk state, and the app has successfully authorized an OTP, subsequent clicks on the "Zur Befragung" Button of the Survey Card in the high-risk detail screen should lead the user directly to the survey URL in the browser instead of to the consent screen again. 

The user should only see the consent screen again when he wants to participate in a survey when he gets a **new** high-risk state. 

Testing: 
- Trigger high-risk state
- Click on "Zur Befragung" in Survey Card
- Consent Screen should show up
- Grant consent to authorize OTP
- Survey should open in the Browser
- Click again on "Zur Befragung" in the survey card
- Browser with survey should be opened instead of the Consent Screen
- Trigger **new** high-risk state (trigger low risk and then high risk)
- Click on "Zur Befragung" in the card should show consent screen again
- If the current fake date of the device is in the same month as when the first OTP was authenticated, the "Only one participation per month" error should be shown, otherwise, the user gets to the survey and subsequent clicks on "Zur Befragung" should navigate him directly to the browser again

