### PR TITLE
Fix risk calc (EXPOSUREAPP-6363)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/appconfig/ConfigChangeDetector.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/appconfig/ConfigChangeDetector.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.appconfig
 
 import androidx.annotation.VisibleForTesting
+import de.rki.coronawarnapp.presencetracing.risk.execution.PresenceTracingWarningTask
 import de.rki.coronawarnapp.risk.RiskLevelSettings
 import de.rki.coronawarnapp.risk.RiskLevelTask
 import de.rki.coronawarnapp.risk.storage.RiskLevelStorage
@@ -46,8 +47,17 @@ class ConfigChangeDetector @Inject constructor(
         val oldConfigId = riskLevelSettings.lastUsedConfigIdentifier
         if (newIdentifier != oldConfigId) {
             Timber.tag(TAG).i("New config id ($newIdentifier) differs from last one ($oldConfigId), resetting.")
-            riskLevelStorage.clear()
-            taskController.submit(DefaultTaskRequest(RiskLevelTask::class, originTag = "ConfigChangeDetector"))
+            riskLevelStorage.clearResults()
+            taskController.submit(
+                DefaultTaskRequest(RiskLevelTask::class, originTag = "ConfigChangeDetector")
+            )
+            taskController.submit(
+                DefaultTaskRequest(
+                    PresenceTracingWarningTask::class,
+                    arguments = PresenceTracingWarningTask.Arguments(true),
+                    originTag = "ConfigChangeDetector"
+                )
+            )
         } else {
             Timber.tag(TAG).v("Config identifier ($oldConfigId) didn't change, NOOP.")
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/appconfig/ConfigChangeDetector.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/appconfig/ConfigChangeDetector.kt
@@ -54,7 +54,6 @@ class ConfigChangeDetector @Inject constructor(
             taskController.submit(
                 DefaultTaskRequest(
                     PresenceTracingWarningTask::class,
-                    arguments = PresenceTracingWarningTask.Arguments(true),
                     originTag = "ConfigChangeDetector"
                 )
             )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/calculation/PresenceTracingRiskMapper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/calculation/PresenceTracingRiskMapper.kt
@@ -62,4 +62,4 @@ class PresenceTracingRiskMapper @Inject constructor(
     }
 }
 
-private const val TAG = ""
+private const val TAG = "PtRiskMapper"

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/calculation/PresenceTracingRiskMapper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/calculation/PresenceTracingRiskMapper.kt
@@ -8,11 +8,18 @@ import de.rki.coronawarnapp.risk.mapToRiskState
 import kotlinx.coroutines.flow.first
 import timber.log.Timber
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class PresenceTracingRiskMapper @Inject constructor(
     private val configProvider: AppConfigProvider
 ) {
     private var presenceTracingRiskCalculationParamContainer: PresenceTracingRiskCalculationParamContainer? = null
+
+    fun clearConfig() {
+        Timber.tag(TAG).i("Clearing config params.")
+        presenceTracingRiskCalculationParamContainer = null
+    }
 
     suspend fun lookupTransmissionRiskValue(transmissionRiskLevel: Int): Double {
         return getTransmissionRiskValueMapping()?.find {
@@ -54,3 +61,5 @@ class PresenceTracingRiskMapper @Inject constructor(
         return presenceTracingRiskCalculationParamContainer
     }
 }
+
+private const val TAG = ""

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/execution/PresenceTracingWarningTask.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/execution/PresenceTracingWarningTask.kt
@@ -62,7 +62,7 @@ class PresenceTracingWarningTask @Inject constructor(
         val nowUTC = timeStamper.nowUTC
         checkCancel()
 
-        Timber.tag(TAG).d("Resetting config.")
+        Timber.tag(TAG).d("Resetting config to make sure latest changes are considered.")
         presenceTracingRiskMapper.clearConfig()
 
         Timber.tag(TAG).d("Syncing packages.")

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/execution/PresenceTracingWarningTask.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/execution/PresenceTracingWarningTask.kt
@@ -42,10 +42,8 @@ class PresenceTracingWarningTask @Inject constructor(
     override suspend fun run(arguments: Task.Arguments): Result = try {
         Timber.d("Running with arguments=%s", arguments)
 
-        arguments as Arguments
-
         try {
-            doWork(arguments.configChange)
+            doWork()
         } catch (e: Exception) {
             // We need to reported a failed calculation to update the risk card state
             presenceTracingRiskRepository.reportCalculation(successful = false)
@@ -60,14 +58,12 @@ class PresenceTracingWarningTask @Inject constructor(
         internalProgress.close()
     }
 
-    private suspend fun doWork(configChange: Boolean = false): Result {
+    private suspend fun doWork(): Result {
         val nowUTC = timeStamper.nowUTC
         checkCancel()
 
-        if (configChange) {
-            Timber.tag(TAG).d("Resetting config.")
-            presenceTracingRiskMapper.clearConfig()
-        }
+        Timber.tag(TAG).d("Resetting config.")
+        presenceTracingRiskMapper.clearConfig()
 
         Timber.tag(TAG).d("Syncing packages.")
         internalProgress.send(PresenceTracingWarningTaskProgress.Downloading())
@@ -170,10 +166,6 @@ class PresenceTracingWarningTask @Inject constructor(
             taskByDagger.get()
         }
     }
-
-    class Arguments(
-        val configChange: Boolean = false
-    ) : Task.Arguments
 
     companion object {
         private const val TAG = "TracingWarningTask"

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/storage/PresenceTracingRiskRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/storage/PresenceTracingRiskRepository.kt
@@ -144,7 +144,12 @@ class PresenceTracingRiskRepository @Inject constructor(
         get() = timeStamper.nowUTC.minus(Days.days(15).toStandardDuration())
 
     suspend fun clearAllTables() {
+        Timber.i("Deleting all matches and results.")
         traceTimeIntervalMatchDao.deleteAll()
+        riskLevelResultDao.deleteAll()
+    }
+
+    suspend fun clearResults() {
         riskLevelResultDao.deleteAll()
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/storage/PresenceTracingRiskRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/storage/PresenceTracingRiskRepository.kt
@@ -31,7 +31,7 @@ import javax.inject.Singleton
 class PresenceTracingRiskRepository @Inject constructor(
     private val presenceTracingRiskCalculator: PresenceTracingRiskCalculator,
     private val databaseFactory: PresenceTracingRiskDatabase.Factory,
-    private val timeStamper: TimeStamper,
+    private val timeStamper: TimeStamper
 ) {
 
     private val database by lazy {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/storage/PresenceTracingRiskRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/storage/PresenceTracingRiskRepository.kt
@@ -150,6 +150,7 @@ class PresenceTracingRiskRepository @Inject constructor(
     }
 
     suspend fun clearResults() {
+        Timber.i("Deleting all results.")
         riskLevelResultDao.deleteAll()
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/storage/BaseRiskLevelStorage.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/storage/BaseRiskLevelStorage.kt
@@ -229,9 +229,9 @@ abstract class BaseRiskLevelStorage constructor(
     }
 
     override suspend fun clearResults() {
-        Timber.w("clear() - Clearing stored risklevel/exposure-detection results.")
+        Timber.w("clearResults() - Clearing stored risklevel/exposure-detection results.")
         database.clearAllTables()
-        Timber.w("clear() - Clearing stored presence tracing results.")
+        Timber.w("clearResults() - Clearing stored presence tracing results.")
         presenceTracingRiskRepository.clearResults()
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/storage/BaseRiskLevelStorage.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/storage/BaseRiskLevelStorage.kt
@@ -224,7 +224,15 @@ abstract class BaseRiskLevelStorage constructor(
     override suspend fun clear() {
         Timber.w("clear() - Clearing stored risklevel/exposure-detection results.")
         database.clearAllTables()
+        Timber.w("clear() - Clearing stored presence tracing matches and results.")
         presenceTracingRiskRepository.clearAllTables()
+    }
+
+    override suspend fun clearResults() {
+        Timber.w("clear() - Clearing stored risklevel/exposure-detection results.")
+        database.clearAllTables()
+        Timber.w("clear() - Clearing stored presence tracing results.")
+        presenceTracingRiskRepository.clearResults()
     }
 
     companion object {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/storage/RiskLevelStorage.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/storage/RiskLevelStorage.kt
@@ -79,4 +79,6 @@ interface RiskLevelStorage {
     suspend fun storeResult(resultEw: EwRiskLevelResult)
 
     suspend fun clear()
+
+    suspend fun clearResults()
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/appconfig/ConfigChangeDetectorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/appconfig/ConfigChangeDetectorTest.kt
@@ -34,6 +34,7 @@ class ConfigChangeDetectorTest : BaseTest() {
         every { taskController.submit(any()) } just Runs
         every { appConfigProvider.currentConfig } returns currentConfigFake
         coEvery { riskLevelStorage.clear() } just Runs
+        coEvery { riskLevelStorage.clearResults() } just Runs
     }
 
     private fun mockConfigId(id: String): ConfigData {
@@ -59,7 +60,7 @@ class ConfigChangeDetectorTest : BaseTest() {
 
         coVerify(exactly = 0) {
             taskController.submit(any())
-            riskLevelStorage.clear()
+            riskLevelStorage.clearResults()
         }
     }
 
@@ -70,20 +71,25 @@ class ConfigChangeDetectorTest : BaseTest() {
         createInstance().launch()
 
         coVerifySequence {
-            riskLevelStorage.clear()
+            riskLevelStorage.clearResults()
             taskController.submit(any())
+            taskController.submit(any())
+        }
+
+        coVerify(exactly = 0) {
+            riskLevelStorage.clear()
         }
     }
 
     @Test
-    fun `same idetifier results in no op`() {
+    fun `same identifier results in no op`() {
         every { riskLevelSettings.lastUsedConfigIdentifier } returns "initial"
 
         createInstance().launch()
 
         coVerify(exactly = 0) {
             taskController.submit(any())
-            riskLevelStorage.clear()
+            riskLevelStorage.clearResults()
         }
     }
 
@@ -96,10 +102,16 @@ class ConfigChangeDetectorTest : BaseTest() {
         currentConfigFake.value = mockConfigId("berry")
 
         coVerifySequence {
-            riskLevelStorage.clear()
+            riskLevelStorage.clearResults()
             taskController.submit(any())
-            riskLevelStorage.clear()
             taskController.submit(any())
+            riskLevelStorage.clearResults()
+            taskController.submit(any())
+            taskController.submit(any())
+        }
+
+        coVerify(exactly = 0) {
+            riskLevelStorage.clear()
         }
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/presencetracing/risk/execution/PresenceTracingWarningTaskTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/presencetracing/risk/execution/PresenceTracingWarningTaskTest.kt
@@ -2,6 +2,7 @@ package de.rki.coronawarnapp.presencetracing.risk.execution
 
 import de.rki.coronawarnapp.eventregistration.checkins.CheckInRepository
 import de.rki.coronawarnapp.presencetracing.risk.calculation.CheckInWarningMatcher
+import de.rki.coronawarnapp.presencetracing.risk.calculation.PresenceTracingRiskMapper
 import de.rki.coronawarnapp.presencetracing.risk.calculation.createCheckIn
 import de.rki.coronawarnapp.presencetracing.risk.calculation.createWarning
 import de.rki.coronawarnapp.presencetracing.risk.storage.PresenceTracingRiskRepository
@@ -40,6 +41,7 @@ class PresenceTracingWarningTaskTest : BaseTest() {
     @MockK lateinit var presenceTracingRiskRepository: PresenceTracingRiskRepository
     @MockK lateinit var traceWarningRepository: TraceWarningRepository
     @MockK lateinit var checkInsRepository: CheckInRepository
+    @MockK lateinit var presenceTracingRiskMapper: PresenceTracingRiskMapper
 
     @BeforeEach
     fun setup() {
@@ -80,6 +82,7 @@ class PresenceTracingWarningTaskTest : BaseTest() {
         presenceTracingRiskRepository = presenceTracingRiskRepository,
         traceWarningRepository = traceWarningRepository,
         checkInsRepository = checkInsRepository,
+        presenceTracingRiskMapper = presenceTracingRiskMapper
     )
 
     @Test

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/presencetracing/risk/execution/PresenceTracingWarningTaskTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/presencetracing/risk/execution/PresenceTracingWarningTaskTest.kt
@@ -74,7 +74,7 @@ class PresenceTracingWarningTaskTest : BaseTest() {
             coEvery { reportCalculation(any(), any()) } just Runs
         }
 
-        every { presenceTracingRiskMapper.clearConfig() } just Runs
+        coEvery { presenceTracingRiskMapper.clearConfig() } just Runs
     }
 
     private fun createInstance() = PresenceTracingWarningTask(
@@ -89,7 +89,7 @@ class PresenceTracingWarningTaskTest : BaseTest() {
 
     @Test
     fun `happy path, match result is reported successfully`() = runBlockingTest {
-        createInstance().run(PresenceTracingWarningTask.Arguments()) shouldNotBe null
+        createInstance().run(mockk()) shouldNotBe null
 
         coVerifySequence {
             syncTool.syncPackages()
@@ -109,7 +109,7 @@ class PresenceTracingWarningTaskTest : BaseTest() {
 
     @Test
     fun `happy path with config change`() = runBlockingTest {
-        createInstance().run(PresenceTracingWarningTask.Arguments(true)) shouldNotBe null
+        createInstance().run(mockk()) shouldNotBe null
 
         coVerifySequence {
             presenceTracingRiskMapper.clearConfig()
@@ -133,7 +133,7 @@ class PresenceTracingWarningTaskTest : BaseTest() {
         coEvery { syncTool.syncPackages() } throws IOException("Unexpected")
 
         shouldThrow<IOException> {
-            createInstance().run(PresenceTracingWarningTask.Arguments())
+            createInstance().run(mockk())
         }
 
         coVerify {
@@ -148,7 +148,7 @@ class PresenceTracingWarningTaskTest : BaseTest() {
     fun `there are no check-ins to match against`() = runBlockingTest {
         coEvery { checkInsRepository.checkInsWithinRetention } returns flowOf(emptyList())
 
-        createInstance().run(PresenceTracingWarningTask.Arguments()) shouldNotBe null
+        createInstance().run(mockk()) shouldNotBe null
 
         coVerifySequence {
             syncTool.syncPackages()
@@ -164,7 +164,7 @@ class PresenceTracingWarningTaskTest : BaseTest() {
     fun `there are no warning packages to process`() = runBlockingTest {
         coEvery { traceWarningRepository.unprocessedWarningPackages } returns flowOf(emptyList())
 
-        createInstance().run(PresenceTracingWarningTask.Arguments()) shouldNotBe null
+        createInstance().run(mockk()) shouldNotBe null
 
         coVerifySequence {
             syncTool.syncPackages()
@@ -180,7 +180,7 @@ class PresenceTracingWarningTaskTest : BaseTest() {
     fun `report failure if downloads fail`() = runBlockingTest {
         coEvery { syncTool.syncPackages() } returns TraceWarningPackageSyncTool.SyncResult(successful = false)
 
-        createInstance().run(PresenceTracingWarningTask.Arguments()) shouldNotBe null
+        createInstance().run(mockk()) shouldNotBe null
 
         coVerifySequence {
             syncTool.syncPackages()
@@ -200,7 +200,7 @@ class PresenceTracingWarningTaskTest : BaseTest() {
     fun `report failure if matching throws exception`() = runBlockingTest {
         coEvery { checkInWarningMatcher.process(any(), any()) } throws IllegalArgumentException()
         shouldThrow<IllegalArgumentException> {
-            createInstance().run(PresenceTracingWarningTask.Arguments()) shouldNotBe null
+            createInstance().run(mockk()) shouldNotBe null
         }
 
         coVerifySequence {


### PR DESCRIPTION
The bug was caused by the ConfigChangeDetector which has cleared the table with matches, resulting in the disappearance of risk encounters.

On config changes, existing matches need to be kept and a new calculation must be triggered with new config
