### PR TITLE
Fix qr code being cut off (fixes #2852) (COMMUNITY)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/organizer/details/QrCodeDetailFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/organizer/details/QrCodeDetailFragment.kt
@@ -138,7 +138,7 @@ class QrCodeDetailFragment : Fragment(R.layout.trace_location_organizer_qr_code_
                     binding.progressBar.hide()
                     binding.qrCodeImage.apply {
                         val resourceId = RoundedBitmapDrawableFactory.create(resources, it)
-                        resourceId.cornerRadius = it.width * 0.1f
+                        resourceId.cornerRadius = 15f
                         setImageDrawable(resourceId)
                     }
                 }


### PR DESCRIPTION
This was causing starkly rounded corners for bigger qr codes which had
trouble being scanned.

Fixes #2852.

### Description

This sets the rounded corner radius to that of the backgound image.

Result (compare to #2852):

![image](https://user-images.githubusercontent.com/105185/115061154-16adf580-9ee9-11eb-93c9-2af465f4928b.png)


### Steps to reproduce

See #2852

---
Internal Tracking ID: [EXPOSUREAPP-6540](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6540)
