### PR TITLE
Replace android.widget.Button with just Button (COMMUNITY)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/bugreporting_debuglog_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/bugreporting_debuglog_fragment.xml
@@ -164,7 +164,7 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <android.widget.Button
+        <Button
             android:id="@+id/toggle_send_error_log"
             style="@style/buttonPrimary"
             android:layout_width="match_parent"
@@ -173,7 +173,7 @@
             android:text="@string/debugging_debuglog_action_share_log"
             tools:text="@string/debugging_debuglog_action_share_log" />
 
-        <android.widget.Button
+        <Button
             android:id="@+id/toggle_store_log"
             style="@style/buttonPrimary"
             android:layout_width="match_parent"
@@ -182,7 +182,7 @@
             android:text="@string/debugging_debuglog_action_local_log_store"
             tools:text="@string/debugging_debuglog_action_local_log_store" />
 
-        <android.widget.Button
+        <Button
             android:id="@+id/toggle_recording"
             style="@style/buttonBarAlertRed"
             android:layout_width="match_parent"

--- a/Corona-Warn-App/src/main/res/layout/bugreporting_debuglog_upload_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/bugreporting_debuglog_upload_fragment.xml
@@ -75,7 +75,7 @@
         </LinearLayout>
 
     </ScrollView>
-    <android.widget.Button
+    <Button
         android:id="@+id/upload_action"
         style="@style/buttonPrimary"
         android:layout_width="0dp"

--- a/Corona-Warn-App/src/main/res/layout/contact_diary_edit_locations_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/contact_diary_edit_locations_fragment.xml
@@ -68,7 +68,7 @@
             app:layout_constraintTop_toBottomOf="@id/toolbar"
             tools:listitem="@layout/contact_diary_edit_list_item" />
 
-        <android.widget.Button
+        <Button
             android:id="@+id/delete_button"
             style="@style/buttonReset"
             android:layout_width="0dp"

--- a/Corona-Warn-App/src/main/res/layout/contact_diary_edit_persons_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/contact_diary_edit_persons_fragment.xml
@@ -67,7 +67,7 @@
             tools:listitem="@layout/contact_diary_edit_list_item"
             app:layout_constraintTop_toBottomOf="@id/toolbar" />
 
-        <android.widget.Button
+        <Button
             android:id="@+id/delete_button"
             style="@style/buttonReset"
             android:layout_width="0dp"

--- a/Corona-Warn-App/src/main/res/layout/contact_diary_onboarding_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/contact_diary_onboarding_fragment.xml
@@ -216,7 +216,7 @@
 
         </ScrollView>
 
-        <android.widget.Button
+        <Button
             android:id="@+id/contact_diary_onboarding_next_button"
             style="@style/buttonPrimary"
             android:layout_width="0dp"

--- a/Corona-Warn-App/src/main/res/layout/new_release_info_screen_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/new_release_info_screen_fragment.xml
@@ -103,7 +103,7 @@
 
         </androidx.core.widget.NestedScrollView>
 
-        <android.widget.Button
+        <Button
             style="@style/buttonPrimary"
             android:id="@+id/new_release_info_next_button"
             android:layout_width="0dp"

--- a/Corona-Warn-App/src/main/res/layout/survey_consent_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/survey_consent_fragment.xml
@@ -221,7 +221,7 @@
 
         </ScrollView>
 
-        <android.widget.Button
+        <Button
             android:id="@+id/survey_next_button"
             style="@style/buttonPrimary"
             android:layout_width="0dp"


### PR DESCRIPTION
This small PR is intended to reduce the diff to CCTG by implementing a change that increases the codebase's compatibility with Android 5.

I noticed that Android 5 does not render background tint correctly if buttons are added to a layout in the app by using `android.widget.Button` instead of just `Button`. I have no clue why this happens but since adjusting the layout declarations accordingly doesn't have any drawbacks, I felt you might be able to merge this.

#### Screenshots for demonstration (Error report screen, CCTG, Android 5)

| Before | After |
|---|---|
| ![Screenshot_1616849752](https://user-images.githubusercontent.com/16943720/112725217-610a0b00-8f17-11eb-88c2-8d5a6dcc69c9.png) | ![Screenshot_1616857963](https://user-images.githubusercontent.com/16943720/112725222-65362880-8f17-11eb-8104-dbe984fd4b37.png) |

Thanks in advance! ❤️
