### PR TITLE
Fix timeformat. API expects exposureWindow timestamp to be in seconds. (EXPOSUREAPP-5529)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/exposurewindows/AnalyticsExposureWindowDonor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/exposurewindows/AnalyticsExposureWindowDonor.kt
@@ -76,7 +76,7 @@ internal fun List<AnalyticsExposureWindowEntityWrapper>.asPpaData() = map {
     }
 
     val exposureWindow = PpaData.PPAExposureWindow.newBuilder()
-        .setDate(it.exposureWindowEntity.dateMillis)
+        .setDate(it.exposureWindowEntity.dateMillis / 1000)
         .setCalibrationConfidence(it.exposureWindowEntity.calibrationConfidence)
         .setInfectiousnessValue(it.exposureWindowEntity.infectiousness)
         .setReportTypeValue(it.exposureWindowEntity.reportType)


### PR DESCRIPTION
Milliseconds to seconds + a unit test.