### PR TITLE
Use the word "einem" instead of "%1$d" (closes #2736)

### DIFF
--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -108,7 +108,7 @@
     <string name="risk_card_low_risk_no_encounters_body">Keine Risiko-Begegnungen</string>
     <!-- XTXT: risk card - Low risk state - Days with low risk encounters -->
     <plurals name="risk_card_low_risk_encounter_days_body">
-        <item quantity="one">"Begegnungen mit niedrigem Risiko an %1$d Tag"</item>
+        <item quantity="one">"Begegnungen mit niedrigem Risiko an einem Tag"</item>
         <item quantity="other">"Begegnungen mit niedrigem Risiko an %1$d Tagen"</item>
         <item quantity="zero">"Keine Risiko-Begegnungen"</item>
         <item quantity="two">"Begegnungen mit niedrigem Risiko an %1$d Tagen"</item>
@@ -131,7 +131,7 @@
 
     <!-- XTXT: risk card - High risk state - Days with high risk encounters -->
     <plurals name="risk_card_high_risk_encounter_days_body">
-        <item quantity="one">"Begegnungen an %1$d Tag mit erhöhtem Risiko"</item>
+        <item quantity="one">"Begegnungen an einem Tag mit erhöhtem Risiko"</item>
         <item quantity="other">"Begegnungen an %1$d Tagen mit erhöhtem Risiko"</item>
         <item quantity="zero">"Begegnungen an %1$d Tagen mit erhöhtem Risiko"</item>
         <item quantity="two">"Begegnungen an %1$d Tagen mit erhöhtem Risiko"</item>


### PR DESCRIPTION
Replace the format specifier "%1$d" with the word "einem" for singular quantities i.e. 1.
Fixes issue #2736