### PR TITLE
Add new test environment TESTER-MOCK + clean up (DEV, EXPOSUREAPP-6138)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/eventregistration/checkins/qrcode/VerifiedTraceLocationTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/eventregistration/checkins/qrcode/VerifiedTraceLocationTest.kt
@@ -21,7 +21,7 @@ class VerifiedTraceLocationTest : BaseTestInstrumentation() {
     @Before
     fun setUp() {
         MockKAnnotations.init(this)
-        every { environmentSetup.appConfigVerificationKey } returns PUB_KEY
+        every { environmentSetup.appConfigPublicKey } returns PUB_KEY
     }
 
     // TODO: Ugly but kinda works

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/util/security/VerificationKeysTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/util/security/VerificationKeysTest.kt
@@ -20,7 +20,7 @@ class VerificationKeysTest {
     @Before
     fun setup() {
         MockKAnnotations.init(this)
-        every { environmentSetup.appConfigVerificationKey } returns PUB_KEY
+        every { environmentSetup.appConfigPublicKey } returns PUB_KEY
     }
 
     private fun createTool() = SignatureValidation(environmentSetup)

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragment.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragment.kt
@@ -70,7 +70,9 @@ class DebugOptionsFragment : Fragment(R.layout.fragment_test_debugoptions), Auto
                 environmentCdnurlSubmission.text = "Submission CDN:\n${state.urlSubmission}"
                 environmentCdnurlVerification.text = "Verification CDN:\n${state.urlVerification}"
                 environmentUrlDatadonation.text = "DataDonation:\n${state.urlDataDonation}"
-                environmentUrlQrcodePosterTemplate.text = "QR-Code Poster Template:\n${state.urlQrCodePosterTemplate}"
+                environmentLogUpload.text = "LogUpload:\n${state.logUpload}"
+                environmentPubkeyCrowdnotifier.text = "CrowdNotifierPubKey:\n${state.pubKeyCrowdNotifier}"
+                environmentPubkeyAppconfig.text = "AppConfigPubKey:\n${state.pubKeyAppConfig}"
             }
         }
         vm.environmentChangeEvent.observe2(this) {

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragment.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragment.kt
@@ -70,7 +70,7 @@ class DebugOptionsFragment : Fragment(R.layout.fragment_test_debugoptions), Auto
                 environmentCdnurlSubmission.text = "Submission CDN:\n${state.urlSubmission}"
                 environmentCdnurlVerification.text = "Verification CDN:\n${state.urlVerification}"
                 environmentUrlDatadonation.text = "DataDonation:\n${state.urlDataDonation}"
-                environmentLogUpload.text = "LogUpload:\n${state.logUpload}"
+                environmentUrlLogUpload.text = "LogUpload:\n${state.urlLogUpload}"
                 environmentPubkeyCrowdnotifier.text = "CrowdNotifierPubKey:\n${state.pubKeyCrowdNotifier}"
                 environmentPubkeyAppconfig.text = "AppConfigPubKey:\n${state.pubKeyAppConfig}"
             }

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/EnvironmentState.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/EnvironmentState.kt
@@ -9,7 +9,7 @@ data class EnvironmentState(
     val urlDownload: String,
     val urlVerification: String,
     val urlDataDonation: String,
-    val logUpload: String,
+    val urlLogUpload: String,
     val pubKeyCrowdNotifier: String,
     val pubKeyAppConfig: String,
 ) {
@@ -21,7 +21,7 @@ data class EnvironmentState(
             urlDownload = downloadCdnUrl,
             urlVerification = verificationCdnUrl,
             urlDataDonation = dataDonationCdnUrl,
-            logUpload = logUploadServerUrl,
+            urlLogUpload = logUploadServerUrl,
             pubKeyCrowdNotifier = crowdNotifierPublicKey,
             pubKeyAppConfig = appConfigPublicKey,
         )

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/EnvironmentState.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/EnvironmentState.kt
@@ -12,8 +12,7 @@ data class EnvironmentState(
     val logUpload: String,
     val pubKeyCrowdNotifier: String,
     val pubKeyAppConfig: String,
-
-    ) {
+) {
     companion object {
         internal fun EnvironmentSetup.toEnvironmentState() = EnvironmentState(
             current = currentEnvironment,

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/EnvironmentState.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/EnvironmentState.kt
@@ -9,9 +9,11 @@ data class EnvironmentState(
     val urlDownload: String,
     val urlVerification: String,
     val urlDataDonation: String,
-    val urlQrCodePosterTemplate: String
+    val logUpload: String,
+    val pubKeyCrowdNotifier: String,
+    val pubKeyAppConfig: String,
 
-) {
+    ) {
     companion object {
         internal fun EnvironmentSetup.toEnvironmentState() = EnvironmentState(
             current = currentEnvironment,
@@ -20,7 +22,9 @@ data class EnvironmentState(
             urlDownload = downloadCdnUrl,
             urlVerification = verificationCdnUrl,
             urlDataDonation = dataDonationCdnUrl,
-            urlQrCodePosterTemplate = qrCodePosterTemplateCdnUrl
+            logUpload = logUploadServerUrl,
+            pubKeyCrowdNotifier = crowdNotifierPublicKey,
+            pubKeyAppConfig = appConfigPublicKey,
         )
     }
 }

--- a/Corona-Warn-App/src/deviceForTesters/res/layout/fragment_test_debugoptions.xml
+++ b/Corona-Warn-App/src/deviceForTesters/res/layout/fragment_test_debugoptions.xml
@@ -54,7 +54,8 @@
                     app:layout_constraintTop_toBottomOf="@+id/new_debuglog_screen_explanation" />
             </androidx.constraintlayout.widget.ConstraintLayout>
 
-            <androidx.constraintlayout.widget.ConstraintLayout
+            <LinearLayout
+                android:orientation="vertical"
                 android:id="@+id/environment_container"
                 style="@style/Card"
                 android:layout_width="match_parent"
@@ -66,77 +67,71 @@
                     style="@style/headline6"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="Server environment"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
+                    android:text="Server environments" />
 
                 <TextView
                     android:id="@+id/environment_cdnurl_download"
-                    style="@style/body2"
+                    style="@style/TextAppearance.MaterialComponents.Caption"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/spacing_tiny"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/environment_title"
                     tools:text="Download: ?" />
 
                 <TextView
                     android:id="@+id/environment_cdnurl_submission"
-                    style="@style/body2"
+                    style="@style/TextAppearance.MaterialComponents.Caption"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/spacing_tiny"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/environment_cdnurl_download"
+                    android:layout_marginTop="4dp"
                     tools:text="Submission: ?" />
 
                 <TextView
                     android:id="@+id/environment_cdnurl_verification"
-                    style="@style/body2"
+                    style="@style/TextAppearance.MaterialComponents.Caption"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/spacing_tiny"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/environment_cdnurl_submission"
+                    android:layout_marginTop="4dp"
                     tools:text="Verification: ?" />
 
                 <TextView
                     android:id="@+id/environment_url_datadonation"
-                    style="@style/body2"
+                    style="@style/TextAppearance.MaterialComponents.Caption"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/spacing_tiny"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/environment_cdnurl_verification"
+                    android:layout_marginTop="4dp"
                     tools:text="DataDonation: ?" />
 
                 <TextView
-                    android:id="@+id/environment_url_qrcode_poster_template"
-                    style="@style/body2"
+                    android:id="@+id/environment_log_upload"
+                    style="@style/TextAppearance.MaterialComponents.Caption"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/spacing_tiny"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/environment_url_datadonation"
-                    tools:text="QR-Code poster template: ?" />
+                    android:layout_marginTop="4dp"
+                    tools:text="LogUpload: ?" />
+
+                <TextView
+                    android:id="@+id/environment_pubkey_appconfig"
+                    style="@style/TextAppearance.MaterialComponents.Caption"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    tools:text="AppConfigPubKey: ?" />
+
+                <TextView
+                    android:id="@+id/environment_pubkey_crowdnotifier"
+                    style="@style/TextAppearance.MaterialComponents.Caption"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    tools:text="CrowdNotifierPubKey: ?" />
 
                 <RadioGroup
                     android:id="@+id/environment_toggle_group"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/spacing_tiny"
-                    android:orientation="vertical"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/environment_url_qrcode_poster_template" />
-            </androidx.constraintlayout.widget.ConstraintLayout>
+                    android:layout_marginTop="16dp"
+                    android:orientation="vertical" />
+            </LinearLayout>
 
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>

--- a/Corona-Warn-App/src/deviceForTesters/res/layout/fragment_test_debugoptions.xml
+++ b/Corona-Warn-App/src/deviceForTesters/res/layout/fragment_test_debugoptions.xml
@@ -102,7 +102,7 @@
                     tools:text="DataDonation: ?" />
 
                 <TextView
-                    android:id="@+id/environment_log_upload"
+                    android:id="@+id/environment_url_log_upload"
                     style="@style/TextAppearance.MaterialComponents.Caption"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/environment/EnvironmentSetup.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/environment/EnvironmentSetup.kt
@@ -35,7 +35,6 @@ class EnvironmentSetup @Inject constructor(
         DOWNLOAD("DOWNLOAD_CDN_URL"),
         VERIFICATION_KEYS("PUB_KEYS_SIGNATURE_VERIFICATION"),
         DATA_DONATION("DATA_DONATION_CDN_URL"),
-        QRCODE_POSTER_TEMPLATE("QRCODE_POSTER_TEMPLATE_URL"),
         LOG_UPLOAD("LOG_UPLOAD_SERVER_URL"),
         SAFETYNET_API_KEY("SAFETYNET_API_KEY"),
         CROWD_NOTIFIER_PUBLIC_KEY("CROWD_NOTIFIER_PUBLIC_KEY")
@@ -48,6 +47,7 @@ class EnvironmentSetup @Inject constructor(
         WRU("WRU"),
         WRU_XA("WRU-XA"), // (aka ACME),
         WRU_XD("WRU-XD"), // (aka Germany)
+        TESTER_MOCK("TESTER-MOCK"), // (aka Germany)
         LOCAL("LOCAL"); // Emulator/CLI tooling
 
         companion object {
@@ -118,10 +118,8 @@ class EnvironmentSetup @Inject constructor(
         get() = getEnvironmentValue(DOWNLOAD).asString
     val dataDonationCdnUrl: String
         get() = getEnvironmentValue(DATA_DONATION).asString
-    val qrCodePosterTemplateCdnUrl: String
-        get() = getEnvironmentValue(EnvKey.QRCODE_POSTER_TEMPLATE).asString
 
-    val appConfigVerificationKey: String
+    val appConfigPublicKey: String
         get() = getEnvironmentValue(VERIFICATION_KEYS).asString
 
     val useEuropeKeyPackageFiles: Boolean

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/environment/eventregistration/qrcodeposter/QrCodePosterTemplateModule.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/environment/eventregistration/qrcodeposter/QrCodePosterTemplateModule.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import dagger.Module
 import dagger.Provides
 import de.rki.coronawarnapp.environment.BaseEnvironmentModule
-import de.rki.coronawarnapp.environment.EnvironmentSetup
 import de.rki.coronawarnapp.environment.download.DownloadCDNHttpClient
+import de.rki.coronawarnapp.environment.download.DownloadCDNServerUrl
 import de.rki.coronawarnapp.eventregistration.events.server.qrcodepostertemplate.QrCodePosterTemplateApiV1
 import de.rki.coronawarnapp.util.di.AppContext
 import okhttp3.Cache
@@ -33,18 +33,10 @@ class QrCodePosterTemplateModule : BaseEnvironmentModule() {
     ): Cache = Cache(File(cacheDir, "cache_http"), CACHE_SIZE_5MB)
 
     @Singleton
-    @QrCodePosterTemplate
-    @Provides
-    fun provideQrCodePosterTemplateCDNServerUrl(environment: EnvironmentSetup): String {
-        val url = environment.qrCodePosterTemplateCdnUrl
-        return requireValidUrl(url)
-    }
-
-    @Singleton
     @Provides
     fun api(
         @DownloadCDNHttpClient client: OkHttpClient,
-        @QrCodePosterTemplate url: String,
+        @DownloadCDNServerUrl url: String,
         @QrCodePosterTemplate cache: Cache
     ): QrCodePosterTemplateApiV1 {
         val httpClient = client.newBuilder().apply {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/security/SignatureValidation.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/security/SignatureValidation.kt
@@ -26,7 +26,7 @@ class SignatureValidation @Inject constructor(
 
     // Public keys within this server environment
     private val publicKeys by lazy {
-        environmentSetup.appConfigVerificationKey.split(KEY_DELIMITER)
+        environmentSetup.appConfigPublicKey.split(KEY_DELIMITER)
             .mapNotNull { pubKeyBase64 -> Base64.decode(pubKeyBase64, Base64.DEFAULT) }
             .map { pubKeyBinary -> keyFactory.generatePublic(X509EncodedKeySpec(pubKeyBinary)) }
             .onEach { Timber.tag(TAG).v("ENV PubKey: %s", it) }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/environment/EnvironmentSetupTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/environment/EnvironmentSetupTest.kt
@@ -63,11 +63,10 @@ class EnvironmentSetupTest : BaseTest() {
                 downloadCdnUrl shouldBe "https://download-${env.rawKey}"
                 submissionCdnUrl shouldBe "https://submission-${env.rawKey}"
                 verificationCdnUrl shouldBe "https://verification-${env.rawKey}"
-                appConfigVerificationKey shouldBe "12345678-${env.rawKey}"
+                appConfigPublicKey shouldBe "12345678-${env.rawKey}"
                 safetyNetApiKey shouldBe "placeholder-${env.rawKey}"
                 dataDonationCdnUrl shouldBe "https://datadonation-${env.rawKey}"
                 logUploadServerUrl shouldBe "https://logupload-${env.rawKey}"
-                qrCodePosterTemplateCdnUrl shouldBe "https://qrcodepostertemplate-${env.rawKey}"
                 crowdNotifierPublicKey shouldBe "123_abc-${env.rawKey}"
             }
         }
@@ -115,8 +114,9 @@ class EnvironmentSetupTest : BaseTest() {
         EnvironmentSetup.Type.WRU.rawKey shouldBe "WRU"
         EnvironmentSetup.Type.WRU_XA.rawKey shouldBe "WRU-XA"
         EnvironmentSetup.Type.WRU_XD.rawKey shouldBe "WRU-XD"
+        EnvironmentSetup.Type.TESTER_MOCK.rawKey shouldBe "TESTER-MOCK"
         EnvironmentSetup.Type.LOCAL.rawKey shouldBe "LOCAL"
-        EnvironmentSetup.Type.values().size shouldBe 7
+        EnvironmentSetup.Type.values().size shouldBe 8
 
         EnvironmentSetup.EnvKey.USE_EUR_KEY_PKGS.rawKey shouldBe "USE_EUR_KEY_PKGS"
         EnvironmentSetup.EnvKey.SUBMISSION.rawKey shouldBe "SUBMISSION_CDN_URL"
@@ -126,9 +126,8 @@ class EnvironmentSetupTest : BaseTest() {
         EnvironmentSetup.EnvKey.DATA_DONATION.rawKey shouldBe "DATA_DONATION_CDN_URL"
         EnvironmentSetup.EnvKey.LOG_UPLOAD.rawKey shouldBe "LOG_UPLOAD_SERVER_URL"
         EnvironmentSetup.EnvKey.SAFETYNET_API_KEY.rawKey shouldBe "SAFETYNET_API_KEY"
-        EnvironmentSetup.EnvKey.QRCODE_POSTER_TEMPLATE.rawKey shouldBe "QRCODE_POSTER_TEMPLATE_URL"
         EnvironmentSetup.EnvKey.CROWD_NOTIFIER_PUBLIC_KEY.rawKey shouldBe "CROWD_NOTIFIER_PUBLIC_KEY"
-        EnvironmentSetup.EnvKey.values().size shouldBe 10
+        EnvironmentSetup.EnvKey.values().size shouldBe 9
     }
 
     companion object {
@@ -137,6 +136,7 @@ class EnvironmentSetupTest : BaseTest() {
             EnvironmentSetup.Type.PRODUCTION,
             EnvironmentSetup.Type.WRU_XD,
             EnvironmentSetup.Type.WRU_XA,
+            EnvironmentSetup.Type.TESTER_MOCK,
             EnvironmentSetup.Type.LOCAL
         )
         private const val GOOD_JSON =
@@ -149,7 +149,6 @@ class EnvironmentSetupTest : BaseTest() {
                     "VERIFICATION_CDN_URL": "https://verification-PROD",
                     "DATA_DONATION_CDN_URL": "https://datadonation-PROD",
                     "LOG_UPLOAD_SERVER_URL": "https://logupload-PROD",
-                    "QRCODE_POSTER_TEMPLATE_URL": "https://qrcodepostertemplate-PROD",
                     "SAFETYNET_API_KEY": "placeholder-PROD",
                     "PUB_KEYS_SIGNATURE_VERIFICATION": "12345678-PROD",
                     "CROWD_NOTIFIER_PUBLIC_KEY": "123_abc-PROD"                    
@@ -161,7 +160,6 @@ class EnvironmentSetupTest : BaseTest() {
                     "VERIFICATION_CDN_URL": "https://verification-DEV",
                     "DATA_DONATION_CDN_URL": "https://datadonation-DEV",
                     "LOG_UPLOAD_SERVER_URL": "https://logupload-DEV",
-                    "QRCODE_POSTER_TEMPLATE_URL": "https://qrcodepostertemplate-DEV",
                     "SAFETYNET_API_KEY": "placeholder-DEV",
                     "PUB_KEYS_SIGNATURE_VERIFICATION": "12345678-DEV",
                     "CROWD_NOTIFIER_PUBLIC_KEY": "123_abc-DEV"
@@ -173,7 +171,6 @@ class EnvironmentSetupTest : BaseTest() {
                     "VERIFICATION_CDN_URL": "https://verification-INT",
                     "DATA_DONATION_CDN_URL": "https://datadonation-INT",
                     "LOG_UPLOAD_SERVER_URL": "https://logupload-INT",
-                    "QRCODE_POSTER_TEMPLATE_URL": "https://qrcodepostertemplate-INT",
                     "SAFETYNET_API_KEY": "placeholder-INT",
                     "PUB_KEYS_SIGNATURE_VERIFICATION": "12345678-INT",
                     "CROWD_NOTIFIER_PUBLIC_KEY": "123_abc-INT"
@@ -185,7 +182,6 @@ class EnvironmentSetupTest : BaseTest() {
                     "VERIFICATION_CDN_URL": "https://verification-WRU",
                     "DATA_DONATION_CDN_URL": "https://datadonation-WRU",
                     "LOG_UPLOAD_SERVER_URL": "https://logupload-WRU",
-                    "QRCODE_POSTER_TEMPLATE_URL": "https://qrcodepostertemplate-WRU",
                     "SAFETYNET_API_KEY": "placeholder-WRU",
                     "PUB_KEYS_SIGNATURE_VERIFICATION": "12345678-WRU",
                     "CREATE_TRACELOCATION_URL": "https://tracelocation-WRU",
@@ -198,7 +194,6 @@ class EnvironmentSetupTest : BaseTest() {
                     "VERIFICATION_CDN_URL": "https://verification-WRU-XD",
                     "DATA_DONATION_CDN_URL": "https://datadonation-WRU-XD",
                     "LOG_UPLOAD_SERVER_URL": "https://logupload-WRU-XD",
-                    "QRCODE_POSTER_TEMPLATE_URL": "https://qrcodepostertemplate-WRU-XD",
                     "SAFETYNET_API_KEY": "placeholder-WRU-XD",
                     "PUB_KEYS_SIGNATURE_VERIFICATION": "12345678-WRU-XD",
                     "CROWD_NOTIFIER_PUBLIC_KEY": "123_abc-WRU-XD"
@@ -210,10 +205,20 @@ class EnvironmentSetupTest : BaseTest() {
                     "VERIFICATION_CDN_URL": "https://verification-WRU-XA",
                     "DATA_DONATION_CDN_URL": "https://datadonation-WRU-XA",
                     "LOG_UPLOAD_SERVER_URL": "https://logupload-WRU-XA",
-                    "QRCODE_POSTER_TEMPLATE_URL": "https://qrcodepostertemplate-WRU-XA",
                     "SAFETYNET_API_KEY": "placeholder-WRU-XA",
                     "PUB_KEYS_SIGNATURE_VERIFICATION": "12345678-WRU-XA",
                     "CROWD_NOTIFIER_PUBLIC_KEY": "123_abc-WRU-XA"
+                },
+                "TESTER-MOCK": {
+                    "USE_EUR_KEY_PKGS" : true,
+                    "SUBMISSION_CDN_URL": "https://submission-TESTER-MOCK",
+                    "DOWNLOAD_CDN_URL": "https://download-TESTER-MOCK",
+                    "VERIFICATION_CDN_URL": "https://verification-TESTER-MOCK",
+                    "DATA_DONATION_CDN_URL": "https://datadonation-TESTER-MOCK",
+                    "LOG_UPLOAD_SERVER_URL": "https://logupload-TESTER-MOCK",
+                    "SAFETYNET_API_KEY": "placeholder-TESTER-MOCK",
+                    "PUB_KEYS_SIGNATURE_VERIFICATION": "12345678-TESTER-MOCK",
+                    "CROWD_NOTIFIER_PUBLIC_KEY": "123_abc-TESTER-MOCK"
                 },
                 "LOCAL": {
                     "USE_EUR_KEY_PKGS" : true,
@@ -222,7 +227,6 @@ class EnvironmentSetupTest : BaseTest() {
                     "VERIFICATION_CDN_URL": "https://verification-LOCAL",
                     "DATA_DONATION_CDN_URL": "https://datadonation-LOCAL",
                     "LOG_UPLOAD_SERVER_URL": "https://logupload-LOCAL",
-                    "QRCODE_POSTER_TEMPLATE_URL": "https://qrcodepostertemplate-LOCAL",
                     "SAFETYNET_API_KEY": "placeholder-LOCAL",
                     "PUB_KEYS_SIGNATURE_VERIFICATION": "12345678-LOCAL",
                     "CROWD_NOTIFIER_PUBLIC_KEY": "123_abc-LOCAL"

--- a/Corona-Warn-App/src/testDeviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragmentViewModelTest.kt
+++ b/Corona-Warn-App/src/testDeviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragmentViewModelTest.kt
@@ -36,7 +36,9 @@ class DebugOptionsFragmentViewModelTest : BaseTestInstrumentation() {
         every { environmentSetup.downloadCdnUrl } returns "downloadUrl"
         every { environmentSetup.verificationCdnUrl } returns "verificationUrl"
         every { environmentSetup.dataDonationCdnUrl } returns "dataDonationUrl"
-        every { environmentSetup.qrCodePosterTemplateCdnUrl } returns "qrCodePosterTemplateUrl"
+        every { environmentSetup.logUploadServerUrl } returns "logUploadServerUrl"
+        every { environmentSetup.crowdNotifierPublicKey } returns "crowdNotifierPublicKey"
+        every { environmentSetup.appConfigPublicKey } returns "appConfigPublicKey"
 
         every { environmentSetup.currentEnvironment = any() } answers {
             currentEnvironment = arg(0)

--- a/prod_environments.json
+++ b/prod_environments.json
@@ -5,8 +5,9 @@
     "DOWNLOAD_CDN_URL": "https://svc90.main.px.t-online.de",
     "VERIFICATION_CDN_URL": "https://verification.coronawarn.app",
     "DATA_DONATION_CDN_URL": "https://data.coronawarn.app",
-    "LOG_UPLOAD_SERVER_URL": "https://logupload.coronawarn.app",
+    "LOG_UPLOAD_SERVER_URL": "https://data.coronawarn.app",
     "SAFETYNET_API_KEY": "placeholder",
-    "PUB_KEYS_SIGNATURE_VERIFICATION": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEc7DEstcUIRcyk35OYDJ95/hTg3UVhsaDXKT0zK7NhHPXoyzipEnOp3GyNXDVpaPi3cAfQmxeuFMZAIX2+6A5Xg=="
+    "PUB_KEYS_SIGNATURE_VERIFICATION": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEc7DEstcUIRcyk35OYDJ95/hTg3UVhsaDXKT0zK7NhHPXoyzipEnOp3GyNXDVpaPi3cAfQmxeuFMZAIX2+6A5Xg==",
+    "CROWD_NOTIFIER_PUBLIC_KEY": "gwLMzE153tQwAOf2MZoUXXfzWTdlSpfS99iZffmcmxOG9njSK4RTimFOFwDh6t0Tyw8XR01ugDYjtuKwjjuK49Oh83FWct6XpefPi9Skjxvvz53i9gaMmUEc96pbtoaA"
   }
 }


### PR DESCRIPTION
* Additional environment option that was requested
* Remove previously added presence tracing entries that are no longer needed
* Show public keys in test fragment
* Compare with https://github.com/corona-warn-app/cwa-app-android-environments/pull/1
