### PR TITLE
If there is an `initialTestResultReceivedTimestamp`  it may be (EXPOSUREAPP-4484)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/SubmissionRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/SubmissionRepository.kt
@@ -165,17 +165,17 @@ class SubmissionRepository @Inject constructor(
             deadmanNotificationScheduler.cancelScheduledWork()
         }
 
-        val initialTestResultReceivedTimestamp = submissionSettings.initialTestResultReceivedAt
-
         // https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4484
         // User removed a test before 1.11 where due to a bug the timestamp was not removed.
-        if (initialTestResultReceivedTimestamp != null &&
+        if (submissionSettings.initialTestResultReceivedAt != null &&
             submissionSettings.registrationToken.value != null &&
             submissionSettings.devicePairingSuccessfulAt == null
         ) {
             Timber.tag(TAG).w("User has stale initialTestResultReceivedAt, fixing EXPOSUREAPP-4484.")
             submissionSettings.initialTestResultReceivedAt = null
         }
+
+        val initialTestResultReceivedTimestamp = submissionSettings.initialTestResultReceivedAt
 
         if (initialTestResultReceivedTimestamp == null) {
             val currentTime = timeStamper.nowUTC

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/SubmissionRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/SubmissionRepository.kt
@@ -167,6 +167,16 @@ class SubmissionRepository @Inject constructor(
 
         val initialTestResultReceivedTimestamp = submissionSettings.initialTestResultReceivedAt
 
+        // https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-4484
+        // User removed a test before 1.11 where due to a bug the timestamp was not removed.
+        if (initialTestResultReceivedTimestamp != null &&
+            submissionSettings.registrationToken.value != null &&
+            submissionSettings.devicePairingSuccessfulAt == null
+        ) {
+            Timber.tag(TAG).w("User has stale initialTestResultReceivedAt, fixing EXPOSUREAPP-4484.")
+            submissionSettings.initialTestResultReceivedAt = null
+        }
+
         if (initialTestResultReceivedTimestamp == null) {
             val currentTime = timeStamper.nowUTC
             submissionSettings.initialTestResultReceivedAt = currentTime


### PR DESCRIPTION
If a user removed a test prior to 1.11, they may have an old timestamp that should have been deleted, this tries to detect that and delete the timestamp.

If there is also a registration value, but no `devicePairingSuccessfulAt` timestamp, then we are being called from `asyncRegisterDeviceViaGUID` or `asyncRegisterDeviceViaTAN`, and it's a new test and `initialTestResultReceivedTimestamp` should be null.


Also see #2637

