### PR TITLE
Update trace location attributes validation

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/organizer/create/TraceLocationCreateViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/organizer/create/TraceLocationCreateViewModel.kt
@@ -93,23 +93,23 @@ class TraceLocationCreateViewModel @AssistedInject constructor(
                 isDateVisible = category.uiType == TraceLocationUIType.EVENT,
                 isSendEnable = when (category.uiType) {
                     TraceLocationUIType.LOCATION -> {
-                        description.trim().length in 1..100 &&
-                            address.trim().length in 0..100 &&
+                        description.isTextFormattedCorrectly() &&
+                            address.isTextFormattedCorrectly() &&
                             checkInLength > Duration.ZERO &&
                             !requestInProgress
                     }
                     TraceLocationUIType.EVENT -> {
-                        description.trim().length in 1..100 &&
-                            address.trim().length in 0..100 &&
-                            begin != null &&
-                            end != null &&
-                            end?.isAfter(begin) == true &&
+                        description.isTextFormattedCorrectly() &&
+                            address.isTextFormattedCorrectly() &&
+                            begin != null && end != null && end?.isAfter(begin) == true &&
                             !requestInProgress
                     }
                 }
             )
         )
     }
+
+    private fun String.isTextFormattedCorrectly() = trim().length in 1..100 && !contains('\n')
 
     data class UIState(
         private val begin: LocalDateTime? = null,


### PR DESCRIPTION
Update trace location attributes validation according to spec changes:

 - Bezeichnung (description) may not be empty, may not contain any line breaks, and may not have more than 100 characters after removing any leading or trailing whitespace
 - Ort (address) may not be empty, may not contain any line breaks, and may not have more than 100 characters after removing any leading or trailing whitespace
 - Beginn (start) must be before Ende (end) if the type is an event; both must be unset if the type is a location.
 - Typische Aufenhaltsdauer (default check-in length) must be greater than zero if the type is a location and must be great than or equal zero if the type is an event (zero meaning no value set)
