### PR TITLE
Fix risk card detail screenshots and device time (EXPOSUREAPP-5970)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -628,7 +628,6 @@ workflows:
   check_buildtype_device:
     jobs:
       - detekt
-      - firebase_screenshots
       - lint_device_release_check
       - ktlint_device_release_check
       - quick_build_device_release_no_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -628,6 +628,7 @@ workflows:
   check_buildtype_device:
     jobs:
       - detekt
+      - firebase_screenshots
       - lint_device_release_check
       - ktlint_device_release_check
       - quick_build_device_release_no_tests

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/contactdiary/ContactDiaryOverviewFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/contactdiary/ContactDiaryOverviewFragmentTest.kt
@@ -25,10 +25,12 @@ import io.mockk.spyk
 import org.joda.time.LocalDate
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import testhelpers.BaseUITest
 import testhelpers.Screenshot
+import testhelpers.SystemUIDemoModeRule
 import testhelpers.TestDispatcherProvider
 import testhelpers.launchFragment2
 import testhelpers.launchInMainActivity
@@ -46,6 +48,9 @@ class ContactDiaryOverviewFragmentTest : BaseUITest() {
     @MockK lateinit var exporter: ContactDiaryExporter
 
     private lateinit var viewModel: ContactDiaryOverviewViewModel
+
+    @get:Rule
+    val systemUIDemoModeRule = SystemUIDemoModeRule()
 
     @Before
     fun setup() {

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/main/home/HomeData.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/main/home/HomeData.kt
@@ -33,13 +33,16 @@ import java.util.Date
 
 object HomeData {
 
+    private val todayAtNineFiftyFive = Instant.now().toDateTime()
+        .withTime(9,55,0,0).toInstant()
+
     object Tracing {
 
         val LOW_RISK_ITEM_NO_ENCOUNTERS = LowRiskCard.Item(
             state = LowRisk(
                 riskState = RiskState.LOW_RISK,
                 isInDetailsMode = false,
-                lastExposureDetectionTime = Instant.now(),
+                lastExposureDetectionTime = todayAtNineFiftyFive,
                 lastEncounterAt = null,
                 allowManualUpdate = false,
                 daysWithEncounters = 0,
@@ -53,8 +56,8 @@ object HomeData {
             state = LowRisk(
                 riskState = RiskState.LOW_RISK,
                 isInDetailsMode = false,
-                lastExposureDetectionTime = Instant.now(),
-                lastEncounterAt = Instant.now(),
+                lastExposureDetectionTime = todayAtNineFiftyFive,
+                lastEncounterAt = todayAtNineFiftyFive,
                 allowManualUpdate = false,
                 daysWithEncounters = 1,
                 daysSinceInstallation = 4
@@ -67,10 +70,10 @@ object HomeData {
             state = IncreasedRisk(
                 riskState = RiskState.INCREASED_RISK,
                 isInDetailsMode = false,
-                lastExposureDetectionTime = Instant.now(),
+                lastExposureDetectionTime = todayAtNineFiftyFive,
                 allowManualUpdate = false,
                 daysWithEncounters = 1,
-                lastEncounterAt = Instant.now()
+                lastEncounterAt = todayAtNineFiftyFive
             ),
             onCardClick = {},
             onUpdateClick = {}
@@ -80,7 +83,7 @@ object HomeData {
             state = TracingDisabled(
                 riskState = RiskState.LOW_RISK,
                 isInDetailsMode = false,
-                lastExposureDetectionTime = Instant.now()
+                lastExposureDetectionTime = todayAtNineFiftyFive
             ),
             onCardClick = {},
             onEnableTracingClick = {}
@@ -99,7 +102,7 @@ object HomeData {
             state = TracingFailed(
                 riskState = RiskState.CALCULATION_FAILED,
                 isInDetailsMode = false,
-                lastExposureDetectionTime = Instant.now()
+                lastExposureDetectionTime = todayAtNineFiftyFive
             ),
             onCardClick = {},
             onRetryClick = {}

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/main/home/HomeFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/main/home/HomeFragmentTest.kt
@@ -42,10 +42,12 @@ import io.mockk.spyk
 import io.mockk.verify
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import testhelpers.BaseUITest
 import testhelpers.Screenshot
+import testhelpers.SystemUIDemoModeRule
 import testhelpers.TestDispatcherProvider
 import testhelpers.launchFragment2
 import testhelpers.launchInMainActivity
@@ -71,6 +73,9 @@ class HomeFragmentTest : BaseUITest() {
     @MockK lateinit var tracingSettings: TracingSettings
 
     private lateinit var homeFragmentViewModel: HomeFragmentViewModel
+
+    @get:Rule
+    val systemUIDemoModeRule = SystemUIDemoModeRule()
 
     @Before
     fun setup() {

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/tracing/TracingData.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/tracing/TracingData.kt
@@ -21,6 +21,9 @@ import org.joda.time.Instant
 
 object TracingData {
 
+    private val todayAtNineFiftyFive = Instant.now().toDateTime()
+        .withTime(9,55,0,0).toInstant()
+
     val TRACING_DISABLED = Pair(
         TracingDetailsState(
             tracingStatus = GeneralTracingStatus.Status.TRACING_INACTIVE,
@@ -32,7 +35,7 @@ object TracingData {
                 state = TracingDisabled(
                     riskState = RiskState.LOW_RISK,
                     isInDetailsMode = true,
-                    lastExposureDetectionTime = Instant.now()
+                    lastExposureDetectionTime = todayAtNineFiftyFive
                 )
             ),
             BehaviorNormalRiskBox.Item(
@@ -52,18 +55,18 @@ object TracingData {
         TracingDetailsState(
             tracingStatus = GeneralTracingStatus.Status.TRACING_ACTIVE,
             riskState = RiskState.LOW_RISK,
-            isManualKeyRetrievalEnabled = false
+            isManualKeyRetrievalEnabled = false,
         ),
         listOf(
             LowRiskBox.Item(
                 state = LowRisk(
                     riskState = RiskState.LOW_RISK,
                     isInDetailsMode = true,
-                    lastExposureDetectionTime = Instant.now(),
+                    lastExposureDetectionTime = todayAtNineFiftyFive,
                     allowManualUpdate = false,
                     daysWithEncounters = 0,
                     daysSinceInstallation = 4,
-                    lastEncounterAt = Instant.now()
+                    lastEncounterAt = null
                 )
             ),
             BehaviorNormalRiskBox.Item(
@@ -90,11 +93,11 @@ object TracingData {
                 state = LowRisk(
                     riskState = RiskState.LOW_RISK,
                     isInDetailsMode = true,
-                    lastExposureDetectionTime = Instant.now(),
+                    lastExposureDetectionTime = todayAtNineFiftyFive,
                     allowManualUpdate = false,
                     daysWithEncounters = 1,
                     daysSinceInstallation = 4,
-                    lastEncounterAt = Instant.now()
+                    lastEncounterAt = todayAtNineFiftyFive
                 )
             ),
             BehaviorNormalRiskBox.Item(
@@ -121,11 +124,11 @@ object TracingData {
                 state = LowRisk(
                     riskState = RiskState.LOW_RISK,
                     isInDetailsMode = true,
-                    lastExposureDetectionTime = Instant.now(),
+                    lastExposureDetectionTime = todayAtNineFiftyFive,
                     allowManualUpdate = false,
                     daysWithEncounters = 2,
                     daysSinceInstallation = 4,
-                    lastEncounterAt = Instant.now()
+                    lastEncounterAt = todayAtNineFiftyFive
                 )
             ),
             BehaviorNormalRiskBox.Item(
@@ -152,10 +155,10 @@ object TracingData {
                 state = IncreasedRisk(
                     riskState = RiskState.INCREASED_RISK,
                     isInDetailsMode = true,
-                    lastExposureDetectionTime = Instant.now(),
+                    lastExposureDetectionTime = todayAtNineFiftyFive,
                     allowManualUpdate = false,
                     daysWithEncounters = 1,
-                    lastEncounterAt = Instant.now()
+                    lastEncounterAt = todayAtNineFiftyFive
                 )
             ),
             BehaviorIncreasedRiskBox.Item,
@@ -165,7 +168,7 @@ object TracingData {
             ),
             DetailsIncreasedRiskBox.Item(
                 riskState = RiskState.INCREASED_RISK,
-                lastEncounteredAt = Instant.now()
+                lastEncounteredAt = todayAtNineFiftyFive
             )
         )
     )


### PR DESCRIPTION
- The device time is now fixed to 10:00 on all screens.
- On the risk detail card, with low risk and no exposure, the days since installation shall be visible.
- On all risk cards, the time of the last successful calculation is now before the device time (at 9:55).

![TracingDetailsFragment_tracing_low_risk](https://user-images.githubusercontent.com/56824/112330743-995fde00-8cb8-11eb-8df5-f54091cd85c6.png)


TODO:

- [x] remove the firebase task from circle-ci config after a successful test run