### PR TITLE
Debug Log Confirmation Dialog (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/debuglog/ui/DebugLogFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/debuglog/ui/DebugLogFragment.kt
@@ -155,9 +155,10 @@ class DebugLogFragment : Fragment(R.layout.bugreporting_debuglog_fragment), Auto
         MaterialAlertDialogBuilder(requireContext()).apply {
             setTitle(R.string.debugging_debuglog_stop_confirmation_title)
             setMessage(R.string.debugging_debuglog_stop_confirmation_message)
-            setPositiveButton(R.string.debugging_debuglog_stop_confirmation_confirmation_button) { _, _ -> vm.stopAndDeleteDebugLog() }
+            setPositiveButton(R.string.debugging_debuglog_stop_confirmation_confirmation_button) { _, _ ->
+                vm.stopAndDeleteDebugLog()
+            }
             setNegativeButton(R.string.debugging_debuglog_stop_confirmation_discard_button) { _, _ -> /* dismiss */ }
-
         }.show()
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/debuglog/ui/DebugLogFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/debuglog/ui/DebugLogFragment.kt
@@ -101,8 +101,8 @@ class DebugLogFragment : Fragment(R.layout.bugreporting_debuglog_fragment), Auto
 
         vm.events.observe2(this) {
             when (it) {
-                DebugLogViewModel.Event.ShowLogDeletedConfirmation -> {
-                    showLogDeletionConfirmation()
+                DebugLogViewModel.Event.ShowLogDeletionRequest -> {
+                    showLogDeletionRequest()
                 }
                 DebugLogViewModel.Event.NavigateToPrivacyFragment -> {
                     doNavigate(
@@ -151,10 +151,13 @@ class DebugLogFragment : Fragment(R.layout.bugreporting_debuglog_fragment), Auto
         )
     }
 
-    private fun showLogDeletionConfirmation() {
+    private fun showLogDeletionRequest() {
         MaterialAlertDialogBuilder(requireContext()).apply {
+            setTitle(R.string.debugging_debuglog_stop_confirmation_title)
             setMessage(R.string.debugging_debuglog_stop_confirmation_message)
-            setPositiveButton(android.R.string.yes) { _, _ -> }
+            setPositiveButton(R.string.debugging_debuglog_stop_confirmation_confirmation_button) { _, _ -> vm.stopAndDeleteDebugLog() }
+            setNegativeButton(R.string.debugging_debuglog_stop_confirmation_discard_button) { _, _ -> /* dismiss */ }
+
         }.show()
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/debuglog/ui/DebugLogViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/debuglog/ui/DebugLogViewModel.kt
@@ -65,8 +65,7 @@ class DebugLogViewModel @AssistedInject constructor(
 
     fun onToggleRecording() = launchWithProgress {
         if (debugLogger.isLogging.value) {
-            debugLogger.stop()
-            events.postValue(Event.ShowLogDeletedConfirmation)
+            events.postValue(Event.ShowLogDeletionRequest)
         } else {
             if (debugLogger.storageCheck.isLowStorage(forceCheck = true)) {
                 Timber.d("Low storage, not starting logger.")
@@ -82,6 +81,14 @@ class DebugLogViewModel @AssistedInject constructor(
                 Timber.tag("ENFClient").i("ENF Version: %d", enfVersion)
             } catch (e: Exception) {
                 Timber.tag("ENFClient").e(e, "Failed to get ENF version for debug log.")
+            }
+        }
+    }
+
+    fun stopAndDeleteDebugLog() {
+        launchWithProgress {
+            if (debugLogger.isLogging.value) {
+                debugLogger.stop()
             }
         }
     }
@@ -147,7 +154,7 @@ class DebugLogViewModel @AssistedInject constructor(
         object NavigateToPrivacyFragment : Event()
         object NavigateToUploadFragment : Event()
         object NavigateToUploadHistory : Event()
-        object ShowLogDeletedConfirmation : Event()
+        object ShowLogDeletionRequest: Event()
         object ShowLowStorageDialog : Event()
         data class ShowLocalExportError(val error: Throwable) : Event()
         data class Error(val error: Throwable) : Event()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/debuglog/ui/DebugLogViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/debuglog/ui/DebugLogViewModel.kt
@@ -154,7 +154,7 @@ class DebugLogViewModel @AssistedInject constructor(
         object NavigateToPrivacyFragment : Event()
         object NavigateToUploadFragment : Event()
         object NavigateToUploadHistory : Event()
-        object ShowLogDeletionRequest: Event()
+        object ShowLogDeletionRequest : Event()
         object ShowLowStorageDialog : Event()
         data class ShowLocalExportError(val error: Throwable) : Event()
         data class Error(val error: Throwable) : Event()

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -905,8 +905,16 @@
     <string name="debugging_debuglog_status_not_recording">"Inaktiv"</string>
     <!-- YTXT: Describtion for current logging status text if a debug log is not being recorded -->
     <string name="debugging_debuglog_status_additional_infos">"Derzeitige Größe: %1$s (unkomprimiert)"</string>
+
+
+    <!-- YTXT: Dialog title if the log recording is stopped, and thus deleted. -->
+    <string name="debugging_debuglog_stop_confirmation_title">"Wollen Sie die Fehleranalyse wirklich stoppen?"</string>
     <!-- YTXT: Dialog message if the log recording is stopped, and thus deleted. -->
-    <string name="debugging_debuglog_stop_confirmation_message">"Der Fehlerbericht wurde gelöscht. Wenn Sie eine lokale Kopie des Fehlerberichts gespeichert haben, wurde diese nicht gelöscht."</string>
+    <string name="debugging_debuglog_stop_confirmation_message">"Hierbei werden alle bereits aufgezeichneten Daten gelöscht. Wenn Sie eine lokale Kopie des Fehlerberichts gespeichert haben, wird diese nicht gelöscht."</string>
+    <!-- YTXT: Dialog confirmation button if the log recording is stopped, and thus deleted. -->
+    <string name="debugging_debuglog_stop_confirmation_confirmation_button">"Analyse stoppen"</string>
+    <!-- YTXT: Dialog discard button if the log recording is stopped, and thus deleted. -->
+    <string name="debugging_debuglog_stop_confirmation_discard_button">"Analyse fortführen"</string>
     <!-- YTXT: Dialog message if there is not enough free storage to start a debug log -->
     <string name="debugging_debuglog_start_low_storage_error">"Sie brauchen mindestens 200 MB Speicherplatz, um die Fehleranalyse zu starten. Bitte geben Sie Speicherplatz frei."</string>
     <!-- XHED: Dialog title if a user has stored a debug log locally -->
@@ -915,7 +923,6 @@
     <string name="debugging_debuglog_localexport_message">"Die Fehleranalyse wurde lokal gespeichert."</string>
     <!-- YTXT: Dialog message if local export has failed -->
     <string name="debugging_debuglog_localexport_error_message">"Das Speichern des Fehlerberichts ist fehlgeschlagen. Bitte überprüfen Sie, ob genügend Speicherplatz zur Verfügung steht."</string>
-
     <!-- XHED: Title for debug legal screen -->
     <string name="debugging_debuglog_legal_dialog_title">"Ausführliche Informationen zur Übersendung der Fehlerberichte"</string>
     <!-- YTXT: Section Title for debug legal screen -->

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -923,8 +923,14 @@
     <string name="debugging_debuglog_status_additional_infos">"Current size: %1$s (uncompressed)"</string>
     <!-- XHED: Title for native sharing dialog -->
     <string name="debugging_debuglog_sharing_dialog_title">"Share CWA Error Report"</string>
+    <!-- YTXT: Dialog title if the log recording is stopped, and thus deleted. -->
+    <string name="debugging_debuglog_stop_confirmation_title">"Wollen Sie die Fehleranalyse wirklich stoppen?"</string>
     <!-- YTXT: Dialog message if the log recording is stopped, and thus deleted. -->
-    <string name="debugging_debuglog_stop_confirmation_message">"Der Fehlerbericht wurde gelöscht. Wenn Sie eine lokale Kopie des Fehlerberichts gespeichert haben, wurde diese nicht gelöscht."</string>
+    <string name="debugging_debuglog_stop_confirmation_message">"Hierbei werden alle bereits aufgezeichneten Daten gelöscht. Wenn Sie eine lokale Kopie des Fehlerberichts gespeichert haben, wird diese nicht gelöscht."</string>
+    <!-- YTXT: Dialog confirmation button if the log recording is stopped, and thus deleted. -->
+    <string name="debugging_debuglog_stop_confirmation_confirmation_button">"Analyse stoppen"</string>
+    <!-- YTXT: Dialog discard button if the log recording is stopped, and thus deleted. -->
+    <string name="debugging_debuglog_stop_confirmation_discard_button">"Analyse fortführen"</string>
     <!-- YTXT: Dialog message if there is not enough free storage to start a debug log -->
     <string name="debugging_debuglog_start_low_storage_error">Sie brauchen mindestens 200 MB Speicherplatz, um die Fehleranalyse zu starten. Bitte geben Sie Speicherplatz frei.</string>
     <!-- XHED: Dialog title if a user has stored a debug log locally -->


### PR DESCRIPTION
This PR introduces a new dialog that ask the user for confirmation when pressing "Stoppen und Löschen". Only if the user pressed "Anayse stoppen" the recording will be stopped and deleted. If the user presses "Analyse fortführen" the alert will be dismissed and the recording continues. 

![image](https://user-images.githubusercontent.com/75120552/110534991-fb004400-811f-11eb-9cf2-fed7ba77557d.png)
