### PR TITLE
Exposure Checks are continued in End-of-Life State (EXPOSUREAPP-5298)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/DownloadDiagnosisKeysTask.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/DownloadDiagnosisKeysTask.kt
@@ -8,6 +8,7 @@ import de.rki.coronawarnapp.environment.EnvironmentSetup
 import de.rki.coronawarnapp.nearby.ENFClient
 import de.rki.coronawarnapp.nearby.modules.detectiontracker.TrackedExposureDetection
 import de.rki.coronawarnapp.risk.RollbackItem
+import de.rki.coronawarnapp.storage.LocalData
 import de.rki.coronawarnapp.task.Task
 import de.rki.coronawarnapp.task.TaskCancellationException
 import de.rki.coronawarnapp.task.TaskFactory
@@ -110,6 +111,11 @@ class DownloadDiagnosisKeysTask @Inject constructor(
 
             // remember version code of this execution for next time
             settings.updateLastVersionCodeToCurrent()
+
+            if (LocalData.isAllowedToSubmitDiagnosisKeys()) {
+                Timber.tag(TAG).i("task aborted, positive test result")
+                return object : Task.Result {}
+            }
 
             Timber.tag(TAG).d("Attempting submission to ENF")
             val isSubmissionSuccessful = enfClient.provideDiagnosisKeys(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/DownloadDiagnosisKeysTask.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/DownloadDiagnosisKeysTask.kt
@@ -26,6 +26,7 @@ import java.util.Date
 import javax.inject.Inject
 import javax.inject.Provider
 
+@Suppress("ReturnCount")
 class DownloadDiagnosisKeysTask @Inject constructor(
     private val enfClient: ENFClient,
     private val environmentSetup: EnvironmentSetup,

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/DownloadDiagnosisKeysTaskTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/DownloadDiagnosisKeysTaskTest.kt
@@ -8,6 +8,7 @@ import de.rki.coronawarnapp.environment.BuildConfigWrap
 import de.rki.coronawarnapp.environment.EnvironmentSetup
 import de.rki.coronawarnapp.nearby.ENFClient
 import de.rki.coronawarnapp.nearby.modules.detectiontracker.TrackedExposureDetection
+import de.rki.coronawarnapp.storage.LocalData
 import de.rki.coronawarnapp.util.TimeStamper
 import io.mockk.MockKAnnotations
 import io.mockk.Runs
@@ -54,6 +55,8 @@ class DownloadDiagnosisKeysTaskTest : BaseTest() {
 
         mockkObject(BuildConfigWrap)
         every { BuildConfigWrap.VERSION_CODE } returns 1080005
+        mockkObject(LocalData)
+        every { LocalData.isAllowedToSubmitDiagnosisKeys() } returns false
 
         availableKey1.apply {
             every { path } returns File("availableKey1")
@@ -224,6 +227,22 @@ class DownloadDiagnosisKeysTaskTest : BaseTest() {
 
         coVerifySequence {
             enfClient.isTracingEnabled
+        }
+
+        coVerify(exactly = 0) {
+            enfClient.provideDiagnosisKeys(any(), any())
+        }
+    }
+
+    @Test
+    fun `we do not submit keys if user got positive test results`() = runBlockingTest {
+        every { LocalData.isAllowedToSubmitDiagnosisKeys() } returns true
+
+        createInstance().run(DownloadDiagnosisKeysTask.Arguments())
+
+        coVerifySequence {
+            enfClient.isTracingEnabled
+            enfClient.latestTrackedExposureDetection()
         }
 
         coVerify(exactly = 0) {


### PR DESCRIPTION
**Fixing:** Exposure Checks are continued in End-of-Life State

**Testing:**
1. Add a positive test to the app
2. There shouldn't be any new exposure check from the time you scanned the QR code until you remove the test from the app. Check in `os settings > google > covid 19 > three dots > exposure checks`
3. Remove QR code exposure checks should continue