### PR TITLE
Improve TraceWarningPackageSync (DEV, EXPOSUREAPP-6270)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/calculation/CheckInWarningMatcher.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/calculation/CheckInWarningMatcher.kt
@@ -34,10 +34,10 @@ class CheckInWarningMatcher @Inject constructor(
         )
 
         val successful = if (matchLists.contains(null)) {
-            Timber.e("Calculation partially failed.")
+            Timber.tag(TAG).e("Calculation partially failed.")
             false
         } else {
-            Timber.d("Matching was successful.")
+            Timber.tag(TAG).d("Matching was successful.")
             true
         }
 
@@ -67,11 +67,11 @@ class CheckInWarningMatcher @Inject constructor(
                 try {
                     packageChunk.map {
                         val overlaps = findMatches(list, it)
-                        Timber.d("%d overlaps for %s", overlaps.size, it.packageId)
+                        Timber.tag(TAG).d("%d overlaps for %s", overlaps.size, it.packageId)
                         MatchesPerPackage(warningPackage = it, overlaps = overlaps)
                     }
                 } catch (e: Throwable) {
-                    Timber.e(e, "Failed to process packages $packageChunk")
+                    Timber.tag(TAG).e(e, "Failed to process packages $packageChunk")
                     null
                 }
             }
@@ -105,9 +105,9 @@ internal suspend fun findMatches(
                 .mapNotNull { checkIn ->
                     checkIn.calculateOverlap(warning, warningPackage.packageId).also { overlap ->
                         if (overlap == null) {
-                            Timber.v("No match found for $checkIn and $warning")
+                            Timber.tag(TAG).v("No match found for $checkIn and $warning")
                         } else {
-                            Timber.w("Overlap was found $overlap")
+                            Timber.tag(TAG).w("Overlap was found $overlap")
                         }
                     }
                 }
@@ -129,7 +129,7 @@ internal fun CheckIn.calculateOverlap(
     val overlapMillis = overlapEndMillis - overlapStartMillis
 
     if (overlapMillis <= 0) {
-        Timber.i("No overlap (%dms) with match %s (%s)", overlapMillis, description, traceLocationIdHash)
+        Timber.tag(TAG).i("Match without overlap (%dms) (%s, %s)", overlapMillis, description, traceLocationIdHash)
         return null
     }
 
@@ -141,3 +141,5 @@ internal fun CheckIn.calculateOverlap(
         endTime = Instant.ofEpochMilli(overlapEndMillis)
     )
 }
+
+private const val TAG = "CheckInWarningMatcher"

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/calculation/CheckInWarningMatcher.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/calculation/CheckInWarningMatcher.kt
@@ -25,6 +25,8 @@ class CheckInWarningMatcher @Inject constructor(
         checkIns: List<CheckIn>,
         warningPackages: List<TraceWarningPackage>
     ): Result {
+        Timber.tag(TAG).d("Processing ${checkIns.size} checkins and ${warningPackages.size} warning pkgs.")
+
         val splitCheckIns = checkIns.flatMap { it.splitByMidnightUTC() }
 
         val matchLists: List<List<MatchesPerPackage>?> = runMatchingLaunchers(
@@ -34,13 +36,12 @@ class CheckInWarningMatcher @Inject constructor(
         )
 
         val successful = if (matchLists.contains(null)) {
-            Timber.tag(TAG).e("Calculation partially failed.")
+            Timber.tag(TAG).e("Calculation partially failed: %s", matchLists)
             false
         } else {
             Timber.tag(TAG).d("Matching was successful.")
             true
         }
-
         return Result(
             successful = successful,
             processedPackages = matchLists.filterNotNull().flatten()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/warning/download/TraceWarningPackageDownloader.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/warning/download/TraceWarningPackageDownloader.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.joda.time.Duration
 import timber.log.Timber
+import java.io.File
 import javax.inject.Inject
 
 @Reusable
@@ -32,9 +33,7 @@ class TraceWarningPackageDownloader @Inject constructor(
         val successful: Boolean,
         val newPackages: Collection<TraceWarningPackageMetadata>
     ) {
-        override fun toString(): String {
-            return "DownloadResult(successful=$successful, newPackages.size=${newPackages.size})"
-        }
+        override fun toString(): String = "DownloadResult(successful=$successful, newPackages.size=${newPackages.size})"
     }
 
     suspend fun launchDownloads(
@@ -42,6 +41,8 @@ class TraceWarningPackageDownloader @Inject constructor(
         hourIntervals: List<HourInterval>,
         downloadTimeout: Duration
     ): DownloadResult {
+        Timber.tag(TAG).d("Launching %d downloads ($location): %s", hourIntervals.size, hourIntervals)
+
         val launcher: CoroutineScope.(HourInterval) -> Deferred<TraceWarningPackageMetadata?> = { hourInterval ->
             async {
                 val metadata = repository.createMetadata(location, hourInterval)
@@ -50,8 +51,6 @@ class TraceWarningPackageDownloader @Inject constructor(
                 }
             }
         }
-
-        Timber.tag(TAG).d("Launching %d downloads.", hourIntervals.size)
 
         val launchedDownloads: Collection<Deferred<TraceWarningPackageMetadata?>> =
             hourIntervals.map { warningPackageId ->
@@ -81,10 +80,12 @@ class TraceWarningPackageDownloader @Inject constructor(
             hourInterval = metaData.hourInterval
         )
 
+        val saveTo = repository.getPathForMetaData(metaData)
+
         if (!downloadInfo.isEmptyPkg) {
             val fileMap = downloadInfo.readBody().unzip().readIntoMap()
             val rawProtoBuf = getValidatedBinary(metaData, fileMap)
-            writeProtoBufToFile(metaData, rawProtoBuf)
+            writeProtoBufToFile(metaData, rawProtoBuf, saveTo)
         } else {
             Timber.tag(TAG).v("Empty package for %s", metaData)
         }
@@ -102,13 +103,13 @@ class TraceWarningPackageDownloader @Inject constructor(
     private fun writeProtoBufToFile(
         metaData: TraceWarningPackageMetadata,
         rawProtoBuf: ByteArray,
+        saveTo: File,
     ) {
         if (rawProtoBuf.isEmpty()) {
             Timber.tag(TAG).d("rawProtoBuf was empty for  %s", metaData.packageId)
             return
         }
 
-        val saveTo = repository.getPathForMetaData(metaData)
         if (saveTo.exists()) {
             Timber.tag(TAG).w("File existed, overwriting: %s", saveTo)
             if (saveTo.delete()) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/warning/download/TraceWarningPackageDownloader.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/warning/download/TraceWarningPackageDownloader.kt
@@ -88,6 +88,9 @@ class TraceWarningPackageDownloader @Inject constructor(
             writeProtoBufToFile(metaData, rawProtoBuf, saveTo)
         } else {
             Timber.tag(TAG).v("Empty package for %s", metaData)
+            if (saveTo.exists() && saveTo.delete()) {
+                Timber.tag(TAG).w("Download file exists for a package that should be empty, deleting: %s", saveTo)
+            }
         }
 
         Timber.tag(TAG).v("Download finished: %s -> %s", metaData, downloadInfo)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/warning/download/TraceWarningPackageSyncTool.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/warning/download/TraceWarningPackageSyncTool.kt
@@ -167,7 +167,10 @@ class TraceWarningPackageSyncTool @Inject constructor(
     data class SyncResult(
         val successful: Boolean,
         val newPackages: Collection<TraceWarningPackageMetadata> = emptyList()
-    )
+    ) {
+        override fun toString(): String =
+            "SyncResult(successful=$successful, newPackages=${newPackages.joinToString(",") { it.packageId }})"
+    }
 
     companion object {
         private const val TAG = "TraceWarningSyncTool"

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/warning/download/TraceWarningPackageSyncTool.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/warning/download/TraceWarningPackageSyncTool.kt
@@ -66,7 +66,7 @@ class TraceWarningPackageSyncTool @Inject constructor(
         val oldestCheckInInterval = oldestCheckIn.checkInStart.deriveHourInterval()
         val firstRelevantInterval: HourInterval = max(oldestCheckInInterval, intervalDiscovery.oldest)
         Timber.tag(TAG).d(
-            "Oldest-server=%d & Oldest-local=%d => first-relevant=%d",
+            "Oldest-server=%s & Oldest-local=%s => first-relevant=%s",
             intervalDiscovery.oldest,
             oldestCheckInInterval,
             firstRelevantInterval

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/warning/download/TraceWarningPackageSyncTool.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/warning/download/TraceWarningPackageSyncTool.kt
@@ -152,7 +152,8 @@ class TraceWarningPackageSyncTool @Inject constructor(
         firstRelevant: HourInterval,
         lastRelevant: HourInterval
     ): List<HourInterval> {
-        val metadatas = repository.getMetaDataForLocation(location)
+        val metadatas = repository.getMetaDataForLocation(location).filter { it.isDownloaded }
+        Timber.tag(TAG).d("We already have downloads for %s", metadatas.joinToString(", ") { it.packageId })
 
         return (firstRelevant..lastRelevant)
             .filter { interval ->

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/warning/download/TraceWarningPackageSyncTool.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/warning/download/TraceWarningPackageSyncTool.kt
@@ -77,7 +77,7 @@ class TraceWarningPackageSyncTool @Inject constructor(
 
         val missingHourIntervals = determineIntervalsToDownload(
             location = location,
-            firstRelevant = oldestCheckIn.checkInStart.deriveHourInterval(),
+            firstRelevant = firstRelevantInterval,
             lastRelevant = intervalDiscovery.latest
         )
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/warning/download/server/TraceWarningPackageDownload.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/warning/download/server/TraceWarningPackageDownload.kt
@@ -10,7 +10,7 @@ data class TraceWarningPackageDownload(val response: Response<ResponseBody>) {
 
     val etag by lazy { headers.values("ETag").singleOrNull() }
 
-    val isEmptyPkg by lazy { headers.values("cwa-empty-pkg").singleOrNull() == "1" }
+    val isEmptyPkg by lazy { headers.values("Content-Length").singleOrNull() == "0" }
 
     fun readBody(): InputStream = requireNotNull(response.body()) { "Response body was null" }.byteStream()
 }


### PR DESCRIPTION
* Fix download attempts on not existing packages (used wrong lower ID bound)
* Adjust empty package header check (use content-length)
* When downloads fails, report a failed calculation (may require follow up PR to result in a gray card)
* If we download a pkg with `isEmpty` attribute, check if there is a file and if so delete it
* When determining which files are missing, only compare against metadata with `isDownloaded` actually set
* Many logging improvements to help narrow down matching issues related to download.