### PR TITLE
1.14 "Ihr Testergebnis liegt vor" -> 1.15 "Risiko-Überprüfung fehlgeschlagen" (EXPOSUREAPP-5843)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelTask.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelTask.kt
@@ -83,8 +83,8 @@ class RiskLevelTask @Inject constructor(
             Timber.d("The current time is %s", it)
         }
 
-        if (submissionSettings.isAllowedToSubmitKeys) {
-            Timber.i("Positive test result, skip risk calculation")
+        if (submissionSettings.isAllowedToSubmitKeys && submissionSettings.hasViewedTestResult.value) {
+            Timber.i("Positive test result and user has seen it, skip risk calculation")
             return RiskLevelTaskResult(
                 calculatedAt = nowUTC,
                 failureReason = FailureReason.POSITIVE_TEST_RESULT


### PR DESCRIPTION
### Description
This PR fixes the bug described in EXPOSUREAPP-5843 by only aborting the risk calculation if the user has also seen the positive test result, allowing the ui to update properly until it is not shown any longer.

### Steps to reproduce
1. install app version < 1.15.x
2. complete onboarding
3. register a positive QR code w/o  warning someone
4. "test  result  available" shall be visible on the home screen
5. update the app to this PR
6. check if a risk calculation is still happening and no error is displayed
