### PR TITLE
Align Check-Ins , Locations dates (EXPOSUREAPP-6297) - (EXPOSUREAPP-6268)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/attendee/checkins/items/ActiveCheckInVH.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/attendee/checkins/items/ActiveCheckInVH.kt
@@ -61,7 +61,7 @@ class ActiveCheckInVH(parent: ViewGroup) :
 
             val startDate = checkInStartUserTZ.toLocalDate()
             context.getString(
-                R.string.trace_location_checkins_card_automatic_checkout_info,
+                R.string.trace_location_checkins_card_automatic_checkout_info_format,
                 startDate.toString("dd.MM.yy"),
                 checkInStartUserTZ.toLocalTime().toString("HH:mm"),
                 hourPeriodFormatter.print(checkoutIn)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/attendee/checkins/items/ActiveCheckInVH.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/attendee/checkins/items/ActiveCheckInVH.kt
@@ -11,7 +11,6 @@ import de.rki.coronawarnapp.util.lists.diffutil.HasPayloadDiffer
 import org.joda.time.Duration
 import org.joda.time.Instant
 import org.joda.time.PeriodType
-import org.joda.time.format.DateTimeFormat
 import org.joda.time.format.PeriodFormat
 import org.joda.time.format.PeriodFormatterBuilder
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/attendee/checkins/items/ActiveCheckInVH.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/attendee/checkins/items/ActiveCheckInVH.kt
@@ -63,7 +63,7 @@ class ActiveCheckInVH(parent: ViewGroup) :
             val startDate = checkInStartUserTZ.toLocalDate()
             context.getString(
                 R.string.trace_location_checkins_card_automatic_checkout_info,
-                startDate.toString(DateTimeFormat.mediumDate()),
+                startDate.toString("dd.MM.yy"),
                 checkInStartUserTZ.toLocalTime().toString("HH:mm"),
                 hourPeriodFormatter.print(checkoutIn)
             )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/attendee/checkins/items/ActiveCheckInVH.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/attendee/checkins/items/ActiveCheckInVH.kt
@@ -49,8 +49,6 @@ class ActiveCheckInVH(parent: ViewGroup) :
 
         description.text = curItem.checkin.description
         address.text = curItem.checkin.address
-        val startDate = checkInStartUserTZ.toLocalDate()
-        traceLocationCardHighlightView.setCaption(startDate.toString(DateTimeFormat.mediumDate()))
 
         checkoutInfo.text = run {
             val checkoutIn = Duration(curItem.checkin.checkInStart, curItem.checkin.checkInEnd).let {
@@ -62,8 +60,10 @@ class ActiveCheckInVH(parent: ViewGroup) :
                 it.toPeriod(periodType)
             }
 
+            val startDate = checkInStartUserTZ.toLocalDate()
             context.getString(
                 R.string.trace_location_checkins_card_automatic_checkout_info,
+                startDate.toString(DateTimeFormat.mediumDate()),
                 checkInStartUserTZ.toLocalTime().toString("HH:mm"),
                 hourPeriodFormatter.print(checkoutIn)
             )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/organizer/list/items/TraceLocationVH.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/organizer/list/items/TraceLocationVH.kt
@@ -38,8 +38,8 @@ class TraceLocationVH(parent: ViewGroup) :
                 context.getString(
                     R.string.trace_location_organizer_list_item_duration_same_day,
                     startTime.toString("dd.MM.yy"),
-                    startTime.toLocalTime().toString("HH:mm"),
-                    endTime.toLocalTime().toString("HH:mm")
+                    startTime.toString("HH:mm"),
+                    endTime.toString("HH:mm")
                 )
             } else {
                 icon.setCaption(null)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/organizer/list/items/TraceLocationVH.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/organizer/list/items/TraceLocationVH.kt
@@ -35,9 +35,9 @@ class TraceLocationVH(parent: ViewGroup) :
 
             duration.isGone = false
             duration.text = if (startTime.toLocalDate() == endTime.toLocalDate()) {
-                icon.setCaption(startTime.toString("dd.MM.yy"))
                 context.getString(
-                    R.string.trace_location_organizer_list_item_duration,
+                    R.string.trace_location_organizer_list_item_duration_same_day,
+                    startTime.toString("dd.MM.yy"),
                     startTime.toLocalTime().toString("HH:mm"),
                     endTime.toLocalTime().toString("HH:mm")
                 )

--- a/Corona-Warn-App/src/main/res/layout/trace_location_attendee_checkins_item_active.xml
+++ b/Corona-Warn-App/src/main/res/layout/trace_location_attendee_checkins_item_active.xml
@@ -17,10 +17,8 @@
         android:layout_marginTop="16dp"
         android:layout_marginBottom="8dp"
         android:orientation="vertical"
-        app:layout_constraintBottom_toTopOf="@+id/checkout_action"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.0">
+        app:layout_constraintTop_toTopOf="parent">
 
         <TextView
             android:id="@+id/highlight_duration_label"

--- a/Corona-Warn-App/src/main/res/layout/trace_location_attendee_checkins_item_active.xml
+++ b/Corona-Warn-App/src/main/res/layout/trace_location_attendee_checkins_item_active.xml
@@ -5,8 +5,8 @@
     style="@style/contactDiaryCardRipple"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginVertical="8dp"
     android:layout_marginHorizontal="16dp"
+    android:layout_marginVertical="8dp"
     android:focusable="true">
 
     <de.rki.coronawarnapp.ui.eventregistration.common.TraceLocationCardHighlightView
@@ -20,7 +20,7 @@
         app:layout_constraintBottom_toTopOf="@+id/checkout_action"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:text="21.01.2021">
+        app:layout_constraintVertical_bias="0.0">
 
         <TextView
             android:id="@+id/highlight_duration_label"
@@ -38,6 +38,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintVertical_chainStyle="packed" />
+
         <TextView
             android:id="@+id/highlight_duration"
             style="@style/headline5Bold"
@@ -91,8 +92,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/traceLocationCardHighlightView"
         app:layout_constraintTop_toBottomOf="@id/address"
-        app:layout_constraintVertical_bias="0.0"
-        tools:text="18:00 - Automatisch auschecken nach 3 Std." />
+        tools:text="21.01.2021 18:00 - Automatisch auschecken nach 3 Std." />
 
     <ImageButton
         android:id="@+id/menu_action"

--- a/Corona-Warn-App/src/main/res/layout/trace_location_organizer_trace_locations_item.xml
+++ b/Corona-Warn-App/src/main/res/layout/trace_location_organizer_trace_locations_item.xml
@@ -17,8 +17,7 @@
         android:layout_marginTop="16dp"
         android:layout_marginBottom="8dp"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="21.01.2021">
+        app:layout_constraintTop_toTopOf="parent">
 
         <ImageView
             android:layout_width="42dp"

--- a/Corona-Warn-App/src/main/res/values-de/event_registration_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/event_registration_strings.xml
@@ -42,7 +42,9 @@
     <!-- XTXT: My check-ins card: Active event, duration label in highlight view -->
     <string name="trace_location_checkins_card_highlight_duration_label">Dauer</string>
     <!-- XTXT: My check-ins card: Active event, checkin information, automatic checkout info -->
-    <string name="trace_location_checkins_card_automatic_checkout_info">"%1$s %2$s - Automatisch auschecken nach %3$s."</string>
+    <string name="trace_location_checkins_card_automatic_checkout_info">"%1$s - Automatisch auschecken nach %2$s."</string>
+    <!-- XTXT: My check-ins card: Active event, checkin information, automatic checkout info -->
+    <string name="trace_location_checkins_card_automatic_checkout_info_format">"%1$s %2$s - Automatisch auschecken nach %3$s."</string>
 
     <!-- XHED: Title of the category list screen of the event creation  -->
     <string name="tracelocation_organizer_category_title">QR-Code erstellen</string>

--- a/Corona-Warn-App/src/main/res/values-de/event_registration_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/event_registration_strings.xml
@@ -198,6 +198,10 @@
 
     <!-- XTXT: Event organiser list item: duration-->
     <string name="trace_location_organizer_list_item_duration">"%1$s - %2$s Uhr"</string>
+
+    <!-- XTXT: Event organiser list item: duration same day-->
+    <string name="trace_location_organizer_list_item_duration_same_day">"%1$s %2$s - %2$s Uhr"</string>
+
     <!-- XBUT: Event organiser list item: checkin button -->
     <string name="trace_location_organizer_list_item_action_checkin">Selbst einchecken</string>
 

--- a/Corona-Warn-App/src/main/res/values-de/event_registration_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/event_registration_strings.xml
@@ -200,7 +200,7 @@
     <string name="trace_location_organizer_list_item_duration">"%1$s - %2$s Uhr"</string>
 
     <!-- XTXT: Event organiser list item: duration same day-->
-    <string name="trace_location_organizer_list_item_duration_same_day">"%1$s %2$s - %2$s Uhr"</string>
+    <string name="trace_location_organizer_list_item_duration_same_day">"%1$s %2$s - %3$s Uhr"</string>
 
     <!-- XBUT: Event organiser list item: checkin button -->
     <string name="trace_location_organizer_list_item_action_checkin">Selbst einchecken</string>

--- a/Corona-Warn-App/src/main/res/values-de/event_registration_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/event_registration_strings.xml
@@ -42,7 +42,7 @@
     <!-- XTXT: My check-ins card: Active event, duration label in highlight view -->
     <string name="trace_location_checkins_card_highlight_duration_label">Dauer</string>
     <!-- XTXT: My check-ins card: Active event, checkin information, automatic checkout info -->
-    <string name="trace_location_checkins_card_automatic_checkout_info">"%1$s - Automatisch auschecken nach %2$s."</string>
+    <string name="trace_location_checkins_card_automatic_checkout_info">"%1$s %2$s - Automatisch auschecken nach %3$s."</string>
 
     <!-- XHED: Title of the category list screen of the event creation  -->
     <string name="tracelocation_organizer_category_title">QR-Code erstellen</string>

--- a/Corona-Warn-App/src/main/res/values/event_registration_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/event_registration_strings.xml
@@ -197,6 +197,10 @@
 
     <!-- XTXT: Event organiser list item: duration-->
     <string name="trace_location_organizer_list_item_duration">"%1$s - %2$s"</string>
+
+    <!-- XTXT: Event organiser list item: duration same day-->
+    <string name="trace_location_organizer_list_item_duration_same_day">"%1$s 2$s - %3$s"</string>
+
     <!-- XBUT: Event organiser list item: checkin button -->
     <string name="trace_location_organizer_list_item_action_checkin">"Check In"</string>
 

--- a/Corona-Warn-App/src/main/res/values/event_registration_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/event_registration_strings.xml
@@ -41,8 +41,9 @@
     <!-- XTXT: My check-ins card: Active event, duration label in highlight view -->
     <string name="trace_location_checkins_card_highlight_duration_label">"Duration"</string>
     <!-- XTXT: My check-ins card: Active event, checkin information, automatic checkout info -->
-    <string name="trace_location_checkins_card_automatic_checkout_info">"%1$s 2$s - check out automatically after %3$s."</string>
-
+    <string name="trace_location_checkins_card_automatic_checkout_info">"%1$s - check out automatically after %2$s."</string>
+    <!-- XTXT: My check-ins card: Active event, checkin information, automatic checkout info -->
+    <string name="trace_location_checkins_card_automatic_checkout_info_format">"%1$s 2$s - check out automatically after %3$s."</string>
     <!-- XHED: Title of the category list screen of the event creation  -->
     <string name="tracelocation_organizer_category_title">"Create QR Code"</string>
 

--- a/Corona-Warn-App/src/main/res/values/event_registration_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/event_registration_strings.xml
@@ -41,7 +41,7 @@
     <!-- XTXT: My check-ins card: Active event, duration label in highlight view -->
     <string name="trace_location_checkins_card_highlight_duration_label">"Duration"</string>
     <!-- XTXT: My check-ins card: Active event, checkin information, automatic checkout info -->
-    <string name="trace_location_checkins_card_automatic_checkout_info">"%1$s - check out automatically after %2$s."</string>
+    <string name="trace_location_checkins_card_automatic_checkout_info">"%1$s 2$s - check out automatically after %3$s."</string>
 
     <!-- XHED: Title of the category list screen of the event creation  -->
     <string name="tracelocation_organizer_category_title">"Create QR Code"</string>


### PR DESCRIPTION
- Align date formatting for same day in trace locations screen
- Move date to info text in Check-Ins screen and adjust the format to match the design and Locations format

<img width="272" alt="Screenshot 2021-04-12 at 15 40 48" src="https://user-images.githubusercontent.com/25054729/114404559-168abe80-9ba6-11eb-9b55-d05fd032afdc.png"> <img width="279" alt="Screenshot 2021-04-12 at 15 41 04" src="https://user-images.githubusercontent.com/25054729/114404566-17bbeb80-9ba6-11eb-8ccb-6cfa54206d96.png">


