### PR TITLE
Diary exporter improvements (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/durationpicker/DurationExtension.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/durationpicker/DurationExtension.kt
@@ -17,8 +17,14 @@ fun Duration.toContactDiaryFormat(): String {
     return "$hours:$minutes"
 }
 
-fun Duration.toReadableDuration(durationSuffix: String?): String {
+// returns readable durations with optional prefix and suffix such as "Dauer 01:30 h"
+fun Duration.toReadableDuration(prefix: String? = null, suffix: String? = null): String {
     val durationInMinutes = standardMinutes
     val durationString = String.format("%02d:%02d", durationInMinutes / 60, (durationInMinutes % 60))
-    return "$durationString $durationSuffix"
+
+    return listOfNotNull(
+        prefix,
+        durationString,
+        suffix
+    ).joinToString(separator = " ")
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/exporter/ContactDiaryExporter.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/exporter/ContactDiaryExporter.kt
@@ -5,12 +5,12 @@ import dagger.Reusable
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.contactdiary.model.ContactDiaryLocationVisit
 import de.rki.coronawarnapp.contactdiary.model.ContactDiaryPersonEncounter
+import de.rki.coronawarnapp.contactdiary.ui.durationpicker.toReadableDuration
 import de.rki.coronawarnapp.util.TimeAndDateExtensions.toLocalDate
 import de.rki.coronawarnapp.util.TimeStamper
 import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
 import de.rki.coronawarnapp.util.di.AppContext
 import kotlinx.coroutines.withContext
-import org.joda.time.Duration
 import org.joda.time.LocalDate
 import java.util.Locale
 import javax.inject.Inject
@@ -115,7 +115,7 @@ class ContactDiaryExporter @Inject constructor(
             date.toFormattedStringWithName(contactDiaryLocation.locationName),
             contactDiaryLocation.phoneNumber?.let { getPhoneWithPrefix(it) },
             contactDiaryLocation.emailAddress?.let { getEMailWithPrefix(it) },
-            getReadableDuration(duration),
+            duration?.toReadableDuration(durationPrefix, durationSuffix),
             circumstances
         ).joinToString(separator = "; ")
     }
@@ -138,14 +138,4 @@ class ContactDiaryExporter @Inject constructor(
 
     // According to tech spec german locale only
     private fun LocalDate.toFormattedString(): String = toString("dd.MM.yyyy", Locale.GERMAN)
-
-    // returns readable durations as e.g. "Dauer 01:30 h"
-    private fun getReadableDuration(duration: Duration?): String? {
-        if (duration == null) return null
-
-        val durationInMinutes = duration.standardMinutes
-        val durationString = String.format("%02d:%02d", durationInMinutes / 60, (durationInMinutes % 60))
-
-        return "$durationPrefix $durationString $durationSuffix"
-    }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/exporter/ContactDiaryExporter.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/exporter/ContactDiaryExporter.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.contactdiary.ui.exporter
 
 import android.content.Context
+import dagger.Reusable
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.contactdiary.model.ContactDiaryLocationVisit
 import de.rki.coronawarnapp.contactdiary.model.ContactDiaryPersonEncounter
@@ -13,9 +14,8 @@ import org.joda.time.Duration
 import org.joda.time.LocalDate
 import java.util.Locale
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
+@Reusable
 class ContactDiaryExporter @Inject constructor(
     @AppContext private val context: Context,
     private val timeStamper: TimeStamper,

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/exporter/ContactDiaryExporter.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/exporter/ContactDiaryExporter.kt
@@ -101,7 +101,7 @@ class ContactDiaryExporter @Inject constructor(
     private fun getStringToSortBy(name: String) = name.toLowerCase(Locale.ROOT)
 
     private fun ContactDiaryPersonEncounter.getExportInfo(date: LocalDate) = listOfNotNull(
-        getDateAndNameString(contactDiaryPerson.fullName, date),
+        date.toFormattedStringWithName(contactDiaryPerson.fullName),
         contactDiaryPerson.phoneNumber?.let { getPhoneWithPrefix(it) },
         contactDiaryPerson.emailAddress?.let { getEMailWithPrefix(it) },
         durationClassification?.let { getDurationClassificationString(it) },
@@ -112,7 +112,7 @@ class ContactDiaryExporter @Inject constructor(
 
     private fun ContactDiaryLocationVisit.getExportInfo(date: LocalDate): String {
         return listOfNotNull(
-            getDateAndNameString(contactDiaryLocation.locationName, date),
+            date.toFormattedStringWithName(contactDiaryLocation.locationName),
             contactDiaryLocation.phoneNumber?.let { getPhoneWithPrefix(it) },
             contactDiaryLocation.emailAddress?.let { getEMailWithPrefix(it) },
             getReadableDuration(duration),
@@ -120,7 +120,7 @@ class ContactDiaryExporter @Inject constructor(
         ).joinToString(separator = "; ")
     }
 
-    private fun getDateAndNameString(name: String, date: LocalDate) = "${date.toFormattedString()} $name"
+    private fun LocalDate.toFormattedStringWithName(name: String) = "${toFormattedString()} $name"
 
     private fun getPhoneWithPrefix(phone: String) = if (phone.isNotBlank()) {
         "$prefixPhone $phone"

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/overview/adapter/ContactDiaryOverviewNestedAdapter.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/overview/adapter/ContactDiaryOverviewNestedAdapter.kt
@@ -52,7 +52,7 @@ class ContactDiaryOverviewNestedAdapter : BaseAdapter<ContactDiaryOverviewNested
                 duration?.run {
                     if (duration != Duration.ZERO) {
                         val durationSuffix = context.getString(R.string.contact_diary_overview_location_duration_suffix)
-                        add(toReadableDuration(durationSuffix))
+                        add(toReadableDuration(suffix = durationSuffix))
                     }
                 }
                 resources?.run { forEach { add(context.getString(it)) } }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/contactdiary/ui/durationpicker/DurationExtensionKtTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/contactdiary/ui/durationpicker/DurationExtensionKtTest.kt
@@ -1,0 +1,57 @@
+package de.rki.coronawarnapp.contactdiary.ui.durationpicker
+
+import io.kotest.matchers.shouldBe
+import org.joda.time.Duration
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+internal class DurationExtensionKtTest {
+
+    @ParameterizedTest
+    @MethodSource("provideArguments")
+    fun `toReadableDuration() should return correct String`(testItem: TestItem) {
+        with(testItem) {
+            duration.toReadableDuration(prefix, suffix) shouldBe expectedReadableDuration
+        }
+    }
+
+    companion object {
+
+        @Suppress("unused")
+        @JvmStatic
+        fun provideArguments() = listOf(
+            TestItem(
+                prefix = null,
+                suffix = null,
+                duration = Duration.standardMinutes(30),
+                expectedReadableDuration = "00:30"
+            ),
+            TestItem(
+                prefix = "Dauer",
+                suffix = null,
+                duration = Duration.standardMinutes(45),
+                expectedReadableDuration = "Dauer 00:45"
+            ),
+            TestItem(
+                prefix = null,
+                suffix = "Std.",
+                duration = Duration.standardMinutes(60),
+                expectedReadableDuration = "01:00 Std."
+            ),
+            TestItem(
+                prefix = "Dauer",
+                suffix = "h",
+                duration = Duration.standardMinutes(75),
+                expectedReadableDuration = "Dauer 01:15 h"
+            ),
+        ).map { Arguments.of(it) }
+    }
+
+    data class TestItem(
+        val prefix: String?,
+        val duration: Duration,
+        val suffix: String?,
+        val expectedReadableDuration: String
+    )
+}


### PR DESCRIPTION
This PR now includes some good suggestions that were given by @BMItter in a review yesterday. Due to time pressure yesterday, we decided to implement them in a separate PR. 

The suggestions were (all in `ContactDiaryExporter`):
- Use the Reusable scope instead of Singleton
- Use `getDateAndNameString` as extension function on `Duration`
- Use `getReadableDuration` as extension function on `Duration`

Since I found an already existing extension function that is similar to `getReadableDuration()` in `DurationExtensions`, I re-used this one and wrote some unit tests for it. 