### PR TITLE
Fix contact journal data visit/encounter updates (EXPOSUREAPP-5751)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/storage/repo/ContactDiaryRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/storage/repo/ContactDiaryRepository.kt
@@ -22,7 +22,11 @@ interface ContactDiaryRepository {
     val locationVisits: Flow<List<ContactDiaryLocationVisit>>
     fun locationVisitsForDate(date: LocalDate): Flow<List<ContactDiaryLocationVisit>>
     suspend fun addLocationVisit(contactDiaryLocationVisit: ContactDiaryLocationVisit)
-    suspend fun updateLocationVisit(contactDiaryLocationVisit: ContactDiaryLocationVisit)
+    suspend fun updateLocationVisit(
+        visitId: Long,
+        update: (ContactDiaryLocationVisit) -> ContactDiaryLocationVisit
+    )
+
     suspend fun deleteLocationVisit(contactDiaryLocationVisit: ContactDiaryLocationVisit)
     suspend fun deleteLocationVisits(contactDiaryLocationVisits: List<ContactDiaryLocationVisit>)
     suspend fun deleteAllLocationVisits()
@@ -39,7 +43,11 @@ interface ContactDiaryRepository {
     val personEncounters: Flow<List<ContactDiaryPersonEncounter>>
     fun personEncountersForDate(date: LocalDate): Flow<List<ContactDiaryPersonEncounter>>
     suspend fun addPersonEncounter(contactDiaryPersonEncounter: ContactDiaryPersonEncounter)
-    suspend fun updatePersonEncounter(contactDiaryPersonEncounter: ContactDiaryPersonEncounter)
+    suspend fun updatePersonEncounter(
+        encounterId: Long,
+        update: (ContactDiaryPersonEncounter) -> ContactDiaryPersonEncounter
+    )
+
     suspend fun deletePersonEncounter(contactDiaryPersonEncounter: ContactDiaryPersonEncounter)
     suspend fun deletePersonEncounters(contactDiaryPersonEncounters: List<ContactDiaryPersonEncounter>)
     suspend fun deleteAllPersonEncounters()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/storage/repo/DefaultContactDiaryRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/storage/repo/DefaultContactDiaryRepository.kt
@@ -11,8 +11,10 @@ import de.rki.coronawarnapp.contactdiary.storage.dao.ContactDiaryLocationVisitDa
 import de.rki.coronawarnapp.contactdiary.storage.dao.ContactDiaryPersonDao
 import de.rki.coronawarnapp.contactdiary.storage.dao.ContactDiaryPersonEncounterDao
 import de.rki.coronawarnapp.contactdiary.storage.entity.toContactDiaryLocationEntity
+import de.rki.coronawarnapp.contactdiary.storage.entity.toContactDiaryLocationVisit
 import de.rki.coronawarnapp.contactdiary.storage.entity.toContactDiaryLocationVisitEntity
 import de.rki.coronawarnapp.contactdiary.storage.entity.toContactDiaryLocationVisitSortedList
+import de.rki.coronawarnapp.contactdiary.storage.entity.toContactDiaryPersonEncounter
 import de.rki.coronawarnapp.contactdiary.storage.entity.toContactDiaryPersonEncounterEntity
 import de.rki.coronawarnapp.contactdiary.storage.entity.toContactDiaryPersonEncounterSortedList
 import de.rki.coronawarnapp.contactdiary.storage.entity.toContactDiaryPersonEntity
@@ -108,10 +110,14 @@ class DefaultContactDiaryRepository @Inject constructor(
         contactDiaryLocationVisitDao.insert(contactDiaryLocationVisitEntity)
     }
 
-    override suspend fun updateLocationVisit(contactDiaryLocationVisit: ContactDiaryLocationVisit) {
-        executeWhenIdNotDefault(contactDiaryLocationVisit.id) {
-            val contactDiaryLocationVisitEntity = contactDiaryLocationVisit.toContactDiaryLocationVisitEntity()
-            contactDiaryLocationVisitDao.update(contactDiaryLocationVisitEntity)
+    override suspend fun updateLocationVisit(
+        visitId: Long,
+        update: (ContactDiaryLocationVisit) -> ContactDiaryLocationVisit
+    ) {
+        executeWhenIdNotDefault(visitId) {
+            val original = contactDiaryLocationVisitDao.entityForId(visitId)
+            val updatedVisit = update(original.toContactDiaryLocationVisit())
+            contactDiaryLocationVisitDao.update(updatedVisit.toContactDiaryLocationVisitEntity())
         }
     }
 
@@ -202,10 +208,14 @@ class DefaultContactDiaryRepository @Inject constructor(
         contactDiaryPersonEncounterDao.insert(contactDiaryPersonEncounterEntity)
     }
 
-    override suspend fun updatePersonEncounter(contactDiaryPersonEncounter: ContactDiaryPersonEncounter) {
-        executeWhenIdNotDefault(contactDiaryPersonEncounter.id) {
-            val contactDiaryPersonEncounterEntity = contactDiaryPersonEncounter.toContactDiaryPersonEncounterEntity()
-            contactDiaryPersonEncounterDao.update(contactDiaryPersonEncounterEntity)
+    override suspend fun updatePersonEncounter(
+        encounterId: Long,
+        update: (ContactDiaryPersonEncounter) -> ContactDiaryPersonEncounter
+    ) {
+        executeWhenIdNotDefault(encounterId) {
+            val original = contactDiaryPersonEncounterDao.entityForId(encounterId)
+            val updatedEncounter = update(original.toContactDiaryPersonEncounter())
+            contactDiaryPersonEncounterDao.update(updatedEncounter.toContactDiaryPersonEncounterEntity())
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/day/tabs/location/ContactDiaryLocationListViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/day/tabs/location/ContactDiaryLocationListViewModel.kt
@@ -99,9 +99,11 @@ class ContactDiaryLocationListViewModel @AssistedInject constructor(
         item: DiaryLocationListItem,
         duration: Duration?
     ) {
-        val visit = item.visit?.toEditableVariant() ?: return
+        val visit = item.visit ?: return
         launchOnAppScope {
-            contactDiaryRepository.updateLocationVisit(visit.copy(duration = duration))
+            contactDiaryRepository.updateLocationVisit(visit.id) {
+                it.toEditableVariant().copy(duration = duration)
+            }
         }
     }
 
@@ -109,10 +111,12 @@ class ContactDiaryLocationListViewModel @AssistedInject constructor(
         item: DiaryLocationListItem,
         circumstances: String
     ) {
-        val visit = item.visit?.toEditableVariant() ?: return
+        val visit = item.visit ?: return
         val sanitized = circumstances.trim().trimToLength(250)
         launchOnAppScope {
-            contactDiaryRepository.updateLocationVisit(visit.copy(circumstances = sanitized))
+            contactDiaryRepository.updateLocationVisit(visit.id) {
+                it.toEditableVariant().copy(circumstances = sanitized)
+            }
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/day/tabs/person/ContactDiaryPersonListViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/day/tabs/person/ContactDiaryPersonListViewModel.kt
@@ -95,9 +95,11 @@ class ContactDiaryPersonListViewModel @AssistedInject constructor(
         duration: ContactDiaryPersonEncounter.DurationClassification?
     ) {
         Timber.d("onDurationChanged(item=%s, duration=%s)", item, duration)
-        val encounter = item.personEncounter?.toEditableVariant() ?: return
+        val encounter = item.personEncounter ?: return
         launchOnAppScope {
-            contactDiaryRepository.updatePersonEncounter(encounter.copy(durationClassification = duration))
+            contactDiaryRepository.updatePersonEncounter(encounter.id) {
+                it.toEditableVariant().copy(durationClassification = duration)
+            }
         }
     }
 
@@ -112,9 +114,11 @@ class ContactDiaryPersonListViewModel @AssistedInject constructor(
         withMask: Boolean?
     ) {
         Timber.d("onWithmaskChanged(item=%s, withMask=%s)", item, withMask)
-        val encounter = item.personEncounter?.toEditableVariant() ?: return
+        val encounter = item.personEncounter ?: return
         launchOnAppScope {
-            contactDiaryRepository.updatePersonEncounter(encounter.copy(withMask = withMask))
+            contactDiaryRepository.updatePersonEncounter(encounter.id) {
+                it.toEditableVariant().copy(withMask = withMask)
+            }
         }
     }
 
@@ -123,9 +127,11 @@ class ContactDiaryPersonListViewModel @AssistedInject constructor(
         wasOutside: Boolean?
     ) {
         Timber.d("onWasOutsideChanged(item=%s, onWasOutside=%s)", item, wasOutside)
-        val encounter = item.personEncounter?.toEditableVariant() ?: return
+        val encounter = item.personEncounter ?: return
         launchOnAppScope {
-            contactDiaryRepository.updatePersonEncounter(encounter.copy(wasOutside = wasOutside))
+            contactDiaryRepository.updatePersonEncounter(encounter.id) {
+                it.toEditableVariant().copy(wasOutside = wasOutside)
+            }
         }
     }
 
@@ -134,10 +140,12 @@ class ContactDiaryPersonListViewModel @AssistedInject constructor(
         circumstances: String
     ) {
         Timber.d("onCircumstancesChanged(item=%s, circumstances=%s)", item, circumstances)
-        val encounter = item.personEncounter?.toEditableVariant() ?: return
+        val encounter = item.personEncounter ?: return
         launchOnAppScope {
             val sanitized = circumstances.trim().trimToLength(250)
-            contactDiaryRepository.updatePersonEncounter(encounter.copy(circumstances = sanitized))
+            contactDiaryRepository.updatePersonEncounter(encounter.id) {
+                it.toEditableVariant().copy(circumstances = sanitized)
+            }
         }
     }
 


### PR DESCRIPTION
This fixes #2594 where depending on the input order, the UI uses an older data object, changes one value, but due to working with an outdated data object, another value that was also changed is lost when the database is updated.

Let the diary repo offer an update method for changing visits and encounters, so we can do delta updates, and don't accidentally overwrite information. So now we pass the ID, the repo gives us the newest object, we change the value we want, and that's then written to the DB.