### PR TITLE
Remove network error messages for trace location creation

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/organizer/create/TraceLocationCreateFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/organizer/create/TraceLocationCreateFragment.kt
@@ -16,10 +16,6 @@ import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.contactdiary.util.getLocale
 import de.rki.coronawarnapp.contactdiary.util.hideKeyboard
 import de.rki.coronawarnapp.databinding.TraceLocationCreateFragmentBinding
-import de.rki.coronawarnapp.exception.http.CwaUnknownHostException
-import de.rki.coronawarnapp.exception.http.CwaWebException
-import de.rki.coronawarnapp.exception.http.NetworkConnectTimeoutException
-import de.rki.coronawarnapp.exception.http.NetworkReadTimeoutException
 import de.rki.coronawarnapp.ui.durationpicker.DurationPicker
 import de.rki.coronawarnapp.ui.durationpicker.toContactDiaryFormat
 import de.rki.coronawarnapp.util.DialogHelper
@@ -34,7 +30,6 @@ import org.joda.time.Duration
 import org.joda.time.LocalDate
 import org.joda.time.LocalDateTime
 import org.joda.time.LocalTime
-import java.lang.Exception
 import javax.inject.Inject
 
 class TraceLocationCreateFragment : Fragment(R.layout.trace_location_create_fragment), AutoInject {
@@ -135,34 +130,14 @@ class TraceLocationCreateFragment : Fragment(R.layout.trace_location_create_frag
     }
 
     private fun getErrorDialogInstance(exception: Exception): DialogHelper.DialogInstance {
-        return when (exception) {
-            is CwaUnknownHostException, is NetworkReadTimeoutException, is NetworkConnectTimeoutException -> {
-                DialogHelper.DialogInstance(
-                    requireActivity(),
-                    R.string.tracelocation_generic_error_title,
-                    R.string.tracelocation_generic_network_error_body,
-                    R.string.errors_generic_button_positive
-                )
-            }
-            is CwaWebException -> {
-                DialogHelper.DialogInstance(
-                    requireActivity(),
-                    R.string.tracelocation_generic_error_title,
-                    getString(R.string.tracelocation_generic_qr_code_error_body_with_error_code, exception.statusCode),
-                    R.string.errors_generic_button_positive
-                )
-            }
-            else -> {
-                DialogHelper.DialogInstance(
-                    requireActivity(),
-                    R.string.tracelocation_generic_error_title,
-                    R.string.tracelocation_generic_qr_code_error_body,
-                    R.string.errors_generic_button_positive,
-                    R.string.errors_generic_button_negative,
-                    negativeButtonFunction = { showExceptionDetails(exception) }
-                )
-            }
-        }
+        return DialogHelper.DialogInstance(
+            requireActivity(),
+            R.string.tracelocation_generic_error_title,
+            R.string.tracelocation_generic_qr_code_error_body,
+            R.string.errors_generic_button_positive,
+            R.string.errors_generic_button_negative,
+            negativeButtonFunction = { showExceptionDetails(exception) }
+        )
     }
 
     private fun showExceptionDetails(exception: Exception) {

--- a/Corona-Warn-App/src/main/res/values-bg/event_registration_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-bg/event_registration_strings.xml
@@ -123,12 +123,8 @@
     <!-- XTXT: Save button text -->
     <string name="tracelocation_organizer_save">"Запазване"</string>
 
-    <!-- XMSG: generic error message body with status code -->
-    <string name="tracelocation_generic_qr_code_error_body_with_error_code">"Създаването на QR код е неуспешно. Моля, опитайте отново по-късно (код на грешката %d)."</string>
     <!-- XMSG: generic web request error without status code -->
     <string name="tracelocation_generic_qr_code_error_body">"Създаването на QR код е неуспешно. Моля, опитайте отново по-късно."</string>
-    <!-- XMSG: Dialog body for generic web request network error -->
-    <string name="tracelocation_generic_network_error_body">"Възможно е да нямате достъп до интернет. Моля, проверете дали имате връзка."</string>
     <!-- XHED: error message title -->
     <string name="tracelocation_generic_error_title">"Грешка"</string>
 

--- a/Corona-Warn-App/src/main/res/values-de/event_registration_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/event_registration_strings.xml
@@ -124,12 +124,8 @@
     <!-- XTXT: Save button text -->
     <string name="tracelocation_organizer_save">"Speichern"</string>
 
-    <!-- XMSG: generic error message body with status code -->
-    <string name="tracelocation_generic_qr_code_error_body_with_error_code">"QR-Code konnte nicht erstellt werden. Bitte versuchen Sie es später noch mal (Fehlercode %d)"</string>
     <!-- XMSG: generic web request error without status code -->
     <string name="tracelocation_generic_qr_code_error_body">"QR-Code konnte nicht erstellt werden. Bitte versuchen Sie es später noch mal."</string>
-    <!-- XMSG: Dialog body for generic web request network error -->
-    <string name="tracelocation_generic_network_error_body">"Möglicherweise wurde Ihre Internet-Verbindung unterbrochen. Bitte stellen Sie sicher, dass Sie mit dem Internet verbunden sind."</string>
     <!-- XHED: error message title -->
     <string name="tracelocation_generic_error_title">"Fehler"</string>
 

--- a/Corona-Warn-App/src/main/res/values-en/event_registration_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-en/event_registration_strings.xml
@@ -123,12 +123,8 @@
     <!-- XTXT: Save button text -->
     <string name="tracelocation_organizer_save">"Save"</string>
 
-    <!-- XMSG: generic error message body with status code -->
-    <string name="tracelocation_generic_qr_code_error_body_with_error_code">"The QR code could not be created. Please try again later (error code %d)."</string>
     <!-- XMSG: generic web request error without status code -->
     <string name="tracelocation_generic_qr_code_error_body">"The QR code could not be created. Please try again later."</string>
-    <!-- XMSG: Dialog body for generic web request network error -->
-    <string name="tracelocation_generic_network_error_body">"Your Internet connection may have been lost. Please ensure that you are connected to the Internet."</string>
     <!-- XHED: error message title -->
     <string name="tracelocation_generic_error_title">"Error"</string>
 

--- a/Corona-Warn-App/src/main/res/values-pl/event_registration_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-pl/event_registration_strings.xml
@@ -123,12 +123,8 @@
     <!-- XTXT: Save button text -->
     <string name="tracelocation_organizer_save">"Zapisz"</string>
 
-    <!-- XMSG: generic error message body with status code -->
-    <string name="tracelocation_generic_qr_code_error_body_with_error_code">"Kod QR nie mógł zostać utworzony. Spróbuj ponownie później (kod błędu %d)."</string>
     <!-- XMSG: generic web request error without status code -->
     <string name="tracelocation_generic_qr_code_error_body">"Kod QR nie mógł zostać utworzony. Spróbuj ponownie później."</string>
-    <!-- XMSG: Dialog body for generic web request network error -->
-    <string name="tracelocation_generic_network_error_body">"Twoje połączenie z Internetem mogło zostać utracone. Zadbaj o jego przywrócenie."</string>
     <!-- XHED: error message title -->
     <string name="tracelocation_generic_error_title">"Błąd"</string>
 

--- a/Corona-Warn-App/src/main/res/values-ro/event_registration_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-ro/event_registration_strings.xml
@@ -123,12 +123,8 @@
     <!-- XTXT: Save button text -->
     <string name="tracelocation_organizer_save">"Salvare"</string>
 
-    <!-- XMSG: generic error message body with status code -->
-    <string name="tracelocation_generic_qr_code_error_body_with_error_code">"Codul QR nu a putut fi creat. Încercați din nou mai târziu (cod de eroare %d)."</string>
     <!-- XMSG: generic web request error without status code -->
     <string name="tracelocation_generic_qr_code_error_body">"Codul QR nu a putut fi creat. Încercați din nou mai târziu."</string>
-    <!-- XMSG: Dialog body for generic web request network error -->
-    <string name="tracelocation_generic_network_error_body">"Se poate să fi pierdut conexiunea la internet. Asigurați-vă că sunteți conectat la internet."</string>
     <!-- XHED: error message title -->
     <string name="tracelocation_generic_error_title">"Eroare"</string>
 

--- a/Corona-Warn-App/src/main/res/values-tr/event_registration_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-tr/event_registration_strings.xml
@@ -123,12 +123,8 @@
     <!-- XTXT: Save button text -->
     <string name="tracelocation_organizer_save">"Kaydet"</string>
 
-    <!-- XMSG: generic error message body with status code -->
-    <string name="tracelocation_generic_qr_code_error_body_with_error_code">"QR kod oluşturulamadı. Lütfen daha sonra tekrar deneyin (hata kodu %d)."</string>
     <!-- XMSG: generic web request error without status code -->
     <string name="tracelocation_generic_qr_code_error_body">"QR kod oluşturulamadı. Lütfen daha sonra tekrar deneyin."</string>
-    <!-- XMSG: Dialog body for generic web request network error -->
-    <string name="tracelocation_generic_network_error_body">"İnternet bağlantınız kesilmiş olabilir. Lütfen internet bağlantınızın olduğundan emin olun."</string>
     <!-- XHED: error message title -->
     <string name="tracelocation_generic_error_title">"Hata"</string>
 

--- a/Corona-Warn-App/src/main/res/values/event_registration_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/event_registration_strings.xml
@@ -123,12 +123,8 @@
     <!-- XTXT: Save button text -->
     <string name="tracelocation_organizer_save">"Save"</string>
 
-    <!-- XMSG: generic error message body with status code -->
-    <string name="tracelocation_generic_qr_code_error_body_with_error_code">"The QR code could not be created. Please try again later (error code %d)."</string>
     <!-- XMSG: generic web request error without status code -->
     <string name="tracelocation_generic_qr_code_error_body">"The QR code could not be created. Please try again later."</string>
-    <!-- XMSG: Dialog body for generic web request network error -->
-    <string name="tracelocation_generic_network_error_body">"Your Internet connection may have been lost. Please ensure that you are connected to the Internet."</string>
     <!-- XHED: error message title -->
     <string name="tracelocation_generic_error_title">"Error"</string>
 


### PR DESCRIPTION
Since we are not performing a network request anymore for trace location creation, we also don't need network error messages for it. 