### PR TITLE
Dialog runs forever (EXPOSUREAPP-5493)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/resultavailable/SubmissionTestResultAvailableViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/resultavailable/SubmissionTestResultAvailableViewModel.kt
@@ -42,43 +42,41 @@ class SubmissionTestResultAvailableViewModel @AssistedInject constructor(
             override fun onTEKAvailable(teks: List<TemporaryExposureKey>) {
                 Timber.d("onTEKAvailable(teks.size=%d)", teks.size)
                 autoSubmission.updateMode(AutoSubmission.Mode.MONITOR)
-
+                showKeysRetrievalProgress.postValue(false)
                 routeToScreen.postValue(
                     SubmissionTestResultAvailableFragmentDirections
                         .actionSubmissionTestResultAvailableFragmentToSubmissionTestResultConsentGivenFragment()
                 )
-
-                showKeysRetrievalProgress.postValue(false)
             }
 
             override fun onTEKPermissionDeclined() {
                 Timber.d("onTEKPermissionDeclined")
+                showKeysRetrievalProgress.postValue(false)
                 routeToScreen.postValue(
                     SubmissionTestResultAvailableFragmentDirections
                         .actionSubmissionTestResultAvailableFragmentToSubmissionTestResultNoConsentFragment()
                 )
-                showKeysRetrievalProgress.postValue(false)
             }
 
             override fun onTracingConsentRequired(onConsentResult: (given: Boolean) -> Unit) {
                 Timber.d("onTracingConsentRequired")
-                showTracingConsentDialog.postValue(onConsentResult)
                 showKeysRetrievalProgress.postValue(false)
+                showTracingConsentDialog.postValue(onConsentResult)
             }
 
             override fun onPermissionRequired(permissionRequest: (Activity) -> Unit) {
                 Timber.d("onPermissionRequired")
-                showPermissionRequest.postValue(permissionRequest)
                 showKeysRetrievalProgress.postValue(false)
+                showPermissionRequest.postValue(permissionRequest)
             }
 
             override fun onError(error: Throwable) {
                 Timber.e(error, "Failed to update TEKs.")
+                showKeysRetrievalProgress.postValue(false)
                 error.report(
                     exceptionCategory = ExceptionCategory.EXPOSURENOTIFICATION,
                     prefix = "SubmissionTestResultAvailableViewModel"
                 )
-                showKeysRetrievalProgress.postValue(false)
             }
         }
     )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/warnothers/SubmissionResultPositiveOtherWarningNoConsentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/warnothers/SubmissionResultPositiveOtherWarningNoConsentViewModel.kt
@@ -100,8 +100,8 @@ class SubmissionResultPositiveOtherWarningNoConsentViewModel @AssistedInject con
                 tekHistoryUpdater.updateTEKHistoryOrRequestPermission()
             } else {
                 Timber.d("showEnableTracingEvent:Unit")
-                showEnableTracingEvent.postValue(Unit)
                 showKeysRetrievalProgress.postValue(false)
+                showEnableTracingEvent.postValue(Unit)
             }
         }
     }


### PR DESCRIPTION
From the logs I see the callback when TEK is received is called ,but despite that the dialog was not hidden.
My best guess here it is a race condition where `routeToScreen.postValue ` is navigating to the next screen and
`showKeysRetrievalProgress.postValue` never got the chance to have an effect.

Fix: `showKeysRetrievalProgress.postValue` is called before `routeToScreen.postValue` to guarantee it is called.

Logs section:
```
2021-03-02T19:16:45.202Z  D/TEKHistoryUpdater$updateHistoryAndTriggerCallback: onTEKAvailable(teks.size=1)
2021-03-02T19:16:45.203Z  I/AutoSubmission: updateMode(mode=MONITOR)
2021-03-02T19:16:45.207Z  V/SharedPreferencesImpl$EditorImpl: android.app.SharedPreferencesImpl@496ca1a:submission.user.activity.last changed to 2021-03-02T19:16:45.203Z
2021-03-02T19:16:45.211Z  V/SharedPreferencesImpl$EditorImpl: android.app.SharedPreferencesImpl@496ca1a:submission.auto.enabled changed to true
2021-03-02T19:16:45.212Z  V/AutoSubmission: scheduleWorker(): Creating periodic worker request for submission.
2021-03-02T19:16:45.229Z  D/AppInjector: Injecting SubmissionTestResultConsentGivenFragment{d21503f} (29a58653-0455-4dc5-814e-03cf0bd44616) id=0x7f090329}
2021-03-02T19:16:45.241Z  D/DefaultTEKHistoryProvider$getPreAuthTEKHistoryOrRequestPermissionOnV18: onTEKHistoryAvailable() -> permission were already available
2021-03-02T19:16:45.288Z  V/SubmissionTestResultConsentGivenViewModel: Initialized
```