### PR TITLE
Corrected 'Information' to 'Informationen' in event_registration_strings file (EXPOSUREAPP-6206)

### DIFF
--- a/Corona-Warn-App/src/main/res/values-de/event_registration_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/event_registration_strings.xml
@@ -178,7 +178,7 @@
     <string name="trace_location_organiser_list_no_codes_subtitle">"Hier werden alle QR-Codes angezeigt, die Sie für ein Ort oder Event erstellt haben. Sie können die QR-Codes löschen, wenn diese nicht mehr verwendet werden sollen."</string>
 
     <!-- XBUT: Event organiser qr codes list: menu: information button  -->
-    <string name="trace_location_organizer_list_menu_information_btn">"Information"</string>
+    <string name="trace_location_organizer_list_menu_information_btn">"Informationen"</string>
     <!-- XBUT: Event organiser qr codes list: menu: remove all button  -->
     <string name="trace_location_organizer_list_menu_remove_all_btn">"Alle entfernen"</string>
 


### PR DESCRIPTION
### Description
Corrected 'Information' to plural 'Informationen'
Bug fix:  EXPOSUREAPP-6206