### PR TITLE
Circle CI Config change: get test env from another repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,7 +396,7 @@ jobs:
       - run:
           name: Download Environment Properties
           command: |
-            curl --header "Authorization: token $keystore_download_token" --header "Accept: application/vnd.github.v3.raw" --remote-name --location "$keystore_download_url$env_prop_download_filename"
+            curl --header "Authorization: token $keystore_download_token" --header "Accept: application/vnd.github.v3.raw" --remote-name --location "$environments_download_url$env_prop_download_filename"
       - run:
           name: Decrypt Keystore
           command: openssl enc -aes-256-cbc -d -pbkdf2 -iter 100000 -in $keystore_download_filename -out $keystore_filename -k $keystore_encrypt_key


### PR DESCRIPTION
### Description

test_environments.json file was moved to another repo to have one source of thruth. Therefore Circle CI Config was updated to get the test_environments.json from the new repo.

### Steps to reproduce
How can your changes be tested?
1. create a test RC tag

Already tested:
https://app.circleci.com/pipelines/github/corona-warn-app/cwa-app-android/12415/workflows/1743ddd2-0cc7-4c2a-a897-29a3d57a6133

result .apk was tested