### PR TITLE
Risk calc unit tests and bug fixes (EXPOSUREAPP-5697)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/overview/ContactDiaryOverviewViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/ui/overview/ContactDiaryOverviewViewModel.kt
@@ -19,8 +19,8 @@ import de.rki.coronawarnapp.contactdiary.ui.overview.adapter.day.contact.Contact
 import de.rki.coronawarnapp.contactdiary.ui.overview.adapter.day.riskenf.RiskEnfItem
 import de.rki.coronawarnapp.contactdiary.ui.overview.adapter.day.riskevent.RiskEventItem
 import de.rki.coronawarnapp.contactdiary.ui.overview.adapter.subheader.OverviewSubHeaderItem
+import de.rki.coronawarnapp.presencetracing.risk.TraceLocationCheckInRisk
 import de.rki.coronawarnapp.risk.RiskState
-import de.rki.coronawarnapp.risk.TraceLocationCheckInRisk
 import de.rki.coronawarnapp.risk.result.ExposureWindowDayRisk
 import de.rki.coronawarnapp.risk.storage.RiskLevelStorage
 import de.rki.coronawarnapp.server.protocols.internal.v2.RiskCalculationParametersOuterClass

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/eventregistration/checkins/CheckIn.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/eventregistration/checkins/CheckIn.kt
@@ -24,6 +24,7 @@ data class CheckIn(
     val completed: Boolean,
     val createJournalEntry: Boolean
 ) {
+    // TODO calculate hash for matching
     // val locationGuidHash: com.google.protobuf.ByteString by lazy { copyFromUtf8(guid.toSHA256()) }
 }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/CheckInWarningMatcher.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/CheckInWarningMatcher.kt
@@ -138,6 +138,7 @@ internal fun CheckIn.calculateOverlap(
     traceWarningPackageId: String
 ): CheckInWarningOverlap? {
 
+    // TODO this is not correct anymore
     if (warning.locationIdHash.toByteArray().toByteString() != traceLocationIdHash) return null
 
     val warningStartMillis = warning.startIntervalNumber.tenMinIntervalToMillis()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/PresenceTracingConversions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/PresenceTracingConversions.kt
@@ -4,9 +4,9 @@ import de.rki.coronawarnapp.risk.RiskState
 import de.rki.coronawarnapp.server.protocols.internal.v2.RiskCalculationParametersOuterClass.NormalizedTimeToRiskLevelMapping.RiskLevel
 
 // converts number of 10min intervals into milliseconds
-internal fun Int.tenMinIntervalToMillis() = this * MILLIS_IN_MIN
+internal fun Int.tenMinIntervalToMillis() = this * MILLIS_IN_TEN_MIN
 
-private const val MILLIS_IN_MIN = 600L * 1000L
+private const val MILLIS_IN_TEN_MIN = 600000L
 
 fun RiskLevel.mapToRiskState(): RiskState {
     return when (this) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/PresenceTracingRiskModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/PresenceTracingRiskModel.kt
@@ -1,7 +1,6 @@
 package de.rki.coronawarnapp.presencetracing.risk
 
 import de.rki.coronawarnapp.risk.RiskState
-import de.rki.coronawarnapp.risk.TraceLocationCheckInRisk
 import de.rki.coronawarnapp.util.TimeAndDateExtensions.toLocalDateUtc
 import org.joda.time.DateTimeConstants
 import org.joda.time.Duration

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/PresenceTracingRiskRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/PresenceTracingRiskRepository.kt
@@ -122,6 +122,7 @@ class PresenceTracingRiskRepository @Inject constructor(
             .map { entity ->
                 if (!lastSuccessfulFound && entity.riskState != RiskState.CALCULATION_FAILED) {
                     lastSuccessfulFound = true
+                    // add risk per day to the last successful result
                     entity.toModel(presenceTracingDayRisk.first())
                 } else {
                     entity.toModel(null)
@@ -137,6 +138,7 @@ class PresenceTracingRiskRepository @Inject constructor(
             .map { entity ->
                 if (!lastSuccessfulFound && entity.riskState != RiskState.CALCULATION_FAILED) {
                     lastSuccessfulFound = true
+                    // add risk per day to the last successful result
                     entity.toModel(presenceTracingDayRisk.first())
                 } else {
                     entity.toModel(null)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/PresenceTracingRiskRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/PresenceTracingRiskRepository.kt
@@ -240,7 +240,7 @@ private fun PresenceTracingRiskLevelResultEntity.toModel(
 ) = PtRiskLevelResult(
     calculatedAt = Instant.ofEpochMilli((calculatedAtMillis)),
     riskState = riskState,
-    presenceTracingDayRisk = if (riskState != RiskState.CALCULATION_FAILED) presenceTracingDayRisk else null
+    presenceTracingDayRisk = presenceTracingDayRisk
 )
 
 private fun PtRiskLevelResult.toEntity() = PresenceTracingRiskLevelResultEntity(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/PtRiskLevelResult.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/PtRiskLevelResult.kt
@@ -7,7 +7,7 @@ import org.joda.time.LocalDate
 data class PtRiskLevelResult(
     val calculatedAt: Instant,
     val riskState: RiskState,
-    // only available for the last successful calculation, otherwise null
+    // only available for the last calculation if successful, otherwise null
     val presenceTracingDayRisk: List<PresenceTracingDayRisk>? = null
 ) {
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/PtRiskLevelResult.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/PtRiskLevelResult.kt
@@ -39,16 +39,3 @@ data class PtRiskLevelResult(
             else -> 0
         }
 }
-
-val ptUndeterminedRiskLevelResult: PtRiskLevelResult by lazy {
-    PtRiskLevelResult(
-        calculatedAt = Instant.EPOCH,
-        riskState = RiskState.CALCULATION_FAILED
-    )
-}
-
-val ptInitialLowRiskLevelResult: PtRiskLevelResult
-    get() = PtRiskLevelResult(
-        calculatedAt = Instant.EPOCH,
-        riskState = RiskState.LOW_RISK
-    )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/PtRiskLevelResult.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/PtRiskLevelResult.kt
@@ -49,6 +49,6 @@ val ptUndeterminedRiskLevelResult: PtRiskLevelResult by lazy {
 
 val ptInitialLowRiskLevelResult: PtRiskLevelResult
     get() = PtRiskLevelResult(
-        calculatedAt = Instant.now(),
+        calculatedAt = Instant.EPOCH,
         riskState = RiskState.LOW_RISK
     )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/PtRiskLevelResult.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/PtRiskLevelResult.kt
@@ -7,6 +7,7 @@ import org.joda.time.LocalDate
 data class PtRiskLevelResult(
     val calculatedAt: Instant,
     val riskState: RiskState,
+    // only available for the last successful calculation, otherwise null
     val presenceTracingDayRisk: List<PresenceTracingDayRisk>? = null
 ) {
 
@@ -38,3 +39,16 @@ data class PtRiskLevelResult(
             else -> 0
         }
 }
+
+val ptUndeterminedRiskLevelResult: PtRiskLevelResult by lazy {
+    PtRiskLevelResult(
+        calculatedAt = Instant.EPOCH,
+        riskState = RiskState.CALCULATION_FAILED
+    )
+}
+
+val ptInitialLowRiskLevelResult: PtRiskLevelResult
+    get() = PtRiskLevelResult(
+        calculatedAt = Instant.now(),
+        riskState = RiskState.LOW_RISK
+    )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/TraceLocationCheckInRisk.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/TraceLocationCheckInRisk.kt
@@ -1,5 +1,6 @@
-package de.rki.coronawarnapp.risk
+package de.rki.coronawarnapp.presencetracing.risk
 
+import de.rki.coronawarnapp.risk.RiskState
 import org.joda.time.LocalDate
 
 interface TraceLocationCheckInRisk {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/CombinedEwPtRisk.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/CombinedEwPtRisk.kt
@@ -1,0 +1,89 @@
+package de.rki.coronawarnapp.risk
+
+import de.rki.coronawarnapp.presencetracing.risk.PtRiskLevelResult
+import de.rki.coronawarnapp.presencetracing.risk.ptInitialLowRiskLevelResult
+import de.rki.coronawarnapp.presencetracing.risk.ptUndeterminedRiskLevelResult
+import de.rki.coronawarnapp.risk.storage.max
+import de.rki.coronawarnapp.util.TimeAndDateExtensions.toLocalDateUtc
+import org.joda.time.Instant
+import org.joda.time.LocalDate
+
+data class CombinedEwPtDayRisk(
+    val localDate: LocalDate,
+    val riskState: RiskState
+)
+
+data class CombinedEwPtRiskLevelResult(
+    val ptRiskLevelResult: PtRiskLevelResult,
+    val ewRiskLevelResult: EwRiskLevelResult
+) {
+
+    val riskState: RiskState by lazy {
+        max(ptRiskLevelResult.riskState, ewRiskLevelResult.riskState)
+    }
+
+    val wasSuccessfullyCalculated: Boolean by lazy {
+        ewRiskLevelResult.wasSuccessfullyCalculated ||
+            ptRiskLevelResult.wasSuccessfullyCalculated
+    }
+
+    val calculatedAt: Instant by lazy {
+        max(ewRiskLevelResult.calculatedAt, ptRiskLevelResult.calculatedAt)
+    }
+
+    val daysWithEncounters: Int by lazy {
+        when (riskState) {
+            RiskState.INCREASED_RISK -> {
+                (ewRiskLevelResult.ewAggregatedRiskResult?.numberOfDaysWithHighRisk ?: 0) +
+                    ptRiskLevelResult.numberOfDaysWithHighRisk
+            }
+            RiskState.LOW_RISK -> {
+                (ewRiskLevelResult.ewAggregatedRiskResult?.numberOfDaysWithLowRisk ?: 0) +
+                    ptRiskLevelResult.numberOfDaysWithLowRisk
+            }
+            else -> 0
+        }
+    }
+
+    val lastRiskEncounterAt: LocalDate? by lazy {
+        when (riskState) {
+            RiskState.INCREASED_RISK -> max(
+                ewRiskLevelResult.ewAggregatedRiskResult?.mostRecentDateWithHighRisk?.toLocalDateUtc(),
+                ptRiskLevelResult.mostRecentDateWithHighRisk
+            )
+            RiskState.LOW_RISK -> max(
+                ewRiskLevelResult.ewAggregatedRiskResult?.mostRecentDateWithLowRisk?.toLocalDateUtc(),
+                ptRiskLevelResult.mostRecentDateWithLowRisk
+            )
+            else -> null
+        }
+    }
+}
+
+fun List<CombinedEwPtRiskLevelResult>.tryLatestCombinedResultsWithDefaults(): LastCombinedRiskResults {
+    val latestCalculation = this.maxByOrNull { it.calculatedAt }
+        ?: combinedInitialLowLevelRiskLevelResult
+
+    val lastSuccessfullyCalculated = this.filter { it.wasSuccessfullyCalculated }
+        .maxByOrNull { it.calculatedAt } ?: combinedUndeterminedRiskLevelResult
+
+    return LastCombinedRiskResults(
+        lastCalculated = latestCalculation,
+        lastSuccessfullyCalculated = lastSuccessfullyCalculated
+    )
+}
+
+data class LastCombinedRiskResults(
+    val lastCalculated: CombinedEwPtRiskLevelResult,
+    val lastSuccessfullyCalculated: CombinedEwPtRiskLevelResult
+)
+
+private val combinedUndeterminedRiskLevelResult = CombinedEwPtRiskLevelResult(
+    ptUndeterminedRiskLevelResult,
+    EwUndeterminedRiskLevelResult
+)
+
+private val combinedInitialLowLevelRiskLevelResult = CombinedEwPtRiskLevelResult(
+    ptInitialLowRiskLevelResult,
+    EwInitialLowRiskLevelResult
+)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/CombinedEwPtRisk.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/CombinedEwPtRisk.kt
@@ -1,8 +1,6 @@
 package de.rki.coronawarnapp.risk
 
 import de.rki.coronawarnapp.presencetracing.risk.PtRiskLevelResult
-import de.rki.coronawarnapp.presencetracing.risk.ptInitialLowRiskLevelResult
-import de.rki.coronawarnapp.presencetracing.risk.ptUndeterminedRiskLevelResult
 import de.rki.coronawarnapp.risk.storage.max
 import de.rki.coronawarnapp.util.TimeAndDateExtensions.toLocalDateUtc
 import org.joda.time.Instant
@@ -23,8 +21,7 @@ data class CombinedEwPtRiskLevelResult(
     }
 
     val wasSuccessfullyCalculated: Boolean by lazy {
-        ewRiskLevelResult.wasSuccessfullyCalculated ||
-            ptRiskLevelResult.wasSuccessfullyCalculated
+        riskState != RiskState.CALCULATION_FAILED
     }
 
     val calculatedAt: Instant by lazy {
@@ -60,30 +57,7 @@ data class CombinedEwPtRiskLevelResult(
     }
 }
 
-fun List<CombinedEwPtRiskLevelResult>.tryLatestCombinedResultsWithDefaults(): LastCombinedRiskResults {
-    val latestCalculation = this.maxByOrNull { it.calculatedAt }
-        ?: combinedInitialLowLevelRiskLevelResult
-
-    val lastSuccessfullyCalculated = this.filter { it.wasSuccessfullyCalculated }
-        .maxByOrNull { it.calculatedAt } ?: combinedUndeterminedRiskLevelResult
-
-    return LastCombinedRiskResults(
-        lastCalculated = latestCalculation,
-        lastSuccessfullyCalculated = lastSuccessfullyCalculated
-    )
-}
-
 data class LastCombinedRiskResults(
     val lastCalculated: CombinedEwPtRiskLevelResult,
     val lastSuccessfullyCalculated: CombinedEwPtRiskLevelResult
-)
-
-private val combinedUndeterminedRiskLevelResult = CombinedEwPtRiskLevelResult(
-    ptUndeterminedRiskLevelResult,
-    EwUndeterminedRiskLevelResult
-)
-
-private val combinedInitialLowLevelRiskLevelResult = CombinedEwPtRiskLevelResult(
-    ptInitialLowRiskLevelResult,
-    EwInitialLowRiskLevelResult
 )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/CombinedEwPtRisk.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/CombinedEwPtRisk.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.risk
 
 import de.rki.coronawarnapp.presencetracing.risk.PtRiskLevelResult
+import de.rki.coronawarnapp.risk.storage.combine
 import de.rki.coronawarnapp.risk.storage.max
 import de.rki.coronawarnapp.util.TimeAndDateExtensions.toLocalDateUtc
 import org.joda.time.Instant
@@ -17,7 +18,7 @@ data class CombinedEwPtRiskLevelResult(
 ) {
 
     val riskState: RiskState by lazy {
-        max(ptRiskLevelResult.riskState, ewRiskLevelResult.riskState)
+        combine(ptRiskLevelResult.riskState, ewRiskLevelResult.riskState)
     }
 
     val wasSuccessfullyCalculated: Boolean by lazy {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelChangeDetector.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelChangeDetector.kt
@@ -68,7 +68,6 @@ class RiskLevelChangeDetector @Inject constructor(
     }
 
     private suspend fun checkCombinedRiskForStateChanges(results: List<CombinedEwPtRiskLevelResult>) {
-        // TODO refactor
         val oldResult = results.first()
         val newResult = results.last()
 
@@ -84,10 +83,7 @@ class RiskLevelChangeDetector @Inject constructor(
         Timber.d("Last combined state was $oldRiskState and current state is $newRiskState")
 
         // Check sending a notification when risk level changes
-        if (hasHighLowLevelChanged(oldRiskState, newRiskState)) {
-            checkSendingNotification()
-            Timber.d("Risk level changed and notification sent. Current Risk level is $newRiskState")
-        }
+        checkSendingNotification(oldRiskState, newRiskState)
     }
 
     private fun checkEwRiskForStateChanges(results: List<EwRiskLevelResult>) {
@@ -146,8 +142,11 @@ class RiskLevelChangeDetector @Inject constructor(
         }
     }
 
-    private suspend fun checkSendingNotification() {
-        if (!submissionSettings.isSubmissionSuccessful) {
+    private suspend fun checkSendingNotification(
+        oldRiskState: RiskState,
+        newRiskState: RiskState
+    ) {
+        if (hasHighLowLevelChanged(oldRiskState, newRiskState) && !submissionSettings.isSubmissionSuccessful) {
             Timber.d("Notification Permission = ${notificationManagerCompat.areNotificationsEnabled()}")
 
             if (!foregroundState.isInForeground.first()) {
@@ -163,6 +162,7 @@ class RiskLevelChangeDetector @Inject constructor(
             } else {
                 Timber.d("App is in foreground, not sending notifications")
             }
+            Timber.d("Risk level changed and notification sent. Current Risk level is $newRiskState")
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelResultExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelResultExtensions.kt
@@ -22,7 +22,7 @@ data class DisplayableEwRiskResults(
     val lastSuccessfullyCalculated: EwRiskLevelResult
 )
 
-object EwInitialLowRiskLevelResult : EwRiskLevelResult {
+private object EwInitialLowRiskLevelResult : EwRiskLevelResult {
     override val calculatedAt: Instant = Instant.now()
     override val riskState: RiskState = RiskState.LOW_RISK
     override val failureReason: EwRiskLevelResult.FailureReason? = null
@@ -32,7 +32,7 @@ object EwInitialLowRiskLevelResult : EwRiskLevelResult {
     override val daysWithEncounters: Int = 0
 }
 
-object EwUndeterminedRiskLevelResult : EwRiskLevelResult {
+private object EwUndeterminedRiskLevelResult : EwRiskLevelResult {
     override val calculatedAt: Instant = Instant.EPOCH
     override val riskState: RiskState = RiskState.CALCULATION_FAILED
     override val failureReason: EwRiskLevelResult.FailureReason? = null

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelResultExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelResultExtensions.kt
@@ -1,9 +1,7 @@
 package de.rki.coronawarnapp.risk
 
 import com.google.android.gms.nearby.exposurenotification.ExposureWindow
-import de.rki.coronawarnapp.presencetracing.risk.PtRiskLevelResult
 import de.rki.coronawarnapp.risk.result.EwAggregatedRiskResult
-import de.rki.coronawarnapp.risk.storage.CombinedEwPtRiskLevelResult
 import org.joda.time.Instant
 
 fun List<EwRiskLevelResult>.tryLatestEwResultsWithDefaults(): DisplayableEwRiskResults {
@@ -24,41 +22,7 @@ data class DisplayableEwRiskResults(
     val lastSuccessfullyCalculated: EwRiskLevelResult
 )
 
-fun List<CombinedEwPtRiskLevelResult>.tryLatestResultsWithDefaults(): DisplayableRiskResults {
-    val latestCalculation = this.maxByOrNull { it.calculatedAt }
-        ?: initialLowLevelEwRiskLevelResult
-
-    val lastSuccessfullyCalculated = this.filter { it.wasSuccessfullyCalculated }
-        .maxByOrNull { it.calculatedAt } ?: undeterminedEwRiskLevelResult
-
-    return DisplayableRiskResults(
-        lastCalculated = latestCalculation,
-        lastSuccessfullyCalculated = lastSuccessfullyCalculated
-    )
-}
-
-data class DisplayableRiskResults(
-    val lastCalculated: CombinedEwPtRiskLevelResult,
-    val lastSuccessfullyCalculated: CombinedEwPtRiskLevelResult
-)
-
-private val undeterminedEwRiskLevelResult = CombinedEwPtRiskLevelResult(
-    PtRiskLevelResult(
-        calculatedAt = Instant.EPOCH,
-        riskState = RiskState.CALCULATION_FAILED
-    ),
-    EwUndeterminedRiskLevelResult
-)
-
-private val initialLowLevelEwRiskLevelResult = CombinedEwPtRiskLevelResult(
-    PtRiskLevelResult(
-        calculatedAt = Instant.now(),
-        riskState = RiskState.LOW_RISK
-    ),
-    EwInitialLowRiskLevelResult
-)
-
-private object EwInitialLowRiskLevelResult : EwRiskLevelResult {
+object EwInitialLowRiskLevelResult : EwRiskLevelResult {
     override val calculatedAt: Instant = Instant.now()
     override val riskState: RiskState = RiskState.LOW_RISK
     override val failureReason: EwRiskLevelResult.FailureReason? = null
@@ -68,7 +32,7 @@ private object EwInitialLowRiskLevelResult : EwRiskLevelResult {
     override val daysWithEncounters: Int = 0
 }
 
-private object EwUndeterminedRiskLevelResult : EwRiskLevelResult {
+object EwUndeterminedRiskLevelResult : EwRiskLevelResult {
     override val calculatedAt: Instant = Instant.EPOCH
     override val riskState: RiskState = RiskState.CALCULATION_FAILED
     override val failureReason: EwRiskLevelResult.FailureReason? = null

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/storage/BaseRiskLevelStorage.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/storage/BaseRiskLevelStorage.kt
@@ -291,10 +291,9 @@ internal fun combineEwPtRiskLevelResults(
     }
 }
 
-// TODO not sure what the initial results should be - low or failed?
 private object EwInitialRiskLevelResult : EwRiskLevelResult {
     override val calculatedAt: Instant = Instant.EPOCH
-    override val riskState: RiskState = RiskState.LOW_RISK
+    override val riskState: RiskState = RiskState.CALCULATION_FAILED
     override val failureReason: EwRiskLevelResult.FailureReason? = null
     override val ewAggregatedRiskResult: EwAggregatedRiskResult? = null
     override val exposureWindows: List<ExposureWindow>? = null
@@ -305,7 +304,7 @@ private object EwInitialRiskLevelResult : EwRiskLevelResult {
 private val ptInitialRiskLevelResult: PtRiskLevelResult by lazy {
     PtRiskLevelResult(
         calculatedAt = Instant.EPOCH,
-        riskState = RiskState.LOW_RISK
+        riskState = RiskState.CALCULATION_FAILED
     )
 }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/storage/BaseRiskLevelStorage.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/storage/BaseRiskLevelStorage.kt
@@ -201,7 +201,7 @@ abstract class BaseRiskLevelStorage constructor(
                 .sortedByDescending { it.calculatedAt }
 
             LastCombinedRiskResults(
-                lastCalculated = combinedResults.firstOrNull() ?: initialCombined,
+                lastCalculated = combinedResults.firstOrNull() ?: currentCombinedLowRisk,
                 lastSuccessfullyCalculated = combinedResults.find { it.wasSuccessfullyCalculated } ?: initialCombined
             )
         }
@@ -308,7 +308,30 @@ private val ptInitialRiskLevelResult: PtRiskLevelResult by lazy {
     )
 }
 
+private val ewCurrentLowRiskLevelResult
+    get() = object : EwRiskLevelResult {
+        override val calculatedAt: Instant = Instant.now()
+        override val riskState: RiskState = RiskState.LOW_RISK
+        override val failureReason: EwRiskLevelResult.FailureReason? = null
+        override val ewAggregatedRiskResult: EwAggregatedRiskResult? = null
+        override val exposureWindows: List<ExposureWindow>? = null
+        override val matchedKeyCount: Int = 0
+        override val daysWithEncounters: Int = 0
+    }
+
+private val ptCurrentLowRiskLevelResult: PtRiskLevelResult
+    get() = PtRiskLevelResult(
+        calculatedAt = Instant.now(),
+        riskState = RiskState.LOW_RISK
+    )
+
 private val initialCombined = CombinedEwPtRiskLevelResult(
     ptInitialRiskLevelResult,
     EwInitialRiskLevelResult
 )
+
+private val currentCombinedLowRisk: CombinedEwPtRiskLevelResult
+    get() = CombinedEwPtRiskLevelResult(
+        ptCurrentLowRiskLevelResult,
+        ewCurrentLowRiskLevelResult
+    )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/storage/BaseRiskLevelStorage.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/storage/BaseRiskLevelStorage.kt
@@ -200,11 +200,6 @@ abstract class BaseRiskLevelStorage constructor(
             val combinedResults = combineEwPtRiskLevelResults(ptRiskLevelResults, ewRiskLevelResults)
                 .sortedByDescending { it.calculatedAt }
 
-            val initialCombined = CombinedEwPtRiskLevelResult(
-                ptInitialLowRiskLevelResult,
-                EwInitialLowRiskLevelResult
-            )
-
             LastCombinedRiskResults(
                 lastCalculated = combinedResults.firstOrNull() ?: initialCombined,
                 lastSuccessfullyCalculated = combinedResults.find { it.wasSuccessfullyCalculated } ?: initialCombined
@@ -287,8 +282,8 @@ internal fun combineEwPtRiskLevelResults(
     val sortedPtResults = ptRiskResults.sortedByDescending { it.calculatedAt }
     val sortedEwResults = ewRiskResults.sortedByDescending { it.calculatedAt }
     return allDates.map { date ->
-        val ptRisk = sortedPtResults.find { it.calculatedAt <= date } ?: ptInitialLowRiskLevelResult
-        val ewRisk = sortedEwResults.find { it.calculatedAt <= date } ?: EwInitialLowRiskLevelResult
+        val ptRisk = sortedPtResults.find { it.calculatedAt <= date } ?: ptInitialRiskLevelResult
+        val ewRisk = sortedEwResults.find { it.calculatedAt <= date } ?: EwInitialRiskLevelResult
         CombinedEwPtRiskLevelResult(
             ptRisk,
             ewRisk
@@ -296,7 +291,8 @@ internal fun combineEwPtRiskLevelResults(
     }
 }
 
-private object EwInitialLowRiskLevelResult : EwRiskLevelResult {
+// TODO not sure what the initial results should be - low or failed?
+private object EwInitialRiskLevelResult : EwRiskLevelResult {
     override val calculatedAt: Instant = Instant.EPOCH
     override val riskState: RiskState = RiskState.LOW_RISK
     override val failureReason: EwRiskLevelResult.FailureReason? = null
@@ -306,9 +302,14 @@ private object EwInitialLowRiskLevelResult : EwRiskLevelResult {
     override val daysWithEncounters: Int = 0
 }
 
-private val ptInitialLowRiskLevelResult: PtRiskLevelResult by lazy {
+private val ptInitialRiskLevelResult: PtRiskLevelResult by lazy {
     PtRiskLevelResult(
         calculatedAt = Instant.EPOCH,
         riskState = RiskState.LOW_RISK
     )
 }
+
+private val initialCombined = CombinedEwPtRiskLevelResult(
+    ptInitialRiskLevelResult,
+    EwInitialRiskLevelResult
+)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/storage/BaseRiskLevelStorage.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/storage/BaseRiskLevelStorage.kt
@@ -7,7 +7,6 @@ import de.rki.coronawarnapp.presencetracing.risk.PresenceTracingRiskRepository
 import de.rki.coronawarnapp.presencetracing.risk.PtRiskLevelResult
 import de.rki.coronawarnapp.presencetracing.risk.TraceLocationCheckInRisk
 import de.rki.coronawarnapp.presencetracing.risk.mapToRiskState
-import de.rki.coronawarnapp.presencetracing.risk.ptInitialLowRiskLevelResult
 import de.rki.coronawarnapp.risk.CombinedEwPtDayRisk
 import de.rki.coronawarnapp.risk.CombinedEwPtRiskLevelResult
 import de.rki.coronawarnapp.risk.EwRiskLevelResult
@@ -254,7 +253,7 @@ internal fun combineRisk(
         val ewRisk = exposureWindowDayRiskList.find { it.localDateUtc == date }
         CombinedEwPtDayRisk(
             date,
-            max(
+            combine(
                 ptRisk?.riskState,
                 ewRisk?.riskLevel?.mapToRiskState()
             )
@@ -262,7 +261,7 @@ internal fun combineRisk(
     }
 }
 
-internal fun max(left: RiskState?, right: RiskState?): RiskState {
+internal fun combine(left: RiskState?, right: RiskState?): RiskState {
     return if (left == RiskState.INCREASED_RISK || right == RiskState.INCREASED_RISK) RiskState.INCREASED_RISK
     else if (left == RiskState.LOW_RISK || right == RiskState.LOW_RISK) RiskState.LOW_RISK
     else RiskState.CALCULATION_FAILED
@@ -305,4 +304,11 @@ private object EwInitialLowRiskLevelResult : EwRiskLevelResult {
     override val exposureWindows: List<ExposureWindow>? = null
     override val matchedKeyCount: Int = 0
     override val daysWithEncounters: Int = 0
+}
+
+private val ptInitialLowRiskLevelResult: PtRiskLevelResult by lazy {
+    PtRiskLevelResult(
+        calculatedAt = Instant.EPOCH,
+        riskState = RiskState.LOW_RISK
+    )
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/states/TracingStateProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/states/TracingStateProvider.kt
@@ -51,12 +51,12 @@ class TracingStateProvider @AssistedInject constructor(
         isBackgroundJobEnabled ->
 
         val latestCalc = riskLevelResults.lastCalculated
-        val lastSuccessfullyCalculated = riskLevelResults.lastSuccessfullyCalculated
+        val lastSuccessfullyCalc = riskLevelResults.lastSuccessfullyCalculated
 
         return@combine when {
             tracingStatus == GeneralTracingStatus.Status.TRACING_INACTIVE -> TracingDisabled(
                 isInDetailsMode = isDetailsMode,
-                riskState = lastSuccessfullyCalculated.riskState,
+                riskState = lastSuccessfullyCalc.riskState,
                 lastExposureDetectionTime = latestSubmission?.startedAt
             )
             tracingProgress != TracingProgress.Idle -> TracingInProgress(
@@ -83,7 +83,7 @@ class TracingStateProvider @AssistedInject constructor(
             )
             else -> TracingFailed(
                 isInDetailsMode = isDetailsMode,
-                riskState = lastSuccessfullyCalculated.riskState,
+                riskState = lastSuccessfullyCalc.riskState,
                 lastExposureDetectionTime = latestSubmission?.startedAt
             )
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/states/TracingStateProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/states/TracingStateProvider.kt
@@ -8,7 +8,6 @@ import de.rki.coronawarnapp.nearby.modules.detectiontracker.ExposureDetectionTra
 import de.rki.coronawarnapp.nearby.modules.detectiontracker.latestSubmission
 import de.rki.coronawarnapp.risk.RiskState
 import de.rki.coronawarnapp.risk.storage.RiskLevelStorage
-import de.rki.coronawarnapp.risk.tryLatestResultsWithDefaults
 import de.rki.coronawarnapp.storage.TracingRepository
 import de.rki.coronawarnapp.tracing.GeneralTracingStatus
 import de.rki.coronawarnapp.tracing.TracingProgress
@@ -51,10 +50,8 @@ class TracingStateProvider @AssistedInject constructor(
         latestSubmission,
         isBackgroundJobEnabled ->
 
-        val (
-            latestCalc,
-            latestSuccessfulCalc
-        ) = riskLevelResults.tryLatestResultsWithDefaults()
+        val latestCalc = riskLevelResults.lastCalculated
+        val latestSuccessfulCalc = riskLevelResults.lastSuccessfullyCalculated
 
         return@combine when {
             tracingStatus == GeneralTracingStatus.Status.TRACING_INACTIVE -> TracingDisabled(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/states/TracingStateProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/states/TracingStateProvider.kt
@@ -51,12 +51,12 @@ class TracingStateProvider @AssistedInject constructor(
         isBackgroundJobEnabled ->
 
         val latestCalc = riskLevelResults.lastCalculated
-        val latestSuccessfulCalc = riskLevelResults.lastSuccessfullyCalculated
+        val lastSuccessfullyCalculated = riskLevelResults.lastSuccessfullyCalculated
 
         return@combine when {
             tracingStatus == GeneralTracingStatus.Status.TRACING_INACTIVE -> TracingDisabled(
                 isInDetailsMode = isDetailsMode,
-                riskState = latestSuccessfulCalc.riskState,
+                riskState = lastSuccessfullyCalculated.riskState,
                 lastExposureDetectionTime = latestSubmission?.startedAt
             )
             tracingProgress != TracingProgress.Idle -> TracingInProgress(
@@ -83,7 +83,7 @@ class TracingStateProvider @AssistedInject constructor(
             )
             else -> TracingFailed(
                 isInDetailsMode = isDetailsMode,
-                riskState = latestSuccessfulCalc.riskState,
+                riskState = lastSuccessfullyCalculated.riskState,
                 lastExposureDetectionTime = latestSubmission?.startedAt
             )
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/details/TracingDetailsFragmentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/details/TracingDetailsFragmentViewModel.kt
@@ -9,7 +9,6 @@ import de.rki.coronawarnapp.datadonation.survey.Surveys.ConsentResult.AlreadyGiv
 import de.rki.coronawarnapp.datadonation.survey.Surveys.ConsentResult.Needed
 import de.rki.coronawarnapp.risk.RiskState
 import de.rki.coronawarnapp.risk.storage.RiskLevelStorage
-import de.rki.coronawarnapp.risk.tryLatestResultsWithDefaults
 import de.rki.coronawarnapp.storage.TracingRepository
 import de.rki.coronawarnapp.tracing.GeneralTracingStatus
 import de.rki.coronawarnapp.tracing.states.IncreasedRisk
@@ -81,7 +80,7 @@ class TracingDetailsFragmentViewModel @AssistedInject constructor(
         riskLevelResults,
         isBackgroundJobEnabled ->
 
-        val (latestCalc, _) = riskLevelResults.tryLatestResultsWithDefaults()
+        val latestCalc = riskLevelResults.lastCalculated
 
         val isRestartButtonEnabled = !isBackgroundJobEnabled || latestCalc.riskState == RiskState.CALCULATION_FAILED
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/details/TracingDetailsItemProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/details/TracingDetailsItemProvider.kt
@@ -5,7 +5,6 @@ import de.rki.coronawarnapp.datadonation.survey.Surveys
 import de.rki.coronawarnapp.installTime.InstallTimeProvider
 import de.rki.coronawarnapp.risk.RiskState
 import de.rki.coronawarnapp.risk.storage.RiskLevelStorage
-import de.rki.coronawarnapp.risk.tryLatestResultsWithDefaults
 import de.rki.coronawarnapp.tracing.GeneralTracingStatus
 import de.rki.coronawarnapp.tracing.GeneralTracingStatus.Status
 import de.rki.coronawarnapp.tracing.ui.details.items.DetailsItem
@@ -43,11 +42,12 @@ class TracingDetailsItemProvider @Inject constructor(
         riskLevelResults,
         availableSurveys ->
 
-        val (latestCalc, _) = riskLevelResults.tryLatestResultsWithDefaults()
+        val latestCalc = riskLevelResults.lastCalculated
 
         mutableListOf<DetailsItem>().apply {
             if (status != Status.TRACING_INACTIVE &&
-                latestCalc.riskState == RiskState.LOW_RISK &&
+                // TODO not sure which risk state should be used here
+                latestCalc.ewRiskLevelResult.riskState == RiskState.LOW_RISK &&
                 latestCalc.ewRiskLevelResult.matchedKeyCount > 0
             ) {
                 add(AdditionalInfoLowRiskBox.Item)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/details/TracingDetailsItemProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/details/TracingDetailsItemProvider.kt
@@ -46,8 +46,7 @@ class TracingDetailsItemProvider @Inject constructor(
 
         mutableListOf<DetailsItem>().apply {
             if (status != Status.TRACING_INACTIVE &&
-                // TODO not sure which risk state should be used here
-                latestCalc.ewRiskLevelResult.riskState == RiskState.LOW_RISK &&
+                latestCalc.riskState == RiskState.LOW_RISK &&
                 latestCalc.ewRiskLevelResult.matchedKeyCount > 0
             ) {
                 add(AdditionalInfoLowRiskBox.Item)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/details/items/riskdetails/DetailsLowRiskBox.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/details/items/riskdetails/DetailsLowRiskBox.kt
@@ -50,6 +50,7 @@ class DetailsLowRiskBox(
     ) : RiskDetailsStateItem {
 
         fun getRiskDetailsRiskLevelBody(c: Context): String {
+            // TODO consider pt encounters?
             return c.getString(
                 if (matchedKeyCount > 0) R.string.risk_details_information_body_low_risk_with_encounter
                 else R.string.risk_details_information_body_low_risk

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/contactdiary/ui/overview/ContactDiaryOverviewViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/contactdiary/ui/overview/ContactDiaryOverviewViewModelTest.kt
@@ -15,8 +15,8 @@ import de.rki.coronawarnapp.contactdiary.ui.overview.adapter.day.riskevent.RiskE
 import de.rki.coronawarnapp.contactdiary.ui.overview.adapter.subheader.OverviewSubHeaderItem
 import de.rki.coronawarnapp.contactdiary.util.ContactDiaryData
 import de.rki.coronawarnapp.contactdiary.util.mockStringsForContactDiaryExporterTests
+import de.rki.coronawarnapp.presencetracing.risk.TraceLocationCheckInRisk
 import de.rki.coronawarnapp.risk.RiskState
-import de.rki.coronawarnapp.risk.TraceLocationCheckInRisk
 import de.rki.coronawarnapp.risk.result.ExposureWindowDayRisk
 import de.rki.coronawarnapp.risk.storage.RiskLevelStorage
 import de.rki.coronawarnapp.server.protocols.internal.v2.RiskCalculationParametersOuterClass

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/presencetracing/risk/CheckInWarningMatcherTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/presencetracing/risk/CheckInWarningMatcherTest.kt
@@ -4,7 +4,6 @@ import de.rki.coronawarnapp.eventregistration.checkins.CheckInRepository
 import de.rki.coronawarnapp.eventregistration.checkins.download.TraceTimeIntervalWarningPackage
 import de.rki.coronawarnapp.eventregistration.checkins.download.TraceTimeIntervalWarningRepository
 import de.rki.coronawarnapp.server.protocols.internal.pt.TraceWarning
-import de.rki.coronawarnapp.util.debug.measureTime
 import io.mockk.MockKAnnotations
 import io.mockk.Runs
 import io.mockk.coEvery
@@ -18,7 +17,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.TestDispatcherProvider
-import timber.log.Timber
 
 class CheckInWarningMatcherTest : BaseTest() {
 
@@ -29,12 +27,10 @@ class CheckInWarningMatcherTest : BaseTest() {
     @BeforeEach
     fun setup() {
         MockKAnnotations.init(this)
-        coEvery { presenceTracingRiskRepository.reportSuccessfulCalculation(any()) } just Runs
+        coEvery { presenceTracingRiskRepository.reportSuccessfulCalculation(any(), any()) } just Runs
         coEvery { presenceTracingRiskRepository.deleteAllMatches() } just Runs
         coEvery { presenceTracingRiskRepository.deleteStaleData() } just Runs
-        // TODO tests
-        coEvery { presenceTracingRiskRepository.deleteMatchesOfPackage(any()) } just Runs
-        coEvery { presenceTracingRiskRepository.markPackageProcessed(any()) } just Runs
+        coEvery { presenceTracingRiskRepository.reportFailedCalculation() } just Runs
     }
 
     @Test
@@ -81,8 +77,20 @@ class CheckInWarningMatcherTest : BaseTest() {
 
         runBlockingTest {
             createInstance().execute()
-            coVerify(exactly = 1) { presenceTracingRiskRepository.reportSuccessfulCalculation(any()) }
-            coVerify(exactly = 0) { presenceTracingRiskRepository.deleteAllMatches() }
+            coVerify(exactly = 1) {
+                presenceTracingRiskRepository.reportSuccessfulCalculation(
+                    listOf(warningPackage), any()
+                )
+            }
+            coVerify(exactly = 0) {
+                presenceTracingRiskRepository.deleteAllMatches()
+            }
+            coVerify(exactly = 0) {
+                presenceTracingRiskRepository.reportFailedCalculation()
+            }
+            coVerify(exactly = 1) {
+                presenceTracingRiskRepository.deleteStaleData()
+            }
         }
     }
 
@@ -130,8 +138,18 @@ class CheckInWarningMatcherTest : BaseTest() {
 
         runBlockingTest {
             createInstance().execute()
-            coVerify(exactly = 1) { presenceTracingRiskRepository.reportSuccessfulCalculation(emptyList()) }
-            coVerify(exactly = 0) { presenceTracingRiskRepository.deleteAllMatches() }
+            coVerify(exactly = 1) {
+                presenceTracingRiskRepository.reportSuccessfulCalculation(listOf(warningPackage), emptyList())
+            }
+            coVerify(exactly = 0) {
+                presenceTracingRiskRepository.deleteAllMatches()
+            }
+            coVerify(exactly = 0) {
+                presenceTracingRiskRepository.reportFailedCalculation()
+            }
+            coVerify(exactly = 1) {
+                presenceTracingRiskRepository.deleteStaleData()
+            }
         }
     }
 
@@ -165,14 +183,26 @@ class CheckInWarningMatcherTest : BaseTest() {
 
         runBlockingTest {
             createInstance().execute()
-            coVerify(exactly = 1) { presenceTracingRiskRepository.reportSuccessfulCalculation(emptyList()) }
-            coVerify(exactly = 0) { presenceTracingRiskRepository.deleteAllMatches() }
+            coVerify(exactly = 1) {
+                presenceTracingRiskRepository.reportSuccessfulCalculation(
+                    warningPackages = listOf(warningPackage),
+                    overlapList = emptyList()
+                )
+            }
+            coVerify(exactly = 0) {
+                presenceTracingRiskRepository.deleteAllMatches()
+            }
+            coVerify(exactly = 0) {
+                presenceTracingRiskRepository.reportFailedCalculation()
+            }
+            coVerify(exactly = 1) {
+                presenceTracingRiskRepository.deleteStaleData()
+            }
         }
     }
 
     @Test
     fun `deletes all matches if no check-ins`() {
-
         val warning1 = createWarning(
             traceLocationId = "69eb427e1a48133970486244487e31b3f1c5bde47415db9b52cc5a2ece1e0060",
             startIntervalDateStr = "2021-03-04T10:00+01:00",
@@ -202,47 +232,65 @@ class CheckInWarningMatcherTest : BaseTest() {
 
         runBlockingTest {
             createInstance().execute()
-            coVerify(exactly = 1) { presenceTracingRiskRepository.reportSuccessfulCalculation(emptyList()) }
-            coVerify(exactly = 1) { presenceTracingRiskRepository.deleteAllMatches() }
+            coVerify(exactly = 1) {
+                presenceTracingRiskRepository.reportSuccessfulCalculation(listOf(warningPackage), emptyList())
+            }
+            coVerify(exactly = 1) {
+                presenceTracingRiskRepository.deleteAllMatches()
+            }
+            coVerify(exactly = 0) {
+                presenceTracingRiskRepository.reportFailedCalculation()
+            }
+            coVerify(exactly = 1) {
+                presenceTracingRiskRepository.deleteStaleData()
+            }
         }
     }
 
     @Test
-    fun `test mass data`() {
-        val checkIns = (1L..100L).map {
-            createCheckIn(
-                id = it,
-                traceLocationId = it.toString(),
-                startDateStr = "2021-03-04T09:50+01:00",
-                endDateStr = "2021-03-04T10:05:15+01:00"
-            )
-        }
-        val warnings = (1L..1000L).map {
-            createWarning(
-                traceLocationId = it.toString(),
-                startIntervalDateStr = "2021-03-04T10:00+01:00",
-                period = 6,
-                transmissionRiskLevel = 8
-            )
-        }
+    fun `report failure if matching throws exception`() {
+        val checkIn1 = createCheckIn(
+            id = 2L,
+            traceLocationId = "fe84394e73838590cc7707aba0350c130f6d0fb6f0f2535f9735f481dee61871",
+            startDateStr = "2021-03-04T10:15+01:00",
+            endDateStr = "2021-03-04T10:17+01:00"
+        )
+        val checkIn2 = createCheckIn(
+            id = 3L,
+            traceLocationId = "69eb427e1a48133970486244487e31b3f1c5bde47415db9b52cc5a2ece1e0060",
+            startDateStr = "2021-03-04T09:15+01:00",
+            endDateStr = "2021-03-04T10:12+01:00"
+        )
+
+        every { checkInsRepository.allCheckIns } returns flowOf(listOf(checkIn1, checkIn2))
 
         val warningPackage = object : TraceTimeIntervalWarningPackage {
             override suspend fun extractTraceTimeIntervalWarnings(): List<TraceWarning.TraceTimeIntervalWarning> {
-                return warnings
+                throw Exception()
             }
 
             override val warningPackageId: String
                 get() = "id"
         }
 
-        every { checkInsRepository.allCheckIns } returns flowOf(checkIns)
         every { traceTimeIntervalWarningRepository.allWarningPackages } returns flowOf(listOf(warningPackage))
 
         runBlockingTest {
-            measureTime(
-                { Timber.d("Time to compare 200 checkIns with 1000 warnings: $it millis") },
-                { createInstance().execute() }
-            )
+            createInstance().execute()
+            coVerify(exactly = 0) {
+                presenceTracingRiskRepository.reportSuccessfulCalculation(
+                    listOf(warningPackage), any()
+                )
+            }
+            coVerify(exactly = 0) {
+                presenceTracingRiskRepository.deleteAllMatches()
+            }
+            coVerify(exactly = 1) {
+                presenceTracingRiskRepository.reportFailedCalculation()
+            }
+            coVerify(exactly = 1) {
+                presenceTracingRiskRepository.deleteStaleData()
+            }
         }
     }
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/presencetracing/risk/CheckInWarningMatcherTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/presencetracing/risk/CheckInWarningMatcherTest.kt
@@ -79,7 +79,8 @@ class CheckInWarningMatcherTest : BaseTest() {
             createInstance().execute()
             coVerify(exactly = 1) {
                 presenceTracingRiskRepository.reportSuccessfulCalculation(
-                    listOf(warningPackage), any()
+                    listOf(warningPackage),
+                    any()
                 )
             }
             coVerify(exactly = 0) {
@@ -279,7 +280,8 @@ class CheckInWarningMatcherTest : BaseTest() {
             createInstance().execute()
             coVerify(exactly = 0) {
                 presenceTracingRiskRepository.reportSuccessfulCalculation(
-                    listOf(warningPackage), any()
+                    listOf(warningPackage),
+                    any()
                 )
             }
             coVerify(exactly = 0) {

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/RiskLevelChangeDetectorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/RiskLevelChangeDetectorTest.kt
@@ -1,11 +1,14 @@
 package de.rki.coronawarnapp.risk
 
+import android.app.Notification
 import android.content.Context
+import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.google.android.gms.nearby.exposurenotification.ExposureWindow
 import de.rki.coronawarnapp.datadonation.analytics.storage.TestResultDonorSettings
 import de.rki.coronawarnapp.datadonation.survey.Surveys
 import de.rki.coronawarnapp.notification.GeneralNotifications
+import de.rki.coronawarnapp.presencetracing.risk.PtRiskLevelResult
 import de.rki.coronawarnapp.risk.RiskState.CALCULATION_FAILED
 import de.rki.coronawarnapp.risk.RiskState.INCREASED_RISK
 import de.rki.coronawarnapp.risk.RiskState.LOW_RISK
@@ -15,6 +18,7 @@ import de.rki.coronawarnapp.storage.TracingSettings
 import de.rki.coronawarnapp.submission.SubmissionSettings
 import de.rki.coronawarnapp.util.TimeStamper
 import de.rki.coronawarnapp.util.device.ForegroundState
+import de.rki.coronawarnapp.util.notifications.setContentTextExpandable
 import io.kotest.matchers.shouldBe
 import io.mockk.Called
 import io.mockk.MockKAnnotations
@@ -47,17 +51,23 @@ class RiskLevelChangeDetectorTest : BaseTest() {
     @MockK lateinit var tracingSettings: TracingSettings
     @MockK lateinit var testResultDonorSettings: TestResultDonorSettings
 
+    @MockK lateinit var builder: NotificationCompat.Builder
+    @MockK lateinit var notification: Notification
+
     @BeforeEach
     fun setup() {
         MockKAnnotations.init(this)
 
         every { tracingSettings.isUserToBeNotifiedOfLoweredRiskLevel } returns mockFlowPreference(false)
         every { submissionSettings.isSubmissionSuccessful } returns false
-        every { foregroundState.isInForeground } returns flowOf(true)
+        every { foregroundState.isInForeground } returns flowOf(false)
         every { notificationManagerCompat.areNotificationsEnabled() } returns true
 
         every { riskLevelSettings.lastChangeCheckedRiskLevelTimestamp = any() } just Runs
         every { riskLevelSettings.lastChangeCheckedRiskLevelTimestamp } returns null
+
+        every { riskLevelSettings.lastChangeCheckedRiskLevelCombinedTimestamp = any() } just Runs
+        every { riskLevelSettings.lastChangeCheckedRiskLevelCombinedTimestamp } returns null
 
         every { riskLevelSettings.lastChangeToHighRiskLevelTimestamp = any() } just Runs
         every { riskLevelSettings.lastChangeToHighRiskLevelTimestamp } returns null
@@ -66,10 +76,17 @@ class RiskLevelChangeDetectorTest : BaseTest() {
 
         every { testResultDonorSettings.riskLevelTurnedRedTime } returns mockFlowPreference(null)
         every { testResultDonorSettings.mostRecentDateWithHighOrLowRiskLevel } returns mockFlowPreference(null)
-        every { riskLevelStorage.latestCombinedEwPtRiskLevelResults } returns flowOf(listOf())
+
+        every { builder.build() } returns notification
+        every { builder.setContentTitle(any()) } returns builder
+        every { builder.setContentTextExpandable(any()) } returns builder
+        every { builder.setContentText(any()) } returns builder
+        every { builder.setStyle(any()) } returns builder
+        every { notificationHelper.newBaseBuilder() } returns builder
+        every { context.getString(any()) } returns ""
     }
 
-    private fun createRiskLevel(
+    private fun createEwRiskLevel(
         riskState: RiskState,
         calculatedAt: Instant = Instant.EPOCH,
         ewAggregatedRiskResult: EwAggregatedRiskResult? = null
@@ -82,6 +99,23 @@ class RiskLevelChangeDetectorTest : BaseTest() {
         override val matchedKeyCount: Int = 0
         override val daysWithEncounters: Int = 0
     }
+
+    private fun createPtRiskLevel(
+        riskState: RiskState,
+        calculatedAt: Instant = Instant.EPOCH
+    ): PtRiskLevelResult = PtRiskLevelResult(
+        calculatedAt = calculatedAt,
+        riskState = riskState
+    )
+
+    private fun createCombinedRiskLevel(
+        riskState: RiskState,
+        calculatedAt: Instant = Instant.EPOCH,
+        ewAggregatedRiskResult: EwAggregatedRiskResult? = null
+    ): CombinedEwPtRiskLevelResult = CombinedEwPtRiskLevelResult(
+        ewRiskLevelResult = createEwRiskLevel(riskState, calculatedAt, ewAggregatedRiskResult),
+        ptRiskLevelResult = createPtRiskLevel(riskState, calculatedAt)
+    )
 
     private fun createInstance(scope: CoroutineScope) = RiskLevelChangeDetector(
         context = context,
@@ -99,7 +133,40 @@ class RiskLevelChangeDetectorTest : BaseTest() {
 
     @Test
     fun `nothing happens if there is only one result yet`() {
-        every { riskLevelStorage.latestEwRiskLevelResults } returns flowOf(listOf(createRiskLevel(LOW_RISK)))
+        every { riskLevelStorage.latestCombinedEwPtRiskLevelResults } returns
+            flowOf(listOf(createCombinedRiskLevel(LOW_RISK)))
+        every { riskLevelStorage.latestEwRiskLevelResults } returns flowOf(listOf(createEwRiskLevel(LOW_RISK)))
+
+        runBlockingTest {
+            val instance = createInstance(scope = this)
+            instance.launch()
+
+            advanceUntilIdle()
+
+            coVerifySequence {
+                notificationManagerCompat wasNot Called
+                surveys wasNot Called
+                testResultDonorSettings wasNot Called
+            }
+        }
+    }
+
+    @Test
+    fun `no risk level change, nothing should happen`() {
+        every { riskLevelStorage.latestEwRiskLevelResults } returns flowOf(
+            listOf(
+                createEwRiskLevel(LOW_RISK),
+                createEwRiskLevel(LOW_RISK)
+            )
+        )
+
+        every { riskLevelStorage.latestCombinedEwPtRiskLevelResults } returns
+            flowOf(
+                listOf(
+                    createCombinedRiskLevel(LOW_RISK),
+                    createCombinedRiskLevel(LOW_RISK)
+                )
+            )
 
         runBlockingTest {
             val instance = createInstance(scope = this)
@@ -115,13 +182,20 @@ class RiskLevelChangeDetectorTest : BaseTest() {
     }
 
     @Test
-    fun `no risklevel change, nothing should happen`() {
+    fun `combined risk state change from HIGH to LOW triggers notification`() {
         every { riskLevelStorage.latestEwRiskLevelResults } returns flowOf(
             listOf(
-                createRiskLevel(LOW_RISK),
-                createRiskLevel(LOW_RISK)
+                createEwRiskLevel(LOW_RISK)
             )
         )
+
+        every { riskLevelStorage.latestCombinedEwPtRiskLevelResults } returns
+            flowOf(
+                listOf(
+                    createCombinedRiskLevel(LOW_RISK, calculatedAt = Instant.EPOCH.plus(1)),
+                    createCombinedRiskLevel(INCREASED_RISK, calculatedAt = Instant.EPOCH)
+                )
+            )
 
         runBlockingTest {
             val instance = createInstance(scope = this)
@@ -130,23 +204,55 @@ class RiskLevelChangeDetectorTest : BaseTest() {
             advanceUntilIdle()
 
             coVerifySequence {
-                notificationManagerCompat wasNot Called
-                surveys wasNot Called
+                submissionSettings.isSubmissionSuccessful
+                foregroundState.isInForeground
+                notificationHelper.newBaseBuilder()
+                notificationHelper.sendNotification(any(), any())
             }
         }
     }
 
-    // TODO test if risk level change for combined risk triggers notification
-
     @Test
-    fun `risklevel went from HIGH to LOW`() {
+    fun `combined risk state change from LOW to HIGH triggers notification`() {
         every { riskLevelStorage.latestEwRiskLevelResults } returns flowOf(
             listOf(
-                createRiskLevel(LOW_RISK, calculatedAt = Instant.EPOCH.plus(1)),
-                createRiskLevel(INCREASED_RISK, calculatedAt = Instant.EPOCH)
+                createEwRiskLevel(LOW_RISK)
             )
         )
 
+        every { riskLevelStorage.latestCombinedEwPtRiskLevelResults } returns
+            flowOf(
+                listOf(
+                    createCombinedRiskLevel(INCREASED_RISK, calculatedAt = Instant.EPOCH.plus(1)),
+                    createCombinedRiskLevel(LOW_RISK, calculatedAt = Instant.EPOCH)
+                )
+            )
+
+        runBlockingTest {
+            val instance = createInstance(scope = this)
+            instance.launch()
+
+            advanceUntilIdle()
+
+            coVerifySequence {
+                submissionSettings.isSubmissionSuccessful
+                foregroundState.isInForeground
+                notificationHelper.newBaseBuilder()
+                notificationHelper.sendNotification(any(), any())
+            }
+        }
+    }
+
+    @Test
+    fun `risk level went from HIGH to LOW resets survey`() {
+        every { riskLevelStorage.latestEwRiskLevelResults } returns flowOf(
+            listOf(
+                createEwRiskLevel(LOW_RISK, calculatedAt = Instant.EPOCH.plus(1)),
+                createEwRiskLevel(INCREASED_RISK, calculatedAt = Instant.EPOCH)
+            )
+        )
+        every { riskLevelStorage.latestCombinedEwPtRiskLevelResults } returns
+            flowOf(listOf(createCombinedRiskLevel(LOW_RISK)))
         runBlockingTest {
             val instance = createInstance(scope = this)
             instance.launch()
@@ -159,16 +265,16 @@ class RiskLevelChangeDetectorTest : BaseTest() {
         }
     }
 
-    // TODO test if risk level change for combined risk triggers notification
-
     @Test
-    fun `risklevel went from LOW to HIGH`() {
+    fun `risk level went from LOW to HIGH`() {
         every { riskLevelStorage.latestEwRiskLevelResults } returns flowOf(
             listOf(
-                createRiskLevel(INCREASED_RISK, calculatedAt = Instant.EPOCH.plus(1)),
-                createRiskLevel(LOW_RISK, calculatedAt = Instant.EPOCH)
+                createEwRiskLevel(INCREASED_RISK, calculatedAt = Instant.EPOCH.plus(1)),
+                createEwRiskLevel(LOW_RISK, calculatedAt = Instant.EPOCH)
             )
         )
+        every { riskLevelStorage.latestCombinedEwPtRiskLevelResults } returns
+            flowOf(listOf(createCombinedRiskLevel(LOW_RISK)))
 
         runBlockingTest {
             val instance = createInstance(scope = this)
@@ -183,14 +289,47 @@ class RiskLevelChangeDetectorTest : BaseTest() {
     }
 
     @Test
-    fun `risklevel went from LOW to HIGH but it is has already been processed`() {
+    fun `risk level went from LOW to HIGH but it is has already been processed`() {
         every { riskLevelStorage.latestEwRiskLevelResults } returns flowOf(
             listOf(
-                createRiskLevel(INCREASED_RISK, calculatedAt = Instant.EPOCH.plus(1)),
-                createRiskLevel(LOW_RISK, calculatedAt = Instant.EPOCH)
+                createEwRiskLevel(INCREASED_RISK, calculatedAt = Instant.EPOCH.plus(1)),
+                createEwRiskLevel(LOW_RISK, calculatedAt = Instant.EPOCH)
             )
         )
+        every { riskLevelStorage.latestCombinedEwPtRiskLevelResults } returns
+            flowOf(listOf(createCombinedRiskLevel(LOW_RISK)))
         every { riskLevelSettings.lastChangeCheckedRiskLevelTimestamp } returns Instant.EPOCH.plus(1)
+
+        runBlockingTest {
+            val instance = createInstance(scope = this)
+            instance.launch()
+
+            advanceUntilIdle()
+
+            coVerifySequence {
+                notificationManagerCompat wasNot Called
+                surveys wasNot Called
+            }
+        }
+    }
+
+    @Test
+    fun `combined risk level went from LOW to HIGH but it is has already been processed`() {
+        every { riskLevelStorage.latestEwRiskLevelResults } returns flowOf(
+            listOf(
+                createEwRiskLevel(LOW_RISK)
+            )
+        )
+
+        every { riskLevelStorage.latestCombinedEwPtRiskLevelResults } returns
+            flowOf(
+                listOf(
+                    createCombinedRiskLevel(INCREASED_RISK, calculatedAt = Instant.EPOCH.plus(1)),
+                    createCombinedRiskLevel(LOW_RISK, calculatedAt = Instant.EPOCH)
+                )
+            )
+
+        every { riskLevelSettings.lastChangeCheckedRiskLevelCombinedTimestamp } returns Instant.EPOCH.plus(1)
 
         runBlockingTest {
             val instance = createInstance(scope = this)
@@ -211,16 +350,19 @@ class RiskLevelChangeDetectorTest : BaseTest() {
 
         every { riskLevelStorage.latestEwRiskLevelResults } returns flowOf(
             listOf(
-                createRiskLevel(
+                createEwRiskLevel(
                     INCREASED_RISK,
                     calculatedAt = Instant.EPOCH.plus(2),
                     ewAggregatedRiskResult = mockk<EwAggregatedRiskResult>().apply {
                         every { isIncreasedRisk() } returns true
                     }
                 ),
-                createRiskLevel(LOW_RISK, calculatedAt = Instant.EPOCH)
+                createEwRiskLevel(LOW_RISK, calculatedAt = Instant.EPOCH)
             )
         )
+
+        every { riskLevelStorage.latestCombinedEwPtRiskLevelResults } returns
+            flowOf(listOf(createCombinedRiskLevel(LOW_RISK)))
 
         runBlockingTest {
             val instance = createInstance(scope = this)
@@ -245,7 +387,7 @@ class RiskLevelChangeDetectorTest : BaseTest() {
     fun `mostRecentDateWithHighOrLowRiskLevel is updated every time`() {
         every { riskLevelStorage.latestEwRiskLevelResults } returns flowOf(
             listOf(
-                createRiskLevel(
+                createEwRiskLevel(
                     INCREASED_RISK,
                     calculatedAt = Instant.EPOCH.plus(1),
                     ewAggregatedRiskResult = mockk<EwAggregatedRiskResult>().apply {
@@ -253,9 +395,11 @@ class RiskLevelChangeDetectorTest : BaseTest() {
                         every { isIncreasedRisk() } returns true
                     }
                 ),
-                createRiskLevel(LOW_RISK, calculatedAt = Instant.EPOCH)
+                createEwRiskLevel(LOW_RISK, calculatedAt = Instant.EPOCH)
             )
         )
+        every { riskLevelStorage.latestCombinedEwPtRiskLevelResults } returns
+            flowOf(listOf(createCombinedRiskLevel(LOW_RISK)))
 
         runBlockingTest {
             val instance = createInstance(scope = this)
@@ -267,7 +411,7 @@ class RiskLevelChangeDetectorTest : BaseTest() {
 
         every { riskLevelStorage.latestEwRiskLevelResults } returns flowOf(
             listOf(
-                createRiskLevel(
+                createEwRiskLevel(
                     INCREASED_RISK,
                     calculatedAt = Instant.EPOCH.plus(1),
                     ewAggregatedRiskResult = mockk<EwAggregatedRiskResult>().apply {
@@ -275,7 +419,7 @@ class RiskLevelChangeDetectorTest : BaseTest() {
                         every { isIncreasedRisk() } returns false
                     }
                 ),
-                createRiskLevel(LOW_RISK, calculatedAt = Instant.EPOCH)
+                createEwRiskLevel(LOW_RISK, calculatedAt = Instant.EPOCH)
             )
         )
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/storage/BaseRiskLevelStorageTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/storage/BaseRiskLevelStorageTest.kt
@@ -256,7 +256,7 @@ class BaseRiskLevelStorageTest : BaseTest() {
 
             // result from the combination with initial ew low risk result
             riskLevelResults[1].calculatedAt shouldBe ewCalculatedAt.minus(400L)
-            riskLevelResults[1].riskState shouldBe RiskState.LOW_RISK
+            riskLevelResults[1].riskState shouldBe RiskState.CALCULATION_FAILED
 
             verify {
                 riskResultTables.latestEntries(2)

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/storage/BaseRiskLevelStorageTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/storage/BaseRiskLevelStorageTest.kt
@@ -1,7 +1,11 @@
 package de.rki.coronawarnapp.risk.storage
 
+import de.rki.coronawarnapp.presencetracing.risk.PresenceTracingDayRisk
 import de.rki.coronawarnapp.presencetracing.risk.PresenceTracingRiskRepository
+import de.rki.coronawarnapp.presencetracing.risk.PtRiskLevelResult
 import de.rki.coronawarnapp.risk.EwRiskLevelResult
+import de.rki.coronawarnapp.risk.RiskState
+import de.rki.coronawarnapp.risk.storage.RiskStorageTestData.ewCalculatedAt
 import de.rki.coronawarnapp.risk.storage.RiskStorageTestData.testAggregatedRiskPerDateResult
 import de.rki.coronawarnapp.risk.storage.RiskStorageTestData.testExposureWindow
 import de.rki.coronawarnapp.risk.storage.RiskStorageTestData.testExposureWindowDaoWrapper
@@ -14,6 +18,7 @@ import de.rki.coronawarnapp.risk.storage.internal.RiskResultDatabase.AggregatedR
 import de.rki.coronawarnapp.risk.storage.internal.RiskResultDatabase.ExposureWindowsDao
 import de.rki.coronawarnapp.risk.storage.internal.RiskResultDatabase.Factory
 import de.rki.coronawarnapp.risk.storage.internal.RiskResultDatabase.RiskResultsDao
+import de.rki.coronawarnapp.util.TimeAndDateExtensions.toLocalDateUtc
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -32,6 +37,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
+import org.joda.time.Instant
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
@@ -72,6 +78,7 @@ class BaseRiskLevelStorageTest : BaseTest() {
         coEvery { presenceTracingRiskRepository.presenceTracingDayRisk } returns emptyFlow()
         coEvery { presenceTracingRiskRepository.latestAndLastSuccessful() } returns emptyFlow()
         coEvery { presenceTracingRiskRepository.latestEntries(any()) } returns emptyFlow()
+        coEvery { presenceTracingRiskRepository.clearAllTables() } just Runs
     }
 
     private fun createInstance(
@@ -104,11 +111,26 @@ class BaseRiskLevelStorageTest : BaseTest() {
             val instance = createInstance()
             val allEntries = instance.aggregatedRiskPerDateResultTables.allEntries()
             allEntries shouldBe testPersistedAggregatedRiskPerDateResultFlow
-            allEntries.first().map { it.toAggregatedRiskPerDateResult() } shouldBe listOf(testAggregatedRiskPerDateResult)
+            allEntries.first().map { it.toAggregatedRiskPerDateResult() } shouldBe listOf(
+                testAggregatedRiskPerDateResult
+            )
 
             val aggregatedRiskPerDateResults = instance.ewDayRiskStates.first()
             aggregatedRiskPerDateResults shouldNotBe listOf(testPersistedAggregatedRiskPerDateResult)
             aggregatedRiskPerDateResults shouldBe listOf(testAggregatedRiskPerDateResult)
+        }
+    }
+
+    @Test
+    fun `ptDayRiskStates are returned from database`() {
+        val testPresenceTracingDayRiskFlow = flowOf(listOf(testPresenceTracingDayRisk))
+        every { presenceTracingRiskRepository.presenceTracingDayRisk } returns testPresenceTracingDayRiskFlow
+
+        runBlockingTest {
+            val instance = createInstance()
+
+            val states = instance.ptDayRiskStates.first()
+            states shouldBe listOf(testPresenceTracingDayRisk)
         }
     }
 
@@ -170,6 +192,45 @@ class BaseRiskLevelStorageTest : BaseTest() {
         }
     }
 
+    @Test
+    fun `latestCombinedEwPtRiskLevelResults are returned from database and mapped`() {
+        every { riskResultTables.latestEntries(any()) } returns flowOf(listOf(testRiskLevelResultDao))
+        every { exposureWindowTables.getWindowsForResult(any()) } returns flowOf(listOf(testExposureWindowDaoWrapper))
+        val calculatedAt = ewCalculatedAt.plus(6000L)
+        every { presenceTracingRiskRepository.latestEntries(2) } returns flowOf(
+            listOf(
+                PtRiskLevelResult(
+                    calculatedAt = calculatedAt,
+                    presenceTracingDayRisk = null,
+                    riskState = RiskState.CALCULATION_FAILED
+                ),
+                PtRiskLevelResult(
+                    calculatedAt = ewCalculatedAt.minus(1000L),
+                    presenceTracingDayRisk = listOf(testPresenceTracingDayRisk),
+                    riskState = RiskState.INCREASED_RISK
+                )
+            )
+        )
+        runBlockingTest2(ignoreActive = true) {
+            val instance = createInstance(scope = this)
+
+            val riskLevelResults = instance.latestCombinedEwPtRiskLevelResults.first()
+            riskLevelResults.size shouldBe 2
+
+            riskLevelResults[0].calculatedAt shouldBe calculatedAt
+            riskLevelResults[0].riskState shouldBe RiskState.INCREASED_RISK
+            riskLevelResults[1].calculatedAt shouldBe ewCalculatedAt
+            riskLevelResults[1].riskState shouldBe RiskState.INCREASED_RISK
+
+            verify {
+                riskResultTables.latestEntries(2)
+                exposureWindowTables.getWindowsForResult(listOf(testRiskLevelResultDao.id))
+                presenceTracingRiskRepository.latestEntries(2)
+
+            }
+        }
+    }
+
     // This just tests the mapping, the correctness of the SQL statement is validated in an instrumentation test
     @Test
     fun `latestAndLastSuccessful with exposure windows are returned from database and mapped`() {
@@ -190,7 +251,46 @@ class BaseRiskLevelStorageTest : BaseTest() {
     }
 
     @Test
-    fun `errors when storing risklevel result are rethrown`() = runBlockingTest {
+    fun `latestAndLastSuccessfulCombinedEwPtRiskLevelResult are combined`() {
+        val calculatedAt = ewCalculatedAt.plus(6000L)
+        every { presenceTracingRiskRepository.latestAndLastSuccessful() } returns flowOf(
+            listOf(
+                PtRiskLevelResult(
+                    calculatedAt = calculatedAt,
+                    presenceTracingDayRisk = null,
+                    riskState = RiskState.CALCULATION_FAILED
+                ),
+                PtRiskLevelResult(
+                    calculatedAt = ewCalculatedAt.minus(1000L),
+                    presenceTracingDayRisk = listOf(testPresenceTracingDayRisk),
+                    riskState = RiskState.INCREASED_RISK
+                )
+            )
+        )
+        every { presenceTracingRiskRepository.presenceTracingDayRisk } returns flowOf(listOf(testPresenceTracingDayRisk))
+
+        every { riskResultTables.latestAndLastSuccessful() } returns flowOf(listOf(testRiskLevelResultDao))
+        every { exposureWindowTables.getWindowsForResult(any()) } returns flowOf(listOf(testExposureWindowDaoWrapper))
+
+        runBlockingTest2(ignoreActive = true) {
+            val instance = createInstance(scope = this)
+
+            val riskLevelResult = instance.latestAndLastSuccessfulCombinedEwPtRiskLevelResult.first()
+
+            riskLevelResult.lastCalculated.calculatedAt shouldBe calculatedAt
+            riskLevelResult.lastCalculated.riskState shouldBe RiskState.INCREASED_RISK
+            riskLevelResult.lastSuccessfullyCalculated.calculatedAt shouldBe calculatedAt
+            riskLevelResult.lastSuccessfullyCalculated.riskState shouldBe RiskState.INCREASED_RISK
+
+            verify {
+                presenceTracingRiskRepository.latestAndLastSuccessful()
+                presenceTracingRiskRepository.presenceTracingDayRisk
+            }
+        }
+    }
+
+    @Test
+    fun `errors when storing risk level result are rethrown`() = runBlockingTest {
         coEvery { riskResultTables.insertEntry(any()) } throws IllegalStateException("No body expects the...")
         val instance = createInstance()
         shouldThrow<java.lang.IllegalStateException> {
@@ -242,6 +342,14 @@ class BaseRiskLevelStorageTest : BaseTest() {
     @Test
     fun `clear works`() = runBlockingTest {
         createInstance().clear()
-        verify { database.clearAllTables() }
+        coVerify {
+            database.clearAllTables()
+            presenceTracingRiskRepository.clearAllTables()
+        }
     }
 }
+
+private val testPresenceTracingDayRisk = PresenceTracingDayRisk(
+    Instant.now().toLocalDateUtc(),
+    RiskState.INCREASED_RISK
+)

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/storage/BaseRiskLevelStorageTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/storage/BaseRiskLevelStorageTest.kt
@@ -226,7 +226,6 @@ class BaseRiskLevelStorageTest : BaseTest() {
                 riskResultTables.latestEntries(2)
                 exposureWindowTables.getWindowsForResult(listOf(testRiskLevelResultDao.id))
                 presenceTracingRiskRepository.latestEntries(2)
-
             }
         }
     }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/storage/CombineRiskTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/storage/CombineRiskTest.kt
@@ -1,13 +1,17 @@
 package de.rki.coronawarnapp.risk.storage
 
+import com.google.android.gms.nearby.exposurenotification.ExposureWindow
 import de.rki.coronawarnapp.presencetracing.risk.PresenceTracingDayRisk
+import de.rki.coronawarnapp.presencetracing.risk.PtRiskLevelResult
+import de.rki.coronawarnapp.risk.EwRiskLevelResult
 import de.rki.coronawarnapp.risk.RiskState
+import de.rki.coronawarnapp.risk.result.EwAggregatedRiskResult
 import de.rki.coronawarnapp.risk.result.ExposureWindowDayRisk
 import de.rki.coronawarnapp.server.protocols.internal.v2.RiskCalculationParametersOuterClass.NormalizedTimeToRiskLevelMapping.RiskLevel
 import io.kotest.matchers.shouldBe
+import org.joda.time.Instant
 import org.joda.time.LocalDate
 import org.junit.jupiter.api.Test
-import java.time.Instant
 
 class CombineRiskTest {
 
@@ -26,33 +30,33 @@ class CombineRiskTest {
             riskState = RiskState.CALCULATION_FAILED
         )
         val ewRisk = ExposureWindowDayRisk(
-            dateMillisSinceEpoch = Instant.parse("2021-03-22T14:00:00.000Z").toEpochMilli(),
+            dateMillisSinceEpoch = Instant.parse("2021-03-22T14:00:00.000Z").millis,
             riskLevel = RiskLevel.HIGH,
             0,
             0
         )
         val ewRisk2 = ExposureWindowDayRisk(
-            dateMillisSinceEpoch = Instant.parse("2021-03-19T14:00:00.000Z").toEpochMilli(),
+            dateMillisSinceEpoch = Instant.parse("2021-03-19T14:00:00.000Z").millis,
             riskLevel = RiskLevel.LOW,
             0,
             0
         )
         val ewRisk3 = ExposureWindowDayRisk(
-            dateMillisSinceEpoch = Instant.parse("2021-03-20T14:00:00.000Z").toEpochMilli(),
+            dateMillisSinceEpoch = Instant.parse("2021-03-20T14:00:00.000Z").millis,
             riskLevel = RiskLevel.UNSPECIFIED,
             0,
             0
         )
         val ewRisk4 = ExposureWindowDayRisk(
-            dateMillisSinceEpoch = Instant.parse("2021-03-15T14:00:00.000Z").toEpochMilli(),
+            dateMillisSinceEpoch = Instant.parse("2021-03-15T14:00:00.000Z").millis,
             riskLevel = RiskLevel.UNSPECIFIED,
             0,
             0
         )
 
-        val ptRiskList: List<PresenceTracingDayRisk> = listOf(ptRisk, ptRisk2, ptRisk3)
-        val exposureWindowDayRiskList: List<ExposureWindowDayRisk> = listOf(ewRisk, ewRisk2, ewRisk3, ewRisk4)
-        val result = combineRisk(ptRiskList, exposureWindowDayRiskList)
+        val ptDayRiskList: List<PresenceTracingDayRisk> = listOf(ptRisk, ptRisk2, ptRisk3)
+        val ewDayRiskList: List<ExposureWindowDayRisk> = listOf(ewRisk, ewRisk2, ewRisk3, ewRisk4)
+        val result = combineRisk(ptDayRiskList, ewDayRiskList)
         result.size shouldBe 5
         result.find {
             it.localDate == LocalDate(2021, 3, 15)
@@ -72,6 +76,65 @@ class CombineRiskTest {
     }
 
     @Test
+    fun `combineEwPtRiskLevelResults works`() {
+        val startInstant = Instant.ofEpochMilli(10000)
+
+        val ptResult = PtRiskLevelResult(
+            calculatedAt = startInstant.plus(1000L),
+            riskState = RiskState.LOW_RISK
+        )
+        val ptResult2 = PtRiskLevelResult(
+            calculatedAt = startInstant.plus(3000L),
+            riskState = RiskState.CALCULATION_FAILED
+        )
+        val ptResult3 = PtRiskLevelResult(
+            calculatedAt = startInstant.plus(6000L),
+            riskState = RiskState.CALCULATION_FAILED
+        )
+        val ptResult4 = PtRiskLevelResult(
+            calculatedAt = startInstant.plus(7000L),
+            riskState = RiskState.CALCULATION_FAILED
+        )
+
+        val ptResults = listOf(ptResult, ptResult2, ptResult4, ptResult3)
+        val ewResult = createEwRiskLevelResult(
+            calculatedAt = startInstant.plus(2000L),
+            riskState = RiskState.CALCULATION_FAILED
+        )
+        val ewResult2 = createEwRiskLevelResult(
+            calculatedAt = startInstant.plus(4000L),
+            riskState = RiskState.INCREASED_RISK
+        )
+        val ewResult3 = createEwRiskLevelResult(
+            calculatedAt = startInstant.plus(5000L),
+            riskState = RiskState.CALCULATION_FAILED
+        )
+        val ewResult4 = createEwRiskLevelResult(
+            calculatedAt = startInstant.plus(8000L),
+            riskState = RiskState.CALCULATION_FAILED
+        )
+        val ewResults = listOf(ewResult, ewResult4, ewResult2, ewResult3)
+        val result = combineEwPtRiskLevelResults(ptResults, ewResults).sortedByDescending { it.calculatedAt }
+        result.size shouldBe 8
+        result[0].riskState shouldBe RiskState.CALCULATION_FAILED
+        result[0].calculatedAt shouldBe startInstant.plus(8000L)
+        result[1].riskState shouldBe RiskState.CALCULATION_FAILED
+        result[1].calculatedAt shouldBe startInstant.plus(7000L)
+        result[2].riskState shouldBe RiskState.CALCULATION_FAILED
+        result[2].calculatedAt shouldBe startInstant.plus(6000L)
+        result[3].riskState shouldBe RiskState.CALCULATION_FAILED
+        result[3].calculatedAt shouldBe startInstant.plus(5000L)
+        result[4].riskState shouldBe RiskState.INCREASED_RISK
+        result[4].calculatedAt shouldBe startInstant.plus(4000L)
+        result[5].riskState shouldBe RiskState.CALCULATION_FAILED
+        result[5].calculatedAt shouldBe startInstant.plus(3000L)
+        result[6].riskState shouldBe RiskState.LOW_RISK
+        result[6].calculatedAt shouldBe startInstant.plus(2000L)
+        result[7].riskState shouldBe RiskState.LOW_RISK
+        result[7].calculatedAt shouldBe startInstant.plus(1000L)
+    }
+
+    @Test
     fun `max RiskState works`() {
         combine(RiskState.INCREASED_RISK, RiskState.INCREASED_RISK) shouldBe RiskState.INCREASED_RISK
         combine(RiskState.INCREASED_RISK, RiskState.LOW_RISK) shouldBe RiskState.INCREASED_RISK
@@ -83,3 +146,17 @@ class CombineRiskTest {
         combine(RiskState.CALCULATION_FAILED, RiskState.CALCULATION_FAILED) shouldBe RiskState.CALCULATION_FAILED
     }
 }
+
+private fun createEwRiskLevelResult(
+    calculatedAt: Instant,
+    riskState: RiskState
+): EwRiskLevelResult = object : EwRiskLevelResult {
+    override val calculatedAt: Instant = calculatedAt
+    override val riskState: RiskState = riskState
+    override val failureReason: EwRiskLevelResult.FailureReason? = null
+    override val ewAggregatedRiskResult: EwAggregatedRiskResult? = null
+    override val exposureWindows: List<ExposureWindow>? = null
+    override val matchedKeyCount: Int = 0
+    override val daysWithEncounters: Int = 0
+}
+

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/storage/CombineRiskTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/storage/CombineRiskTest.kt
@@ -73,13 +73,13 @@ class CombineRiskTest {
 
     @Test
     fun `max RiskState works`() {
-        max(RiskState.INCREASED_RISK, RiskState.INCREASED_RISK) shouldBe RiskState.INCREASED_RISK
-        max(RiskState.INCREASED_RISK, RiskState.LOW_RISK) shouldBe RiskState.INCREASED_RISK
-        max(RiskState.INCREASED_RISK, RiskState.CALCULATION_FAILED) shouldBe RiskState.INCREASED_RISK
-        max(RiskState.LOW_RISK, RiskState.INCREASED_RISK) shouldBe RiskState.INCREASED_RISK
-        max(RiskState.CALCULATION_FAILED, RiskState.INCREASED_RISK) shouldBe RiskState.INCREASED_RISK
-        max(RiskState.LOW_RISK, RiskState.LOW_RISK) shouldBe RiskState.LOW_RISK
-        max(RiskState.CALCULATION_FAILED, RiskState.LOW_RISK) shouldBe RiskState.LOW_RISK
-        max(RiskState.CALCULATION_FAILED, RiskState.CALCULATION_FAILED) shouldBe RiskState.CALCULATION_FAILED
+        combine(RiskState.INCREASED_RISK, RiskState.INCREASED_RISK) shouldBe RiskState.INCREASED_RISK
+        combine(RiskState.INCREASED_RISK, RiskState.LOW_RISK) shouldBe RiskState.INCREASED_RISK
+        combine(RiskState.INCREASED_RISK, RiskState.CALCULATION_FAILED) shouldBe RiskState.INCREASED_RISK
+        combine(RiskState.LOW_RISK, RiskState.INCREASED_RISK) shouldBe RiskState.INCREASED_RISK
+        combine(RiskState.CALCULATION_FAILED, RiskState.INCREASED_RISK) shouldBe RiskState.INCREASED_RISK
+        combine(RiskState.LOW_RISK, RiskState.LOW_RISK) shouldBe RiskState.LOW_RISK
+        combine(RiskState.CALCULATION_FAILED, RiskState.LOW_RISK) shouldBe RiskState.LOW_RISK
+        combine(RiskState.CALCULATION_FAILED, RiskState.CALCULATION_FAILED) shouldBe RiskState.CALCULATION_FAILED
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/storage/CombineRiskTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/storage/CombineRiskTest.kt
@@ -159,4 +159,3 @@ private fun createEwRiskLevelResult(
     override val matchedKeyCount: Int = 0
     override val daysWithEncounters: Int = 0
 }
-

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/storage/RiskStorageTestData.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/storage/RiskStorageTestData.kt
@@ -14,9 +14,11 @@ import org.joda.time.Instant
 
 object RiskStorageTestData {
 
+    val ewCalculatedAt = Instant.ofEpochMilli(9999L)
+
     val testRiskLevelResultDao = PersistedRiskLevelResultDao(
         id = "riskresult-id",
-        calculatedAt = Instant.ofEpochMilli(9999L),
+        calculatedAt = ewCalculatedAt,
         failureReason = null,
         aggregatedRiskResult = PersistedRiskLevelResultDao.PersistedAggregatedRiskResult(
             totalRiskLevel = RiskCalculationParametersOuterClass.NormalizedTimeToRiskLevelMapping.RiskLevel.HIGH,
@@ -40,7 +42,7 @@ object RiskStorageTestData {
     )
 
     val testRisklevelResult = EwRiskLevelTaskResult(
-        calculatedAt = Instant.ofEpochMilli(9999L),
+        calculatedAt = ewCalculatedAt,
         ewAggregatedRiskResult = testAggregatedRiskResult,
         exposureWindows = null
     )
@@ -76,14 +78,14 @@ object RiskStorageTestData {
     }.build()
 
     val testAggregatedRiskPerDateResult = ExposureWindowDayRisk(
-        dateMillisSinceEpoch = 9999L,
+        dateMillisSinceEpoch = ewCalculatedAt.millis,
         riskLevel = RiskCalculationParametersOuterClass.NormalizedTimeToRiskLevelMapping.RiskLevel.HIGH,
         minimumDistinctEncountersWithLowRisk = 0,
         minimumDistinctEncountersWithHighRisk = 0
     )
 
     val testPersistedAggregatedRiskPerDateResult = PersistedAggregatedRiskPerDateResult(
-        dateMillisSinceEpoch = 9999L,
+        dateMillisSinceEpoch = ewCalculatedAt.millis,
         riskLevel = RiskCalculationParametersOuterClass.NormalizedTimeToRiskLevelMapping.RiskLevel.HIGH,
         minimumDistinctEncountersWithLowRisk = 0,
         minimumDistinctEncountersWithHighRisk = 0

--- a/Corona-Warn-App/src/testDevice/java/de/rki/coronawarnapp/test/risk/storage/DefaultRiskLevelStorageTest.kt
+++ b/Corona-Warn-App/src/testDevice/java/de/rki/coronawarnapp/test/risk/storage/DefaultRiskLevelStorageTest.kt
@@ -88,7 +88,7 @@ class DefaultRiskLevelStorageTest : BaseTest() {
 
         every { presenceTracingRiskRepository.traceLocationCheckInRiskStates } returns emptyFlow()
         every { presenceTracingRiskRepository.presenceTracingDayRisk } returns emptyFlow()
-        every { presenceTracingRiskRepository.latestAndLastSuccessful() } returns emptyFlow()
+        every { presenceTracingRiskRepository.allEntries() } returns emptyFlow()
         every { presenceTracingRiskRepository.latestEntries(any()) } returns emptyFlow()
     }
 

--- a/Corona-Warn-App/src/testDeviceForTesters/java/de/rki/coronawarnapp/test/risk/storage/DefaultRiskLevelStorageTest.kt
+++ b/Corona-Warn-App/src/testDeviceForTesters/java/de/rki/coronawarnapp/test/risk/storage/DefaultRiskLevelStorageTest.kt
@@ -88,7 +88,7 @@ class DefaultRiskLevelStorageTest : BaseTestInstrumentation() {
         // TODO tests
         every { presenceTracingRiskRepository.traceLocationCheckInRiskStates } returns emptyFlow()
         every { presenceTracingRiskRepository.presenceTracingDayRisk } returns emptyFlow()
-        every { presenceTracingRiskRepository.latestAndLastSuccessful() } returns emptyFlow()
+        every { presenceTracingRiskRepository.allEntries() } returns emptyFlow()
         every { presenceTracingRiskRepository.latestEntries(any()) } returns emptyFlow()
     }
 

--- a/Corona-Warn-App/src/testDeviceForTesters/java/de/rki/coronawarnapp/test/risk/storage/DefaultRiskLevelStorageTest.kt
+++ b/Corona-Warn-App/src/testDeviceForTesters/java/de/rki/coronawarnapp/test/risk/storage/DefaultRiskLevelStorageTest.kt
@@ -85,7 +85,6 @@ class DefaultRiskLevelStorageTest : BaseTestInstrumentation() {
         coEvery { exposureWindowTables.insertScanInstances(any()) } just Runs
         coEvery { exposureWindowTables.deleteByRiskResultId(any()) } returns 1
 
-        // TODO tests
         every { presenceTracingRiskRepository.traceLocationCheckInRiskStates } returns emptyFlow()
         every { presenceTracingRiskRepository.presenceTracingDayRisk } returns emptyFlow()
         every { presenceTracingRiskRepository.allEntries() } returns emptyFlow()

--- a/Corona-Warn-App/src/testDeviceForTesters/java/de/rki/coronawarnapp/test/risk/storage/DefaultRiskLevelStorageTest.kt
+++ b/Corona-Warn-App/src/testDeviceForTesters/java/de/rki/coronawarnapp/test/risk/storage/DefaultRiskLevelStorageTest.kt
@@ -85,6 +85,7 @@ class DefaultRiskLevelStorageTest : BaseTestInstrumentation() {
         coEvery { exposureWindowTables.insertScanInstances(any()) } just Runs
         coEvery { exposureWindowTables.deleteByRiskResultId(any()) } returns 1
 
+        // TODO tests
         every { presenceTracingRiskRepository.traceLocationCheckInRiskStates } returns emptyFlow()
         every { presenceTracingRiskRepository.presenceTracingDayRisk } returns emptyFlow()
         every { presenceTracingRiskRepository.latestAndLastSuccessful() } returns emptyFlow()


### PR DESCRIPTION
Bug fixes and unit tests

- Moved logic of reporting calculation success and failure from matcher to repository
- fixes bug in combining risk results
- adds db clearing on data reset

Still missing: unit test for PresenceTracingRiskRepository