### PR TITLE
Event Check-in - automatically check out time: minute wise (EXPOSUREAPP-6253)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/attendee/confirm/ConfirmCheckInFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/attendee/confirm/ConfirmCheckInFragment.kt
@@ -99,7 +99,6 @@ class ConfirmCheckInFragment : Fragment(R.layout.fragment_confirm_check_in), Aut
     ) {
         val durationPicker = DurationPicker.Builder()
             .duration(defaultValue ?: "00:00")
-            .minutes()
             .title(getString(R.string.duration_dialog_title))
             .build()
         durationPicker.show(parentFragmentManager, DURATION_PICKER_TAG)


### PR DESCRIPTION
### Description
This PR changes the duration picker interval to 15 minute increments
it also rounds the default checkin time to the closest increment

### Steps to reproduce
1. Scan a qr code with none 15 minute based checkin duration
2. check if duration is rounded
3. check if picker is aligned to 15 minute increments
