### PR TITLE
Adapt automatic screenshots for contact diary extension (EXPOSUREAPP-5115)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/contactdiary/ContactDiaryDayFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/contactdiary/ContactDiaryDayFragmentTest.kt
@@ -112,10 +112,10 @@ class ContactDiaryDayFragmentTest : BaseUITest() {
             fragmentArgs = fragmentArgs,
             themeResId = R.style.AppTheme_Main
         )
-        takeScreenshot<ContactDiaryDayFragment>(suffix)
+        takeScreenshot<ContactDiaryDayFragment>("persons_$suffix")
         onView(withId(R.id.contact_diary_day_tab_layout))
             .perform(selectTabAtPosition(1))
-        takeScreenshot<ContactDiaryDayFragment>(suffix + "_2")
+        takeScreenshot<ContactDiaryDayFragment>("locations_$suffix")
     }
 
     private fun setupViewModels() {

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/contactdiary/DiaryData.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/contactdiary/DiaryData.kt
@@ -3,6 +3,7 @@ package de.rki.coronawarnapp.ui.contactdiary
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.contactdiary.model.ContactDiaryLocation
 import de.rki.coronawarnapp.contactdiary.model.ContactDiaryPerson
+import de.rki.coronawarnapp.contactdiary.model.ContactDiaryPersonEncounter
 import de.rki.coronawarnapp.contactdiary.model.DefaultContactDiaryLocation
 import de.rki.coronawarnapp.contactdiary.model.DefaultContactDiaryLocationVisit
 import de.rki.coronawarnapp.contactdiary.model.DefaultContactDiaryPerson
@@ -18,40 +19,35 @@ object DiaryData {
     val DATA_ITEMS = listOf(
         ListItem.Data(
             R.drawable.ic_contact_diary_person_item,
-            "Max Mustermann",
+            "Rewe",
+            Duration.standardMinutes(30),
+            attributes = null,
+            circumstances = null,
+            ListItem.Type.LOCATION
+        ),
+        ListItem.Data(
+            R.drawable.ic_contact_diary_person_item,
+            "Andrea Steinhauer",
             null,
             listOf(
                 R.string.contact_diary_person_encounter_duration_below_15_min,
-                R.string.contact_diary_person_encounter_mask_with,
-                R.string.contact_diary_person_encounter_environment_inside
+                R.string.contact_diary_person_encounter_environment_outside
             ),
-            "Notizen notizen",
-            ListItem.Type.PERSON
-        ),
-
-        ListItem.Data(
-            R.drawable.ic_contact_diary_person_item,
-            "Erika Mustermann",
             null,
-            listOf(
-                R.string.contact_diary_person_encounter_environment_inside
-            ),
-            "Notizen notizen",
             ListItem.Type.PERSON
         ),
 
         ListItem.Data(
             R.drawable.ic_contact_diary_location,
-            "Fitnessstudio",
-            Duration.millis(1800000),
+            "Bäcker",
             null,
-            "Notizen notizen",
+            null,
+            null,
             ListItem.Type.LOCATION
         ),
-
         ListItem.Data(
             R.drawable.ic_contact_diary_location,
-            "Supermarket",
+            "Büro",
             null,
             null,
             null,
@@ -77,10 +73,11 @@ object DiaryData {
 
     val LOCATIONS: List<DiaryLocationListItem> = listOf(
         DiaryLocationListItem(
-            item = DefaultContactDiaryLocation(locationName = "Sport"),
+            item = DefaultContactDiaryLocation(locationName = "Physiotherapie"),
             visit = DefaultContactDiaryLocationVisit(
                 contactDiaryLocation = DefaultContactDiaryLocation(locationName = ""),
-                date = LocalDate.now()
+                date = LocalDate.now(),
+                duration = Duration.standardMinutes(90)
             ),
             onItemClick = {},
             onDurationChanged = { _, _ -> },
@@ -89,19 +86,7 @@ object DiaryData {
             onDurationDialog = { _, _ -> }
         ),
         DiaryLocationListItem(
-            item = DefaultContactDiaryLocation(locationName = "Büro"),
-            visit = DefaultContactDiaryLocationVisit(
-                contactDiaryLocation = DefaultContactDiaryLocation(locationName = ""),
-                date = LocalDate.now()
-            ),
-            onItemClick = {},
-            onDurationChanged = { _, _ -> },
-            onCircumstancesChanged = { _, _ -> },
-            onCircumStanceInfoClicked = {},
-            onDurationDialog = { _, _ -> }
-        ),
-        DiaryLocationListItem(
-            item = DefaultContactDiaryLocation(locationName = "Supermarkt"),
+            item = DefaultContactDiaryLocation(locationName = "Hausarzt"),
             visit = null,
             onItemClick = {},
             onDurationChanged = { _, _ -> },
@@ -113,10 +98,14 @@ object DiaryData {
 
     val PERSONS: List<DiaryPersonListItem> = listOf(
         DiaryPersonListItem(
-            item = DefaultContactDiaryPerson(fullName = "Erika Mustermann"),
+            item = DefaultContactDiaryPerson(fullName = "Andrea Steinhauer"),
             personEncounter = DefaultContactDiaryPersonEncounter(
                 contactDiaryPerson = DefaultContactDiaryPerson(fullName = ""),
-                date = LocalDate.now()
+                date = LocalDate.now(),
+                durationClassification = ContactDiaryPersonEncounter.DurationClassification.LESS_THAN_15_MINUTES,
+                withMask = false,
+                wasOutside = true,
+                circumstances = "saßen nah beieinander"
             ),
             onItemClick = {},
             onDurationChanged = { _, _ -> },
@@ -126,21 +115,11 @@ object DiaryData {
             onCircumstanceInfoClicked = {}
         ),
         DiaryPersonListItem(
-            item = DefaultContactDiaryPerson(fullName = "Max Mustermann"),
+            item = DefaultContactDiaryPerson(fullName = "Constantin Frenzel"),
             personEncounter = DefaultContactDiaryPersonEncounter(
                 contactDiaryPerson = DefaultContactDiaryPerson(fullName = ""),
                 date = LocalDate.now()
             ),
-            onItemClick = {},
-            onDurationChanged = { _, _ -> },
-            onCircumstancesChanged = { _, _ -> },
-            onWithMaskChanged = { _, _ -> },
-            onWasOutsideChanged = { _, _ -> },
-            onCircumstanceInfoClicked = {}
-        ),
-        DiaryPersonListItem(
-            item = DefaultContactDiaryPerson(fullName = "John Doe"),
-            personEncounter = null,
             onItemClick = {},
             onDurationChanged = { _, _ -> },
             onCircumstancesChanged = { _, _ -> },

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/contactdiary/DiaryData.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/contactdiary/DiaryData.kt
@@ -18,7 +18,7 @@ object DiaryData {
 
     val DATA_ITEMS = listOf(
         ListItem.Data(
-            R.drawable.ic_contact_diary_person_item,
+            R.drawable.ic_contact_diary_location_item,
             "Rewe",
             Duration.standardMinutes(30),
             attributes = null,
@@ -36,17 +36,8 @@ object DiaryData {
             null,
             ListItem.Type.PERSON
         ),
-
         ListItem.Data(
-            R.drawable.ic_contact_diary_location,
-            "Bäcker",
-            null,
-            null,
-            null,
-            ListItem.Type.LOCATION
-        ),
-        ListItem.Data(
-            R.drawable.ic_contact_diary_location,
+            R.drawable.ic_contact_diary_location_item,
             "Büro",
             null,
             null,

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/main/MainActivityTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/main/MainActivityTest.kt
@@ -291,7 +291,7 @@ class MainActivityTest : BaseUITest() {
         takeScreenshot<ContactDiaryOverviewFragment>()
 
         onView(withId(R.id.contact_diary_overview_recyclerview))
-            .perform(recyclerScrollTo(1))
+            .perform(recyclerScrollTo(4))
         takeScreenshot<ContactDiaryOverviewFragment>("2")
     }
 
@@ -328,11 +328,16 @@ class MainActivityTest : BaseUITest() {
                 .map { LocalDate.now().minusDays(it) }
                 .mapIndexed { index, localDate ->
                     ListItem(localDate).apply {
-                        data.addAll(DiaryData.DATA_ITEMS)
-                        risk = when (index % 3) {
-                            0 -> DiaryData.HIGH_RISK
-                            1 -> DiaryData.HIGH_RISK_DUE_LOW_RISK_ENCOUNTERS
-                            else -> DiaryData.LOW_RISK
+                        if (index == 1) {
+                            data.add(DiaryData.DATA_ITEMS[0])
+                            data.add(DiaryData.DATA_ITEMS[1])
+                        } else if (index == 3) {
+                            data.add(DiaryData.DATA_ITEMS[2])
+                            data.add(DiaryData.DATA_ITEMS[3])
+                        }
+                        risk = when (index % 5) {
+                            3 -> DiaryData.HIGH_RISK_DUE_LOW_RISK_ENCOUNTERS
+                            else -> null // DiaryData.LOW_RISK OR DiaryData.HIGH_RISK POSSIBLE
                         }
                     }
                 }

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/main/MainActivityTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/main/MainActivityTest.kt
@@ -333,7 +333,6 @@ class MainActivityTest : BaseUITest() {
                             data.add(DiaryData.DATA_ITEMS[1])
                         } else if (index == 3) {
                             data.add(DiaryData.DATA_ITEMS[2])
-                            data.add(DiaryData.DATA_ITEMS[3])
                         }
                         risk = when (index % 5) {
                             3 -> DiaryData.HIGH_RISK_DUE_LOW_RISK_ENCOUNTERS


### PR DESCRIPTION
I adapted our screenshots for the contact diary extension to look like our figma designs:

![image](https://user-images.githubusercontent.com/10398034/109185585-719c5980-7790-11eb-85e3-ac9b7cbc9fa4.png)
![image](https://user-images.githubusercontent.com/10398034/109185664-837dfc80-7790-11eb-98d4-7f49ad7da0aa.png)
![image](https://user-images.githubusercontent.com/10398034/109185707-8d076480-7790-11eb-9b48-5ccc8f39dfba.png)
![image](https://user-images.githubusercontent.com/10398034/109185740-92fd4580-7790-11eb-8776-5d7e633f93b7.png)
