### PR TITLE
Remove app shortcut when resetting the app (EXPOSURE-5401)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsResetViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/settings/SettingsResetViewModel.kt
@@ -7,10 +7,10 @@ import de.rki.coronawarnapp.exception.ExceptionCategory
 import de.rki.coronawarnapp.exception.reporting.report
 import de.rki.coronawarnapp.nearby.InternalExposureNotificationClient
 import de.rki.coronawarnapp.notification.ShareTestResultNotificationService
-import de.rki.coronawarnapp.submission.SubmissionRepository
 import de.rki.coronawarnapp.ui.SingleLiveEvent
 import de.rki.coronawarnapp.util.DataReset
 import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
+import de.rki.coronawarnapp.util.shortcuts.AppShortcutsHelper
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
 import de.rki.coronawarnapp.util.viewmodel.SimpleCWAViewModelFactory
 import de.rki.coronawarnapp.worker.BackgroundWorkScheduler
@@ -19,7 +19,7 @@ class SettingsResetViewModel @AssistedInject constructor(
     dispatcherProvider: DispatcherProvider,
     private val dataReset: DataReset,
     private val shareTestResultNotificationService: ShareTestResultNotificationService,
-    private val submissionRepository: SubmissionRepository
+    private val shortcutsHelper: AppShortcutsHelper
 ) : CWAViewModel(dispatcherProvider = dispatcherProvider) {
 
     val clickEvent: SingleLiveEvent<SettingsEvents> = SingleLiveEvent()
@@ -51,6 +51,7 @@ class SettingsResetViewModel @AssistedInject constructor(
             shareTestResultNotificationService.resetSharePositiveTestResultNotification()
 
             dataReset.clearAllLocalData()
+            shortcutsHelper.removeAppShortcut()
             clickEvent.postValue(SettingsEvents.GoToOnboarding)
         }
     }


### PR DESCRIPTION

### Testing
Open the CWA and finish onboarding. App-shortcut should be available.
Open the CWA go to Settings > Reset App and confirm reset and close the app. App-shortcut shouldn't be available. 