### PR TITLE
Fix test result donor calculation (EXPOSUREAPP-5814)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/storage/TestResultDonorSettings.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/storage/TestResultDonorSettings.kt
@@ -65,6 +65,34 @@ class TestResultDonorSettings @Inject constructor(
         }
     )
 
+    val mostRecentDateWithHighOrLowRiskLevel = prefs.createFlowPreference(
+        key = PREFS_KEY_MOST_RECENT_WITH_HIGH_OR_LOW_RISK_LEVEL,
+        reader = { key ->
+            getLong(key, 0L).let {
+                if (it != 0L) {
+                    Instant.ofEpochMilli(it)
+                } else null
+            }
+        },
+        writer = { key, value ->
+            putLong(key, value?.millis ?: 0L)
+        }
+    )
+
+    val riskLevelTurnedRedTime = prefs.createFlowPreference(
+        key = PREFS_KEY_RISK_LEVEL_TURNED_RED_TIME,
+        reader = { key ->
+            getLong(key, 0L).let {
+                if (it != 0L) {
+                    Instant.ofEpochMilli(it)
+                } else null
+            }
+        },
+        writer = { key, value ->
+            putLong(key, value?.millis ?: 0L)
+        }
+    )
+
     fun saveTestResultDonorDataAtRegistration(testResult: TestResult, lastRiskResult: RiskLevelResult) {
         testScannedAfterConsent.update { true }
         testResultAtRegistration.update { testResult }
@@ -82,5 +110,8 @@ class TestResultDonorSettings @Inject constructor(
         private const val PREFS_KEY_TEST_RESULT_AT_REGISTRATION = "testResultDonor.testResultAtRegistration"
         private const val PREFS_KEY_RISK_LEVEL_AT_REGISTRATION = "testResultDonor.riskLevelAtRegistration"
         private const val PREFS_KEY_FINAL_TEST_RESULT_RECEIVED_AT = "testResultDonor.finalTestResultReceivedAt"
+        private const val PREFS_KEY_RISK_LEVEL_TURNED_RED_TIME = "testResultDonor.riskLevelTurnedRedTime"
+        private const val PREFS_KEY_MOST_RECENT_WITH_HIGH_OR_LOW_RISK_LEVEL =
+            "testResultDonor.mostRecentWithHighOrLowRiskLevel"
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelChangeDetector.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelChangeDetector.kt
@@ -82,7 +82,7 @@ class RiskLevelChangeDetector @Inject constructor(
     private fun saveTestDonorRiskLevelAnalytics(
         newRiskState: RiskLevelResult
     ) {
-        // Save if not already set before for increased risk
+        // Save riskLevelTurnedRedTime if not already set before for high risk detection
         Timber.i("riskLevelTurnedRedTime:%s", testResultDonorSettings.riskLevelTurnedRedTime.value)
         if (testResultDonorSettings.riskLevelTurnedRedTime.value == null) {
             if (newRiskState.isIncreasedRisk) {
@@ -97,7 +97,7 @@ class RiskLevelChangeDetector @Inject constructor(
             }
         }
 
-        // Save most recent date high or low risks
+        // Save most recent date of high or low risks
         if (newRiskState.riskState in listOf(RiskState.INCREASED_RISK, RiskState.LOW_RISK)) {
             Timber.i(
                 "newRiskState:%s, mostRecentDateWithHighOrLowRiskLevel:%s",

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelChangeDetector.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelChangeDetector.kt
@@ -83,14 +83,14 @@ class RiskLevelChangeDetector @Inject constructor(
         newRiskState: RiskLevelResult
     ) {
         // Save riskLevelTurnedRedTime if not already set before for high risk detection
-        Timber.i("riskLevelTurnedRedTime:%s", testResultDonorSettings.riskLevelTurnedRedTime.value)
+        Timber.i("riskLevelTurnedRedTime=%s", testResultDonorSettings.riskLevelTurnedRedTime.value)
         if (testResultDonorSettings.riskLevelTurnedRedTime.value == null) {
             if (newRiskState.isIncreasedRisk) {
                 testResultDonorSettings.riskLevelTurnedRedTime.update {
                     newRiskState.calculatedAt
                 }
                 Timber.i(
-                    "newRiskState:%s, riskLevelTurnedRedTime:%s",
+                    "riskLevelTurnedRedTime: newRiskState=%s, riskLevelTurnedRedTime=%s",
                     newRiskState.riskState,
                     newRiskState.calculatedAt
                 )
@@ -100,7 +100,7 @@ class RiskLevelChangeDetector @Inject constructor(
         // Save most recent date of high or low risks
         if (newRiskState.riskState in listOf(RiskState.INCREASED_RISK, RiskState.LOW_RISK)) {
             Timber.i(
-                "newRiskState:%s, lastRiskEncounterAt:%s",
+                "mostRecentDateWithHighOrLowRiskLevel: newRiskState=%s, lastRiskEncounterAt=%s",
                 newRiskState.riskState,
                 newRiskState.lastRiskEncounterAt
             )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelChangeDetector.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelChangeDetector.kt
@@ -100,17 +100,17 @@ class RiskLevelChangeDetector @Inject constructor(
 
         // Save most recent date of high or low risks
         if (newRiskState.riskState in listOf(RiskState.INCREASED_RISK, RiskState.LOW_RISK)) {
-            Timber.i(
-                "newRiskState:%s, mostRecentDateWithHighOrLowRiskLevel:%s",
-                newRiskState.riskState,
-                newRiskState.calculatedAt
-            )
-
             val lastRiskEncounterAt: Instant? = if (newRiskState.isIncreasedRisk) {
                 newRiskState.aggregatedRiskResult?.mostRecentDateWithHighRisk
             } else {
                 newRiskState.aggregatedRiskResult?.mostRecentDateWithLowRisk
             }
+
+            Timber.i(
+                "newRiskState:%s, lastRiskEncounterAt:%s",
+                newRiskState.riskState,
+                lastRiskEncounterAt
+            )
 
             testResultDonorSettings.mostRecentDateWithHighOrLowRiskLevel.update {
                 lastRiskEncounterAt

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelChangeDetector.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelChangeDetector.kt
@@ -91,7 +91,7 @@ class RiskLevelChangeDetector @Inject constructor(
                 }
                 Timber.i(
                     "newRiskState:%s, riskLevelTurnedRedTime:%s",
-                    newRiskState,
+                    newRiskState.riskState,
                     newRiskState.calculatedAt
                 )
             }
@@ -101,7 +101,7 @@ class RiskLevelChangeDetector @Inject constructor(
         if (newRiskState.riskState in listOf(RiskState.INCREASED_RISK, RiskState.LOW_RISK)) {
             Timber.i(
                 "newRiskState:%s, mostRecentDateWithHighOrLowRiskLevel:%s",
-                newRiskState,
+                newRiskState.riskState,
                 newRiskState.calculatedAt
             )
             testResultDonorSettings.mostRecentDateWithHighOrLowRiskLevel.update {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelChangeDetector.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelChangeDetector.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
-import org.joda.time.Instant
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -100,20 +99,14 @@ class RiskLevelChangeDetector @Inject constructor(
 
         // Save most recent date of high or low risks
         if (newRiskState.riskState in listOf(RiskState.INCREASED_RISK, RiskState.LOW_RISK)) {
-            val lastRiskEncounterAt: Instant? = if (newRiskState.isIncreasedRisk) {
-                newRiskState.aggregatedRiskResult?.mostRecentDateWithHighRisk
-            } else {
-                newRiskState.aggregatedRiskResult?.mostRecentDateWithLowRisk
-            }
-
             Timber.i(
                 "newRiskState:%s, lastRiskEncounterAt:%s",
                 newRiskState.riskState,
-                lastRiskEncounterAt
+                newRiskState.lastRiskEncounterAt
             )
 
             testResultDonorSettings.mostRecentDateWithHighOrLowRiskLevel.update {
-                lastRiskEncounterAt
+                newRiskState.lastRiskEncounterAt
             }
         }
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelChangeDetector.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelChangeDetector.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import org.joda.time.Instant
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -104,8 +105,15 @@ class RiskLevelChangeDetector @Inject constructor(
                 newRiskState.riskState,
                 newRiskState.calculatedAt
             )
+
+            val lastRiskEncounterAt: Instant? = if (newRiskState.isIncreasedRisk) {
+                newRiskState.aggregatedRiskResult?.mostRecentDateWithHighRisk
+            } else {
+                newRiskState.aggregatedRiskResult?.mostRecentDateWithLowRisk
+            }
+
             testResultDonorSettings.mostRecentDateWithHighOrLowRiskLevel.update {
-                newRiskState.calculatedAt
+                lastRiskEncounterAt
             }
         }
     }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDonorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDonorTest.kt
@@ -140,6 +140,92 @@ class TestResultDonorTest : BaseTest() {
     }
 
     @Test
+    fun `No donation when test is  POSITIVE and HighRisk but riskLevelTurnedRedTime is missing`() {
+        runBlockingTest {
+            with(testResultDonorSettings) {
+                every { testScannedAfterConsent } returns mockFlowPreference(true)
+                every { testResultAtRegistration } returns mockFlowPreference(TestResult.POSITIVE)
+                every { finalTestResultReceivedAt } returns mockFlowPreference(baseTime)
+                every { riskLevelTurnedRedTime } returns mockFlowPreference(null)
+                every { riskLevelAtTestRegistration } returns mockFlowPreference(PpaData.PPARiskLevel.RISK_LEVEL_HIGH)
+            }
+            testResultDonor.beginDonation(TestRequest) shouldBe TestResultDonor.TestResultMetadataNoContribution
+        }
+    }
+
+    @Test
+    fun `No donation when test is NEGATIVE and HighRisk but riskLevelTurnedRedTime is missing`() {
+        runBlockingTest {
+            with(testResultDonorSettings) {
+                every { testScannedAfterConsent } returns mockFlowPreference(true)
+                every { testResultAtRegistration } returns mockFlowPreference(TestResult.NEGATIVE)
+                every { finalTestResultReceivedAt } returns mockFlowPreference(baseTime)
+                every { riskLevelTurnedRedTime } returns mockFlowPreference(null)
+                every { riskLevelAtTestRegistration } returns mockFlowPreference(PpaData.PPARiskLevel.RISK_LEVEL_HIGH)
+            }
+            testResultDonor.beginDonation(TestRequest) shouldBe TestResultDonor.TestResultMetadataNoContribution
+        }
+    }
+
+    @Test
+    fun `No donation when test is  POSITIVE and HighRisk but mostRecentDateWithHighOrLowRiskLevel is missing`() {
+        runBlockingTest {
+            with(testResultDonorSettings) {
+                every { testScannedAfterConsent } returns mockFlowPreference(true)
+                every { testResultAtRegistration } returns mockFlowPreference(TestResult.POSITIVE)
+                every { finalTestResultReceivedAt } returns mockFlowPreference(baseTime)
+                every { riskLevelTurnedRedTime } returns mockFlowPreference(baseTime)
+                every { mostRecentDateWithHighOrLowRiskLevel } returns mockFlowPreference(null)
+                every { riskLevelAtTestRegistration } returns mockFlowPreference(PpaData.PPARiskLevel.RISK_LEVEL_HIGH)
+            }
+            testResultDonor.beginDonation(TestRequest) shouldBe TestResultDonor.TestResultMetadataNoContribution
+        }
+    }
+
+    @Test
+    fun `No donation when test is NEGATIVE and HighRisk but mostRecentDateWithHighOrLowRiskLevel is missing`() {
+        runBlockingTest {
+            with(testResultDonorSettings) {
+                every { testScannedAfterConsent } returns mockFlowPreference(true)
+                every { testResultAtRegistration } returns mockFlowPreference(TestResult.NEGATIVE)
+                every { finalTestResultReceivedAt } returns mockFlowPreference(baseTime)
+                every { riskLevelTurnedRedTime } returns mockFlowPreference(baseTime)
+                every { mostRecentDateWithHighOrLowRiskLevel } returns mockFlowPreference(null)
+                every { riskLevelAtTestRegistration } returns mockFlowPreference(PpaData.PPARiskLevel.RISK_LEVEL_HIGH)
+            }
+            testResultDonor.beginDonation(TestRequest) shouldBe TestResultDonor.TestResultMetadataNoContribution
+        }
+    }
+
+    @Test
+    fun `No donation when test is  POSITIVE and LowRisk but mostRecentDateWithHighOrLowRiskLevel is missing`() {
+        runBlockingTest {
+            with(testResultDonorSettings) {
+                every { testScannedAfterConsent } returns mockFlowPreference(true)
+                every { testResultAtRegistration } returns mockFlowPreference(TestResult.POSITIVE)
+                every { finalTestResultReceivedAt } returns mockFlowPreference(baseTime)
+                every { riskLevelTurnedRedTime } returns mockFlowPreference(null)
+                every { mostRecentDateWithHighOrLowRiskLevel } returns mockFlowPreference(null)
+            }
+            testResultDonor.beginDonation(TestRequest) shouldBe TestResultDonor.TestResultMetadataNoContribution
+        }
+    }
+
+    @Test
+    fun `No donation when test is NEGATIVE and LowRisk but mostRecentDateWithHighOrLowRiskLevel is missing`() {
+        runBlockingTest {
+            with(testResultDonorSettings) {
+                every { testScannedAfterConsent } returns mockFlowPreference(true)
+                every { testResultAtRegistration } returns mockFlowPreference(TestResult.NEGATIVE)
+                every { finalTestResultReceivedAt } returns mockFlowPreference(baseTime)
+                every { riskLevelTurnedRedTime } returns mockFlowPreference(null)
+                every { mostRecentDateWithHighOrLowRiskLevel } returns mockFlowPreference(null)
+            }
+            testResultDonor.beginDonation(TestRequest) shouldBe TestResultDonor.TestResultMetadataNoContribution
+        }
+    }
+
+    @Test
     fun `Donation is collected when test result is NEGATIVE`() {
         runBlockingTest {
             every { testResultDonorSettings.testScannedAfterConsent } returns mockFlowPreference(true)

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDonorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDonorTest.kt
@@ -4,8 +4,6 @@ import de.rki.coronawarnapp.appconfig.AnalyticsConfig
 import de.rki.coronawarnapp.appconfig.ConfigData
 import de.rki.coronawarnapp.datadonation.analytics.modules.DonorModule
 import de.rki.coronawarnapp.datadonation.analytics.storage.TestResultDonorSettings
-import de.rki.coronawarnapp.risk.RiskLevelSettings
-import de.rki.coronawarnapp.risk.storage.RiskLevelStorage
 import de.rki.coronawarnapp.server.protocols.internal.ppdd.PpaData
 import de.rki.coronawarnapp.submission.SubmissionSettings
 import de.rki.coronawarnapp.util.TimeStamper

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDonorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDonorTest.kt
@@ -31,8 +31,6 @@ import testhelpers.preferences.mockFlowPreference
 
 class TestResultDonorTest : BaseTest() {
     @MockK lateinit var testResultDonorSettings: TestResultDonorSettings
-    @MockK lateinit var riskLevelSettings: RiskLevelSettings
-    @MockK lateinit var riskLevelStorage: RiskLevelStorage
     @MockK lateinit var timeStamper: TimeStamper
     @MockK lateinit var submissionSettings: SubmissionSettings
 
@@ -43,16 +41,16 @@ class TestResultDonorTest : BaseTest() {
     @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this, true)
+        with(testResultDonorSettings) {
+            every { mostRecentDateWithHighOrLowRiskLevel } returns mockFlowPreference(baseTime)
+            every { riskLevelTurnedRedTime } returns mockFlowPreference(baseTime)
+            every { riskLevelAtTestRegistration } returns mockFlowPreference(PpaData.PPARiskLevel.RISK_LEVEL_LOW)
+        }
         every { timeStamper.nowUTC } returns baseTime
-        every { riskLevelSettings.lastChangeCheckedRiskLevelTimestamp } returns baseTime
-        every { testResultDonorSettings.riskLevelAtTestRegistration } returns
-            mockFlowPreference(PpaData.PPARiskLevel.RISK_LEVEL_LOW)
         every { submissionSettings.initialTestResultReceivedAt } returns baseTime
 
         testResultDonor = TestResultDonor(
             testResultDonorSettings,
-            riskLevelSettings,
-            riskLevelStorage,
             timeStamper,
             submissionSettings
         )
@@ -108,7 +106,9 @@ class TestResultDonorTest : BaseTest() {
 
             val timeDayBefore = baseTime.minus(Duration.standardDays(1))
             every { submissionSettings.initialTestResultReceivedAt } returns timeDayBefore
-            every { riskLevelSettings.lastChangeCheckedRiskLevelTimestamp } returns timeDayBefore
+            every { testResultDonorSettings.mostRecentDateWithHighOrLowRiskLevel } returns mockFlowPreference(
+                timeDayBefore
+            )
 
             val donation = testResultDonor.beginDonation(TestRequest)
             donation.shouldBeInstanceOf<TestResultDonor.TestResultMetadataContribution>()

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/RiskLevelChangeDetectorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/RiskLevelChangeDetectorTest.kt
@@ -3,6 +3,7 @@ package de.rki.coronawarnapp.risk
 import android.content.Context
 import androidx.core.app.NotificationManagerCompat
 import com.google.android.gms.nearby.exposurenotification.ExposureWindow
+import de.rki.coronawarnapp.datadonation.analytics.storage.TestResultDonorSettings
 import de.rki.coronawarnapp.datadonation.survey.Surveys
 import de.rki.coronawarnapp.notification.NotificationHelper
 import de.rki.coronawarnapp.risk.RiskState.CALCULATION_FAILED
@@ -43,6 +44,7 @@ class RiskLevelChangeDetectorTest : BaseTest() {
     @MockK lateinit var surveys: Surveys
     @MockK lateinit var submissionSettings: SubmissionSettings
     @MockK lateinit var tracingSettings: TracingSettings
+    @MockK lateinit var testResultDonorSettings: TestResultDonorSettings
 
     @BeforeEach
     fun setup() {
@@ -80,7 +82,8 @@ class RiskLevelChangeDetectorTest : BaseTest() {
         notificationHelper = notificationHelper,
         surveys = surveys,
         submissionSettings = submissionSettings,
-        tracingSettings = tracingSettings
+        tracingSettings = tracingSettings,
+        testResultDonorSettings = testResultDonorSettings
     )
 
     @Test


### PR DESCRIPTION
- Introduced new time specifically for test result donor calculation saved in RiskResultDetector
- Skip donation if the timestamps required for calculation is missing

### Testing
- Register a test and try donation from the menu