### PR TITLE
Test donor -  update pending result (EXPOSUREAPP-5900)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDataCollector.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDataCollector.kt
@@ -37,6 +37,7 @@ class TestResultDataCollector @Inject constructor(
                 .first()
                 .tryLatestResultsWithDefaults()
                 .lastCalculated
+            Timber.d("saveTestResultDonorDataAtRegistration($testResult, $lastRiskResult)")
             testResultDonorSettings.saveTestResultDonorDataAtRegistration(testResult, lastRiskResult)
         }
     }
@@ -53,7 +54,7 @@ class TestResultDataCollector @Inject constructor(
             newTestResult in listOf(TestResult.POSITIVE, TestResult.NEGATIVE)
         if (shouldUpdate) {
             val receivedAt = timeStamper.nowUTC
-            Timber.d("New Test result=$newTestResult received at=$receivedAt")
+            Timber.d("updatePendingTestResultReceivedTime($newTestResult, $receivedAt")
             testResultDonorSettings.finalTestResultReceivedAt.update { receivedAt }
             testResultDonorSettings.testResultAtRegistration.update { newTestResult }
         }
@@ -63,6 +64,7 @@ class TestResultDataCollector @Inject constructor(
      * Clear saved test donor saved metadata
      */
     fun clear() {
+        Timber.d("clear TestResultDonorSettings")
         testResultDonorSettings.clear()
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDataCollector.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDataCollector.kt
@@ -7,7 +7,6 @@ import de.rki.coronawarnapp.risk.tryLatestResultsWithDefaults
 import de.rki.coronawarnapp.util.TimeStamper
 import de.rki.coronawarnapp.util.formatter.TestResult
 import kotlinx.coroutines.flow.first
-import org.joda.time.Instant
 import timber.log.Timber
 import javax.inject.Inject
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDataCollector.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDataCollector.kt
@@ -53,9 +53,9 @@ class TestResultDataCollector @Inject constructor(
             // Final Test result received
             newTestResult in listOf(TestResult.POSITIVE, TestResult.NEGATIVE)
         if (shouldUpdate) {
-            Timber.d("Update finalTestResultReceivedAt time")
-            // TODO clarify this
-            testResultDonorSettings.finalTestResultReceivedAt.update { timeStamper.nowUTC }
+            val receivedAt = timeStamper.nowUTC
+            Timber.d("New Test result=$newTestResult received at=$receivedAt")
+            testResultDonorSettings.finalTestResultReceivedAt.update { receivedAt }
             testResultDonorSettings.testResultAtRegistration.update { newTestResult }
         }
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDataCollector.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDataCollector.kt
@@ -4,14 +4,18 @@ import de.rki.coronawarnapp.datadonation.analytics.storage.AnalyticsSettings
 import de.rki.coronawarnapp.datadonation.analytics.storage.TestResultDonorSettings
 import de.rki.coronawarnapp.risk.storage.RiskLevelStorage
 import de.rki.coronawarnapp.risk.tryLatestResultsWithDefaults
+import de.rki.coronawarnapp.util.TimeStamper
 import de.rki.coronawarnapp.util.formatter.TestResult
 import kotlinx.coroutines.flow.first
+import org.joda.time.Instant
+import timber.log.Timber
 import javax.inject.Inject
 
 class TestResultDataCollector @Inject constructor(
     private val analyticsSettings: AnalyticsSettings,
     private val testResultDonorSettings: TestResultDonorSettings,
     private val riskLevelStorage: RiskLevelStorage,
+    private val timeStamper: TimeStamper,
 ) {
 
     /**
@@ -27,6 +31,7 @@ class TestResultDataCollector @Inject constructor(
 
         if (testResult !in validTestResults) return // Not interested in other values
 
+        // User consented to donate analytics data
         if (analyticsSettings.analyticsEnabled.value) {
             val lastRiskResult = riskLevelStorage
                 .latestAndLastSuccessful
@@ -35,5 +40,30 @@ class TestResultDataCollector @Inject constructor(
                 .lastCalculated
             testResultDonorSettings.saveTestResultDonorDataAtRegistration(testResult, lastRiskResult)
         }
+    }
+
+    fun updatePendingTestResultReceivedTime(newTestResult: TestResult) {
+        // Analytics is enabled
+        val shouldUpdate = analyticsSettings.analyticsEnabled.value &&
+            // Test was scanned after giving consent and this a QR-Code Test registration
+            // For TAN test registration this flag is not set
+            testResultDonorSettings.testScannedAfterConsent.value &&
+            // Result was Pending
+            testResultDonorSettings.testResultAtRegistration.value == TestResult.PENDING &&
+            // Final Test result received
+            newTestResult in listOf(TestResult.POSITIVE, TestResult.NEGATIVE)
+        if (shouldUpdate) {
+            Timber.d("Update finalTestResultReceivedAt time")
+            // TODO clarify this
+            testResultDonorSettings.finalTestResultReceivedAt.update { timeStamper.nowUTC }
+            testResultDonorSettings.testResultAtRegistration.update { newTestResult }
+        }
+    }
+
+    /**
+     * Clear saved test donor saved metadata
+     */
+    fun clear() {
+        testResultDonorSettings.clear()
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDonor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDonor.kt
@@ -50,6 +50,11 @@ class TestResultDonor @Inject constructor(
                 lastChangeCheckedRiskLevelTimestamp,
                 timestampAtRegistration
             )
+        Timber.i(
+            "lastChangeCheckedRiskLevelTimestamp=%s,timestampAtRegistration=%s",
+            lastChangeCheckedRiskLevelTimestamp,
+            timestampAtRegistration
+        )
 
         Timber.i(
             "daysSinceMostRecentDateAtRiskLevelAtTestRegistration: %s",
@@ -83,6 +88,7 @@ class TestResultDonor @Inject constructor(
         val configHours = request.currentConfig.analytics.hoursSinceTestRegistrationToSubmitTestResultMetadata
         val hoursSinceTestRegistrationTime = Duration(timestampAtRegistration, timeStamper.nowUTC).standardHours.toInt()
         val isDiffHoursMoreThanConfigHoursForPendingTest = hoursSinceTestRegistrationTime >= configHours
+        Timber.i("hoursSinceTestRegistrationTime=$hoursSinceTestRegistrationTime, configHours=$configHours")
 
         return when {
             /**

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDonor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDonor.kt
@@ -236,7 +236,6 @@ class TestResultDonor @Inject constructor(
     }
 
     companion object {
-        private const val DEFAULT_DAYS_SINCE_MOST_RECENT_DATE_AT_RISK_LEVEL = -1
         private const val DEFAULT_HOURS_SINCE_HIGH_RISK_WARNING = -1
         private const val DEFAULT_HOURS_SINCE_TEST_REGISTRATION_TIME = 0
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDonor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDonor.kt
@@ -41,15 +41,13 @@ class TestResultDonor @Inject constructor(
 
         val lastChangeCheckedRiskLevelTimestamp = testResultDonorSettings.mostRecentDateWithHighOrLowRiskLevel.value
 
-        val daysSinceMostRecentDateAtRiskLevelAtTestRegistration = if (lastChangeCheckedRiskLevelTimestamp == null) {
-            Timber.d("lastChangeCheckedRiskLevelTimestamp is missing - Using default value=-1")
-            DEFAULT_DAYS_SINCE_MOST_RECENT_DATE_AT_RISK_LEVEL
-        } else {
+        // Default -1 value is covered by calculateDaysSinceMostRecentDateAtRiskLevelAtTestRegistration
+        // In case lastChangeCheckedRiskLevelTimestamp is null
+        val daysSinceMostRecentDateAtRiskLevelAtTestRegistration =
             calculateDaysSinceMostRecentDateAtRiskLevelAtTestRegistration(
                 lastChangeCheckedRiskLevelTimestamp,
                 timestampAtRegistration
             )
-        }
 
         Timber.i(
             "lastChangeCheckedRiskLevelTimestamp=%s,timestampAtRegistration=%s",

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDonor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDonor.kt
@@ -40,16 +40,17 @@ class TestResultDonor @Inject constructor(
         }
 
         val lastChangeCheckedRiskLevelTimestamp = testResultDonorSettings.mostRecentDateWithHighOrLowRiskLevel.value
-        if (lastChangeCheckedRiskLevelTimestamp == null) {
-            Timber.d("Skipping TestResultMetadata donation (lastChangeCheckedRiskLevelTimestamp is missing)")
-            return TestResultMetadataNoContribution
-        }
 
-        val daysSinceMostRecentDateAtRiskLevelAtTestRegistration =
+        val daysSinceMostRecentDateAtRiskLevelAtTestRegistration = if (lastChangeCheckedRiskLevelTimestamp == null) {
+            Timber.d("lastChangeCheckedRiskLevelTimestamp is missing - Using default value=-1")
+            DEFAULT_DAYS_SINCE_MOST_RECENT_DATE_AT_RISK_LEVEL
+        } else {
             calculateDaysSinceMostRecentDateAtRiskLevelAtTestRegistration(
                 lastChangeCheckedRiskLevelTimestamp,
                 timestampAtRegistration
             )
+        }
+
         Timber.i(
             "lastChangeCheckedRiskLevelTimestamp=%s,timestampAtRegistration=%s",
             lastChangeCheckedRiskLevelTimestamp,
@@ -237,6 +238,7 @@ class TestResultDonor @Inject constructor(
     }
 
     companion object {
+        private const val DEFAULT_DAYS_SINCE_MOST_RECENT_DATE_AT_RISK_LEVEL = -1
         private const val DEFAULT_HOURS_SINCE_HIGH_RISK_WARNING = -1
         private const val DEFAULT_HOURS_SINCE_TEST_REGISTRATION_TIME = 0
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/storage/TestResultDonorSettings.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/datadonation/analytics/storage/TestResultDonorSettings.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import de.rki.coronawarnapp.datadonation.analytics.common.toMetadataRiskLevel
 import de.rki.coronawarnapp.risk.RiskLevelResult
 import de.rki.coronawarnapp.server.protocols.internal.ppdd.PpaData
+import de.rki.coronawarnapp.util.TimeStamper
 import de.rki.coronawarnapp.util.di.AppContext
 import de.rki.coronawarnapp.util.formatter.TestResult
 import de.rki.coronawarnapp.util.preferences.clearAndNotify
@@ -14,7 +15,8 @@ import javax.inject.Singleton
 
 @Singleton
 class TestResultDonorSettings @Inject constructor(
-    @AppContext private val context: Context
+    @AppContext private val context: Context,
+    private val timeStamper: TimeStamper
 ) {
     private val prefs by lazy {
         context.getSharedPreferences("analytics_testResultDonor", Context.MODE_PRIVATE)
@@ -97,7 +99,7 @@ class TestResultDonorSettings @Inject constructor(
         testScannedAfterConsent.update { true }
         testResultAtRegistration.update { testResult }
         if (testResult in listOf(TestResult.POSITIVE, TestResult.NEGATIVE)) {
-            finalTestResultReceivedAt.update { Instant.now() }
+            finalTestResultReceivedAt.update { timeStamper.nowUTC }
         }
 
         riskLevelAtTestRegistration.update { lastRiskResult.toMetadataRiskLevel() }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelChangeDetector.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelChangeDetector.kt
@@ -100,7 +100,7 @@ class RiskLevelChangeDetector @Inject constructor(
         // Save most recent date of high or low risks
         if (newRiskState.riskState in listOf(RiskState.INCREASED_RISK, RiskState.LOW_RISK)) {
             Timber.d("newRiskState=$newRiskState")
-            val lastRiskEncounterAt = newRiskState.lastRiskEncounterAt ?: newRiskState.calculatedAt
+            val lastRiskEncounterAt = newRiskState.lastRiskEncounterAt
             Timber.i(
                 "mostRecentDateWithHighOrLowRiskLevel: newRiskState=%s, lastRiskEncounterAt=%s",
                 newRiskState.riskState,

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelChangeDetector.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelChangeDetector.kt
@@ -99,14 +99,16 @@ class RiskLevelChangeDetector @Inject constructor(
 
         // Save most recent date of high or low risks
         if (newRiskState.riskState in listOf(RiskState.INCREASED_RISK, RiskState.LOW_RISK)) {
+            Timber.d("newRiskState=$newRiskState")
+            val lastRiskEncounterAt = newRiskState.lastRiskEncounterAt ?: newRiskState.calculatedAt
             Timber.i(
                 "mostRecentDateWithHighOrLowRiskLevel: newRiskState=%s, lastRiskEncounterAt=%s",
                 newRiskState.riskState,
-                newRiskState.lastRiskEncounterAt
+                lastRiskEncounterAt
             )
 
             testResultDonorSettings.mostRecentDateWithHighOrLowRiskLevel.update {
-                newRiskState.lastRiskEncounterAt
+                lastRiskEncounterAt
             }
         }
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/SubmissionRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/SubmissionRepository.kt
@@ -2,6 +2,7 @@ package de.rki.coronawarnapp.submission
 
 import androidx.annotation.VisibleForTesting
 import de.rki.coronawarnapp.datadonation.analytics.modules.keysubmission.AnalyticsKeySubmissionCollector
+import de.rki.coronawarnapp.datadonation.analytics.modules.registeredtest.TestResultDataCollector
 import de.rki.coronawarnapp.deadman.DeadmanNotificationScheduler
 import de.rki.coronawarnapp.exception.ExceptionCategory
 import de.rki.coronawarnapp.exception.NoRegistrationTokenSetException
@@ -37,7 +38,8 @@ class SubmissionRepository @Inject constructor(
     private val deadmanNotificationScheduler: DeadmanNotificationScheduler,
     private val backgroundNoise: BackgroundNoise,
     private val analyticsKeySubmissionCollector: AnalyticsKeySubmissionCollector,
-    private val tracingSettings: TracingSettings
+    private val tracingSettings: TracingSettings,
+    private val testResultDataCollector: TestResultDataCollector
 ) {
     private val testResultReceivedDateFlowInternal =
         MutableStateFlow((submissionSettings.initialTestResultReceivedAt ?: timeStamper.nowUTC).toDate())
@@ -142,10 +144,11 @@ class SubmissionRepository @Inject constructor(
         submissionSettings.registrationToken.update {
             registrationData.registrationToken
         }
-        updateTestResult(registrationData.testResult)
+        updateTestResult(registrationData.testResult) // This saves initial time
         submissionSettings.devicePairingSuccessfulAt = timeStamper.nowUTC
         backgroundNoise.scheduleDummyPattern()
         analyticsKeySubmissionCollector.reportTestRegistered()
+        testResultDataCollector.saveTestResultAnalyticsSettings(registrationData.testResult) // This saves received at
         return registrationData.testResult
     }
 
@@ -158,6 +161,8 @@ class SubmissionRepository @Inject constructor(
     @VisibleForTesting
     fun updateTestResult(testResult: TestResult) {
         testResultFlow.value = testResult
+
+        testResultDataCollector.updatePendingTestResultReceivedTime(testResult)
 
         if (testResult == TestResult.POSITIVE) {
             submissionSettings.isAllowedToSubmitKeys = true
@@ -208,6 +213,7 @@ class SubmissionRepository @Inject constructor(
         submissionSettings.isAllowedToSubmitKeys = false
         tracingSettings.isTestResultAvailableNotificationSent = false
         submissionSettings.isSubmissionSuccessful = false
+        testResultDataCollector.clear()
     }
 
     private fun deriveUiState(testResult: TestResult?): DeviceUIState = when (testResult) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/SubmissionRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/SubmissionRepository.kt
@@ -28,6 +28,7 @@ import java.util.Date
 import javax.inject.Inject
 import javax.inject.Singleton
 
+@Suppress("LongParameterList")
 @Singleton
 class SubmissionRepository @Inject constructor(
     private val submissionSettings: SubmissionSettings,

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/scan/SubmissionQRCodeScanViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/scan/SubmissionQRCodeScanViewModel.kt
@@ -22,10 +22,8 @@ import de.rki.coronawarnapp.util.viewmodel.SimpleCWAViewModelFactory
 import timber.log.Timber
 
 class SubmissionQRCodeScanViewModel @AssistedInject constructor(
-    private val submissionRepository: SubmissionRepository,
-    private val testResultDataCollector: TestResultDataCollector
-) :
-    CWAViewModel() {
+    private val submissionRepository: SubmissionRepository
+) : CWAViewModel() {
     val routeToScreen = SingleLiveEvent<SubmissionNavigationEvents>()
     val showRedeemedTokenWarning = SingleLiveEvent<Unit>()
     val scanStatusValue = SingleLiveEvent<ScanStatus>()
@@ -56,10 +54,6 @@ class SubmissionQRCodeScanViewModel @AssistedInject constructor(
         try {
             registrationState.postValue(RegistrationState(ApiRequestState.STARTED))
             val testResult = submissionRepository.asyncRegisterDeviceViaGUID(scanResult.guid!!)
-            // Order here is important. When `registrationState.postValue` is called before
-            // `saveTestResultAnalyticsSettings`, this coroutine will get canceled due to the navigation
-            // to the next screen.
-            testResultDataCollector.saveTestResultAnalyticsSettings(testResult)
             checkTestResult(testResult)
             registrationState.postValue(RegistrationState(ApiRequestState.SUCCESS, testResult))
         } catch (err: CwaWebException) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/scan/SubmissionQRCodeScanViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/scan/SubmissionQRCodeScanViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.MutableLiveData
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import de.rki.coronawarnapp.bugreporting.censors.QRCodeCensor
-import de.rki.coronawarnapp.datadonation.analytics.modules.registeredtest.TestResultDataCollector
 import de.rki.coronawarnapp.exception.ExceptionCategory
 import de.rki.coronawarnapp.exception.TransactionException
 import de.rki.coronawarnapp.exception.http.CwaWebException

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDataCollectorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDataCollectorTest.kt
@@ -37,6 +37,7 @@ class TestResultDataCollectorTest : BaseTest() {
         MockKAnnotations.init(this)
 
         every { timeStamper.nowUTC } returns Instant.now()
+        every { testResultDonorSettings.clear() } just Runs
         testResultDataCollector = TestResultDataCollector(
             analyticsSettings,
             testResultDonorSettings,
@@ -46,49 +47,115 @@ class TestResultDataCollectorTest : BaseTest() {
     }
 
     @Test
-    fun `saveTestResultAnalyticsSettings does not save anything when no user consent`() = runBlockingTest {
-        every { analyticsSettings.analyticsEnabled } returns mockFlowPreference(false)
-        testResultDataCollector.saveTestResultAnalyticsSettings(TestResult.POSITIVE)
+    fun `saveTestResultAnalyticsSettings does not save anything when no user consent`() =
+        runBlockingTest {
+            every { analyticsSettings.analyticsEnabled } returns mockFlowPreference(false)
+            testResultDataCollector.saveTestResultAnalyticsSettings(TestResult.POSITIVE)
 
-        verify(exactly = 0) {
-            testResultDonorSettings.saveTestResultDonorDataAtRegistration(any(), any())
+            verify(exactly = 0) {
+                testResultDonorSettings.saveTestResultDonorDataAtRegistration(any(), any())
+            }
         }
-    }
 
     @Test
-    fun `saveTestResultAnalyticsSettings saves data when user gave consent`() = runBlockingTest {
-        every { analyticsSettings.analyticsEnabled } returns mockFlowPreference(true)
+    fun `saveTestResultAnalyticsSettings saves data when user gave consent`() =
+        runBlockingTest {
+            every { analyticsSettings.analyticsEnabled } returns mockFlowPreference(true)
 
-        val mockRiskLevelResult = mockk<RiskLevelResult>().apply {
-            every { calculatedAt } returns Instant.now()
-            every { wasSuccessfullyCalculated } returns true
-        }
-        every { riskLevelStorage.latestAndLastSuccessful } returns flowOf(listOf(mockRiskLevelResult))
-        every { testResultDonorSettings.saveTestResultDonorDataAtRegistration(any(), any()) } just Runs
-        testResultDataCollector.saveTestResultAnalyticsSettings(TestResult.POSITIVE)
+            val mockRiskLevelResult = mockk<RiskLevelResult>().apply {
+                every { calculatedAt } returns Instant.now()
+                every { wasSuccessfullyCalculated } returns true
+            }
+            every { riskLevelStorage.latestAndLastSuccessful } returns flowOf(listOf(mockRiskLevelResult))
+            every { testResultDonorSettings.saveTestResultDonorDataAtRegistration(any(), any()) } just Runs
+            testResultDataCollector.saveTestResultAnalyticsSettings(TestResult.POSITIVE)
 
-        verify(exactly = 1) {
-            testResultDonorSettings.saveTestResultDonorDataAtRegistration(any(), any())
+            verify(exactly = 1) {
+                testResultDonorSettings.saveTestResultDonorDataAtRegistration(any(), any())
+            }
         }
-    }
 
     @Test
-    fun `saveTestResultAnalyticsSettings does not save data when TestResult is INVALID`() = runBlockingTest {
-        every { analyticsSettings.analyticsEnabled } returns mockFlowPreference(false)
-        testResultDataCollector.saveTestResultAnalyticsSettings(TestResult.INVALID)
+    fun `saveTestResultAnalyticsSettings does not save data when TestResult is INVALID`() =
+        runBlockingTest {
+            every { analyticsSettings.analyticsEnabled } returns mockFlowPreference(false)
+            testResultDataCollector.saveTestResultAnalyticsSettings(TestResult.INVALID)
 
-        verify {
-            analyticsSettings.analyticsEnabled wasNot Called
+            verify {
+                analyticsSettings.analyticsEnabled wasNot Called
+            }
         }
-    }
 
     @Test
-    fun `saveTestResultAnalyticsSettings does not save data when TestResult is REDEEMED`() = runBlockingTest {
-        every { analyticsSettings.analyticsEnabled } returns mockFlowPreference(false)
-        testResultDataCollector.saveTestResultAnalyticsSettings(TestResult.REDEEMED)
+    fun `saveTestResultAnalyticsSettings does not save data when TestResult is REDEEMED`() =
+        runBlockingTest {
+            every { analyticsSettings.analyticsEnabled } returns mockFlowPreference(false)
+            testResultDataCollector.saveTestResultAnalyticsSettings(TestResult.REDEEMED)
 
-        verify {
-            analyticsSettings.analyticsEnabled wasNot Called
+            verify {
+                analyticsSettings.analyticsEnabled wasNot Called
+            }
         }
+
+    @Test
+    fun `updatePendingTestResultReceivedTime doesn't update when TestResult isn't POS or NEG`() =
+        runBlockingTest {
+            for (testResult in listOf(TestResult.REDEEMED, TestResult.INVALID, TestResult.PENDING)) {
+                every { analyticsSettings.analyticsEnabled } returns mockFlowPreference(true)
+                every { testResultDonorSettings.testScannedAfterConsent } returns mockFlowPreference(true)
+                every { testResultDonorSettings.testResultAtRegistration } returns mockFlowPreference(TestResult.PENDING)
+                testResultDataCollector.updatePendingTestResultReceivedTime(testResult)
+
+                verify {
+                    analyticsSettings.analyticsEnabled
+                    testResultDonorSettings.testScannedAfterConsent
+                    testResultDonorSettings.testResultAtRegistration
+                    testResultDonorSettings.finalTestResultReceivedAt wasNot Called
+                    testResultDonorSettings.testResultAtRegistration wasNot Called
+                }
+            }
+        }
+
+    @Test
+    fun `updatePendingTestResultReceivedTime doesn't update when Test is not scanned after consent`() =
+        runBlockingTest {
+            every { analyticsSettings.analyticsEnabled } returns mockFlowPreference(true)
+            every { testResultDonorSettings.testScannedAfterConsent } returns mockFlowPreference(false)
+            every { testResultDonorSettings.testResultAtRegistration } returns mockFlowPreference(TestResult.PENDING)
+            testResultDataCollector.updatePendingTestResultReceivedTime(TestResult.NEGATIVE)
+
+            verify {
+                analyticsSettings.analyticsEnabled
+                testResultDonorSettings.testScannedAfterConsent
+                testResultDonorSettings.testResultAtRegistration wasNot Called
+                testResultDonorSettings.finalTestResultReceivedAt wasNot Called
+                testResultDonorSettings.testResultAtRegistration wasNot Called
+            }
+        }
+
+    @Test
+    fun `updatePendingTestResultReceivedTime update when TestResult is POS or NEG`() =
+        runBlockingTest {
+            for (testResult in listOf(TestResult.NEGATIVE, TestResult.POSITIVE)) {
+                every { analyticsSettings.analyticsEnabled } returns mockFlowPreference(true)
+                every { testResultDonorSettings.testScannedAfterConsent } returns mockFlowPreference(true)
+                every { testResultDonorSettings.testResultAtRegistration } returns mockFlowPreference(TestResult.PENDING)
+                every { testResultDonorSettings.finalTestResultReceivedAt } returns mockFlowPreference(Instant.EPOCH)
+                testResultDataCollector.updatePendingTestResultReceivedTime(testResult)
+
+                verify {
+                    analyticsSettings.analyticsEnabled
+                    testResultDonorSettings.testScannedAfterConsent
+                    testResultDonorSettings.testResultAtRegistration
+                    testResultDonorSettings.finalTestResultReceivedAt
+                    testResultDonorSettings.testResultAtRegistration
+                }
+            }
+        }
+
+    @Test
+    fun `clear is clearing saved data`() {
+        testResultDataCollector.clear()
+        verify { testResultDonorSettings.clear() }
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDataCollectorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDataCollectorTest.kt
@@ -36,7 +36,7 @@ class TestResultDataCollectorTest : BaseTest() {
     fun setup() {
         MockKAnnotations.init(this)
 
-        every { timeStamper.nowUTC } returns Instant.now()
+        every { timeStamper.nowUTC } returns Instant.parse("2021-03-02T09:57:11+01:00")
         every { testResultDonorSettings.clear() } just Runs
         testResultDataCollector = TestResultDataCollector(
             analyticsSettings,

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDataCollectorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDataCollectorTest.kt
@@ -4,6 +4,7 @@ import de.rki.coronawarnapp.datadonation.analytics.storage.AnalyticsSettings
 import de.rki.coronawarnapp.datadonation.analytics.storage.TestResultDonorSettings
 import de.rki.coronawarnapp.risk.RiskLevelResult
 import de.rki.coronawarnapp.risk.storage.RiskLevelStorage
+import de.rki.coronawarnapp.util.TimeStamper
 import de.rki.coronawarnapp.util.formatter.TestResult
 import io.mockk.Called
 import io.mockk.MockKAnnotations
@@ -27,6 +28,7 @@ class TestResultDataCollectorTest : BaseTest() {
     @MockK lateinit var analyticsSettings: AnalyticsSettings
     @MockK lateinit var testResultDonorSettings: TestResultDonorSettings
     @MockK lateinit var riskLevelStorage: RiskLevelStorage
+    @MockK lateinit var timeStamper: TimeStamper
 
     private lateinit var testResultDataCollector: TestResultDataCollector
 
@@ -34,10 +36,12 @@ class TestResultDataCollectorTest : BaseTest() {
     fun setup() {
         MockKAnnotations.init(this)
 
+        every { timeStamper.nowUTC } returns Instant.now()
         testResultDataCollector = TestResultDataCollector(
             analyticsSettings,
             testResultDonorSettings,
-            riskLevelStorage
+            riskLevelStorage,
+            timeStamper
         )
     }
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDonorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/datadonation/analytics/modules/registeredtest/TestResultDonorTest.kt
@@ -140,7 +140,7 @@ class TestResultDonorTest : BaseTest() {
     }
 
     @Test
-    fun `No donation when test is  POSITIVE and HighRisk but riskLevelTurnedRedTime is missing`() =
+    fun `No donation when test is POSITIVE and HighRisk but riskLevelTurnedRedTime is missing`() =
         runBlockingTest {
             with(testResultDonorSettings) {
                 every { testScannedAfterConsent } returns mockFlowPreference(true)
@@ -166,7 +166,7 @@ class TestResultDonorTest : BaseTest() {
         }
 
     @Test
-    fun `No donation when test is  POSITIVE and HighRisk but mostRecentDateWithHighOrLowRiskLevel is missing`() =
+    fun `Donation when test is POSITIVE and HighRisk but mostRecentDateWithHighOrLowRiskLevel is missing`() =
         runBlockingTest {
             with(testResultDonorSettings) {
                 every { testScannedAfterConsent } returns mockFlowPreference(true)
@@ -176,11 +176,16 @@ class TestResultDonorTest : BaseTest() {
                 every { mostRecentDateWithHighOrLowRiskLevel } returns mockFlowPreference(null)
                 every { riskLevelAtTestRegistration } returns mockFlowPreference(PpaData.PPARiskLevel.RISK_LEVEL_HIGH)
             }
-            testResultDonor.beginDonation(TestRequest) shouldBe TestResultDonor.TestResultMetadataNoContribution
+
+            val donation = testResultDonor.beginDonation(TestRequest)
+            donation.shouldBeInstanceOf<TestResultDonor.TestResultMetadataContribution>()
+            donation.testResultMetadata.apply {
+                daysSinceMostRecentDateAtRiskLevelAtTestRegistration shouldBe -1
+            }
         }
 
     @Test
-    fun `No donation when test is NEGATIVE and HighRisk but mostRecentDateWithHighOrLowRiskLevel is missing`() =
+    fun `Donation when test is NEGATIVE and HighRisk but mostRecentDateWithHighOrLowRiskLevel is missing`() =
         runBlockingTest {
             with(testResultDonorSettings) {
                 every { testScannedAfterConsent } returns mockFlowPreference(true)
@@ -190,11 +195,15 @@ class TestResultDonorTest : BaseTest() {
                 every { mostRecentDateWithHighOrLowRiskLevel } returns mockFlowPreference(null)
                 every { riskLevelAtTestRegistration } returns mockFlowPreference(PpaData.PPARiskLevel.RISK_LEVEL_HIGH)
             }
-            testResultDonor.beginDonation(TestRequest) shouldBe TestResultDonor.TestResultMetadataNoContribution
+            val donation = testResultDonor.beginDonation(TestRequest)
+            donation.shouldBeInstanceOf<TestResultDonor.TestResultMetadataContribution>()
+            donation.testResultMetadata.apply {
+                daysSinceMostRecentDateAtRiskLevelAtTestRegistration shouldBe -1
+            }
         }
 
     @Test
-    fun `No donation when test is  POSITIVE and LowRisk but mostRecentDateWithHighOrLowRiskLevel is missing`() =
+    fun `Donation when test is  POSITIVE and LowRisk but mostRecentDateWithHighOrLowRiskLevel is missing`() =
         runBlockingTest {
             with(testResultDonorSettings) {
                 every { testScannedAfterConsent } returns mockFlowPreference(true)
@@ -203,11 +212,16 @@ class TestResultDonorTest : BaseTest() {
                 every { riskLevelTurnedRedTime } returns mockFlowPreference(null)
                 every { mostRecentDateWithHighOrLowRiskLevel } returns mockFlowPreference(null)
             }
-            testResultDonor.beginDonation(TestRequest) shouldBe TestResultDonor.TestResultMetadataNoContribution
+
+            val donation = testResultDonor.beginDonation(TestRequest)
+            donation.shouldBeInstanceOf<TestResultDonor.TestResultMetadataContribution>()
+            donation.testResultMetadata.apply {
+                daysSinceMostRecentDateAtRiskLevelAtTestRegistration shouldBe -1
+            }
         }
 
     @Test
-    fun `No donation when test is NEGATIVE and LowRisk but mostRecentDateWithHighOrLowRiskLevel is missing`() =
+    fun `Donation when test is NEGATIVE and LowRisk but mostRecentDateWithHighOrLowRiskLevel is missing`() =
         runBlockingTest {
             with(testResultDonorSettings) {
                 every { testScannedAfterConsent } returns mockFlowPreference(true)
@@ -216,7 +230,11 @@ class TestResultDonorTest : BaseTest() {
                 every { riskLevelTurnedRedTime } returns mockFlowPreference(null)
                 every { mostRecentDateWithHighOrLowRiskLevel } returns mockFlowPreference(null)
             }
-            testResultDonor.beginDonation(TestRequest) shouldBe TestResultDonor.TestResultMetadataNoContribution
+            val donation = testResultDonor.beginDonation(TestRequest)
+            donation.shouldBeInstanceOf<TestResultDonor.TestResultMetadataContribution>()
+            donation.testResultMetadata.apply {
+                daysSinceMostRecentDateAtRiskLevelAtTestRegistration shouldBe -1
+            }
         }
 
     @Test

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/storage/SubmissionRepositoryTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/storage/SubmissionRepositoryTest.kt
@@ -163,6 +163,8 @@ class SubmissionRepositoryTest : BaseTest() {
             submissionSettings.devicePairingSuccessfulAt = any()
             backgroundNoise.scheduleDummyPattern()
         }
+
+        coVerify { testResultDataCollector.saveTestResultAnalyticsSettings(any()) }
     }
 
     @Test
@@ -183,6 +185,10 @@ class SubmissionRepositoryTest : BaseTest() {
             registrationTokenPreference.update(any())
             submissionSettings.devicePairingSuccessfulAt = any()
             backgroundNoise.scheduleDummyPattern()
+        }
+
+        coVerify(exactly = 0) {
+            testResultDataCollector.saveTestResultAnalyticsSettings(any())
         }
     }
 
@@ -336,5 +342,13 @@ class SubmissionRepositoryTest : BaseTest() {
         submissionRepository.updateTestResult(TestResult.NEGATIVE)
 
         verify(exactly = 0) { submissionSettings.initialTestResultReceivedAt = null }
+    }
+
+    @Test
+    fun `updateTestResult updates test result donor data`() = runBlockingTest {
+        val submissionRepository = createInstance(scope = this)
+        submissionRepository.updateTestResult(TestResult.NEGATIVE)
+
+        verify { testResultDataCollector.updatePendingTestResultReceivedTime(any()) }
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/qrcode/scan/SubmissionQRCodeScanViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/qrcode/scan/SubmissionQRCodeScanViewModelTest.kt
@@ -1,7 +1,6 @@
 package de.rki.coronawarnapp.ui.submission.qrcode.scan
 
 import de.rki.coronawarnapp.bugreporting.censors.QRCodeCensor
-import de.rki.coronawarnapp.datadonation.analytics.modules.registeredtest.TestResultDataCollector
 import de.rki.coronawarnapp.service.submission.QRScanResult
 import de.rki.coronawarnapp.submission.SubmissionRepository
 import de.rki.coronawarnapp.ui.submission.ScanStatus
@@ -9,7 +8,6 @@ import de.rki.coronawarnapp.util.formatter.TestResult
 import io.kotest.matchers.shouldBe
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
-import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/qrcode/scan/SubmissionQRCodeScanViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/qrcode/scan/SubmissionQRCodeScanViewModelTest.kt
@@ -24,7 +24,6 @@ import testhelpers.extensions.InstantExecutorExtension
 class SubmissionQRCodeScanViewModelTest : BaseTest() {
 
     @MockK lateinit var submissionRepository: SubmissionRepository
-    @MockK lateinit var testResultDataCollector: TestResultDataCollector
 
     @BeforeEach
     fun setUp() {
@@ -32,8 +31,7 @@ class SubmissionQRCodeScanViewModelTest : BaseTest() {
     }
 
     private fun createViewModel() = SubmissionQRCodeScanViewModel(
-        submissionRepository,
-        testResultDataCollector
+        submissionRepository
     )
 
     @Test
@@ -67,7 +65,5 @@ class SubmissionQRCodeScanViewModelTest : BaseTest() {
 
         coEvery { submissionRepository.asyncRegisterDeviceViaGUID(any()) } returns TestResult.POSITIVE
         viewModel.doDeviceRegistration(mockResult)
-
-        coVerify { testResultDataCollector.saveTestResultAnalyticsSettings(any()) }
     }
 }


### PR DESCRIPTION
- Update Pending test result when it turns into positive or negative as well as received time.
- Delete test donor data when test is deleted
- Add fallback for aggregated date in `RiskLevelChangeDetector` at fresh install this date is null while in Home Screen risk level show low risk


### Testing 
For Updating:
1- Scan pending test from CLI
2- you may change the device time in the future to see if the hoursSinceRegistration is calculated properly 
3- Change the test status to positive or negative  from CLI
4- Update test in the App to get the latest state 
5- collect the data from test menu 
you should see the right test result and the right hours based on the time you travelled in the future 
for example if you set the time to 1 day later it should 24 hours 

For test deletion:
1- Register a pending test and then delete it 
2- Collect the data 
3- Nothing should collected 
