### PR TITLE
Hide progress dialog on missing consent from both Google and App (EXPOSUREAPP-5320)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/resultavailable/SubmissionTestResultAvailableFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/resultavailable/SubmissionTestResultAvailableFragment.kt
@@ -54,7 +54,7 @@ class SubmissionTestResultAvailableFragment : Fragment(R.layout.fragment_submiss
             binding.submissionTestResultAvailableConsentStatus.consent = it
         }
 
-        vm.showKeyRetrievalProgress.observe2(this) { show ->
+        vm.showKeysRetrievalProgress.observe2(this) { show ->
             Timber.i("SubmissionTestResult:showKeyRetrievalProgress:$show")
             keyRetrievalProgress.setState(show)
             binding.submissionTestResultAvailableProceedButton.isEnabled = !show

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/resultavailable/SubmissionTestResultAvailableViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/resultavailable/SubmissionTestResultAvailableViewModel.kt
@@ -32,7 +32,7 @@ class SubmissionTestResultAvailableViewModel @AssistedInject constructor(
     val consent = consentFlow.asLiveData(dispatcherProvider.Default)
     val showPermissionRequest = SingleLiveEvent<(Activity) -> Unit>()
     val showCloseDialog = SingleLiveEvent<Unit>()
-    val showKeyRetrievalProgress = SingleLiveEvent<Boolean>()
+    val showKeysRetrievalProgress = SingleLiveEvent<Boolean>()
     val showTracingConsentDialog = SingleLiveEvent<(Boolean) -> Unit>()
 
     private val tekHistoryUpdater = tekHistoryUpdaterFactory.create(object : TEKHistoryUpdater.Callback {
@@ -45,25 +45,28 @@ class SubmissionTestResultAvailableViewModel @AssistedInject constructor(
                     .actionSubmissionTestResultAvailableFragmentToSubmissionTestResultConsentGivenFragment()
             )
 
-            showKeyRetrievalProgress.postValue(false)
+            showKeysRetrievalProgress.postValue(false)
         }
 
         override fun onTEKPermissionDeclined() {
+            Timber.d("onTEKPermissionDeclined")
             routeToScreen.postValue(
                 SubmissionTestResultAvailableFragmentDirections
                     .actionSubmissionTestResultAvailableFragmentToSubmissionTestResultNoConsentFragment()
             )
-            showKeyRetrievalProgress.postValue(false)
+            showKeysRetrievalProgress.postValue(false)
         }
 
         override fun onTracingConsentRequired(onConsentResult: (given: Boolean) -> Unit) {
+            Timber.d("onTracingConsentRequired")
             showTracingConsentDialog.postValue(onConsentResult)
-            showKeyRetrievalProgress.postValue(false)
+            showKeysRetrievalProgress.postValue(false)
         }
 
         override fun onPermissionRequired(permissionRequest: (Activity) -> Unit) {
+            Timber.d("onPermissionRequired")
             showPermissionRequest.postValue(permissionRequest)
-            showKeyRetrievalProgress.postValue(false)
+            showKeysRetrievalProgress.postValue(false)
         }
 
         override fun onError(error: Throwable) {
@@ -72,7 +75,7 @@ class SubmissionTestResultAvailableViewModel @AssistedInject constructor(
                 exceptionCategory = ExceptionCategory.EXPOSURENOTIFICATION,
                 prefix = "SubmissionTestResultAvailableViewModel"
             )
-            showKeyRetrievalProgress.postValue(false)
+            showKeysRetrievalProgress.postValue(false)
         }
     })
 
@@ -101,11 +104,14 @@ class SubmissionTestResultAvailableViewModel @AssistedInject constructor(
     }
 
     fun proceed() {
-        showKeyRetrievalProgress.value = true
+        showKeysRetrievalProgress.value = true
         launch {
             if (consentFlow.first()) {
+                Timber.d("tekHistoryUpdater.updateTEKHistoryOrRequestPermission")
                 tekHistoryUpdater.updateTEKHistoryOrRequestPermission()
             } else {
+                Timber.d("routeToScreen:SubmissionTestResultNoConsentFragment")
+                showKeysRetrievalProgress.postValue(false)
                 routeToScreen.postValue(
                     SubmissionTestResultAvailableFragmentDirections
                         .actionSubmissionTestResultAvailableFragmentToSubmissionTestResultNoConsentFragment()
@@ -115,7 +121,7 @@ class SubmissionTestResultAvailableViewModel @AssistedInject constructor(
     }
 
     fun handleActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        showKeyRetrievalProgress.value = true
+        showKeysRetrievalProgress.value = true
         tekHistoryUpdater.handleActivityResult(requestCode, resultCode, data)
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/warnothers/SubmissionResultPositiveOtherWarningNoConsentFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/warnothers/SubmissionResultPositiveOtherWarningNoConsentFragment.kt
@@ -52,7 +52,7 @@ class SubmissionResultPositiveOtherWarningNoConsentFragment :
             doNavigate(it)
         }
 
-        viewModel.keysRetrievalProgress.observe2(this) { show ->
+        viewModel.showKeysRetrievalProgress.observe2(this) { show ->
             keysRetrievalProgress.setState(show)
             binding.submissionPositiveOtherWarningNoConsentButtonNext.isEnabled = !show
         }
@@ -93,6 +93,6 @@ class SubmissionResultPositiveOtherWarningNoConsentFragment :
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        viewModel.handleActivityRersult(requestCode, resultCode, data)
+        viewModel.handleActivityResult(requestCode, resultCode, data)
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/warnothers/SubmissionResultPositiveOtherWarningNoConsentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/warnothers/SubmissionResultPositiveOtherWarningNoConsentViewModel.kt
@@ -32,7 +32,7 @@ class SubmissionResultPositiveOtherWarningNoConsentViewModel @AssistedInject con
 
     val routeToScreen = SingleLiveEvent<NavDirections>()
 
-    val keysRetrievalProgress = SingleLiveEvent<Boolean>()
+    val showKeysRetrievalProgress = SingleLiveEvent<Boolean>()
 
     val showPermissionRequest = SingleLiveEvent<(Activity) -> Unit>()
 
@@ -47,7 +47,7 @@ class SubmissionResultPositiveOtherWarningNoConsentViewModel @AssistedInject con
         override fun onTEKAvailable(teks: List<TemporaryExposureKey>) {
             Timber.d("onTEKAvailable(tek.size=%d)", teks.size)
             autoSubmission.updateMode(AutoSubmission.Mode.MONITOR)
-            keysRetrievalProgress.postValue(false)
+            showKeysRetrievalProgress.postValue(false)
             routeToScreen.postValue(
                 SubmissionResultPositiveOtherWarningNoConsentFragmentDirections
                     .actionSubmissionResultPositiveOtherWarningNoConsentFragmentToSubmissionResultReadyFragment()
@@ -55,23 +55,26 @@ class SubmissionResultPositiveOtherWarningNoConsentViewModel @AssistedInject con
         }
 
         override fun onTEKPermissionDeclined() {
-            keysRetrievalProgress.postValue(false)
+            Timber.d("onTEKPermissionDeclined")
+            showKeysRetrievalProgress.postValue(false)
             // stay on screen
         }
 
         override fun onTracingConsentRequired(onConsentResult: (given: Boolean) -> Unit) {
-            keysRetrievalProgress.postValue(false)
+            Timber.d("onTracingConsentRequired")
+            showKeysRetrievalProgress.postValue(false)
             showTracingConsentDialog.postValue(onConsentResult)
         }
 
         override fun onPermissionRequired(permissionRequest: (Activity) -> Unit) {
-            keysRetrievalProgress.postValue(false)
+            Timber.d("onPermissionRequired")
+            showKeysRetrievalProgress.postValue(false)
             showPermissionRequest.postValue(permissionRequest)
         }
 
         override fun onError(error: Throwable) {
-            keysRetrievalProgress.postValue(false)
             Timber.e(error, "Couldn't access temporary exposure key history.")
+            showKeysRetrievalProgress.postValue(false)
             error.report(ExceptionCategory.EXPOSURENOTIFICATION, "Failed to obtain TEKs.")
         }
     })
@@ -84,13 +87,16 @@ class SubmissionResultPositiveOtherWarningNoConsentViewModel @AssistedInject con
     }
 
     fun onConsentButtonClicked() {
-        keysRetrievalProgress.value = true
+        showKeysRetrievalProgress.value = true
         submissionRepository.giveConsentToSubmission()
         launch {
             if (enfClient.isTracingEnabled.first()) {
+                Timber.d("tekHistoryUpdater.updateTEKHistoryOrRequestPermission()")
                 tekHistoryUpdater.updateTEKHistoryOrRequestPermission()
             } else {
+                Timber.d("showEnableTracingEvent:Unit")
                 showEnableTracingEvent.postValue(Unit)
+                showKeysRetrievalProgress.postValue(false)
             }
         }
     }
@@ -102,8 +108,8 @@ class SubmissionResultPositiveOtherWarningNoConsentViewModel @AssistedInject con
         )
     }
 
-    fun handleActivityRersult(requestCode: Int, resultCode: Int, data: Intent?) {
-        keysRetrievalProgress.value = true
+    fun handleActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        showKeysRetrievalProgress.value = true
         tekHistoryUpdater.handleActivityResult(requestCode, resultCode, data)
     }
 


### PR DESCRIPTION
Before the fix:
1- Open the App and proceed  with QR code scanning 
2- Disallow Google consent 
3- Scan a positive test
4- Proceed to sharing
5- Click on Consent button and disallow our consent flag
6- return back and try to share the keys 
7- the progress dialog will be shown forever

After:
Dialog will hide if consent has not been given