### PR TITLE
Event Registration: Restrict check-in time (EXPOSUREAPP-6177)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/attendee/edit/EditCheckInFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/attendee/edit/EditCheckInFragment.kt
@@ -94,7 +94,9 @@ class EditCheckInFragment : Fragment(R.layout.fragment_edit_check_in), AutoInjec
 
                 editCheckinDurationEditHintCard.isGone = !uiState.diaryWarningVisible
 
-                editCheckinConfirmButton.isEnabled = uiState.canSaveChanges
+                editCheckinConfirmButton.isEnabled = uiState.saveButtonEnabled
+
+                editCheckinWrongInputWarning.isGone = !uiState.wrongInputErrorShown
             }
         }
 

--- a/Corona-Warn-App/src/main/res/layout/fragment_edit_check_in.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_edit_check_in.xml
@@ -223,7 +223,6 @@
                     style="@style/Card.NoElevation"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="24dp"
                     android:layout_marginHorizontal="@dimen/spacing_normal"
                     android:layout_marginTop="@dimen/spacing_tiny">
 
@@ -233,6 +232,17 @@
                         android:layout_height="wrap_content"
                         android:text="@string/edit_checkin_duration_edit_hint_card_text" />
                 </LinearLayout>
+
+                <TextView
+                    android:id="@+id/edit_checkin_wrong_input_warning"
+                    style="@style/body2"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/spacing_normal"
+                    android:layout_marginTop="@dimen/spacing_tiny"
+                    android:text="@string/edit_checkin_wrong_input_warning_text"
+                    android:textColor="@color/colorTextSemanticRed"
+                    android:visibility="gone" />
 
             </LinearLayout>
 

--- a/Corona-Warn-App/src/main/res/values-de/event_registration_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/event_registration_strings.xml
@@ -238,6 +238,8 @@
     <string name="edit_checkin_edit_card_checkin_time_label">"Eingecheckt"</string>
     <!-- XTXT: Checkin Edit: hint for unchanged contact diary checkin duration -->
     <string name="edit_checkin_duration_edit_hint_card_text">"Die Aufenthaltsdauer wird nicht automatisch in Ihrem Kontakt-Tagebuch angepasst."</string>
+    <!-- XTXT: Checkin Edit: warning if user input is incorrect -->
+    <string name="edit_checkin_wrong_input_warning_text">"Sie können für maximal 24 Stunden eingecheckt sein und die Auscheck-Zeit muss nach der Eincheck-Zeit liegen."</string>
     <!-- XBUT: Checkin Edit: Save Button -->
     <string name="edit_checkin_confirm_button_text">"Speichern"</string>
 

--- a/Corona-Warn-App/src/main/res/values/event_registration_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/event_registration_strings.xml
@@ -239,6 +239,8 @@
     <string name="edit_checkin_edit_card_checkin_time_label">"Eingecheckt"</string>
     <!-- XTXT: Checkin Edit: hint for unchanged contact diary checkin duration -->
     <string name="edit_checkin_duration_edit_hint_card_text">"Die Aufenthaltsdauer wird nicht automatisch in Ihrem Kontakt-Tagebuch angepasst."</string>
+    <!-- XTXT: Checkin Edit: warning if user input is incorrect -->
+    <string name="edit_checkin_wrong_input_warning_text">"Sie können für maximal 24 Stunden eingecheckt sein und die Auscheck-Zeit muss nach der Eincheck-Zeit liegen."</string>
     <!-- XBUT: Checkin Edit: Save Button -->
     <string name="edit_checkin_confirm_button_text">"Speichern"</string>
 


### PR DESCRIPTION
### Description
This Pr adds a warning text to the edit checkin screen that informs the user why the save button is disabled,
also fixed an issue where having a 0 duration checkin could be saved when opening and closing the timepicker instantly

### Steps to reproduce
1. check into event
2. try to edit the event
3. check if event can be longer than 24h
4. check if checkout can be before checkin
