### PR TITLE
Check-in selection in submission flow (EXPOSUREAPP-6514) 

### DIFF
--- a/Corona-Warn-App/schemas/de.rki.coronawarnapp.eventregistration.storage.TraceLocationDatabase/2.json
+++ b/Corona-Warn-App/schemas/de.rki.coronawarnapp.eventregistration.storage.TraceLocationDatabase/2.json
@@ -1,0 +1,204 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "3950e8c7f3123a41f0960bc30b4f07f4",
+    "entities": [
+      {
+        "tableName": "checkin",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `traceLocationIdBase64` TEXT NOT NULL, `version` INTEGER NOT NULL, `type` INTEGER NOT NULL, `description` TEXT NOT NULL, `address` TEXT NOT NULL, `traceLocationStart` TEXT, `traceLocationEnd` TEXT, `defaultCheckInLengthInMinutes` INTEGER, `cryptographicSeedBase64` TEXT NOT NULL, `cnPublicKey` TEXT NOT NULL, `checkInStart` TEXT NOT NULL, `checkInEnd` TEXT NOT NULL, `completed` INTEGER NOT NULL, `createJournalEntry` INTEGER NOT NULL, `submitted` INTEGER NOT NULL, `submissionConsent` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "traceLocationIdBase64",
+            "columnName": "traceLocationIdBase64",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "traceLocationStart",
+            "columnName": "traceLocationStart",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "traceLocationEnd",
+            "columnName": "traceLocationEnd",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "defaultCheckInLengthInMinutes",
+            "columnName": "defaultCheckInLengthInMinutes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cryptographicSeedBase64",
+            "columnName": "cryptographicSeedBase64",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cnPublicKey",
+            "columnName": "cnPublicKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checkInStart",
+            "columnName": "checkInStart",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checkInEnd",
+            "columnName": "checkInEnd",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completed",
+            "columnName": "completed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createJournalEntry",
+            "columnName": "createJournalEntry",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSubmitted",
+            "columnName": "submitted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasSubmissionConsent",
+            "columnName": "submissionConsent",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "traceLocations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `version` INTEGER NOT NULL, `type` INTEGER NOT NULL, `description` TEXT NOT NULL, `address` TEXT NOT NULL, `startDate` TEXT, `endDate` TEXT, `defaultCheckInLengthInMinutes` INTEGER, `cryptographicSeedBase64` TEXT NOT NULL, `cnPublicKey` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startDate",
+            "columnName": "startDate",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "endDate",
+            "columnName": "endDate",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "defaultCheckInLengthInMinutes",
+            "columnName": "defaultCheckInLengthInMinutes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cryptographicSeedBase64",
+            "columnName": "cryptographicSeedBase64",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cnPublicKey",
+            "columnName": "cnPublicKey",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3950e8c7f3123a41f0960bc30b4f07f4')"
+    ]
+  }
+}

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/eventregistration/storage/CheckInDatabaseData.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/eventregistration/storage/CheckInDatabaseData.kt
@@ -23,6 +23,7 @@ object CheckInDatabaseData {
         completed = false,
         createJournalEntry = true,
         isSubmitted = false,
+        hasSubmissionConsent = false,
     )
 
     val testCheckInWithoutCheckOutTime = TraceLocationCheckInEntity(
@@ -41,5 +42,6 @@ object CheckInDatabaseData {
         completed = false,
         createJournalEntry = true,
         isSubmitted = false,
+        hasSubmissionConsent = false,
     )
 }

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/presencetracing/migration/PresenceTracingDatabaseMigrationTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/presencetracing/migration/PresenceTracingDatabaseMigrationTest.kt
@@ -1,0 +1,133 @@
+package de.rki.coronawarnapp.presencetracing.migration
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import de.rki.coronawarnapp.eventregistration.storage.TraceLocationDatabase
+import de.rki.coronawarnapp.eventregistration.storage.entity.TraceLocationCheckInEntity
+import de.rki.coronawarnapp.eventregistration.storage.migration.PresenceTracingDatabaseMigration1To2
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import okio.ByteString.Companion.encode
+import org.joda.time.Instant
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import testhelpers.BaseTestInstrumentation
+import java.io.IOException
+
+@RunWith(AndroidJUnit4::class)
+class PresenceTracingDatabaseMigrationTest : BaseTestInstrumentation() {
+    private val DB_NAME = "TraceLocations_test_db"
+
+    @get:Rule
+    val helper: MigrationTestHelper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        TraceLocationDatabase::class.java.canonicalName,
+        FrameworkSQLiteOpenHelperFactory()
+    )
+
+    @Test
+    fun migrate1To2() {
+        val locationIdBase64 = "41da2115-eba2-49bd-bf17-adb3d635ddaf".encode().base64()
+        val cryptoGraphicSeed = "cryptographicSeed".encode().base64()
+        val locationStart = Instant.parse("2021-01-01T12:30:00.000Z")
+        val locationEnd = Instant.parse("2021-01-01T18:30:00.000Z")
+        val checkInStart = Instant.parse("2021-01-01T14:30:00.000Z")
+        val checkInEnd = Instant.parse("2021-01-01T16:30:00.000Z")
+        helper.createDatabase(DB_NAME, 1).apply {
+            execSQL(
+                """
+                    INSERT INTO "checkin" (
+                        "id",
+                        "traceLocationIdBase64",
+                        "version",
+                        "type",
+                        "description",
+                        "address",
+                        "traceLocationStart",
+                        "traceLocationEnd",
+                        "defaultCheckInLengthInMinutes",
+                        "cryptographicSeedBase64",
+                        "cnPublicKey",
+                        "checkInStart",
+                        "checkInEnd",
+                        "completed",
+                        "createJournalEntry",
+                        "submitted"
+                    ) VALUES (
+                        '1',
+                        '$locationIdBase64',
+                        '1',
+                        '2',
+                        'brothers birthday',
+                        'Malibu',
+                        '$locationStart',
+                        '$locationEnd',
+                        '42',
+                        '$cryptoGraphicSeed',
+                        'cnPublicKey',
+                        '$checkInStart',
+                        '$checkInEnd',
+                        '0',
+                        '1',
+                        '0'
+                    );
+                """.trimIndent()
+            )
+            close()
+        }
+
+        // Run migration
+        helper.runMigrationsAndValidate(
+            DB_NAME,
+            2,
+            true,
+            PresenceTracingDatabaseMigration1To2
+        )
+
+        val daoDb = TraceLocationDatabase.Factory(
+            context = ApplicationProvider.getApplicationContext()
+        ).create(databaseName = DB_NAME)
+
+        val checkin = TraceLocationCheckInEntity(
+            id = 1L,
+            traceLocationIdBase64 = locationIdBase64,
+            version = 1,
+            type = 2,
+            description = "brothers birthday",
+            address = "Malibu",
+            traceLocationStart = locationStart,
+            traceLocationEnd = locationEnd,
+            defaultCheckInLengthInMinutes = 42,
+            cryptographicSeedBase64 = cryptoGraphicSeed,
+            cnPublicKey = "cnPublicKey",
+            checkInStart = checkInStart,
+            checkInEnd = checkInEnd,
+            completed = false,
+            createJournalEntry = true,
+            isSubmitted = false,
+            hasSubmissionConsent = false,
+        )
+        runBlocking { daoDb.eventCheckInDao().allEntries().first() }.single() shouldBe checkin
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun migrateAll() {
+        helper.createDatabase(DB_NAME, 1).apply {
+            close()
+        }
+
+        // Open latest version of the database. Room will validate the schema once all migrations execute.
+        TraceLocationDatabase.Factory(
+            context = ApplicationProvider.getApplicationContext()
+        ).create(databaseName = DB_NAME).apply {
+            openHelper.writableDatabase
+            close()
+        }
+    }
+}

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/submission/SubmissionTestResultAvailableFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/submission/SubmissionTestResultAvailableFragmentTest.kt
@@ -5,6 +5,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import dagger.Module
 import dagger.android.ContributesAndroidInjector
 import de.rki.coronawarnapp.datadonation.analytics.modules.keysubmission.AnalyticsKeySubmissionCollector
+import de.rki.coronawarnapp.eventregistration.checkins.CheckInRepository
 import de.rki.coronawarnapp.submission.SubmissionRepository
 import de.rki.coronawarnapp.submission.auto.AutoSubmission
 import de.rki.coronawarnapp.submission.data.tekhistory.TEKHistoryUpdater_Factory_Impl
@@ -39,6 +40,7 @@ class SubmissionTestResultAvailableFragmentTest : BaseUITest() {
     @MockK lateinit var autoSubmission: AutoSubmission
     @MockK lateinit var appShortcutsHelper: AppShortcutsHelper
     @MockK lateinit var analyticsKeySubmissionCollector: AnalyticsKeySubmissionCollector
+    @MockK lateinit var checkInRepository: CheckInRepository
 
     @Rule
     @JvmField
@@ -57,11 +59,12 @@ class SubmissionTestResultAvailableFragmentTest : BaseUITest() {
 
         viewModel = spyk(
             SubmissionTestResultAvailableViewModel(
-                TestDispatcherProvider(),
-                tekHistoryUpdaterFactory,
-                submissionRepository,
-                autoSubmission,
-                analyticsKeySubmissionCollector
+                dispatcherProvider = TestDispatcherProvider(),
+                tekHistoryUpdaterFactory = tekHistoryUpdaterFactory,
+                submissionRepository = submissionRepository,
+                autoSubmission = autoSubmission,
+                analyticsKeySubmissionCollector = analyticsKeySubmissionCollector,
+                checkInRepository = checkInRepository
             )
         )
 

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/presencetracing/ui/PresenceTracingTestFragment.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/presencetracing/ui/PresenceTracingTestFragment.kt
@@ -10,6 +10,7 @@ import androidx.core.text.color
 import androidx.core.text.scale
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.FragmentTestPresenceTracingBinding
 import de.rki.coronawarnapp.eventregistration.checkins.qrcode.TraceLocation
@@ -60,6 +61,10 @@ class PresenceTracingTestFragment : Fragment(R.layout.fragment_test_presence_tra
 
         binding.runPtWarningTask.setOnClickListener {
             viewModel.runPresenceTracingWarningTask()
+        }
+
+        binding.openConsent.setOnClickListener {
+            findNavController().navigate(R.id.checkInsConsentFragment)
         }
 
         viewModel.lastOrganiserLocation.observe(viewLifecycleOwner) {

--- a/Corona-Warn-App/src/deviceForTesters/res/layout/fragment_test_presence_tracing.xml
+++ b/Corona-Warn-App/src/deviceForTesters/res/layout/fragment_test_presence_tracing.xml
@@ -16,8 +16,8 @@
             style="@style/Card"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
             android:layout_marginHorizontal="@dimen/spacing_tiny"
+            android:layout_marginTop="10dp"
             android:orientation="vertical">
 
             <TextView
@@ -167,6 +167,15 @@
                 android:textIsSelectable="true"
                 tools:text="ID" />
         </LinearLayout>
+
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/open_consent"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginTop="16dp"
+            android:text="Consent" />
 
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/eventregistration/checkins/CheckIn.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/eventregistration/checkins/CheckIn.kt
@@ -24,7 +24,7 @@ data class CheckIn(
     val completed: Boolean,
     val createJournalEntry: Boolean,
     val isSubmitted: Boolean = false,
-    val isSubmissionPermitted: Boolean = false,
+    val hasSubmissionConsent: Boolean = false,
 ) {
     /**
      *  Returns SHA-256 hash of [traceLocationId] which itself may also be SHA-256 hash.
@@ -52,4 +52,5 @@ fun CheckIn.toEntity() = TraceLocationCheckInEntity(
     completed = completed,
     createJournalEntry = createJournalEntry,
     isSubmitted = isSubmitted,
+    hasSubmissionConsent = hasSubmissionConsent,
 )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/eventregistration/checkins/CheckIn.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/eventregistration/checkins/CheckIn.kt
@@ -24,6 +24,7 @@ data class CheckIn(
     val completed: Boolean,
     val createJournalEntry: Boolean,
     val isSubmitted: Boolean = false,
+    val isSubmissionPermitted: Boolean = false,
 ) {
     /**
      *  Returns SHA-256 hash of [traceLocationId] which itself may also be SHA-256 hash.

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/eventregistration/checkins/CheckInRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/eventregistration/checkins/CheckInRepository.kt
@@ -65,7 +65,7 @@ class CheckInRepository @Inject constructor(
         checkInDao.updateEntityById(checkInId, update)
     }
 
-    suspend fun markCheckInAsSubmitted(checkInId: Long) {
+    suspend fun updatePostSubmissionFlags(checkInId: Long) {
         Timber.d("markCheckInAsSubmitted(checkInId=$checkInId)")
         checkInDao.updateEntity(
             TraceLocationCheckInEntity.SubmissionUpdate(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/eventregistration/checkins/CheckInRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/eventregistration/checkins/CheckInRepository.kt
@@ -68,7 +68,11 @@ class CheckInRepository @Inject constructor(
     suspend fun markCheckInAsSubmitted(checkInId: Long) {
         Timber.d("markCheckInAsSubmitted(checkInId=$checkInId)")
         checkInDao.updateEntity(
-            TraceLocationCheckInEntity.SubmissionUpdate(checkInId = checkInId, isSubmitted = true)
+            TraceLocationCheckInEntity.SubmissionUpdate(
+                checkInId = checkInId,
+                isSubmitted = true,
+                hasSubmissionConsent = false,
+            )
         )
     }
 
@@ -87,5 +91,16 @@ class CheckInRepository @Inject constructor(
             ?: throw IllegalArgumentException("No checkIn found for ID=$checkInId")
 
         return checkIn.toCheckIn()
+    }
+
+    suspend fun updateSubmissionConsents(checkInIds: Collection<Long>, consent: Boolean) {
+        Timber.d("updateSubmissionConsents(checkInIds=%s, consent=%b)", checkInIds, consent)
+        val consentUpdates = checkInIds.map {
+            TraceLocationCheckInEntity.SubmissionConsentUpdate(
+                checkInId = it,
+                hasSubmissionConsent = consent
+            )
+        }
+        checkInDao.updateSubmissionConsents(consentUpdates)
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/eventregistration/storage/TraceLocationDatabase.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/eventregistration/storage/TraceLocationDatabase.kt
@@ -10,6 +10,7 @@ import de.rki.coronawarnapp.eventregistration.storage.dao.TraceLocationDao
 import de.rki.coronawarnapp.eventregistration.storage.entity.TraceLocationCheckInEntity
 import de.rki.coronawarnapp.eventregistration.storage.entity.TraceLocationConverters
 import de.rki.coronawarnapp.eventregistration.storage.entity.TraceLocationEntity
+import de.rki.coronawarnapp.eventregistration.storage.migration.PresenceTracingDatabaseMigration1To2
 import de.rki.coronawarnapp.util.database.CommonConverters
 import de.rki.coronawarnapp.util.di.AppContext
 import javax.inject.Inject
@@ -19,7 +20,7 @@ import javax.inject.Inject
         TraceLocationCheckInEntity::class,
         TraceLocationEntity::class
     ],
-    version = 1,
+    version = 2,
     exportSchema = true
 )
 @TypeConverters(CommonConverters::class, TraceLocationConverters::class)
@@ -29,8 +30,9 @@ abstract class TraceLocationDatabase : RoomDatabase() {
     abstract fun traceLocationDao(): TraceLocationDao
 
     class Factory @Inject constructor(@AppContext private val context: Context) {
-        fun create() = Room
-            .databaseBuilder(context, TraceLocationDatabase::class.java, TRACE_LOCATIONS_DATABASE_NAME)
+        fun create(databaseName: String = TRACE_LOCATIONS_DATABASE_NAME): TraceLocationDatabase = Room
+            .databaseBuilder(context, TraceLocationDatabase::class.java, databaseName)
+            .addMigrations(PresenceTracingDatabaseMigration1To2)
             .build()
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/eventregistration/storage/dao/CheckInDao.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/eventregistration/storage/dao/CheckInDao.kt
@@ -40,6 +40,9 @@ interface CheckInDao {
     @Update(entity = TraceLocationCheckInEntity::class)
     suspend fun updateEntity(update: TraceLocationCheckInEntity.SubmissionUpdate)
 
+    @Update(entity = TraceLocationCheckInEntity::class)
+    suspend fun updateSubmissionConsents(update: Collection<TraceLocationCheckInEntity.SubmissionConsentUpdate>)
+
     @Query("DELETE FROM checkin")
     suspend fun deleteAll()
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/eventregistration/storage/entity/TraceLocationCheckInEntity.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/eventregistration/storage/entity/TraceLocationCheckInEntity.kt
@@ -25,12 +25,20 @@ data class TraceLocationCheckInEntity(
     @ColumnInfo(name = "completed") val completed: Boolean,
     @ColumnInfo(name = "createJournalEntry") val createJournalEntry: Boolean,
     @ColumnInfo(name = "submitted") val isSubmitted: Boolean,
+    @ColumnInfo(name = "submissionConsent") val hasSubmissionConsent: Boolean,
 ) {
 
     @Entity
     data class SubmissionUpdate(
         @PrimaryKey @ColumnInfo(name = "id") val checkInId: Long,
         @ColumnInfo(name = "submitted") val isSubmitted: Boolean,
+        @ColumnInfo(name = "submissionConsent") val hasSubmissionConsent: Boolean,
+    )
+
+    @Entity
+    data class SubmissionConsentUpdate(
+        @PrimaryKey @ColumnInfo(name = "id") val checkInId: Long,
+        @ColumnInfo(name = "submissionConsent") val hasSubmissionConsent: Boolean,
     )
 }
 
@@ -50,5 +58,6 @@ fun TraceLocationCheckInEntity.toCheckIn() = CheckIn(
     checkInEnd = checkInEnd,
     completed = completed,
     createJournalEntry = createJournalEntry,
-    isSubmitted = isSubmitted
+    isSubmitted = isSubmitted,
+    hasSubmissionConsent = hasSubmissionConsent
 )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/eventregistration/storage/migration/PresenceTracingDatabaseMigration1To2.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/eventregistration/storage/migration/PresenceTracingDatabaseMigration1To2.kt
@@ -1,0 +1,38 @@
+package de.rki.coronawarnapp.eventregistration.storage.migration
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+import de.rki.coronawarnapp.exception.ExceptionCategory
+import de.rki.coronawarnapp.exception.reporting.report
+import timber.log.Timber
+
+/**
+ * Migrates the presence tracing database from version 1 to 2.
+ * The additional attribute:
+ * PresenceTracingCheckInEntity.submissionConsent was added
+ */
+object PresenceTracingDatabaseMigration1To2 : Migration(1, 2) {
+
+    override fun migrate(database: SupportSQLiteDatabase) {
+        try {
+            Timber.i("Attempting migration 1->2...")
+            performMigration(database)
+            Timber.i("Migration 1->2 successful.")
+        } catch (e: Exception) {
+            Timber.e(e, "Migration 1->2 failed")
+            e.report(ExceptionCategory.INTERNAL, "PresenceTracing database migration failed.")
+            throw e
+        }
+    }
+
+    private fun performMigration(database: SupportSQLiteDatabase) = with(database) {
+        Timber.d("Running MIGRATION_1_2")
+
+        migrateTraceLocationCheckInEntity()
+    }
+
+    private val migrateTraceLocationCheckInEntity: SupportSQLiteDatabase.() -> Unit = {
+        Timber.d("Table 'checkin': Add column 'submissionConsent'")
+        execSQL("ALTER TABLE `checkin` ADD COLUMN `submissionConsent` INTEGER NOT NULL DEFAULT '0'")
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/checkins/common/CheckInRepositoryExtension.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/checkins/common/CheckInRepositoryExtension.kt
@@ -1,0 +1,13 @@
+package de.rki.coronawarnapp.presencetracing.checkins.common
+
+import de.rki.coronawarnapp.eventregistration.checkins.CheckIn
+import de.rki.coronawarnapp.eventregistration.checkins.CheckInRepository
+import kotlinx.coroutines.flow.map
+
+/**
+ * Returns completed [CheckIn]s only
+ */
+val CheckInRepository.completedCheckIns
+    get() = checkInsWithinRetention.map { checkIns ->
+        checkIns.filter { checkIn -> checkIn.completed }
+    }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/task/SubmissionTask.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/task/SubmissionTask.kt
@@ -143,7 +143,9 @@ class SubmissionTask @Inject constructor(
         )
         Timber.tag(TAG).d("Transformed keys with symptoms %s from %s to %s", symptoms, keys, transformedKeys)
 
-        val checkIns = checkInsRepository.checkInsWithinRetention.first()
+        val checkIns = checkInsRepository.checkInsWithinRetention.first().filter {
+            it.completed && it.hasSubmissionConsent && !it.isSubmitted
+        }
         val transformedCheckIns = checkInsTransformer.transform(checkIns, symptoms)
 
         Timber.tag(TAG).d("Transformed CheckIns from: %s to: %s", checkIns, transformedCheckIns)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/task/SubmissionTask.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/task/SubmissionTask.kt
@@ -10,6 +10,7 @@ import de.rki.coronawarnapp.exception.NoRegistrationTokenSetException
 import de.rki.coronawarnapp.notification.ShareTestResultNotificationService
 import de.rki.coronawarnapp.notification.TestResultAvailableNotificationService
 import de.rki.coronawarnapp.playbook.Playbook
+import de.rki.coronawarnapp.presencetracing.checkins.common.completedCheckIns
 import de.rki.coronawarnapp.submission.SubmissionSettings
 import de.rki.coronawarnapp.submission.Symptoms
 import de.rki.coronawarnapp.submission.auto.AutoSubmission
@@ -143,8 +144,8 @@ class SubmissionTask @Inject constructor(
         )
         Timber.tag(TAG).d("Transformed keys with symptoms %s from %s to %s", symptoms, keys, transformedKeys)
 
-        val checkIns = checkInsRepository.checkInsWithinRetention.first().filter {
-            it.completed && it.hasSubmissionConsent && !it.isSubmitted
+        val checkIns = checkInsRepository.completedCheckIns.first().filter {
+            it.hasSubmissionConsent && !it.isSubmitted
         }
         val transformedCheckIns = checkInsTransformer.transform(checkIns, symptoms)
 
@@ -173,7 +174,7 @@ class SubmissionTask @Inject constructor(
         Timber.tag(TAG).d("Marking %d submitted CheckIns.", checkIns.size)
         checkIns.forEach { checkIn ->
             try {
-                checkInsRepository.markCheckInAsSubmitted(checkIn.id)
+                checkInsRepository.updatePostSubmissionFlags(checkIn.id)
             } catch (e: Exception) {
                 e.reportProblem(TAG, "CheckIn $checkIn could not be marked as submitted")
             }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/EventRegistrationUIModule.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/EventRegistrationUIModule.kt
@@ -24,6 +24,8 @@ import de.rki.coronawarnapp.ui.eventregistration.organizer.poster.QrCodePosterFr
 import de.rki.coronawarnapp.ui.eventregistration.organizer.poster.QrCodePosterFragmentModule
 import de.rki.coronawarnapp.ui.eventregistration.organizer.qrinfo.TraceLocationQRInfoFragment
 import de.rki.coronawarnapp.ui.eventregistration.organizer.qrinfo.TraceLocationQRInfoFragmentModule
+import de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent.CheckInsConsentFragment
+import de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent.CheckInsConsentFragmentModule
 
 @Module
 internal abstract class EventRegistrationUIModule {
@@ -60,4 +62,7 @@ internal abstract class EventRegistrationUIModule {
 
     @ContributesAndroidInjector(modules = [QrCodeDetailFragmentModule::class])
     abstract fun showEventDetail(): QrCodeDetailFragment
+
+    @ContributesAndroidInjector(modules = [CheckInsConsentFragmentModule::class])
+    abstract fun checkInsConsentFragment(): CheckInsConsentFragment
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/attendee/checkins/items/PastCheckInVH.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/attendee/checkins/items/PastCheckInVH.kt
@@ -4,10 +4,9 @@ import android.view.ViewGroup
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.TraceLocationAttendeeCheckinsItemPastBinding
 import de.rki.coronawarnapp.eventregistration.checkins.CheckIn
-import de.rki.coronawarnapp.util.TimeAndDateExtensions.toUserTimeZone
+import de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.common.checkoutInfo
 import de.rki.coronawarnapp.util.list.SwipeConsumer
 import de.rki.coronawarnapp.util.lists.diffutil.HasPayloadDiffer
-import org.joda.time.format.DateTimeFormat
 
 class PastCheckInVH(parent: ViewGroup) :
     BaseCheckInVH<PastCheckInVH.Item, TraceLocationAttendeeCheckinsItemPastBinding>(
@@ -24,20 +23,10 @@ class PastCheckInVH(parent: ViewGroup) :
         payloads: List<Any>
     ) -> Unit = { item, payloads ->
         val curItem = payloads.filterIsInstance<Item>().singleOrNull() ?: item
-
-        val checkInStartUserTZ = curItem.checkin.checkInStart.toUserTimeZone()
-        val checkInEndUserTZ = curItem.checkin.checkInEnd.toUserTimeZone()
-
         description.text = curItem.checkin.description
         address.text = curItem.checkin.address
 
-        checkoutInfo.text = run {
-            val dayFormatted = checkInStartUserTZ.toLocalDate().toString(DateTimeFormat.mediumDate())
-            val startTimeFormatted = checkInStartUserTZ.toLocalTime().toString(DateTimeFormat.shortTime())
-            val endTimeFormatted = checkInEndUserTZ.toLocalTime().toString(DateTimeFormat.shortTime())
-
-            "$dayFormatted, $startTimeFormatted - $endTimeFormatted"
-        }
+        checkoutInfo.text = curItem.checkin.checkoutInfo
 
         menuAction.setupMenu(R.menu.menu_trace_location_attendee_checkin_item) {
             when (it.itemId) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/common/CompletedCheckIn.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/common/CompletedCheckIn.kt
@@ -1,0 +1,16 @@
+package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.common
+
+import de.rki.coronawarnapp.eventregistration.checkins.CheckIn
+import de.rki.coronawarnapp.util.TimeAndDateExtensions.toUserTimeZone
+import org.joda.time.format.DateTimeFormat
+
+inline val CheckIn.checkoutInfo: String
+    get() {
+        val checkInStartUserTZ = checkInStart.toUserTimeZone()
+        val checkInEndUserTZ = checkInEnd.toUserTimeZone()
+
+        val dayFormatted = checkInStartUserTZ.toLocalDate().toString(DateTimeFormat.mediumDate())
+        val startTimeFormatted = checkInStartUserTZ.toLocalTime().toString(DateTimeFormat.shortTime())
+        val endTimeFormatted = checkInEndUserTZ.toLocalTime().toString(DateTimeFormat.shortTime())
+        return "$dayFormatted, $startTimeFormatted - $endTimeFormatted"
+    }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentAdapter.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentAdapter.kt
@@ -1,0 +1,37 @@
+package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent
+
+import android.view.ViewGroup
+import androidx.annotation.LayoutRes
+import androidx.viewbinding.ViewBinding
+import de.rki.coronawarnapp.util.lists.BindableVH
+import de.rki.coronawarnapp.util.lists.diffutil.AsyncDiffUtilAdapter
+import de.rki.coronawarnapp.util.lists.diffutil.AsyncDiffer
+import de.rki.coronawarnapp.util.lists.modular.ModularAdapter
+import de.rki.coronawarnapp.util.lists.modular.mods.DataBinderMod
+import de.rki.coronawarnapp.util.lists.modular.mods.StableIdMod
+import de.rki.coronawarnapp.util.lists.modular.mods.TypedVHCreatorMod
+
+class CheckInsConsentAdapter :
+    ModularAdapter<CheckInsConsentAdapter.ItemVH<CheckInsConsentItem, ViewBinding>>(),
+    AsyncDiffUtilAdapter<CheckInsConsentItem> {
+
+    override val asyncDiffer: AsyncDiffer<CheckInsConsentItem> = AsyncDiffer(adapter = this)
+
+    init {
+        modules.addAll(
+            listOf(
+                StableIdMod(data),
+                DataBinderMod<CheckInsConsentItem, ItemVH<CheckInsConsentItem, ViewBinding>>(data),
+                TypedVHCreatorMod({ data[it] is HeaderCheckInsVH.Item }) { HeaderCheckInsVH(it) },
+                TypedVHCreatorMod({ data[it] is SelectableCheckInVH.Item }) { SelectableCheckInVH(it) },
+            )
+        )
+    }
+
+    override fun getItemCount(): Int = data.size
+
+    abstract class ItemVH<Item : CheckInsConsentItem, VB : ViewBinding>(
+        @LayoutRes layoutRes: Int,
+        parent: ViewGroup
+    ) : ModularAdapter.VH(layoutRes, parent), BindableVH<Item, VB>
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentFragment.kt
@@ -3,21 +3,23 @@ package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
-import androidx.navigation.fragment.navArgs
+import androidx.activity.OnBackPressedCallback
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.CheckInsConsentFragmentBinding
+import de.rki.coronawarnapp.util.DialogHelper
 import de.rki.coronawarnapp.util.di.AutoInject
 import de.rki.coronawarnapp.util.lists.diffutil.update
+import de.rki.coronawarnapp.util.ui.doNavigate
 import de.rki.coronawarnapp.util.ui.viewBindingLazy
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactoryProvider
 import de.rki.coronawarnapp.util.viewmodel.cwaViewModelsAssisted
+import timber.log.Timber
 import javax.inject.Inject
 
 class CheckInsConsentFragment : Fragment(R.layout.check_ins_consent_fragment), AutoInject {
 
     private val binding: CheckInsConsentFragmentBinding by viewBindingLazy()
-    private val navArgs by navArgs<CheckInsConsentFragmentArgs>()
 
     @Inject lateinit var viewModelFactory: CWAViewModelFactoryProvider.Factory
     private val viewModel: CheckInsConsentViewModel by cwaViewModelsAssisted(
@@ -33,25 +35,42 @@ class CheckInsConsentFragment : Fragment(R.layout.check_ins_consent_fragment), A
     private val adapter = CheckInsConsentAdapter()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+
+        val backCallback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() = viewModel.onCloseClick()
+        }
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, backCallback)
+
         with(binding) {
             checkInsRecycler.adapter = adapter
             toolbar.setNavigationOnClickListener {
-                if (navArgs.preConsentGiven) {
-                    // TODO show dialog from Test screen
-                } else {
-                    showSkipDialog()
-                }
+                viewModel.onCloseClick()
             }
-            skipButton.setOnClickListener { showSkipDialog() }
-            continueButton.setOnClickListener {
-                viewModel.shareSelectedCheckIns()
-            }
+            skipButton.setOnClickListener { viewModel.onSkipClick() }
+            continueButton.setOnClickListener { viewModel.shareSelectedCheckIns() }
         }
 
         viewModel.checkIns.observe(viewLifecycleOwner) {
             adapter.update(it)
             binding.continueButton.isEnabled = it.any { item ->
                 item is SelectableCheckInVH.Item && item.checkIn.hasSubmissionConsent
+            }
+        }
+
+        viewModel.events.observe(viewLifecycleOwner) {
+            when (it) {
+                CheckInsConsentNavigation.OpenCloseDialog -> showCloseDialog()
+                CheckInsConsentNavigation.OpenSkipDialog -> showSkipDialog()
+                CheckInsConsentNavigation.ToHomeFragment -> doNavigate(
+                    CheckInsConsentFragmentDirections.actionCheckInsConsentFragmentToMainFragment()
+                )
+                CheckInsConsentNavigation.ToSubmissionResultReadyFragment -> doNavigate(
+                    CheckInsConsentFragmentDirections.actionCheckInsConsentFragmentToSubmissionResultReadyFragment()
+                )
+                CheckInsConsentNavigation.ToSubmissionTestResultConsentGivenFragment -> doNavigate(
+                    CheckInsConsentFragmentDirections
+                        .actionCheckInsConsentFragmentToSubmissionTestResultConsentGivenFragment()
+                )
             }
         }
     }
@@ -61,11 +80,27 @@ class CheckInsConsentFragment : Fragment(R.layout.check_ins_consent_fragment), A
             .setTitle(R.string.trace_location_attendee_consent_dialog_title)
             .setMessage(R.string.trace_location_attendee_consent_dialog_message)
             .setPositiveButton(R.string.trace_location_attendee_consent_dialog_positive_button) { _, _ ->
-                viewModel.shareSelectedCheckIns()
+                Timber.d("showSkipDialog:Stay on CheckInsConsentFragment")
             }
             .setNegativeButton(R.string.trace_location_attendee_consent_dialog_negative_button) { _, _ ->
                 viewModel.doNotShareCheckIns()
             }
             .show()
+    }
+
+    private fun showCloseDialog() {
+        val closeDialogInstance = DialogHelper.DialogInstance(
+            context = requireActivity(),
+            title = R.string.submission_test_result_available_close_dialog_title_consent_given,
+            message = R.string.submission_test_result_available_close_dialog_body_consent_given,
+            positiveButton = R.string.submission_test_result_available_close_dialog_continue_button,
+            negativeButton = R.string.submission_test_result_available_close_dialog_cancel_button,
+            cancelable = true,
+            positiveButtonFunction = {
+                Timber.d("showCloseDialog:Stay on CheckInsConsentFragment")
+            },
+            negativeButtonFunction = { viewModel.onCancelConfirmed() }
+        )
+        DialogHelper.showDialog(closeDialogInstance)
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentFragment.kt
@@ -1,8 +1,8 @@
 package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.View
+import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import de.rki.coronawarnapp.R
@@ -51,7 +51,7 @@ class CheckInsConsentFragment : Fragment(R.layout.check_ins_consent_fragment), A
         viewModel.checkIns.observe(viewLifecycleOwner) {
             adapter.update(it)
             binding.continueButton.isEnabled = it.any { item ->
-                item is SelectableCheckInVH.Item && item.checkIn.isSubmissionPermitted
+                item is SelectableCheckInVH.Item && item.checkIn.hasSubmissionConsent
             }
         }
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentFragment.kt
@@ -1,0 +1,71 @@
+package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.View
+import androidx.navigation.fragment.navArgs
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import de.rki.coronawarnapp.R
+import de.rki.coronawarnapp.databinding.CheckInsConsentFragmentBinding
+import de.rki.coronawarnapp.util.di.AutoInject
+import de.rki.coronawarnapp.util.lists.diffutil.update
+import de.rki.coronawarnapp.util.ui.viewBindingLazy
+import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactoryProvider
+import de.rki.coronawarnapp.util.viewmodel.cwaViewModelsAssisted
+import javax.inject.Inject
+
+class CheckInsConsentFragment : Fragment(R.layout.check_ins_consent_fragment), AutoInject {
+
+    private val binding: CheckInsConsentFragmentBinding by viewBindingLazy()
+    private val navArgs by navArgs<CheckInsConsentFragmentArgs>()
+
+    @Inject lateinit var viewModelFactory: CWAViewModelFactoryProvider.Factory
+    private val viewModel: CheckInsConsentViewModel by cwaViewModelsAssisted(
+        factoryProducer = { viewModelFactory },
+        constructorCall = { factory, savedState ->
+            factory as CheckInsConsentViewModel.Factory
+            factory.create(
+                savedState = savedState
+            )
+        }
+    )
+
+    private val adapter = CheckInsConsentAdapter()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        with(binding) {
+            checkInsRecycler.adapter = adapter
+            toolbar.setNavigationOnClickListener {
+                if (navArgs.preConsentGiven) {
+                    // TODO show dialog from Test screen
+                } else {
+                    showSkipDialog()
+                }
+            }
+            skipButton.setOnClickListener { showSkipDialog() }
+            continueButton.setOnClickListener {
+                viewModel.shareSelectedCheckIns()
+            }
+        }
+
+        viewModel.checkIns.observe(viewLifecycleOwner) {
+            adapter.update(it)
+            binding.continueButton.isEnabled = it.any { item ->
+                item is SelectableCheckInVH.Item && item.checkIn.isSubmissionPermitted
+            }
+        }
+    }
+
+    private fun showSkipDialog() {
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.trace_location_attendee_consent_dialog_title)
+            .setMessage(R.string.trace_location_attendee_consent_dialog_message)
+            .setPositiveButton(R.string.trace_location_attendee_consent_dialog_positive_button) { _, _ ->
+                viewModel.shareSelectedCheckIns()
+            }
+            .setNegativeButton(R.string.trace_location_attendee_consent_dialog_negative_button) { _, _ ->
+                viewModel.doNotShareCheckIns()
+            }
+            .show()
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentFragmentModule.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentFragmentModule.kt
@@ -1,0 +1,19 @@
+package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent
+
+import dagger.Binds
+import dagger.Module
+import dagger.multibindings.IntoMap
+import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
+import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactory
+import de.rki.coronawarnapp.util.viewmodel.CWAViewModelKey
+
+@Module
+abstract class CheckInsConsentFragmentModule {
+
+    @Binds
+    @IntoMap
+    @CWAViewModelKey(CheckInsConsentViewModel::class)
+    abstract fun checkInsConsentFragment(
+        factory: CheckInsConsentViewModel.Factory
+    ): CWAViewModelFactory<out CWAViewModel>
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentItem.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentItem.kt
@@ -1,0 +1,5 @@
+package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent
+
+import de.rki.coronawarnapp.util.lists.HasStableId
+
+interface CheckInsConsentItem : HasStableId

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentNavigation.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentNavigation.kt
@@ -1,0 +1,9 @@
+package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent
+
+sealed class CheckInsConsentNavigation {
+    object OpenCloseDialog : CheckInsConsentNavigation()
+    object OpenSkipDialog : CheckInsConsentNavigation()
+    object ToHomeFragment : CheckInsConsentNavigation()
+    object ToSubmissionTestResultConsentGivenFragment : CheckInsConsentNavigation()
+    object ToSubmissionResultReadyFragment : CheckInsConsentNavigation()
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModel.kt
@@ -18,7 +18,7 @@ import timber.log.Timber
 class CheckInsConsentViewModel @AssistedInject constructor(
     @Assisted private val savedState: SavedStateHandle,
     dispatcherProvider: DispatcherProvider,
-    checkInRepository: CheckInRepository,
+    private val checkInRepository: CheckInRepository,
 ) : CWAViewModel(dispatcherProvider) {
 
     private val selectedSetFlow = MutableStateFlow(initialSet())
@@ -33,7 +33,12 @@ class CheckInsConsentViewModel @AssistedInject constructor(
         }
     }.asLiveData(context = dispatcherProvider.Default)
 
-    fun shareSelectedCheckIns() {
+    fun shareSelectedCheckIns() = launch {
+        val idsWithConsent = selectedSetFlow.value
+        checkInRepository.updateSubmissionConsents(
+            checkInIds = idsWithConsent,
+            consent = true,
+        )
         // TODO persist selection and proceed to submitting check-ins
     }
 
@@ -55,7 +60,7 @@ class CheckInsConsentViewModel @AssistedInject constructor(
             .sortedByDescending { it.checkInEnd }
             .map { checkIn ->
                 SelectableCheckInVH.Item(
-                    checkIn = checkIn.copy(isSubmissionPermitted = ids.contains(checkIn.id)),
+                    checkIn = checkIn.copy(hasSubmissionConsent = ids.contains(checkIn.id)),
                     onItemSelected = { selectedSetFlow.value = updateSet(listOf(it.id)) }
                 )
             }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModel.kt
@@ -1,0 +1,90 @@
+package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import de.rki.coronawarnapp.eventregistration.checkins.CheckIn
+import de.rki.coronawarnapp.eventregistration.checkins.CheckInRepository
+import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
+import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
+import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactory
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import timber.log.Timber
+
+class CheckInsConsentViewModel @AssistedInject constructor(
+    @Assisted private val savedState: SavedStateHandle,
+    dispatcherProvider: DispatcherProvider,
+    checkInRepository: CheckInRepository,
+) : CWAViewModel(dispatcherProvider) {
+
+    private val selectedSetFlow = MutableStateFlow(initialSet())
+
+    val checkIns: LiveData<List<CheckInsConsentItem>> = combine(
+        checkInRepository.checkInsWithinRetention,
+        selectedSetFlow
+    ) { checkIns, ids ->
+        mutableListOf<CheckInsConsentItem>().apply {
+            add(headerItem(checkIns))
+            addAll(mapCheckIns(checkIns, ids))
+        }
+    }.asLiveData(context = dispatcherProvider.Default)
+
+    fun shareSelectedCheckIns() {
+        // TODO persist selection and proceed to submitting check-ins
+    }
+
+    fun doNotShareCheckIns() {
+        // TODO proceed to submitting keys only
+    }
+
+    private fun headerItem(checkIns: List<CheckIn>) = HeaderCheckInsVH.Item(
+        selectAll = {
+            val ids = checkIns.map { it.id }
+            if (!selectedSetFlow.value.containsAll(ids)) {
+                selectedSetFlow.value = updateSet(ids)
+            }
+        }
+    )
+
+    private fun mapCheckIns(checkIns: List<CheckIn>, ids: Set<Long>): List<CheckInsConsentItem> =
+        checkIns.filter { it.completed }
+            .sortedByDescending { it.checkInEnd }
+            .map { checkIn ->
+                SelectableCheckInVH.Item(
+                    checkIn = checkIn.copy(isSubmissionPermitted = ids.contains(checkIn.id)),
+                    onItemSelected = { selectedSetFlow.value = updateSet(listOf(it.id)) }
+                )
+            }
+
+    private fun updateSet(ids: List<Long>) =
+        mutableSetOf<Long>().apply {
+            if (!selectedSetFlow.value.containsAll(ids)) {
+                addAll(ids) // New Ids
+                addAll(selectedSetFlow.value) // Existing Ids
+            } else {
+                addAll(
+                    selectedSetFlow.value.toMutableSet().apply { removeAll(ids) }
+                )
+            }
+        }.also {
+            savedState.set(SET_KEY, it)
+            Timber.d("SelectedCheckIns=$it")
+        }
+
+    private fun initialSet(): Set<Long> = savedState.get(SET_KEY) ?: emptySet()
+
+    @AssistedFactory
+    interface Factory : CWAViewModelFactory<CheckInsConsentViewModel> {
+        fun create(
+            savedState: SavedStateHandle,
+        ): CheckInsConsentViewModel
+    }
+
+    companion object {
+        private const val SET_KEY = "selected_checkIn_set"
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/HeaderCheckInsVH.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/HeaderCheckInsVH.kt
@@ -1,0 +1,31 @@
+package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent
+
+import android.view.ViewGroup
+import de.rki.coronawarnapp.R
+import de.rki.coronawarnapp.databinding.TraceLocationAttendeeConsentHeaderBinding
+import de.rki.coronawarnapp.util.lists.diffutil.HasPayloadDiffer
+
+class HeaderCheckInsVH(parent: ViewGroup) :
+    CheckInsConsentAdapter.ItemVH<HeaderCheckInsVH.Item, TraceLocationAttendeeConsentHeaderBinding>(
+        layoutRes = R.layout.trace_location_attendee_consent_header,
+        parent = parent
+    ) {
+
+    override val viewBinding: Lazy<TraceLocationAttendeeConsentHeaderBinding> = lazy {
+        TraceLocationAttendeeConsentHeaderBinding.bind(itemView)
+    }
+
+    override val onBindData: TraceLocationAttendeeConsentHeaderBinding.(
+        item: Item,
+        payloads: List<Any>
+    ) -> Unit = { item, _ ->
+        selectAllButton.setOnClickListener { item.selectAll() }
+    }
+
+    data class Item(
+        val selectAll: () -> Unit
+    ) : CheckInsConsentItem, HasPayloadDiffer {
+        override val stableId: Long = Item::class.simpleName.hashCode().toLong()
+        override fun diffPayload(old: Any, new: Any): Any? = if (old::class == new::class) new else null
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/SelectableCheckInVH.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/SelectableCheckInVH.kt
@@ -1,0 +1,44 @@
+package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent
+
+import android.view.ViewGroup
+import de.rki.coronawarnapp.R
+import de.rki.coronawarnapp.databinding.TraceLocationAttendeeConsentSelectableCheckInBinding
+import de.rki.coronawarnapp.eventregistration.checkins.CheckIn
+import de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.common.checkoutInfo
+import de.rki.coronawarnapp.util.lists.diffutil.HasPayloadDiffer
+
+class SelectableCheckInVH(parent: ViewGroup) :
+    CheckInsConsentAdapter.ItemVH<SelectableCheckInVH.Item, TraceLocationAttendeeConsentSelectableCheckInBinding>(
+        layoutRes = R.layout.trace_location_attendee_consent_selectable_check_in,
+        parent = parent
+    ) {
+
+    override val viewBinding: Lazy<TraceLocationAttendeeConsentSelectableCheckInBinding> = lazy {
+        TraceLocationAttendeeConsentSelectableCheckInBinding.bind(itemView)
+    }
+
+    override val onBindData: TraceLocationAttendeeConsentSelectableCheckInBinding.(
+        item: Item,
+        payloads: List<Any>
+    ) -> Unit = { item, payloads ->
+        val curItem = payloads.filterIsInstance<Item>().singleOrNull() ?: item
+        val checkIn = curItem.checkIn
+        val imageResource = if (checkIn.isSubmissionPermitted) R.drawable.ic_selected else R.drawable.ic_unselected
+
+        checkbox.setImageResource(imageResource)
+        title.text = checkIn.description
+        subtitle.text = checkIn.address
+        checkoutInfo.text = checkIn.checkoutInfo
+
+        checkbox.setOnClickListener { item.onItemSelected(checkIn) }
+        itemView.setOnClickListener { item.onItemSelected(checkIn) }
+    }
+
+    data class Item(
+        val checkIn: CheckIn,
+        val onItemSelected: (CheckIn) -> Unit
+    ) : CheckInsConsentItem, HasPayloadDiffer {
+        override val stableId: Long = checkIn.id
+        override fun diffPayload(old: Any, new: Any): Any? = if (old::class == new::class) new else null
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/SelectableCheckInVH.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/SelectableCheckInVH.kt
@@ -23,7 +23,7 @@ class SelectableCheckInVH(parent: ViewGroup) :
     ) -> Unit = { item, payloads ->
         val curItem = payloads.filterIsInstance<Item>().singleOrNull() ?: item
         val checkIn = curItem.checkIn
-        val imageResource = if (checkIn.isSubmissionPermitted) R.drawable.ic_selected else R.drawable.ic_unselected
+        val imageResource = if (checkIn.hasSubmissionConsent) R.drawable.ic_selected else R.drawable.ic_unselected
 
         checkbox.setImageResource(imageResource)
         title.text = checkIn.description

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/resultavailable/SubmissionTestResultAvailableViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/resultavailable/SubmissionTestResultAvailableViewModel.kt
@@ -8,11 +8,13 @@ import com.google.android.gms.nearby.exposurenotification.TemporaryExposureKey
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import de.rki.coronawarnapp.datadonation.analytics.modules.keysubmission.AnalyticsKeySubmissionCollector
+import de.rki.coronawarnapp.eventregistration.checkins.CheckInRepository
 import de.rki.coronawarnapp.exception.ExceptionCategory
 import de.rki.coronawarnapp.exception.reporting.report
 import de.rki.coronawarnapp.submission.SubmissionRepository
 import de.rki.coronawarnapp.submission.auto.AutoSubmission
 import de.rki.coronawarnapp.submission.data.tekhistory.TEKHistoryUpdater
+import de.rki.coronawarnapp.presencetracing.checkins.common.completedCheckIns
 import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
 import de.rki.coronawarnapp.util.ui.SingleLiveEvent
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
@@ -24,13 +26,14 @@ class SubmissionTestResultAvailableViewModel @AssistedInject constructor(
     dispatcherProvider: DispatcherProvider,
     tekHistoryUpdaterFactory: TEKHistoryUpdater.Factory,
     submissionRepository: SubmissionRepository,
+    private val checkInRepository: CheckInRepository,
     private val autoSubmission: AutoSubmission,
     private val analyticsKeySubmissionCollector: AnalyticsKeySubmissionCollector
 ) : CWAViewModel(dispatcherProvider = dispatcherProvider) {
 
     val routeToScreen = SingleLiveEvent<NavDirections>()
 
-    val consentFlow = submissionRepository.hasGivenConsentToSubmission
+    private val consentFlow = submissionRepository.hasGivenConsentToSubmission
     val consent = consentFlow.asLiveData(dispatcherProvider.Default)
     val showPermissionRequest = SingleLiveEvent<(Activity) -> Unit>()
     val showCloseDialog = SingleLiveEvent<Unit>()
@@ -39,14 +42,21 @@ class SubmissionTestResultAvailableViewModel @AssistedInject constructor(
 
     private val tekHistoryUpdater = tekHistoryUpdaterFactory.create(
         object : TEKHistoryUpdater.Callback {
-            override fun onTEKAvailable(teks: List<TemporaryExposureKey>) {
-                Timber.d("onTEKAvailable(teks.size=%d)", teks.size)
-                autoSubmission.updateMode(AutoSubmission.Mode.MONITOR)
+            override fun onTEKAvailable(teks: List<TemporaryExposureKey>) = launch {
+                Timber.tag(TAG).d("onTEKAvailable(teks.size=%d)", teks.size)
                 showKeysRetrievalProgress.postValue(false)
-                routeToScreen.postValue(
+                val completedCheckInsExist = checkInRepository.completedCheckIns.first().isNotEmpty()
+                val navDirections = if (completedCheckInsExist) {
+                    Timber.tag(TAG).d("Navigate to CheckInsConsentFragment")
+                    SubmissionTestResultAvailableFragmentDirections
+                        .actionSubmissionTestResultAvailableFragmentToCheckInsConsentFragment()
+                } else {
+                    autoSubmission.updateMode(AutoSubmission.Mode.MONITOR)
+                    Timber.tag(TAG).d("Navigate to SubmissionTestResultConsentGivenFragment")
                     SubmissionTestResultAvailableFragmentDirections
                         .actionSubmissionTestResultAvailableFragmentToSubmissionTestResultConsentGivenFragment()
-                )
+                }
+                routeToScreen.postValue(navDirections)
             }
 
             override fun onTEKPermissionDeclined() {
@@ -59,13 +69,13 @@ class SubmissionTestResultAvailableViewModel @AssistedInject constructor(
             }
 
             override fun onTracingConsentRequired(onConsentResult: (given: Boolean) -> Unit) {
-                Timber.d("onTracingConsentRequired")
+                Timber.tag(TAG).d("onTracingConsentRequired")
                 showKeysRetrievalProgress.postValue(false)
                 showTracingConsentDialog.postValue(onConsentResult)
             }
 
             override fun onPermissionRequired(permissionRequest: (Activity) -> Unit) {
-                Timber.d("onPermissionRequired")
+                Timber.tag(TAG).d("onPermissionRequired")
                 showKeysRetrievalProgress.postValue(false)
                 showPermissionRequest.postValue(permissionRequest)
             }
@@ -109,10 +119,10 @@ class SubmissionTestResultAvailableViewModel @AssistedInject constructor(
         showKeysRetrievalProgress.value = true
         launch {
             if (consentFlow.first()) {
-                Timber.d("tekHistoryUpdater.updateTEKHistoryOrRequestPermission")
+                Timber.tag(TAG).d("tekHistoryUpdater.updateTEKHistoryOrRequestPermission")
                 tekHistoryUpdater.updateTEKHistoryOrRequestPermission()
             } else {
-                Timber.d("routeToScreen:SubmissionTestResultNoConsentFragment")
+                Timber.tag(TAG).d("routeToScreen:SubmissionTestResultNoConsentFragment")
                 analyticsKeySubmissionCollector.reportConsentWithdrawn()
                 showKeysRetrievalProgress.postValue(false)
                 routeToScreen.postValue(
@@ -130,4 +140,8 @@ class SubmissionTestResultAvailableViewModel @AssistedInject constructor(
 
     @AssistedFactory
     interface Factory : SimpleCWAViewModelFactory<SubmissionTestResultAvailableViewModel>
+
+    companion object {
+        private const val TAG = "TestAvailableViewModel"
+    }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/warnothers/SubmissionResultPositiveOtherWarningNoConsentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/warnothers/SubmissionResultPositiveOtherWarningNoConsentViewModel.kt
@@ -9,6 +9,7 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import de.rki.coronawarnapp.datadonation.analytics.modules.keysubmission.AnalyticsKeySubmissionCollector
 import de.rki.coronawarnapp.datadonation.analytics.modules.keysubmission.Screen
+import de.rki.coronawarnapp.eventregistration.checkins.CheckInRepository
 import de.rki.coronawarnapp.exception.ExceptionCategory
 import de.rki.coronawarnapp.exception.reporting.report
 import de.rki.coronawarnapp.nearby.ENFClient
@@ -16,6 +17,7 @@ import de.rki.coronawarnapp.storage.interoperability.InteroperabilityRepository
 import de.rki.coronawarnapp.submission.SubmissionRepository
 import de.rki.coronawarnapp.submission.auto.AutoSubmission
 import de.rki.coronawarnapp.submission.data.tekhistory.TEKHistoryUpdater
+import de.rki.coronawarnapp.presencetracing.checkins.common.completedCheckIns
 import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
 import de.rki.coronawarnapp.util.ui.SingleLiveEvent
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
@@ -30,6 +32,7 @@ class SubmissionResultPositiveOtherWarningNoConsentViewModel @AssistedInject con
     tekHistoryUpdaterFactory: TEKHistoryUpdater.Factory,
     interoperabilityRepository: InteroperabilityRepository,
     private val submissionRepository: SubmissionRepository,
+    private val checkInRepository: CheckInRepository,
     private val analyticsKeySubmissionCollector: AnalyticsKeySubmissionCollector
 ) : CWAViewModel(dispatcherProvider = dispatcherProvider) {
 
@@ -48,36 +51,44 @@ class SubmissionResultPositiveOtherWarningNoConsentViewModel @AssistedInject con
 
     private val tekHistoryUpdater = tekHistoryUpdaterFactory.create(
         object : TEKHistoryUpdater.Callback {
-            override fun onTEKAvailable(teks: List<TemporaryExposureKey>) {
-                Timber.d("onTEKAvailable(tek.size=%d)", teks.size)
-                autoSubmission.updateMode(AutoSubmission.Mode.MONITOR)
+            override fun onTEKAvailable(teks: List<TemporaryExposureKey>) = launch {
+                Timber.tag(TAG).d("onTEKAvailable(tek.size=%d)", teks.size)
                 showKeysRetrievalProgress.postValue(false)
-                routeToScreen.postValue(
+
+                val completedCheckInsExist = checkInRepository.completedCheckIns.first().isNotEmpty()
+                val navDirections = if (completedCheckInsExist) {
+                    Timber.tag(TAG).d("Navigate to CheckInsConsentFragment")
+                    SubmissionResultPositiveOtherWarningNoConsentFragmentDirections
+                        .actionSubmissionResultPositiveOtherWarningNoConsentFragmentToCheckInsConsentFragment()
+                } else {
+                    autoSubmission.updateMode(AutoSubmission.Mode.MONITOR)
+                    Timber.tag(TAG).d("Navigate to SubmissionResultReadyFragment")
                     SubmissionResultPositiveOtherWarningNoConsentFragmentDirections
                         .actionSubmissionResultPositiveOtherWarningNoConsentFragmentToSubmissionResultReadyFragment()
-                )
+                }
+                routeToScreen.postValue(navDirections)
             }
 
             override fun onTEKPermissionDeclined() {
-                Timber.d("onTEKPermissionDeclined")
+                Timber.tag(TAG).d("onTEKPermissionDeclined")
                 showKeysRetrievalProgress.postValue(false)
                 // stay on screen
             }
 
             override fun onTracingConsentRequired(onConsentResult: (given: Boolean) -> Unit) {
-                Timber.d("onTracingConsentRequired")
+                Timber.tag(TAG).d("onTracingConsentRequired")
                 showKeysRetrievalProgress.postValue(false)
                 showTracingConsentDialog.postValue(onConsentResult)
             }
 
             override fun onPermissionRequired(permissionRequest: (Activity) -> Unit) {
-                Timber.d("onPermissionRequired")
+                Timber.tag(TAG).d("onPermissionRequired")
                 showKeysRetrievalProgress.postValue(false)
                 showPermissionRequest.postValue(permissionRequest)
             }
 
             override fun onError(error: Throwable) {
-                Timber.e(error, "Couldn't access temporary exposure key history.")
+                Timber.tag(TAG).e(error, "Couldn't access temporary exposure key history.")
                 showKeysRetrievalProgress.postValue(false)
                 error.report(ExceptionCategory.EXPOSURENOTIFICATION, "Failed to obtain TEKs.")
             }
@@ -96,10 +107,10 @@ class SubmissionResultPositiveOtherWarningNoConsentViewModel @AssistedInject con
         submissionRepository.giveConsentToSubmission()
         launch {
             if (enfClient.isTracingEnabled.first()) {
-                Timber.d("tekHistoryUpdater.updateTEKHistoryOrRequestPermission()")
+                Timber.tag(TAG).d("tekHistoryUpdater.updateTEKHistoryOrRequestPermission()")
                 tekHistoryUpdater.updateTEKHistoryOrRequestPermission()
             } else {
-                Timber.d("showEnableTracingEvent:Unit")
+                Timber.tag(TAG).d("showEnableTracingEvent:Unit")
                 showKeysRetrievalProgress.postValue(false)
                 showEnableTracingEvent.postValue(Unit)
             }
@@ -107,6 +118,7 @@ class SubmissionResultPositiveOtherWarningNoConsentViewModel @AssistedInject con
     }
 
     fun onDataPrivacyClick() {
+        Timber.tag(TAG).d("onDataPrivacyClick")
         routeToScreen.postValue(
             SubmissionResultPositiveOtherWarningNoConsentFragmentDirections
                 .actionSubmissionResultPositiveOtherWarningNoConsentFragmentToInformationPrivacyFragment()
@@ -114,6 +126,7 @@ class SubmissionResultPositiveOtherWarningNoConsentViewModel @AssistedInject con
     }
 
     fun handleActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        Timber.tag(TAG).d("handleActivityResult($resultCode)")
         showKeysRetrievalProgress.value = true
         tekHistoryUpdater.handleActivityResult(requestCode, resultCode, data)
     }
@@ -125,5 +138,9 @@ class SubmissionResultPositiveOtherWarningNoConsentViewModel @AssistedInject con
     @AssistedFactory
     interface Factory : CWAViewModelFactory<SubmissionResultPositiveOtherWarningNoConsentViewModel> {
         fun create(): SubmissionResultPositiveOtherWarningNoConsentViewModel
+    }
+
+    companion object {
+        private const val TAG = "WarnNoConsentViewModel"
     }
 }

--- a/Corona-Warn-App/src/main/res/layout/check_ins_consent_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/check_ins_consent_fragment.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.presencetracing.attendee.checkins.consent.CheckInsConsentFragment">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/CWAToolbar.Close"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/trace_location_attendee_consent_title" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/checkInsRecycler"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginBottom="16dp"
+        android:orientation="vertical"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintBottom_toTopOf="@id/continue_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
+        tools:listitem="@layout/trace_location_attendee_consent_selectable_check_in" />
+
+    <Button
+        android:id="@+id/continue_button"
+        style="@style/buttonPrimary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="24dp"
+        android:layout_marginBottom="16dp"
+        android:text="@string/trace_location_attendee_consent_continue"
+        app:layout_constraintBottom_toTopOf="@id/skip_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <Button
+        android:id="@+id/skip_button"
+        style="@style/buttonPrimary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="24dp"
+        android:layout_marginBottom="24dp"
+        android:text="@string/trace_location_attendee_consent_skip"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Corona-Warn-App/src/main/res/layout/trace_location_attendee_consent_header.xml
+++ b/Corona-Warn-App/src/main/res/layout/trace_location_attendee_consent_header.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingStart="24dp"
+    android:paddingTop="18dp"
+    android:paddingEnd="24dp"
+    android:paddingBottom="8dp">
+
+    <TextView
+        style="@style/subtitleMedium"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/trace_location_attendee_consent_header_description" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/select_all_button"
+        style="@style/materialTextButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_marginTop="8dp"
+        android:text="@string/trace_location_attendee_consent_header_button" />
+</LinearLayout>

--- a/Corona-Warn-App/src/main/res/layout/trace_location_attendee_consent_selectable_check_in.xml
+++ b/Corona-Warn-App/src/main/res/layout/trace_location_attendee_consent_selectable_check_in.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/contactDiaryCardRipple"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="16dp"
+    android:layout_marginVertical="8dp"
+    android:focusable="true">
+
+    <ImageView
+        android:id="@+id/checkbox"
+        android:layout_width="@dimen/spacing_medium"
+        android:layout_height="@dimen/spacing_medium"
+        android:layout_marginStart="@dimen/spacing_small"
+        android:layout_marginTop="13dp"
+        android:background="?selectableItemBackgroundBorderless"
+        android:clickable="false"
+        android:focusable="false"
+        android:importantForAccessibility="no"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_unselected"
+        tools:srcCompat="@drawable/ic_selected" />
+
+    <TextView
+        android:id="@+id/title"
+        style="@style/materialSubtitleSixteen"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="15dp"
+        android:layout_marginTop="13dp"
+        android:layout_marginEnd="10dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/checkbox"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Hairdresser" />
+
+    <TextView
+        android:id="@+id/subtitle"
+        style="@style/body2"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="10dp"
+        android:textColor="@color/colorTextPrimary2"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@id/title"
+        app:layout_constraintTop_toBottomOf="@id/title"
+        tools:text="Berlin" />
+
+    <TextView
+        android:id="@+id/checkoutInfo"
+        style="@style/body2"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="10dp"
+        android:layout_marginBottom="10dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@id/title"
+        app:layout_constraintTop_toBottomOf="@id/subtitle"
+        tools:text="21.01.21, 18:01 - 21:00 Uhr" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
+++ b/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
@@ -609,4 +609,15 @@
         android:name="de.rki.coronawarnapp.bugreporting.debuglog.ui.legal.DebugLogLegalFragment"
         android:label="DebugLogLegalFragment"
         tools:layout="@layout/bugreporting_legal_fragment" />
+
+    <fragment
+        android:id="@+id/checkInsConsentFragment"
+        android:name="de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent.CheckInsConsentFragment"
+        android:label="check_ins_consent_fragment"
+        tools:layout="@layout/check_ins_consent_fragment">
+        <argument
+            android:name="preConsentGiven"
+            android:defaultValue="false"
+            app:argType="boolean" />
+    </fragment>
 </navigation>

--- a/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
+++ b/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
@@ -278,6 +278,11 @@
             app:destination="@id/submissionResultReadyFragment"
             app:popUpTo="@id/mainFragment"
             app:popUpToInclusive="false" />
+        <action
+            android:id="@+id/action_submissionResultPositiveOtherWarningNoConsentFragment_to_checkInsConsentFragment"
+            app:destination="@id/checkInsConsentFragment"
+            app:popUpTo="@id/mainFragment"
+            app:popUpToInclusive="false" />
     </fragment>
     <fragment
         android:id="@+id/submissionTestResultPendingFragment"
@@ -489,6 +494,11 @@
             app:popUpTo="@id/mainFragment"
             app:popUpToInclusive="false" />
         <action
+            android:id="@+id/action_submissionTestResultAvailableFragment_to_checkInsConsentFragment"
+            app:destination="@id/checkInsConsentFragment"
+            app:popUpTo="@id/mainFragment"
+            app:popUpToInclusive="false" />
+        <action
             android:id="@+id/action_submissionTestResultAvailableFragment_to_submissionTestResultNoConsentFragment"
             app:destination="@id/submissionTestResultNoConsentFragment"
             app:popUpTo="@id/mainFragment"
@@ -615,9 +625,22 @@
         android:name="de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent.CheckInsConsentFragment"
         android:label="check_ins_consent_fragment"
         tools:layout="@layout/check_ins_consent_fragment">
-        <argument
-            android:name="preConsentGiven"
-            android:defaultValue="false"
-            app:argType="boolean" />
+        <action
+            android:id="@+id/action_checkInsConsentFragment_to_mainFragment"
+            app:destination="@id/mainFragment"
+            app:popUpTo="@id/nav_graph"
+            app:popUpToInclusive="true" />
+
+        <action
+            android:id="@+id/action_checkInsConsentFragment_to_submissionResultReadyFragment"
+            app:destination="@id/submissionResultReadyFragment"
+            app:popUpTo="@id/mainFragment"
+            app:popUpToInclusive="false" />
+
+        <action
+            android:id="@+id/action_checkInsConsentFragment_to_submissionTestResultConsentGivenFragment"
+            app:destination="@id/submissionTestResultConsentGivenFragment"
+            app:popUpTo="@id/mainFragment"
+            app:popUpToInclusive="false" />
     </fragment>
 </navigation>

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -1974,4 +1974,22 @@
     <string name="trace_location_organiser_poster_share">"Teilen"</string>
     <!-- XHED: Trace location poster title -->
     <string name="trace_location_organiser_poster_title">"Druckversion"</string>
+    <!-- XHED: Trace location check-ins consent screen title -->
+    <string name="trace_location_attendee_consent_title">Check-ins für diese Orte teilen?</string>
+    <!-- XTXT: Trace location check-ins consent screen header description -->
+    <string name="trace_location_attendee_consent_header_description">Teilen Sie Ihre Check-ins, um andere zu warnen, die in Ihrer Nähe waren. Ihre Identität bleibt geheim.</string>
+    <!-- XBUT: Trace location check-ins consent screen header button -->
+    <string name="trace_location_attendee_consent_header_button">Alle auswählen</string>
+    <!-- XBUT: Trace location check-ins consent screen continue button -->
+    <string name="trace_location_attendee_consent_continue">Weiter</string>
+    <!-- XBUT: Trace location check-ins consent screen skip button -->
+    <string name="trace_location_attendee_consent_skip">Überspringen</string>
+    <!-- XHED: Trace location check-ins consent screen dialog title -->
+    <string name="trace_location_attendee_consent_dialog_title">Sind Sie sicher, dass Sie Ihre Check-Ins nicht teilen wollen?</string>
+    <!-- XTXT: Trace location check-ins consent screen dialog message -->
+    <string name="trace_location_attendee_consent_dialog_message">Dadurch werden andere, die in Ihrer Nähe waren, nicht gewarnt.</string>
+    <!-- XBUT: Trace location check-ins consent screen dialog positive button -->
+    <string name="trace_location_attendee_consent_dialog_positive_button">Teilen</string>
+    <!-- XBUT: Trace location check-ins consent screen dialog negative button -->
+    <string name="trace_location_attendee_consent_dialog_negative_button">Nicht teilen</string>
 </resources>

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -1982,4 +1982,22 @@
     <string name="trace_location_organiser_poster_share">"Share"</string>
     <!-- XHED: Trace location poster title -->
     <string name="trace_location_organiser_poster_title">"Print Version"</string>
+    <!-- XHED: Trace location check-ins consent screen title -->
+    <string name="trace_location_attendee_consent_title">Check-ins für diese Orte teilen?</string>
+    <!-- XTXT: Trace location check-ins consent screen header description -->
+    <string name="trace_location_attendee_consent_header_description">Teilen Sie Ihre Check-ins, um andere zu warnen, die in Ihrer Nähe waren. Ihre Identität bleibt geheim.</string>
+    <!-- XBUT: Trace location check-ins consent screen header button -->
+    <string name="trace_location_attendee_consent_header_button">Alle auswählen</string>
+    <!-- XBUT: Trace location check-ins consent screen continue button -->
+    <string name="trace_location_attendee_consent_continue">Weiter</string>
+    <!-- XBUT: Trace location check-ins consent screen skip button -->
+    <string name="trace_location_attendee_consent_skip">Überspringen</string>
+    <!-- XHED: Trace location check-ins consent screen dialog title -->
+    <string name="trace_location_attendee_consent_dialog_title">Sind Sie sicher, dass Sie Ihre Check-Ins nicht teilen wollen?</string>
+    <!-- XTXT: Trace location check-ins consent screen dialog message -->
+    <string name="trace_location_attendee_consent_dialog_message">Dadurch werden andere, die in Ihrer Nähe waren, nicht gewarnt.</string>
+    <!-- XBUT: Trace location check-ins consent screen dialog positive button -->
+    <string name="trace_location_attendee_consent_dialog_positive_button">Teilen</string>
+    <!-- XBUT: Trace location check-ins consent screen dialog negative button -->
+    <string name="trace_location_attendee_consent_dialog_negative_button">Nicht teilen</string>
 </resources>

--- a/Corona-Warn-App/src/main/res/values/styles.xml
+++ b/Corona-Warn-App/src/main/res/values/styles.xml
@@ -155,6 +155,10 @@
         <item name="android:textColor">@color/colorAccent</item>
     </style>
 
+    <style name="materialTextButton" parent="Widget.MaterialComponents.Button.TextButton.Dialog.Flush">
+        <item name="android:textColor">@color/colorAccent</item>
+    </style>
+
     <style name="buttonIcon">
         <item name="android:background">@drawable/circle_ripple</item>
         <item name="android:backgroundTint">@color/button_back</item>
@@ -289,9 +293,13 @@
         <item name="android:textColor">@color/colorTextPrimary1</item>
     </style>
 
-    <style name="subtitleBoldSixteen" parent="@style/TextAppearance.MaterialComponents.Subtitle1">
+
+    <style name="materialSubtitleSixteen" parent="@style/TextAppearance.MaterialComponents.Subtitle1">
         <item name="android:textColor">@color/colorTextPrimary1</item>
         <item name="android:textSize">16sp</item>
+    </style>
+
+    <style name="subtitleBoldSixteen" parent="materialSubtitleSixteen">
         <item name="android:textStyle">bold</item>
     </style>
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/eventregistration/checkins/CheckInRepositoryTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/eventregistration/checkins/CheckInRepositoryTest.kt
@@ -115,6 +115,7 @@ class CheckInRepositoryTest : BaseTest() {
                         completed = false,
                         createJournalEntry = false,
                         isSubmitted = true,
+                        hasSubmissionConsent = false,
                     )
                 )
             }
@@ -160,6 +161,7 @@ class CheckInRepositoryTest : BaseTest() {
                 completed = false,
                 createJournalEntry = false,
                 isSubmitted = true,
+                hasSubmissionConsent = true,
             )
         )
         runBlockingTest {
@@ -181,6 +183,7 @@ class CheckInRepositoryTest : BaseTest() {
                     completed = false,
                     createJournalEntry = false,
                     isSubmitted = true,
+                    hasSubmissionConsent = true,
                 )
             )
         }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/submission/task/SubmissionTaskTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/submission/task/SubmissionTaskTest.kt
@@ -74,7 +74,7 @@ class SubmissionTaskTest : BaseTest() {
 
     private val settingLastUserActivityUTC: FlowPreference<Instant> = mockFlowPreference(Instant.EPOCH.plus(1))
 
-    private val testCheckIn1 = CheckIn(
+    private val validCheckIn = CheckIn(
         id = 1L,
         traceLocationId = mockk(),
         version = 1,
@@ -93,6 +93,10 @@ class SubmissionTaskTest : BaseTest() {
         isSubmitted = false,
         hasSubmissionConsent = true
     )
+
+    private val invalidCheckIn1 = validCheckIn.copy(id = 2L, completed = false)
+    private val invalidCheckIn2 = validCheckIn.copy(id = 3L, isSubmitted = true)
+    private val invalidCheckIn3 = validCheckIn.copy(id = 4L, hasSubmissionConsent = false)
 
     @BeforeEach
     fun setup() {
@@ -134,7 +138,14 @@ class SubmissionTaskTest : BaseTest() {
 
         every { timeStamper.nowUTC } returns Instant.EPOCH.plus(Duration.standardHours(1))
 
-        every { checkInRepository.checkInsWithinRetention } returns flowOf(listOf(testCheckIn1))
+        every { checkInRepository.checkInsWithinRetention } returns flowOf(
+            listOf(
+                validCheckIn,
+                invalidCheckIn1,
+                invalidCheckIn2,
+                invalidCheckIn3
+            )
+        )
         coEvery { checkInsTransformer.transform(any(), any()) } returns emptyList()
     }
 
@@ -200,7 +211,7 @@ class SubmissionTaskTest : BaseTest() {
             submissionSettings.symptoms
             settingSymptomsPreference.update(match { it.invoke(mockk()) == null })
 
-            checkInRepository.markCheckInAsSubmitted(testCheckIn1.id)
+            checkInRepository.updatePostSubmissionFlags(validCheckIn.id)
 
             autoSubmission.updateMode(AutoSubmission.Mode.DISABLED)
 
@@ -210,6 +221,12 @@ class SubmissionTaskTest : BaseTest() {
 
             shareTestResultNotificationService.cancelSharePositiveTestResultNotification()
             testResultAvailableNotificationService.cancelTestResultAvailableNotification()
+        }
+
+        coVerify(exactly = 0) {
+            checkInRepository.updatePostSubmissionFlags(invalidCheckIn1.id)
+            checkInRepository.updatePostSubmissionFlags(invalidCheckIn2.id)
+            checkInRepository.updatePostSubmissionFlags(invalidCheckIn3.id)
         }
     }
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/submission/task/SubmissionTaskTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/submission/task/SubmissionTaskTest.kt
@@ -88,9 +88,10 @@ class SubmissionTaskTest : BaseTest() {
         cnPublicKey = "cnPublicKey",
         checkInStart = Instant.EPOCH,
         checkInEnd = Instant.EPOCH.plus(9000),
-        completed = false,
+        completed = true,
         createJournalEntry = false,
-        isSubmitted = true
+        isSubmitted = false,
+        hasSubmissionConsent = true
     )
 
     @BeforeEach

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModelTest.kt
@@ -1,0 +1,243 @@
+package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent
+
+import androidx.lifecycle.SavedStateHandle
+import de.rki.coronawarnapp.eventregistration.checkins.CheckIn
+import de.rki.coronawarnapp.eventregistration.checkins.CheckInRepository
+import io.kotest.matchers.shouldBe
+import io.mockk.MockKAnnotations
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.just
+import kotlinx.coroutines.flow.flowOf
+import okio.ByteString.Companion.decodeBase64
+import okio.ByteString.Companion.encode
+import org.joda.time.Instant
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import testhelpers.BaseTest
+import testhelpers.TestDispatcherProvider
+import testhelpers.extensions.InstantExecutorExtension
+import testhelpers.extensions.getOrAwaitValue
+
+@ExtendWith(InstantExecutorExtension::class)
+class CheckInsConsentViewModelTest : BaseTest() {
+
+    @MockK lateinit var savedState: SavedStateHandle
+    @MockK lateinit var checkInRepository: CheckInRepository
+
+    private val checkIn1 = CheckIn(
+        id = 1L,
+        traceLocationId = "41da2115-eba2-49bd-bf17-adb3d635ddaf".decodeBase64()!!,
+        version = 1,
+        type = 2,
+        description = "brothers birthday",
+        address = "Malibu",
+        traceLocationStart = Instant.EPOCH,
+        traceLocationEnd = null,
+        defaultCheckInLengthInMinutes = null,
+        cryptographicSeed = "cryptographicSeed".encode(),
+        cnPublicKey = "cnPublicKey",
+        checkInStart = Instant.EPOCH,
+        checkInEnd = Instant.EPOCH,
+        completed = true,
+        createJournalEntry = false
+    )
+
+    private val checkIn2 = CheckIn(
+        id = 2L,
+        traceLocationId = "41da2115-eba2-49bd-bf17-adb3d635ddaf".decodeBase64()!!,
+        version = 1,
+        type = 2,
+        description = "brothers birthday",
+        address = "Malibu",
+        traceLocationStart = Instant.EPOCH,
+        traceLocationEnd = null,
+        defaultCheckInLengthInMinutes = null,
+        cryptographicSeed = "cryptographicSeed".encode(),
+        cnPublicKey = "cnPublicKey",
+        checkInStart = Instant.EPOCH,
+        checkInEnd = Instant.EPOCH,
+        completed = true,
+        createJournalEntry = false
+    )
+
+    private val checkIn3 = CheckIn(
+        id = 3L,
+        traceLocationId = "41da2115-eba2-49bd-bf17-adb3d635ddaf".decodeBase64()!!,
+        version = 1,
+        type = 2,
+        description = "brothers birthday",
+        address = "Malibu",
+        traceLocationStart = Instant.EPOCH,
+        traceLocationEnd = null,
+        defaultCheckInLengthInMinutes = null,
+        cryptographicSeed = "cryptographicSeed".encode(),
+        cnPublicKey = "cnPublicKey",
+        checkInStart = Instant.EPOCH,
+        checkInEnd = Instant.EPOCH,
+        completed = false,
+        createJournalEntry = false
+    )
+
+    @BeforeEach
+    fun setUp() {
+        MockKAnnotations.init(this)
+
+        every { checkInRepository.checkInsWithinRetention } returns flowOf(listOf(checkIn1, checkIn2, checkIn3))
+        every { savedState.set(any(), any<Set<Long>>()) } just Runs
+    }
+
+    @Test
+    fun `Nothing is selected initially`() {
+        every { savedState.get<Set<Long>>(any()) } returns emptySet()
+
+        val viewModel = createViewModel()
+        viewModel.checkIns.getOrAwaitValue().apply {
+            size shouldBe 3
+            get(0).apply {
+                this is HeaderCheckInsVH.Item
+            }
+
+            get(1).apply {
+                this as SelectableCheckInVH.Item
+                this.checkIn.isSubmissionPermitted shouldBe false
+            }
+
+            get(2).apply {
+                this as SelectableCheckInVH.Item
+                this.checkIn.isSubmissionPermitted shouldBe false
+            }
+        }
+    }
+
+    @Test
+    fun `Saved state is restored`() {
+        every { savedState.get<Set<Long>>(any()) } returns setOf(1L)
+        val viewModel = createViewModel()
+        viewModel.checkIns.getOrAwaitValue().apply {
+            size shouldBe 3
+            get(0).apply {
+                this is HeaderCheckInsVH.Item
+            }
+
+            get(1).apply {
+                this as SelectableCheckInVH.Item
+                this.checkIn.isSubmissionPermitted shouldBe true
+            }
+
+            get(2).apply {
+                this as SelectableCheckInVH.Item
+                this.checkIn.isSubmissionPermitted shouldBe false
+            }
+        }
+    }
+
+    @Test
+    fun `Select all`() {
+        every { savedState.get<Set<Long>>(any()) } returns emptySet()
+        val viewModel = createViewModel()
+        viewModel.checkIns.getOrAwaitValue().apply {
+            size shouldBe 3
+            get(0).apply {
+                this as HeaderCheckInsVH.Item
+                (get(1) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe false
+                (get(2) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe false
+
+                this.selectAll()
+
+                viewModel.checkIns.getOrAwaitValue().apply {
+                    (get(1) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe true
+                    (get(2) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe true
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `Select all does not un-select all`() {
+        every { savedState.get<Set<Long>>(any()) } returns emptySet()
+        val viewModel = createViewModel()
+        viewModel.checkIns.getOrAwaitValue().apply {
+            size shouldBe 3
+            get(0).apply {
+                this as HeaderCheckInsVH.Item
+                (get(1) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe false
+                (get(2) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe false
+
+                this.selectAll()
+
+                viewModel.checkIns.getOrAwaitValue().apply {
+                    (get(1) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe true
+                    (get(2) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe true
+                }
+
+                this.selectAll()
+
+                viewModel.checkIns.getOrAwaitValue().apply {
+                    (get(1) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe true
+                    (get(2) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe true
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `Single selection`() {
+        every { savedState.get<Set<Long>>(any()) } returns emptySet()
+        val viewModel = createViewModel()
+        viewModel.checkIns.getOrAwaitValue().apply {
+
+            (get(1) as SelectableCheckInVH.Item).apply {
+                checkIn.isSubmissionPermitted shouldBe false
+                onItemSelected(checkIn)
+            }
+
+            viewModel.checkIns.getOrAwaitValue().apply {
+                (get(1) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe true
+            }
+        }
+    }
+
+    @Test
+    fun `Single deselection`() {
+        every { savedState.get<Set<Long>>(any()) } returns emptySet()
+        val viewModel = createViewModel()
+        viewModel.checkIns.getOrAwaitValue().apply {
+            (get(1) as SelectableCheckInVH.Item).apply {
+                checkIn.isSubmissionPermitted shouldBe false
+                onItemSelected(checkIn)
+            }
+
+            viewModel.checkIns.getOrAwaitValue().apply {
+                (get(1) as SelectableCheckInVH.Item).apply {
+                    checkIn.isSubmissionPermitted shouldBe true
+                    onItemSelected(checkIn)
+                }
+            }
+
+            viewModel.checkIns.getOrAwaitValue().apply {
+                (get(1) as SelectableCheckInVH.Item).apply {
+                    checkIn.isSubmissionPermitted shouldBe false
+                }
+            }
+        }
+    }
+
+    @Test
+    fun shareSelectedCheckIns() {
+        // TODO test navigation
+    }
+
+    @Test
+    fun doNotShareCheckIns() {
+        // TODO test navigation
+    }
+
+    private fun createViewModel() = CheckInsConsentViewModel(
+        savedState = savedState,
+        dispatcherProvider = TestDispatcherProvider(),
+        checkInRepository = checkInRepository
+    )
+}

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModelTest.kt
@@ -102,12 +102,12 @@ class CheckInsConsentViewModelTest : BaseTest() {
 
             get(1).apply {
                 this as SelectableCheckInVH.Item
-                this.checkIn.isSubmissionPermitted shouldBe false
+                this.checkIn.hasSubmissionConsent shouldBe false
             }
 
             get(2).apply {
                 this as SelectableCheckInVH.Item
-                this.checkIn.isSubmissionPermitted shouldBe false
+                this.checkIn.hasSubmissionConsent shouldBe false
             }
         }
     }
@@ -124,12 +124,12 @@ class CheckInsConsentViewModelTest : BaseTest() {
 
             get(1).apply {
                 this as SelectableCheckInVH.Item
-                this.checkIn.isSubmissionPermitted shouldBe true
+                this.checkIn.hasSubmissionConsent shouldBe true
             }
 
             get(2).apply {
                 this as SelectableCheckInVH.Item
-                this.checkIn.isSubmissionPermitted shouldBe false
+                this.checkIn.hasSubmissionConsent shouldBe false
             }
         }
     }
@@ -142,14 +142,14 @@ class CheckInsConsentViewModelTest : BaseTest() {
             size shouldBe 3
             get(0).apply {
                 this as HeaderCheckInsVH.Item
-                (get(1) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe false
-                (get(2) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe false
+                (get(1) as SelectableCheckInVH.Item).checkIn.hasSubmissionConsent shouldBe false
+                (get(2) as SelectableCheckInVH.Item).checkIn.hasSubmissionConsent shouldBe false
 
                 this.selectAll()
 
                 viewModel.checkIns.getOrAwaitValue().apply {
-                    (get(1) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe true
-                    (get(2) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe true
+                    (get(1) as SelectableCheckInVH.Item).checkIn.hasSubmissionConsent shouldBe true
+                    (get(2) as SelectableCheckInVH.Item).checkIn.hasSubmissionConsent shouldBe true
                 }
             }
         }
@@ -163,21 +163,21 @@ class CheckInsConsentViewModelTest : BaseTest() {
             size shouldBe 3
             get(0).apply {
                 this as HeaderCheckInsVH.Item
-                (get(1) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe false
-                (get(2) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe false
+                (get(1) as SelectableCheckInVH.Item).checkIn.hasSubmissionConsent shouldBe false
+                (get(2) as SelectableCheckInVH.Item).checkIn.hasSubmissionConsent shouldBe false
 
                 this.selectAll()
 
                 viewModel.checkIns.getOrAwaitValue().apply {
-                    (get(1) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe true
-                    (get(2) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe true
+                    (get(1) as SelectableCheckInVH.Item).checkIn.hasSubmissionConsent shouldBe true
+                    (get(2) as SelectableCheckInVH.Item).checkIn.hasSubmissionConsent shouldBe true
                 }
 
                 this.selectAll()
 
                 viewModel.checkIns.getOrAwaitValue().apply {
-                    (get(1) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe true
-                    (get(2) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe true
+                    (get(1) as SelectableCheckInVH.Item).checkIn.hasSubmissionConsent shouldBe true
+                    (get(2) as SelectableCheckInVH.Item).checkIn.hasSubmissionConsent shouldBe true
                 }
             }
         }
@@ -190,12 +190,12 @@ class CheckInsConsentViewModelTest : BaseTest() {
         viewModel.checkIns.getOrAwaitValue().apply {
 
             (get(1) as SelectableCheckInVH.Item).apply {
-                checkIn.isSubmissionPermitted shouldBe false
+                checkIn.hasSubmissionConsent shouldBe false
                 onItemSelected(checkIn)
             }
 
             viewModel.checkIns.getOrAwaitValue().apply {
-                (get(1) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe true
+                (get(1) as SelectableCheckInVH.Item).checkIn.hasSubmissionConsent shouldBe true
             }
         }
     }
@@ -206,20 +206,20 @@ class CheckInsConsentViewModelTest : BaseTest() {
         val viewModel = createViewModel()
         viewModel.checkIns.getOrAwaitValue().apply {
             (get(1) as SelectableCheckInVH.Item).apply {
-                checkIn.isSubmissionPermitted shouldBe false
+                checkIn.hasSubmissionConsent shouldBe false
                 onItemSelected(checkIn)
             }
 
             viewModel.checkIns.getOrAwaitValue().apply {
                 (get(1) as SelectableCheckInVH.Item).apply {
-                    checkIn.isSubmissionPermitted shouldBe true
+                    checkIn.hasSubmissionConsent shouldBe true
                     onItemSelected(checkIn)
                 }
             }
 
             viewModel.checkIns.getOrAwaitValue().apply {
                 (get(1) as SelectableCheckInVH.Item).apply {
-                    checkIn.isSubmissionPermitted shouldBe false
+                    checkIn.hasSubmissionConsent shouldBe false
                 }
             }
         }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModelTest.kt
@@ -93,6 +93,7 @@ class CheckInsConsentViewModelTest : BaseTest() {
 
         every { checkInRepository.checkInsWithinRetention } returns flowOf(listOf(checkIn1, checkIn2, checkIn3))
         coEvery { checkInRepository.updateSubmissionConsents(any(), true) } just Runs
+        coEvery { checkInRepository.updateSubmissionConsents(any(), false) } just Runs
         every { savedState.set(any(), any<Set<Long>>()) } just Runs
         every { autoSubmission.updateMode(any()) } just Runs
         every { submissionRepository.hasViewedTestResult } returns flowOf(false)
@@ -278,6 +279,7 @@ class CheckInsConsentViewModelTest : BaseTest() {
         }
 
         coVerify {
+            checkInRepository.updateSubmissionConsents(any(), false)
             autoSubmission.updateMode(AutoSubmission.Mode.MONITOR)
             checkInRepository.updateSubmissionConsents(any(), true)
         }
@@ -292,6 +294,7 @@ class CheckInsConsentViewModelTest : BaseTest() {
         }
 
         coVerify {
+            checkInRepository.updateSubmissionConsents(any(), false)
             autoSubmission.updateMode(AutoSubmission.Mode.MONITOR)
             checkInRepository.updateSubmissionConsents(any(), true)
         }
@@ -306,6 +309,7 @@ class CheckInsConsentViewModelTest : BaseTest() {
         }
 
         coVerify {
+            checkInRepository.updateSubmissionConsents(any(), false)
             autoSubmission.updateMode(AutoSubmission.Mode.MONITOR)
         }
     }
@@ -319,6 +323,7 @@ class CheckInsConsentViewModelTest : BaseTest() {
         }
 
         coVerify {
+            checkInRepository.updateSubmissionConsents(any(), false)
             autoSubmission.updateMode(AutoSubmission.Mode.MONITOR)
         }
     }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/testavailable/SubmissionTestResultAvailableViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/testavailable/SubmissionTestResultAvailableViewModelTest.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.ui.submission.testavailable
 
 import de.rki.coronawarnapp.datadonation.analytics.modules.keysubmission.AnalyticsKeySubmissionCollector
+import de.rki.coronawarnapp.eventregistration.checkins.CheckInRepository
 import de.rki.coronawarnapp.submission.SubmissionRepository
 import de.rki.coronawarnapp.submission.auto.AutoSubmission
 import de.rki.coronawarnapp.submission.data.tekhistory.TEKHistoryUpdater
@@ -31,6 +32,7 @@ class SubmissionTestResultAvailableViewModelTest : BaseTest() {
     @MockK lateinit var tekHistoryUpdater: TEKHistoryUpdater
     @MockK lateinit var tekHistoryUpdaterFactory: TEKHistoryUpdater.Factory
     @MockK lateinit var analyticsKeySubmissionCollector: AnalyticsKeySubmissionCollector
+    @MockK lateinit var checkInRepository: CheckInRepository
 
     @BeforeEach
     fun setUp() {
@@ -49,7 +51,8 @@ class SubmissionTestResultAvailableViewModelTest : BaseTest() {
         dispatcherProvider = TestDispatcherProvider(),
         tekHistoryUpdaterFactory = tekHistoryUpdaterFactory,
         autoSubmission = autoSubmission,
-        analyticsKeySubmissionCollector = analyticsKeySubmissionCollector
+        analyticsKeySubmissionCollector = analyticsKeySubmissionCollector,
+        checkInRepository = checkInRepository
     )
 
     @Test

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/warnothers/SubmissionResultPositiveOtherWarningNoConsentViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/warnothers/SubmissionResultPositiveOtherWarningNoConsentViewModelTest.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.ui.submission.warnothers
 
 import de.rki.coronawarnapp.datadonation.analytics.modules.keysubmission.AnalyticsKeySubmissionCollector
+import de.rki.coronawarnapp.eventregistration.checkins.CheckInRepository
 import de.rki.coronawarnapp.nearby.ENFClient
 import de.rki.coronawarnapp.storage.interoperability.InteroperabilityRepository
 import de.rki.coronawarnapp.submission.SubmissionRepository
@@ -33,6 +34,7 @@ class SubmissionResultPositiveOtherWarningNoConsentViewModelTest : BaseTest() {
     @MockK lateinit var interoperabilityRepository: InteroperabilityRepository
     @MockK lateinit var enfClient: ENFClient
     @MockK lateinit var analyticsKeySubmissionCollector: AnalyticsKeySubmissionCollector
+    @MockK lateinit var checkInRepository: CheckInRepository
 
     @BeforeEach
     fun setUp() {
@@ -53,7 +55,8 @@ class SubmissionResultPositiveOtherWarningNoConsentViewModelTest : BaseTest() {
         enfClient = enfClient,
         interoperabilityRepository = interoperabilityRepository,
         submissionRepository = submissionRepository,
-        analyticsKeySubmissionCollector = analyticsKeySubmissionCollector
+        analyticsKeySubmissionCollector = analyticsKeySubmissionCollector,
+        checkInRepository = checkInRepository
     )
 
     @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,5 +19,5 @@ org.gradle.dependency.verification.console=verbose
 # Versioning, this is used by the app & pipelines to calculate the current versionCode & versionName
 VERSION_MAJOR=2
 VERSION_MINOR=0
-VERSION_PATCH=2
+VERSION_PATCH=3
 VERSION_BUILD=0


### PR DESCRIPTION
## Important Notes
- CheckIns screen should not be displayed if there are no completed check-ins , meaning the flow should be like as it is at the moment
- Android back action should behave as `X` button and the behaviour is explained below

## Case 1: User has given CWA submission consent (this is not the access TEKs ENS Consent)
* Start at `SubmissionTestResultAvailableFragment`
* Press NEXT, If TEK consent is available
	* From `SubmissionTestResultAvailableFragment` go to `CheckInsConsentFragment`
* Press NEXT, If TEK consent is not available
	* Get TEK consent on this screen (TEKHistoryUpdater)
	* If user shared TEKS then go to `CheckInsConsentFragment`
	* If user didn't share TEKs, stay
* On `CheckInsConsentFragment` and (`SubmissionRepository.hasViewedTestResult==false`)
	* If the user presses X
		* Show the same abort dialog as on `SubmissionTestResultAvailableFragment`
			* If the user choses "don't show test result" -> go to home screen
			* If the user choses "show test result" -> user stays on the same screen (so they can give consent) (to advance to the test result screen, the user has to either press NEXT or SKIP)
	* If the user presses NEXT
		* (because at least 1 entry is selected) we update the checkins in the database
		* We set `AutoSubmission.updateMode(MONITOR)`
		* We navigate to `SubmissionTestResultConsentGivenFragment`
	* If the user presses SKIP
		* We show a confirmation dialog 
			* If user chooses "Share" we stay on the same screen
			* If the user choses don't share go to the `SubmissionTestResultConsentGivenFragment`
				* We set `AutoSubmission.updateMode(MONITOR)`

## Case 2: User has not given CWA submission consent
 * Start at `SubmissionResultPositiveOtherWarningNoConsentFragment`
 * Press AGREE, If TEK consent is available
 	* We go to `CheckInsConsentFragment`
 * Press AGREE, if TEK is not available
 	* Get TEK consent on this screen (TEKHistoryUpdater)
 	* Then go to `CheckInsConsentFragment` if user shared TEKs
 	* If user didn't share TEKs, stay on screen
* On `CheckInsConsentFragment` and (`SubmissionRepository.hasViewedTestResult==true`)
	* If the user presses X
		* Show same dialog as SKIP option
	* If the user presses NEXT
		* (because at least 1 entry is selected) we update the checkins database
		* We set `AutoSubmission.updateMode(MONITOR)`
		* We go to `SubmissionResultReadyFragment`
	* If we press SKIP
		* We show a confirmation dialog 
			* If the user presses "DONT SHARE"
				* We set `AutoSubmission.updateMode(MONITOR)`
				* Go to `SubmissionResultReadyFragment`
			* If the user presses "SHARE" we stay on the screen