### PR TITLE
Duration Picker Minute State (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/durationpicker/ContactDiaryDurationPickerFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/durationpicker/ContactDiaryDurationPickerFragment.kt
@@ -45,9 +45,6 @@ class ContactDiaryDurationPickerFragment : DialogFragment() {
             var duration = requireArguments().getString(DURATION_ARGUMENT_KEY)!!.split(":").toTypedArray()
             if (duration.size < 2) duration = arrayOf("00", "00")
 
-           // hours.value = if (hoursArray.size > duration[0].toInt()) hoursArray.indexOf(duration[0]) else 0
-           // minutes.value = if (minutesArray.size > duration[1].toInt()) minutesArray.indexOf(duration[1]) else 0
-
             hours.value = hoursArray.indexOf(duration[0])
             minutes.value = minutesArray.indexOf(duration[1])
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/durationpicker/ContactDiaryDurationPickerFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/durationpicker/ContactDiaryDurationPickerFragment.kt
@@ -45,8 +45,11 @@ class ContactDiaryDurationPickerFragment : DialogFragment() {
             var duration = requireArguments().getString(DURATION_ARGUMENT_KEY)!!.split(":").toTypedArray()
             if (duration.size < 2) duration = arrayOf("00", "00")
 
-            hours.value = if (hoursArray.size > duration[0].toInt()) hoursArray.indexOf(duration[0]) else 0
-            minutes.value = if (minutesArray.size > duration[1].toInt()) minutesArray.indexOf(duration[1]) else 0
+           // hours.value = if (hoursArray.size > duration[0].toInt()) hoursArray.indexOf(duration[0]) else 0
+           // minutes.value = if (minutesArray.size > duration[1].toInt()) minutesArray.indexOf(duration[1]) else 0
+
+            hours.value = hoursArray.indexOf(duration[0])
+            minutes.value = minutesArray.indexOf(duration[1])
 
             cancelButton.setOnClickListener { dismiss() }
             okButton.setOnClickListener {


### PR DESCRIPTION
This PR fixes an issue where the previously picked minutes are not set when opening the duration picker again, instead 00 was set for minutes. Now, the minutes for the duration picker are set to the current duration.

To test this PR: Go to the contact diary day screen (Places) and pick a duration with Minutes ≠ 00 e.g. 04:15. Save the duration and press on the duration picker again, check if the minutes are displayed correctly. 