### PR TITLE
Fix logging related OOM issue (EXPOSUREAPP-5670/5691)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/BugCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/BugCensor.kt
@@ -38,7 +38,7 @@ interface BugCensor {
             return true
         }
 
-        fun LogLine.tryNewMessage(newMessage: String): LogLine? {
+        fun LogLine.toNewLogLineIfDifferent(newMessage: String): LogLine? {
             return if (newMessage != message) copy(message = newMessage) else null
         }
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/BugCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/BugCensor.kt
@@ -12,7 +12,7 @@ interface BugCensor {
     companion object {
         fun withValidName(name: String?, action: (String) -> Unit): Boolean {
             if (name.isNullOrBlank()) return false
-            if (name.length < 2) return false
+            if (name.length < 3) return false
             action(name)
             return true
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/BugCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/BugCensor.kt
@@ -8,4 +8,34 @@ interface BugCensor {
      * If there is something to censor a new log line is returned, otherwise returns null
      */
     suspend fun checkLog(entry: LogLine): LogLine?
+
+    companion object {
+        fun withValidName(name: String?, action: (String) -> Unit): Boolean {
+            if (name.isNullOrBlank()) return false
+            if (name.length < 2) return false
+            action(name)
+            return true
+        }
+
+        fun withValidEmail(email: String?, action: (String) -> Unit): Boolean {
+            if (email.isNullOrBlank()) return false
+            if (email.length < 6) return false
+            action(email)
+            return true
+        }
+
+        fun withValidPhoneNumber(number: String?, action: (String) -> Unit): Boolean {
+            if (number.isNullOrBlank()) return false
+            if (number.length < 4) return false
+            action(number)
+            return true
+        }
+
+        fun withValidComment(comment: String?, action: (String) -> Unit): Boolean {
+            if (comment.isNullOrBlank()) return false
+            if (comment.length < 3) return false
+            action(comment)
+            return true
+        }
+    }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/BugCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/BugCensor.kt
@@ -37,5 +37,9 @@ interface BugCensor {
             action(comment)
             return true
         }
+
+        fun LogLine.tryNewMessage(newMessage: String): LogLine? {
+            return if (newMessage != message) copy(message = newMessage) else null
+        }
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryEncounterCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryEncounterCensor.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.bugreporting.censors
 
 import dagger.Reusable
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidComment
 import de.rki.coronawarnapp.bugreporting.debuglog.LogLine
 import de.rki.coronawarnapp.bugreporting.debuglog.internal.DebuggerScope
 import de.rki.coronawarnapp.contactdiary.storage.repo.ContactDiaryRepository
@@ -31,11 +32,15 @@ class DiaryEncounterCensor @Inject constructor(
         if (encountersNow.isEmpty()) return null
 
         val newMessage = encountersNow.fold(entry.message) { orig, encounter ->
-            if (encounter.circumstances.isNullOrBlank()) return@fold orig
+            var wip = orig
 
-            orig.replace(encounter.circumstances!!, "Encounter#${encounter.id}/Circumstances")
+            withValidComment(encounter.circumstances) {
+                wip = orig.replace(it, "Encounter#${encounter.id}/Circumstances")
+            }
+
+            wip
         }
 
-        return entry.copy(message = newMessage)
+        return if (newMessage != entry.message) entry.copy(message = newMessage) else null
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryEncounterCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryEncounterCensor.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.bugreporting.censors
 
 import dagger.Reusable
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.tryNewMessage
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidComment
 import de.rki.coronawarnapp.bugreporting.debuglog.LogLine
 import de.rki.coronawarnapp.bugreporting.debuglog.internal.DebuggerScope
@@ -41,6 +42,6 @@ class DiaryEncounterCensor @Inject constructor(
             wip
         }
 
-        return if (newMessage != entry.message) entry.copy(message = newMessage) else null
+        return entry.tryNewMessage(newMessage)
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryEncounterCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryEncounterCensor.kt
@@ -1,7 +1,7 @@
 package de.rki.coronawarnapp.bugreporting.censors
 
 import dagger.Reusable
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.tryNewMessage
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.toNewLogLineIfDifferent
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidComment
 import de.rki.coronawarnapp.bugreporting.debuglog.LogLine
 import de.rki.coronawarnapp.bugreporting.debuglog.internal.DebuggerScope
@@ -42,6 +42,6 @@ class DiaryEncounterCensor @Inject constructor(
             wip
         }
 
-        return entry.tryNewMessage(newMessage)
+        return entry.toNewLogLineIfDifferent(newMessage)
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryEncounterCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryEncounterCensor.kt
@@ -35,7 +35,7 @@ class DiaryEncounterCensor @Inject constructor(
             var wip = orig
 
             withValidComment(encounter.circumstances) {
-                wip = orig.replace(it, "Encounter#${encounter.id}/Circumstances")
+                wip = wip.replace(it, "Encounter#${encounter.id}/Circumstances")
             }
 
             wip

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryLocationCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryLocationCensor.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.bugreporting.censors
 
 import dagger.Reusable
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.tryNewMessage
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidEmail
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidName
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidPhoneNumber
@@ -49,6 +50,6 @@ class DiaryLocationCensor @Inject constructor(
             wip
         }
 
-        return if (newMessage != entry.message) entry.copy(message = newMessage) else null
+        return entry.tryNewMessage(newMessage)
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryLocationCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryLocationCensor.kt
@@ -37,7 +37,7 @@ class DiaryLocationCensor @Inject constructor(
             var wip = orig
 
             withValidName(location.locationName) {
-                wip = orig.replace(it, "Location#${location.locationId}/Name")
+                wip = wip.replace(it, "Location#${location.locationId}/Name")
             }
             withValidEmail(location.emailAddress) {
                 wip = wip.replace(it, "Location#${location.locationId}/EMail")

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryLocationCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryLocationCensor.kt
@@ -1,7 +1,7 @@
 package de.rki.coronawarnapp.bugreporting.censors
 
 import dagger.Reusable
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.tryNewMessage
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.toNewLogLineIfDifferent
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidEmail
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidName
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidPhoneNumber
@@ -50,6 +50,6 @@ class DiaryLocationCensor @Inject constructor(
             wip
         }
 
-        return entry.tryNewMessage(newMessage)
+        return entry.toNewLogLineIfDifferent(newMessage)
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryLocationCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryLocationCensor.kt
@@ -1,6 +1,9 @@
 package de.rki.coronawarnapp.bugreporting.censors
 
 import dagger.Reusable
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidEmail
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidName
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidPhoneNumber
 import de.rki.coronawarnapp.bugreporting.debuglog.LogLine
 import de.rki.coronawarnapp.bugreporting.debuglog.internal.DebuggerScope
 import de.rki.coronawarnapp.contactdiary.storage.repo.ContactDiaryRepository
@@ -31,19 +34,21 @@ class DiaryLocationCensor @Inject constructor(
         if (locationsNow.isEmpty()) return null
 
         val newMessage = locationsNow.fold(entry.message) { orig, location ->
-            var wip = orig.replace(location.locationName, "Location#${location.locationId}/Name")
+            var wip = orig
 
-            location.emailAddress?.let {
+            withValidName(location.locationName) {
+                wip = orig.replace(it, "Location#${location.locationId}/Name")
+            }
+            withValidEmail(location.emailAddress) {
                 wip = wip.replace(it, "Location#${location.locationId}/EMail")
             }
-
-            location.phoneNumber?.let {
+            withValidPhoneNumber(location.phoneNumber) {
                 wip = wip.replace(it, "Location#${location.locationId}/PhoneNumber")
             }
 
             wip
         }
 
-        return entry.copy(message = newMessage)
+        return if (newMessage != entry.message) entry.copy(message = newMessage) else null
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryPersonCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryPersonCensor.kt
@@ -1,7 +1,7 @@
 package de.rki.coronawarnapp.bugreporting.censors
 
 import dagger.Reusable
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.tryNewMessage
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.toNewLogLineIfDifferent
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidEmail
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidName
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidPhoneNumber
@@ -50,6 +50,6 @@ class DiaryPersonCensor @Inject constructor(
             wip
         }
 
-        return entry.tryNewMessage(newMessage)
+        return entry.toNewLogLineIfDifferent(newMessage)
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryPersonCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryPersonCensor.kt
@@ -1,6 +1,9 @@
 package de.rki.coronawarnapp.bugreporting.censors
 
 import dagger.Reusable
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidEmail
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidName
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidPhoneNumber
 import de.rki.coronawarnapp.bugreporting.debuglog.LogLine
 import de.rki.coronawarnapp.bugreporting.debuglog.internal.DebuggerScope
 import de.rki.coronawarnapp.contactdiary.storage.repo.ContactDiaryRepository
@@ -31,19 +34,21 @@ class DiaryPersonCensor @Inject constructor(
         if (personsNow.isEmpty()) return null
 
         val newMessage = personsNow.fold(entry.message) { orig, person ->
-            var wip = orig.replace(person.fullName, "Person#${person.personId}/Name")
+            var wip = orig
 
-            person.emailAddress?.let {
+            withValidName(person.fullName) {
+                wip = orig.replace(it, "Person#${person.personId}/Name")
+            }
+            withValidEmail(person.emailAddress) {
                 wip = wip.replace(it, "Person#${person.personId}/EMail")
             }
-
-            person.phoneNumber?.let {
+            withValidPhoneNumber(person.phoneNumber) {
                 wip = wip.replace(it, "Person#${person.personId}/PhoneNumber")
             }
 
             wip
         }
 
-        return entry.copy(message = newMessage)
+        return if (newMessage != entry.message) entry.copy(message = newMessage) else null
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryPersonCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryPersonCensor.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.bugreporting.censors
 
 import dagger.Reusable
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.tryNewMessage
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidEmail
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidName
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidPhoneNumber
@@ -49,6 +50,6 @@ class DiaryPersonCensor @Inject constructor(
             wip
         }
 
-        return if (newMessage != entry.message) entry.copy(message = newMessage) else null
+        return entry.tryNewMessage(newMessage)
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryPersonCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryPersonCensor.kt
@@ -37,7 +37,7 @@ class DiaryPersonCensor @Inject constructor(
             var wip = orig
 
             withValidName(person.fullName) {
-                wip = orig.replace(it, "Person#${person.personId}/Name")
+                wip = wip.replace(it, "Person#${person.personId}/Name")
             }
             withValidEmail(person.emailAddress) {
                 wip = wip.replace(it, "Person#${person.personId}/EMail")

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryVisitCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryVisitCensor.kt
@@ -34,7 +34,7 @@ class DiaryVisitCensor @Inject constructor(
             var wip = orig
 
             BugCensor.withValidComment(visit.circumstances) {
-                wip = orig.replace(it, "Visit#${visit.id}/Circumstances")
+                wip = wip.replace(it, "Visit#${visit.id}/Circumstances")
             }
 
             wip

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryVisitCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryVisitCensor.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.bugreporting.censors
 
 import dagger.Reusable
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.tryNewMessage
 import de.rki.coronawarnapp.bugreporting.debuglog.LogLine
 import de.rki.coronawarnapp.bugreporting.debuglog.internal.DebuggerScope
 import de.rki.coronawarnapp.contactdiary.storage.repo.ContactDiaryRepository
@@ -40,6 +41,6 @@ class DiaryVisitCensor @Inject constructor(
             wip
         }
 
-        return if (newMessage != entry.message) entry.copy(message = newMessage) else null
+        return entry.tryNewMessage(newMessage)
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryVisitCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryVisitCensor.kt
@@ -1,7 +1,7 @@
 package de.rki.coronawarnapp.bugreporting.censors
 
 import dagger.Reusable
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.tryNewMessage
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.toNewLogLineIfDifferent
 import de.rki.coronawarnapp.bugreporting.debuglog.LogLine
 import de.rki.coronawarnapp.bugreporting.debuglog.internal.DebuggerScope
 import de.rki.coronawarnapp.contactdiary.storage.repo.ContactDiaryRepository
@@ -41,6 +41,6 @@ class DiaryVisitCensor @Inject constructor(
             wip
         }
 
-        return entry.tryNewMessage(newMessage)
+        return entry.toNewLogLineIfDifferent(newMessage)
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryVisitCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/DiaryVisitCensor.kt
@@ -31,11 +31,15 @@ class DiaryVisitCensor @Inject constructor(
         if (visitsNow.isEmpty()) return null
 
         val newMessage = visitsNow.fold(entry.message) { orig, visit ->
-            if (visit.circumstances.isNullOrBlank()) return@fold orig
+            var wip = orig
 
-            orig.replace(visit.circumstances!!, "Visit#${visit.id}/Circumstances")
+            BugCensor.withValidComment(visit.circumstances) {
+                wip = orig.replace(it, "Visit#${visit.id}/Circumstances")
+            }
+
+            wip
         }
 
-        return entry.copy(message = newMessage)
+        return if (newMessage != entry.message) entry.copy(message = newMessage) else null
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/QRCodeCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/QRCodeCensor.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.bugreporting.censors
 
 import dagger.Reusable
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.tryNewMessage
 import de.rki.coronawarnapp.bugreporting.debuglog.LogLine
 import de.rki.coronawarnapp.util.CWADebug
 import javax.inject.Inject
@@ -19,7 +20,7 @@ class QRCodeCensor @Inject constructor() : BugCensor {
             entry.message.replace(guid, PLACEHOLDER + guid.takeLast(4))
         }
 
-        return if (newMessage != entry.message) entry.copy(message = newMessage) else null
+        return entry.tryNewMessage(newMessage)
     }
 
     companion object {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/QRCodeCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/QRCodeCensor.kt
@@ -19,7 +19,7 @@ class QRCodeCensor @Inject constructor() : BugCensor {
             entry.message.replace(guid, PLACEHOLDER + guid.takeLast(4))
         }
 
-        return entry.copy(message = newMessage)
+        return if (newMessage != entry.message) entry.copy(message = newMessage) else null
     }
 
     companion object {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/QRCodeCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/QRCodeCensor.kt
@@ -1,7 +1,7 @@
 package de.rki.coronawarnapp.bugreporting.censors
 
 import dagger.Reusable
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.tryNewMessage
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.toNewLogLineIfDifferent
 import de.rki.coronawarnapp.bugreporting.debuglog.LogLine
 import de.rki.coronawarnapp.util.CWADebug
 import javax.inject.Inject
@@ -20,7 +20,7 @@ class QRCodeCensor @Inject constructor() : BugCensor {
             entry.message.replace(guid, PLACEHOLDER + guid.takeLast(4))
         }
 
-        return entry.tryNewMessage(newMessage)
+        return entry.toNewLogLineIfDifferent(newMessage)
     }
 
     companion object {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/RegistrationTokenCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/RegistrationTokenCensor.kt
@@ -18,7 +18,7 @@ class RegistrationTokenCensor @Inject constructor() : BugCensor {
             entry.message.replace(token, PLACEHOLDER + token.takeLast(4))
         }
 
-        return entry.copy(message = newMessage)
+        return if (newMessage != entry.message) entry.copy(message = newMessage) else null
     }
 
     companion object {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/RegistrationTokenCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/RegistrationTokenCensor.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.bugreporting.censors
 
 import dagger.Reusable
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.tryNewMessage
 import de.rki.coronawarnapp.bugreporting.debuglog.LogLine
 import de.rki.coronawarnapp.storage.LocalData
 import de.rki.coronawarnapp.util.CWADebug
@@ -18,7 +19,7 @@ class RegistrationTokenCensor @Inject constructor() : BugCensor {
             entry.message.replace(token, PLACEHOLDER + token.takeLast(4))
         }
 
-        return if (newMessage != entry.message) entry.copy(message = newMessage) else null
+        return entry.tryNewMessage(newMessage)
     }
 
     companion object {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/RegistrationTokenCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/RegistrationTokenCensor.kt
@@ -1,7 +1,7 @@
 package de.rki.coronawarnapp.bugreporting.censors
 
 import dagger.Reusable
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.tryNewMessage
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.toNewLogLineIfDifferent
 import de.rki.coronawarnapp.bugreporting.debuglog.LogLine
 import de.rki.coronawarnapp.storage.LocalData
 import de.rki.coronawarnapp.util.CWADebug
@@ -19,7 +19,7 @@ class RegistrationTokenCensor @Inject constructor() : BugCensor {
             entry.message.replace(token, PLACEHOLDER + token.takeLast(4))
         }
 
-        return entry.tryNewMessage(newMessage)
+        return entry.toNewLogLineIfDifferent(newMessage)
     }
 
     companion object {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/debuglog/DebugLogger.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/debuglog/DebugLogger.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.yield
 import timber.log.Timber
 import java.io.File
-import java.util.LinkedList
 
 @SuppressLint("LogNotTimber", "StaticFieldLeak")
 @Suppress("BlockingMethodInNonBlockingContext")
@@ -149,7 +148,6 @@ class DebugLogger(
         logWriter.teardown()
     }
 
-    private val times = LinkedList<Double>()
     private fun startNewLogJob(logLines: Flow<LogLine>) = scope.launch {
         try {
             logLines.collect { rawLine ->
@@ -162,15 +160,9 @@ class DebugLogger(
                 launch {
                     // Censor data sources need a moment to know what to censor
                     delay(1000)
-                    val censorStart = System.nanoTime()
                     val censoredLine = bugCensors.get().fold(rawLine) { prev, censor ->
                         censor.checkLog(prev) ?: prev
                     }
-                    val stop = System.nanoTime()
-                    val time = (stop - censorStart).toDouble()
-                    times.add(time)
-
-                    Log.i(TAG, "Avg CensorTime: ${times.average() / 1000000}ms | time ${time / 1000000}ms")
                     logWriter.write(censoredLine)
                 }
             }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/BugCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/BugCensorTest.kt
@@ -1,0 +1,52 @@
+package de.rki.coronawarnapp.bugreporting.censors
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class BugCensorTest : BaseTest() {
+
+    @Test
+    fun `name censoring validity`() {
+        BugCensor.withValidName(null) {} shouldBe false
+        BugCensor.withValidName("") {} shouldBe false
+        BugCensor.withValidName("  ") {} shouldBe false
+        BugCensor.withValidName("       ") {} shouldBe false
+        BugCensor.withValidName("J") {} shouldBe false
+        BugCensor.withValidName("Jo") {} shouldBe true
+    }
+
+    @Test
+    fun `email censoring validity`() {
+        BugCensor.withValidEmail(null) {} shouldBe false
+        BugCensor.withValidEmail("") {} shouldBe false
+        BugCensor.withValidEmail("     ") {} shouldBe false
+        BugCensor.withValidEmail("      ") {} shouldBe false
+        BugCensor.withValidEmail("@") {} shouldBe false
+        BugCensor.withValidEmail("@.") {} shouldBe false
+        BugCensor.withValidEmail("@.de") {} shouldBe false
+        BugCensor.withValidEmail("a@.de") {} shouldBe false
+        BugCensor.withValidEmail("a@b.de") {} shouldBe true
+    }
+
+    @Test
+    fun `phone censoring validity`() {
+        BugCensor.withValidPhoneNumber(null) {} shouldBe false
+        BugCensor.withValidPhoneNumber("    ") {} shouldBe false
+        BugCensor.withValidPhoneNumber("        ") {} shouldBe false
+        BugCensor.withValidPhoneNumber("0") {} shouldBe false
+        BugCensor.withValidPhoneNumber("01") {} shouldBe false
+        BugCensor.withValidPhoneNumber("012") {} shouldBe false
+        BugCensor.withValidPhoneNumber("0123") {} shouldBe true
+    }
+
+    @Test
+    fun `comment censoring validity`() {
+        BugCensor.withValidComment(null) {} shouldBe false
+        BugCensor.withValidComment("   ") {} shouldBe false
+        BugCensor.withValidComment("        ") {} shouldBe false
+        BugCensor.withValidComment("a") {} shouldBe false
+        BugCensor.withValidComment("ab") {} shouldBe false
+        BugCensor.withValidComment("abc") {} shouldBe true
+    }
+}

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/BugCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/BugCensorTest.kt
@@ -1,6 +1,9 @@
 package de.rki.coronawarnapp.bugreporting.censors
 
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.tryNewMessage
+import de.rki.coronawarnapp.bugreporting.debuglog.LogLine
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 
@@ -49,5 +52,18 @@ class BugCensorTest : BaseTest() {
         BugCensor.withValidComment("a") {} shouldBe false
         BugCensor.withValidComment("ab") {} shouldBe false
         BugCensor.withValidComment("abc") {} shouldBe true
+    }
+
+    @Test
+    fun `loglines are only copied if the message is different`() {
+        val logLine = LogLine(
+            timestamp = 1,
+            priority = 3,
+            message = "Message",
+            tag = "Tag",
+            throwable = null
+        )
+        logLine.tryNewMessage("Message") shouldBe null
+        logLine.tryNewMessage("Message ") shouldNotBe logLine
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/BugCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/BugCensorTest.kt
@@ -13,7 +13,8 @@ class BugCensorTest : BaseTest() {
         BugCensor.withValidName("  ") {} shouldBe false
         BugCensor.withValidName("       ") {} shouldBe false
         BugCensor.withValidName("J") {} shouldBe false
-        BugCensor.withValidName("Jo") {} shouldBe true
+        BugCensor.withValidName("Jo") {} shouldBe false
+        BugCensor.withValidName("Joe") {} shouldBe true
     }
 
     @Test

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/BugCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/BugCensorTest.kt
@@ -1,6 +1,6 @@
 package de.rki.coronawarnapp.bugreporting.censors
 
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.tryNewMessage
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.toNewLogLineIfDifferent
 import de.rki.coronawarnapp.bugreporting.debuglog.LogLine
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -63,7 +63,7 @@ class BugCensorTest : BaseTest() {
             tag = "Tag",
             throwable = null
         )
-        logLine.tryNewMessage("Message") shouldBe null
-        logLine.tryNewMessage("Message ") shouldNotBe logLine
+        logLine.toNewLogLineIfDifferent("Message") shouldBe null
+        logLine.toNewLogLineIfDifferent("Message ") shouldNotBe logLine
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryEncounterCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryEncounterCensorTest.kt
@@ -10,10 +10,12 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import kotlin.concurrent.thread
 
 class DiaryEncounterCensorTest : BaseTest() {
 
@@ -97,5 +99,63 @@ class DiaryEncounterCensorTest : BaseTest() {
             throwable = null
         )
         instance.checkLog(notCensored) shouldBe null
+    }
+
+    @Test
+    fun `censoring returns null if the message did not change`() = runBlockingTest {
+        every { diaryRepo.personEncounters } returns flowOf(
+            listOf(
+                mockEncounter(1, _circumstances = "March weather"),
+                mockEncounter(2, _circumstances = "Rainy, cold"),
+            )
+        )
+
+        val instance = createInstance(this)
+        val notCensored = LogLine(
+            timestamp = 1,
+            priority = 3,
+            message = "I like turtles",
+            tag = "I'm a tag",
+            throwable = null
+        )
+        instance.checkLog(notCensored) shouldBe null
+    }
+
+    // EXPOSUREAPP-5670 / EXPOSUREAPP-5691
+    @Test
+    fun `replacement doesn't cause recursion`() {
+        every { diaryRepo.personEncounters } returns flowOf(
+            listOf(
+                mockEncounter(1, _circumstances = "March weather"),
+                mockEncounter(2, _circumstances = "Rainy, cold"),
+            )
+        )
+
+        val logLine = LogLine(
+            timestamp = 1,
+            priority = 3,
+            message = "Lorem ipsum",
+            tag = "I'm a tag",
+            throwable = null
+        )
+
+        var isFinished = false
+
+        thread {
+            Thread.sleep(500)
+            if (isFinished) return@thread
+            Runtime.getRuntime().exit(1)
+        }
+
+        runBlocking {
+            val instance = createInstance(this)
+
+            val processedLine = try {
+                instance.checkLog(logLine)
+            } finally {
+                isFinished = true
+            }
+            processedLine shouldBe null
+        }
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryLocationCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryLocationCensorTest.kt
@@ -10,10 +10,12 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import kotlin.concurrent.thread
 
 class DiaryLocationCensorTest : BaseTest() {
 
@@ -83,5 +85,64 @@ class DiaryLocationCensorTest : BaseTest() {
             throwable = null
         )
         instance.checkLog(notCensored) shouldBe null
+    }
+
+    @Test
+    fun `if message is the same, don't copy the log line`() = runBlockingTest {
+        every { diaryRepo.locations } returns flowOf(
+            listOf(
+                mockLocation(1, "Test", phone = null, mail = null),
+                mockLocation(2, "Test", phone = null, mail = null),
+                mockLocation(3, "Test", phone = null, mail = null)
+            )
+        )
+        val instance = createInstance(this)
+        val logLine = LogLine(
+            timestamp = 1,
+            priority = 3,
+            message = "Lorem ipsum",
+            tag = "I'm a tag",
+            throwable = null
+        )
+        instance.checkLog(logLine) shouldBe null
+    }
+
+    // EXPOSUREAPP-5670 / EXPOSUREAPP-5691
+    @Test
+    fun `replacement doesn't cause recursion`() {
+        every { diaryRepo.locations } returns flowOf(
+            listOf(
+                mockLocation(1, "Test", phone = null, mail = null),
+                mockLocation(2, "Test", phone = null, mail = null),
+                mockLocation(3, "Test", phone = null, mail = null)
+            )
+        )
+
+        val logLine = LogLine(
+            timestamp = 1,
+            priority = 3,
+            message = "Lorem ipsum",
+            tag = "I'm a tag",
+            throwable = null
+        )
+
+        var isFinished = false
+
+        thread {
+            Thread.sleep(500)
+            if (isFinished) return@thread
+            Runtime.getRuntime().exit(1)
+        }
+
+        runBlocking {
+            val instance = createInstance(this)
+
+            val processedLine = try {
+                instance.checkLog(logLine)
+            } finally {
+                isFinished = true
+            }
+            processedLine shouldBe null
+        }
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryPersonCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryPersonCensorTest.kt
@@ -10,10 +10,13 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import java.lang.Thread.sleep
+import kotlin.concurrent.thread
 
 class DiaryPersonCensorTest : BaseTest() {
 
@@ -83,5 +86,64 @@ class DiaryPersonCensorTest : BaseTest() {
             throwable = null
         )
         instance.checkLog(notCensored) shouldBe null
+    }
+
+    @Test
+    fun `if message is the same, don't copy the log line`() = runBlockingTest {
+        every { diaryRepo.people } returns flowOf(
+            listOf(
+                mockPerson(1, "Test", phone = null, mail = null),
+                mockPerson(2, "Test", phone = null, mail = null),
+                mockPerson(3, "Test", phone = null, mail = null)
+            )
+        )
+        val instance = createInstance(this)
+        val logLine = LogLine(
+            timestamp = 1,
+            priority = 3,
+            message = "Lorem ipsum",
+            tag = "I'm a tag",
+            throwable = null
+        )
+        instance.checkLog(logLine) shouldBe null
+    }
+
+    // EXPOSUREAPP-5670 / EXPOSUREAPP-5691
+    @Test
+    fun `replacement doesn't cause recursion`() {
+        every { diaryRepo.people } returns flowOf(
+            listOf(
+                mockPerson(1, "Test", phone = "", mail = ""),
+                mockPerson(2, "Test", phone = "", mail = ""),
+                mockPerson(3, "Test", phone = "", mail = "")
+            )
+        )
+
+        val logLine = LogLine(
+            timestamp = 1,
+            priority = 3,
+            message = "Lorem ipsum",
+            tag = "I'm a tag",
+            throwable = null
+        )
+
+        var isFinished = false
+
+        thread {
+            sleep(500)
+            if (isFinished) return@thread
+            Runtime.getRuntime().exit(1)
+        }
+
+        runBlocking {
+            val instance = createInstance(this)
+
+            val processedLine = try {
+                instance.checkLog(logLine)
+            } finally {
+                isFinished = true
+            }
+            processedLine shouldBe null
+        }
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryVisitCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryVisitCensorTest.kt
@@ -10,10 +10,12 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import kotlin.concurrent.thread
 
 class DiaryVisitCensorTest : BaseTest() {
 
@@ -93,5 +95,62 @@ class DiaryVisitCensorTest : BaseTest() {
             throwable = null
         )
         instance.checkLog(notCensored) shouldBe null
+    }
+
+    @Test
+    fun `censoring returns null if the message didn't change`() = runBlockingTest {
+        every { diaryRepo.locationVisits } returns flowOf(
+            listOf(
+                mockVisit(1, _circumstances = "Coffee"),
+                mockVisit(2, _circumstances = "fuels the world."),
+            )
+        )
+        val instance = createInstance(this)
+        val notCensored = LogLine(
+            timestamp = 1,
+            priority = 3,
+            message = "Wakey wakey, eggs and bakey.",
+            tag = "I'm a tag",
+            throwable = null
+        )
+        instance.checkLog(notCensored) shouldBe null
+    }
+
+    // EXPOSUREAPP-5670 / EXPOSUREAPP-5691
+    @Test
+    fun `replacement doesn't cause recursion`() {
+        every { diaryRepo.locationVisits } returns flowOf(
+            listOf(
+                mockVisit(1, _circumstances = "Coffee"),
+                mockVisit(2, _circumstances = "fuels the world."),
+            )
+        )
+
+        val logLine = LogLine(
+            timestamp = 1,
+            priority = 3,
+            message = "Lorem ipsum",
+            tag = "I'm a tag",
+            throwable = null
+        )
+
+        var isFinished = false
+
+        thread {
+            Thread.sleep(500)
+            if (isFinished) return@thread
+            Runtime.getRuntime().exit(1)
+        }
+
+        runBlocking {
+            val instance = createInstance(this)
+
+            val processedLine = try {
+                instance.checkLog(logLine)
+            } finally {
+                isFinished = true
+            }
+            processedLine shouldBe null
+        }
     }
 }


### PR DESCRIPTION
The issue was that we didn't filter out `""` (empty string) phone numbers, emails etc. so when it came to logging we attempted to replace `""` in every log line, with `fold` this lead to an OOM if more than one person/location existed due to recursion.

To reproduce without this PR, create 3 persons or locations that just have a name and no phone or email.

You can also check out this early commit in this PR, which has unit tests that reproduce this issue:
https://github.com/corona-warn-app/cwa-app-android/commit/dc5631421c614fbfe3ce776ee1d853552e89f914
