### PR TITLE
Incompatibility warning card on main screen (COMMUNITY)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeAdapter.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeAdapter.kt
@@ -20,6 +20,7 @@ import de.rki.coronawarnapp.tracing.ui.homecards.TracingFailedCard
 import de.rki.coronawarnapp.tracing.ui.homecards.TracingProgressCard
 import de.rki.coronawarnapp.ui.main.home.items.FAQCard
 import de.rki.coronawarnapp.ui.main.home.items.HomeItem
+import de.rki.coronawarnapp.ui.main.home.items.IncompatibleCard
 import de.rki.coronawarnapp.ui.main.home.items.ReenableRiskCard
 import de.rki.coronawarnapp.util.lists.BindableVH
 import de.rki.coronawarnapp.util.lists.diffutil.AsyncDiffUtilAdapter
@@ -42,6 +43,7 @@ class HomeAdapter :
                 StableIdMod(data),
                 DataBinderMod<HomeItem, HomeItemVH<HomeItem, ViewBinding>>(data),
                 TypedVHCreatorMod({ data[it] is FAQCard.Item }) { FAQCard(it) },
+                TypedVHCreatorMod({ data[it] is IncompatibleCard.Item}) { IncompatibleCard(it) },
                 TypedVHCreatorMod({ data[it] is ReenableRiskCard.Item }) { ReenableRiskCard(it) },
                 TypedVHCreatorMod({ data[it] is IncreasedRiskCard.Item }) { IncreasedRiskCard(it) },
                 TypedVHCreatorMod({ data[it] is LowRiskCard.Item }) { LowRiskCard(it) },

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeAdapter.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeAdapter.kt
@@ -43,7 +43,7 @@ class HomeAdapter :
                 StableIdMod(data),
                 DataBinderMod<HomeItem, HomeItemVH<HomeItem, ViewBinding>>(data),
                 TypedVHCreatorMod({ data[it] is FAQCard.Item }) { FAQCard(it) },
-                TypedVHCreatorMod({ data[it] is IncompatibleCard.Item}) { IncompatibleCard(it) },
+                TypedVHCreatorMod({ data[it] is IncompatibleCard.Item }) { IncompatibleCard(it) },
                 TypedVHCreatorMod({ data[it] is ReenableRiskCard.Item }) { ReenableRiskCard(it) },
                 TypedVHCreatorMod({ data[it] is IncreasedRiskCard.Item }) { IncreasedRiskCard(it) },
                 TypedVHCreatorMod({ data[it] is LowRiskCard.Item }) { LowRiskCard(it) },

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragment.kt
@@ -78,6 +78,10 @@ class HomeFragment : Fragment(R.layout.home_fragment_layout), AutoInject {
             ExternalActionHelper.openUrl(this@HomeFragment, getString(R.string.main_about_link))
         }
 
+        vm.openIncompatibleEvent.observe2(this) {
+            // TODO give further information about the incompatibility
+        }
+
         vm.popupEvents.observe2(this) { event ->
             when (event) {
                 is HomeFragmentEvents.ShowTracingExplanation -> {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragmentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragmentViewModel.kt
@@ -52,9 +52,12 @@ import de.rki.coronawarnapp.ui.main.home.HomeFragmentEvents.ShowErrorResetDialog
 import de.rki.coronawarnapp.ui.main.home.HomeFragmentEvents.ShowTracingExplanation
 import de.rki.coronawarnapp.ui.main.home.items.FAQCard
 import de.rki.coronawarnapp.ui.main.home.items.HomeItem
+import de.rki.coronawarnapp.ui.main.home.items.IncompatibleCard
 import de.rki.coronawarnapp.ui.main.home.items.ReenableRiskCard
 import de.rki.coronawarnapp.util.DeviceUIState
 import de.rki.coronawarnapp.util.NetworkRequestWrapper.Companion.withSuccess
+import de.rki.coronawarnapp.util.bluetooth.isAdvertisingSupported
+import de.rki.coronawarnapp.util.bluetooth.isScanningSupported
 import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
 import de.rki.coronawarnapp.util.security.EncryptionErrorResetTool
 import de.rki.coronawarnapp.util.shortcuts.AppShortcutsHelper
@@ -88,6 +91,7 @@ class HomeFragmentViewModel @AssistedInject constructor(
 
     val routeToScreen = SingleLiveEvent<NavDirections>()
     val openFAQUrlEvent = SingleLiveEvent<Unit>()
+    val openIncompatibleEvent = SingleLiveEvent<Unit>()
 
     val tracingHeaderState: LiveData<TracingHeaderState> = tracingStatus.generalStatus
         .map { it.toHeaderState() }
@@ -221,6 +225,10 @@ class HomeFragmentViewModel @AssistedInject constructor(
                     // Don't show risk card
                 }
                 else -> add(tracingItem)
+            }
+
+            if (isAdvertisingSupported() == false) {
+                add(IncompatibleCard.Item({ openIncompatibleEvent.postValue(Unit) }, isScanningSupported() != false))
             }
 
             add(submissionItem)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/items/IncompatibleCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/items/IncompatibleCard.kt
@@ -6,7 +6,8 @@ import de.rki.coronawarnapp.databinding.HomeIncompatibleCardLayoutBinding
 import de.rki.coronawarnapp.ui.main.home.HomeAdapter
 import de.rki.coronawarnapp.util.lists.diffutil.HasPayloadDiffer
 
-class IncompatibleCard(parent: ViewGroup) : HomeAdapter.HomeItemVH<IncompatibleCard.Item, HomeIncompatibleCardLayoutBinding>(
+class IncompatibleCard(parent: ViewGroup)
+    : HomeAdapter.HomeItemVH<IncompatibleCard.Item, HomeIncompatibleCardLayoutBinding>(
     R.layout.home_card_container_layout,
     parent
 ) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/items/IncompatibleCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/items/IncompatibleCard.kt
@@ -6,11 +6,11 @@ import de.rki.coronawarnapp.databinding.HomeIncompatibleCardLayoutBinding
 import de.rki.coronawarnapp.ui.main.home.HomeAdapter
 import de.rki.coronawarnapp.util.lists.diffutil.HasPayloadDiffer
 
-class IncompatibleCard(parent: ViewGroup)
-    : HomeAdapter.HomeItemVH<IncompatibleCard.Item, HomeIncompatibleCardLayoutBinding>(
-    R.layout.home_card_container_layout,
-    parent
-) {
+class IncompatibleCard(parent: ViewGroup) :
+    HomeAdapter.HomeItemVH<IncompatibleCard.Item, HomeIncompatibleCardLayoutBinding>(
+        R.layout.home_card_container_layout,
+        parent
+    ) {
 
     override val viewBinding = lazy {
         HomeIncompatibleCardLayoutBinding.inflate(layoutInflater, itemView.findViewById(R.id.card_container), true)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/items/IncompatibleCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/items/IncompatibleCard.kt
@@ -1,0 +1,41 @@
+package de.rki.coronawarnapp.ui.main.home.items
+
+import android.view.ViewGroup
+import de.rki.coronawarnapp.R
+import de.rki.coronawarnapp.databinding.HomeIncompatibleCardLayoutBinding
+import de.rki.coronawarnapp.ui.main.home.HomeAdapter
+import de.rki.coronawarnapp.util.lists.diffutil.HasPayloadDiffer
+
+class IncompatibleCard(parent: ViewGroup) : HomeAdapter.HomeItemVH<IncompatibleCard.Item, HomeIncompatibleCardLayoutBinding>(
+    R.layout.home_card_container_layout,
+    parent
+) {
+
+    override val viewBinding = lazy {
+        HomeIncompatibleCardLayoutBinding.inflate(layoutInflater, itemView.findViewById(R.id.card_container), true)
+    }
+
+    override val onBindData: HomeIncompatibleCardLayoutBinding.(
+        item: Item,
+        payloads: List<Any>
+    ) -> Unit = { item, payloads ->
+
+        when (item.bluetoothSupported) {
+            true ->
+                mainCardContentBody.setText(R.string.incompatible_advertising_not_supported)
+            false ->
+                mainCardContentBody.setText(R.string.incompatible_scanning_not_supported)
+        }
+
+        itemView.setOnClickListener {
+            val curItem = payloads.filterIsInstance<Item>().singleOrNull() ?: item
+            curItem.onClickAction(item)
+        }
+    }
+
+    data class Item(val onClickAction: (Item) -> Unit, val bluetoothSupported: Boolean) : HomeItem, HasPayloadDiffer {
+        override val stableId: Long = Item::class.java.name.hashCode().toLong()
+
+        override fun diffPayload(old: Any, new: Any): Any? = if (old::class == new::class) new else null
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/bluetooth/BluetoothSupport.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/bluetooth/BluetoothSupport.kt
@@ -28,7 +28,8 @@ fun isAdvertisingSupported(): Boolean? {
     val adapter = BluetoothAdapter.getDefaultAdapter()
     return when {
         adapter == null -> false
-        Build.VERSION.SDK_INT >= 26 && (adapter.isLeExtendedAdvertisingSupported || adapter.isLePeriodicAdvertisingSupported) -> true
+        Build.VERSION.SDK_INT >= 26
+            && (adapter.isLeExtendedAdvertisingSupported || adapter.isLePeriodicAdvertisingSupported) -> true
         adapter.state != BluetoothAdapter.STATE_ON -> null
         adapter.bluetoothLeAdvertiser != null -> true
         else -> false

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/bluetooth/BluetoothSupport.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/bluetooth/BluetoothSupport.kt
@@ -1,0 +1,36 @@
+package de.rki.coronawarnapp.util.bluetooth
+
+import android.bluetooth.BluetoothAdapter
+import android.os.Build
+
+/**
+ * Determine whether Bluetooth low Energy scanning is supported
+ *
+ * @return true if supported, false if not supported, null if unknown
+ */
+fun isScanningSupported(): Boolean? {
+    val adapter = BluetoothAdapter.getDefaultAdapter()
+    return when {
+        adapter == null -> false
+        adapter.state != BluetoothAdapter.STATE_ON -> null
+        adapter.bluetoothLeScanner != null -> true
+        else -> false
+    }
+}
+
+/**
+ * Determine whether Bluetooth Low Energy peripheral mode (advertising
+ * beacons) is supported
+ *
+ * @return true if supported, false if not supported, null if unknown
+ */
+fun isAdvertisingSupported(): Boolean? {
+    val adapter = BluetoothAdapter.getDefaultAdapter()
+    return when {
+        adapter == null -> false
+        Build.VERSION.SDK_INT >= 26 && (adapter.isLeExtendedAdvertisingSupported || adapter.isLePeriodicAdvertisingSupported) -> true
+        adapter.state != BluetoothAdapter.STATE_ON -> null
+        adapter.bluetoothLeAdvertiser != null -> true
+        else -> false
+    }
+}

--- a/Corona-Warn-App/src/main/res/layout/home_incompatible_card_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_incompatible_card_layout.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="@dimen/spacing_normal"
+        tools:showIn="@layout/home_card_container_layout">
+
+        <ImageView
+            android:id="@+id/main_card_header_icon"
+            android:layout_width="@dimen/icon_size_button"
+            android:layout_height="@dimen/icon_size_button"
+            android:importantForAccessibility="no"
+            android:src="@drawable/ic_high_risk_alert"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/main_card_header_headline"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.0" />
+
+        <TextView
+            android:id="@+id/main_card_header_headline"
+            style="@style/headline5"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/spacing_small"
+            android:layout_marginEnd="@dimen/spacing_small"
+            android:accessibilityHeading="true"
+            android:text="@string/incompatible_headline"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/main_card_header_icon"
+            app:layout_constraintTop_toTopOf="@+id/main_card_header_icon"
+            app:layout_constraintVertical_bias="0.0" />
+        <TextView
+            android:id="@+id/main_card_content_body"
+            style="@style/subtitleMedium"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/spacing_small"
+            android:text="@string/incompatible_advertising_not_supported"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/main_card_header_headline" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -1909,4 +1909,16 @@
     <string name="duration_dialog_ok_button">OK</string>
     <!-- NOTR -->
     <string name="duration_dialog_default_value">00:00</string>
+
+    <!-- ####################################
+       Incompatibility warning card
+   ###################################### -->
+    <string name="incompatible_headline">Incompatibility warning</string>
+    <string name="incompatible_advertising_not_supported">Unfortunately, your device is only
+        partially compatible with Exposure Notifications. You can be notified for risk contacts
+        but won\'t be able to warn others.
+    </string>
+    <string name="incompatible_scanning_not_supported">Unfortunately, your device is not
+        compatible with Exposure Notifications.
+    </string>
 </resources>


### PR DESCRIPTION
As discussed in https://github.com/corona-warn-app/cwa-app-android/issues/688#issuecomment-785622753, this PR introduces a warning card on the main screen that informs users when their device is incompatible or only partially compatible with Exposure Notifications.

### Screenshots


| 1: BLE broadcasts not supported | 2: BLE scans not supported |
|---|---|
|![Screenshot_1614350339](https://user-images.githubusercontent.com/16943720/109313813-eaf78300-7848-11eb-8761-521a0f5843a4.png)|![Screenshot_1614350116](https://user-images.githubusercontent.com/16943720/109313821-ecc14680-7848-11eb-9194-dea80e47a1db.png)|


#### 



### To test

* On most devices: open app's main screen. Nothing changes with this PR.
* Use a device that doesn't support broadcasting beacons. Open app's main screen. New card like in screenshot 1. (For example, some operating systems for Fairphone 2 have a Bluetooth driver that doesn't support BLE peripheral mode, see also #780. Note that I don't own such a device)
* Use Android emulator. Open app's main screen. New card like in screenshot 2. (Android emulator doesn't support Bluetooth at all)

### What this PR doesn't do, but should still be done

* Add some further information to the app or to the FAQ or another website that can be displayed once the warning card is clicked.
* Block sharing test results if BLE broadcasts are not supported.

---
Internal Tracking ID: [EXPOSUREAPP-5464](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-5464)
