### PR TITLE
Contact Journal Button Styling in Darkmode (EXPOSUREAPP-5160)

### DIFF
--- a/Corona-Warn-App/src/main/res/values/styles.xml
+++ b/Corona-Warn-App/src/main/res/values/styles.xml
@@ -111,7 +111,7 @@
         <item name="textAllCaps">false</item>
         <item name="android:fontFamily">sans-serif-medium</item>
         <item name="android:textStyle">normal</item>
-        <item name="android:textColor">#000000</item>
+        <item name="android:textColor">@color/colorTextPrimary1</item>
 
     </style>
 


### PR DESCRIPTION
Small PR that changes the dark mode button text color in the contact journal day screen.

![button_styling](https://user-images.githubusercontent.com/75120552/108851271-8a680c00-75e4-11eb-813f-238e41d6322a.png)


