### PR TITLE
Missing screenshots in tracing detail low risk with exposure (EXPOSUREAPP-5561)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/tracing/TracingData.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/tracing/TracingData.kt
@@ -62,7 +62,69 @@ object TracingData {
                     lastExposureDetectionTime = Instant.now(),
                     allowManualUpdate = false,
                     daysWithEncounters = 0,
-                    activeTracingDays = 0,
+                    activeTracingDays = 5,
+                    lastEncounterAt = Instant.now()
+                )
+            ),
+            BehaviorNormalRiskBox.Item(
+                tracingStatus = GeneralTracingStatus.Status.TRACING_ACTIVE,
+                riskState = RiskState.LOW_RISK
+            ),
+
+            PeriodLoggedBox.Item(
+                activeTracingDaysInRetentionPeriod = 0,
+                tracingStatus = GeneralTracingStatus.Status.TRACING_ACTIVE
+            ),
+            DetailsLowRiskBox.Item(riskState = RiskState.LOW_RISK, matchedKeyCount = 0)
+        )
+    )
+
+    val LOW_RISK_WITH_ONE_ENCOUNTER = Pair(
+        TracingDetailsState(
+            tracingStatus = GeneralTracingStatus.Status.TRACING_ACTIVE,
+            riskState = RiskState.LOW_RISK,
+            isManualKeyRetrievalEnabled = false
+        ),
+        listOf(
+            LowRiskBox.Item(
+                state = LowRisk(
+                    riskState = RiskState.LOW_RISK,
+                    isInDetailsMode = true,
+                    lastExposureDetectionTime = Instant.now(),
+                    allowManualUpdate = false,
+                    daysWithEncounters = 1,
+                    activeTracingDays = 5,
+                    lastEncounterAt = Instant.now()
+                )
+            ),
+            BehaviorNormalRiskBox.Item(
+                tracingStatus = GeneralTracingStatus.Status.TRACING_ACTIVE,
+                riskState = RiskState.LOW_RISK
+            ),
+
+            PeriodLoggedBox.Item(
+                activeTracingDaysInRetentionPeriod = 0,
+                tracingStatus = GeneralTracingStatus.Status.TRACING_ACTIVE
+            ),
+            DetailsLowRiskBox.Item(riskState = RiskState.LOW_RISK, matchedKeyCount = 0)
+        )
+    )
+
+    val LOW_RISK_WITH_TWO_ENCOUNTERS = Pair(
+        TracingDetailsState(
+            tracingStatus = GeneralTracingStatus.Status.TRACING_ACTIVE,
+            riskState = RiskState.LOW_RISK,
+            isManualKeyRetrievalEnabled = false
+        ),
+        listOf(
+            LowRiskBox.Item(
+                state = LowRisk(
+                    riskState = RiskState.LOW_RISK,
+                    isInDetailsMode = true,
+                    lastExposureDetectionTime = Instant.now(),
+                    allowManualUpdate = false,
+                    daysWithEncounters = 2,
+                    activeTracingDays = 5,
                     lastEncounterAt = Instant.now()
                 )
             ),

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/tracing/TracingDetailsFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/tracing/TracingDetailsFragmentTest.kt
@@ -96,6 +96,20 @@ class TracingDetailsFragmentTest : BaseUITest() {
 
     @Screenshot
     @Test
+    fun capture_screenshot_tracing_low_risk_with_one_encounter() {
+        mockData(TracingData.LOW_RISK_WITH_ONE_ENCOUNTER)
+        captureScreenshot("tracing_low_risk_with_one_encounters")
+    }
+
+    @Screenshot
+    @Test
+    fun capture_screenshot_tracing_low_risk_with_two_encounters() {
+        mockData(TracingData.LOW_RISK_WITH_TWO_ENCOUNTERS)
+        captureScreenshot("tracing_low_risk_with_two_encounters")
+    }
+
+    @Screenshot
+    @Test
     fun capture_screenshot_tracing_disabled() {
         mockData(TracingData.TRACING_DISABLED)
         captureScreenshot("tracing_disabled")


### PR DESCRIPTION
This PR adds two new screenshots for

- Risk Detail Screen for low risk with one encounter
- Risk Detail Screen for low risk with two encounters

![TracingDetailsFragment_tracing_low_risk_with_one_encounters](https://user-images.githubusercontent.com/10398034/110117722-8f357880-7db9-11eb-87fe-e36ab474d239.png)

![TracingDetailsFragment_tracing_low_risk_with_two_encounters](https://user-images.githubusercontent.com/10398034/110117736-93619600-7db9-11eb-858a-e775680ffe16.png)
