### PR TITLE
CheckIns Consent (EXPOSUREAPP-6530)

### DIFF
--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/presencetracing/ui/PresenceTracingTestFragment.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/presencetracing/ui/PresenceTracingTestFragment.kt
@@ -10,6 +10,7 @@ import androidx.core.text.color
 import androidx.core.text.scale
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.FragmentTestPresenceTracingBinding
 import de.rki.coronawarnapp.eventregistration.checkins.qrcode.TraceLocation
@@ -60,6 +61,10 @@ class PresenceTracingTestFragment : Fragment(R.layout.fragment_test_presence_tra
 
         binding.runPtWarningTask.setOnClickListener {
             viewModel.runPresenceTracingWarningTask()
+        }
+
+        binding.openConsent.setOnClickListener {
+            findNavController().navigate(R.id.checkInsConsentFragment)
         }
 
         viewModel.lastOrganiserLocation.observe(viewLifecycleOwner) {

--- a/Corona-Warn-App/src/deviceForTesters/res/layout/fragment_test_presence_tracing.xml
+++ b/Corona-Warn-App/src/deviceForTesters/res/layout/fragment_test_presence_tracing.xml
@@ -16,8 +16,8 @@
             style="@style/Card"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
             android:layout_marginHorizontal="@dimen/spacing_tiny"
+            android:layout_marginTop="10dp"
             android:orientation="vertical">
 
             <TextView
@@ -167,6 +167,15 @@
                 android:textIsSelectable="true"
                 tools:text="ID" />
         </LinearLayout>
+
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/open_consent"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginTop="16dp"
+            android:text="Consent" />
 
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>

--- a/Corona-Warn-App/src/deviceForTesters/res/navigation/test_nav_graph.xml
+++ b/Corona-Warn-App/src/deviceForTesters/res/navigation/test_nav_graph.xml
@@ -146,4 +146,10 @@
             android:name="traceLocationId"
             app:argType="long" />
     </fragment>
+
+    <fragment
+        android:id="@+id/checkInsConsentFragment"
+        android:name="de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent.CheckInsConsentFragment"
+        android:label="check_ins_consent_fragment"
+        tools:layout="@layout/check_ins_consent_fragment" />
 </navigation>

--- a/Corona-Warn-App/src/deviceForTesters/res/navigation/test_nav_graph.xml
+++ b/Corona-Warn-App/src/deviceForTesters/res/navigation/test_nav_graph.xml
@@ -146,15 +146,4 @@
             android:name="traceLocationId"
             app:argType="long" />
     </fragment>
-
-    <fragment
-        android:id="@+id/checkInsConsentFragment"
-        android:name="de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent.CheckInsConsentFragment"
-        android:label="check_ins_consent_fragment"
-        tools:layout="@layout/check_ins_consent_fragment">
-        <argument
-            android:name="preConsentGiven"
-            android:defaultValue="false"
-            app:argType="boolean" />
-    </fragment>
 </navigation>

--- a/Corona-Warn-App/src/deviceForTesters/res/navigation/test_nav_graph.xml
+++ b/Corona-Warn-App/src/deviceForTesters/res/navigation/test_nav_graph.xml
@@ -151,5 +151,10 @@
         android:id="@+id/checkInsConsentFragment"
         android:name="de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent.CheckInsConsentFragment"
         android:label="check_ins_consent_fragment"
-        tools:layout="@layout/check_ins_consent_fragment" />
+        tools:layout="@layout/check_ins_consent_fragment">
+        <argument
+            android:name="preConsentGiven"
+            android:defaultValue="false"
+            app:argType="boolean" />
+    </fragment>
 </navigation>

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/eventregistration/checkins/CheckIn.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/eventregistration/checkins/CheckIn.kt
@@ -24,6 +24,7 @@ data class CheckIn(
     val completed: Boolean,
     val createJournalEntry: Boolean,
     val isSubmitted: Boolean = false,
+    val isSubmissionPermitted: Boolean = false,
 ) {
     /**
      *  Returns SHA-256 hash of [traceLocationId] which itself may also be SHA-256 hash.

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/EventRegistrationUIModule.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/EventRegistrationUIModule.kt
@@ -24,6 +24,8 @@ import de.rki.coronawarnapp.ui.eventregistration.organizer.poster.QrCodePosterFr
 import de.rki.coronawarnapp.ui.eventregistration.organizer.poster.QrCodePosterFragmentModule
 import de.rki.coronawarnapp.ui.eventregistration.organizer.qrinfo.TraceLocationQRInfoFragment
 import de.rki.coronawarnapp.ui.eventregistration.organizer.qrinfo.TraceLocationQRInfoFragmentModule
+import de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent.CheckInsConsentFragment
+import de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent.CheckInsConsentFragmentModule
 
 @Module
 internal abstract class EventRegistrationUIModule {
@@ -60,4 +62,7 @@ internal abstract class EventRegistrationUIModule {
 
     @ContributesAndroidInjector(modules = [QrCodeDetailFragmentModule::class])
     abstract fun showEventDetail(): QrCodeDetailFragment
+
+    @ContributesAndroidInjector(modules = [CheckInsConsentFragmentModule::class])
+    abstract fun checkInsConsentFragment(): CheckInsConsentFragment
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/attendee/checkins/items/PastCheckInVH.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/attendee/checkins/items/PastCheckInVH.kt
@@ -4,6 +4,7 @@ import android.view.ViewGroup
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.TraceLocationAttendeeCheckinsItemPastBinding
 import de.rki.coronawarnapp.eventregistration.checkins.CheckIn
+import de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.common.checkoutInfo
 import de.rki.coronawarnapp.util.TimeAndDateExtensions.toUserTimeZone
 import de.rki.coronawarnapp.util.list.SwipeConsumer
 import de.rki.coronawarnapp.util.lists.diffutil.HasPayloadDiffer
@@ -24,20 +25,10 @@ class PastCheckInVH(parent: ViewGroup) :
         payloads: List<Any>
     ) -> Unit = { item, payloads ->
         val curItem = payloads.filterIsInstance<Item>().singleOrNull() ?: item
-
-        val checkInStartUserTZ = curItem.checkin.checkInStart.toUserTimeZone()
-        val checkInEndUserTZ = curItem.checkin.checkInEnd.toUserTimeZone()
-
         description.text = curItem.checkin.description
         address.text = curItem.checkin.address
 
-        checkoutInfo.text = run {
-            val dayFormatted = checkInStartUserTZ.toLocalDate().toString(DateTimeFormat.mediumDate())
-            val startTimeFormatted = checkInStartUserTZ.toLocalTime().toString(DateTimeFormat.shortTime())
-            val endTimeFormatted = checkInEndUserTZ.toLocalTime().toString(DateTimeFormat.shortTime())
-
-            "$dayFormatted, $startTimeFormatted - $endTimeFormatted"
-        }
+        checkoutInfo.text = curItem.checkin.checkoutInfo
 
         menuAction.setupMenu(R.menu.menu_trace_location_attendee_checkin_item) {
             when (it.itemId) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/attendee/checkins/items/PastCheckInVH.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/eventregistration/attendee/checkins/items/PastCheckInVH.kt
@@ -5,10 +5,8 @@ import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.TraceLocationAttendeeCheckinsItemPastBinding
 import de.rki.coronawarnapp.eventregistration.checkins.CheckIn
 import de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.common.checkoutInfo
-import de.rki.coronawarnapp.util.TimeAndDateExtensions.toUserTimeZone
 import de.rki.coronawarnapp.util.list.SwipeConsumer
 import de.rki.coronawarnapp.util.lists.diffutil.HasPayloadDiffer
-import org.joda.time.format.DateTimeFormat
 
 class PastCheckInVH(parent: ViewGroup) :
     BaseCheckInVH<PastCheckInVH.Item, TraceLocationAttendeeCheckinsItemPastBinding>(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/common/CompletedCheckIn.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/common/CompletedCheckIn.kt
@@ -1,0 +1,16 @@
+package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.common
+
+import de.rki.coronawarnapp.eventregistration.checkins.CheckIn
+import de.rki.coronawarnapp.util.TimeAndDateExtensions.toUserTimeZone
+import org.joda.time.format.DateTimeFormat
+
+inline val CheckIn.checkoutInfo: String
+    get() {
+        val checkInStartUserTZ = checkInStart.toUserTimeZone()
+        val checkInEndUserTZ = checkInEnd.toUserTimeZone()
+
+        val dayFormatted = checkInStartUserTZ.toLocalDate().toString(DateTimeFormat.mediumDate())
+        val startTimeFormatted = checkInStartUserTZ.toLocalTime().toString(DateTimeFormat.shortTime())
+        val endTimeFormatted = checkInEndUserTZ.toLocalTime().toString(DateTimeFormat.shortTime())
+        return "$dayFormatted, $startTimeFormatted - $endTimeFormatted"
+    }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentAdapter.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentAdapter.kt
@@ -1,0 +1,37 @@
+package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent
+
+import android.view.ViewGroup
+import androidx.annotation.LayoutRes
+import androidx.viewbinding.ViewBinding
+import de.rki.coronawarnapp.util.lists.BindableVH
+import de.rki.coronawarnapp.util.lists.diffutil.AsyncDiffUtilAdapter
+import de.rki.coronawarnapp.util.lists.diffutil.AsyncDiffer
+import de.rki.coronawarnapp.util.lists.modular.ModularAdapter
+import de.rki.coronawarnapp.util.lists.modular.mods.DataBinderMod
+import de.rki.coronawarnapp.util.lists.modular.mods.StableIdMod
+import de.rki.coronawarnapp.util.lists.modular.mods.TypedVHCreatorMod
+
+class CheckInsConsentAdapter :
+    ModularAdapter<CheckInsConsentAdapter.ItemVH<CheckInsConsentItem, ViewBinding>>(),
+    AsyncDiffUtilAdapter<CheckInsConsentItem> {
+
+    override val asyncDiffer: AsyncDiffer<CheckInsConsentItem> = AsyncDiffer(adapter = this)
+
+    init {
+        modules.addAll(
+            listOf(
+                StableIdMod(data),
+                DataBinderMod<CheckInsConsentItem, ItemVH<CheckInsConsentItem, ViewBinding>>(data),
+                TypedVHCreatorMod({ data[it] is HeaderCheckInsVH.Item }) { HeaderCheckInsVH(it) },
+                TypedVHCreatorMod({ data[it] is SelectableCheckInVH.Item }) { SelectableCheckInVH(it) },
+            )
+        )
+    }
+
+    override fun getItemCount(): Int = data.size
+
+    abstract class ItemVH<Item : CheckInsConsentItem, VB : ViewBinding>(
+        @LayoutRes layoutRes: Int,
+        parent: ViewGroup
+    ) : ModularAdapter.VH(layoutRes, parent), BindableVH<Item, VB>
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentFragment.kt
@@ -3,6 +3,7 @@ package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.View
+import androidx.navigation.fragment.navArgs
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.CheckInsConsentFragmentBinding
@@ -16,6 +17,7 @@ import javax.inject.Inject
 class CheckInsConsentFragment : Fragment(R.layout.check_ins_consent_fragment), AutoInject {
 
     private val binding: CheckInsConsentFragmentBinding by viewBindingLazy()
+    private val navArgs by navArgs<CheckInsConsentFragmentArgs>()
 
     @Inject lateinit var viewModelFactory: CWAViewModelFactoryProvider.Factory
     private val viewModel: CheckInsConsentViewModel by cwaViewModelsAssisted(
@@ -34,11 +36,15 @@ class CheckInsConsentFragment : Fragment(R.layout.check_ins_consent_fragment), A
         with(binding) {
             checkInsRecycler.adapter = adapter
             toolbar.setNavigationOnClickListener {
-                showSkipDialog()
+                if (navArgs.preConsentGiven) {
+                    // TODO show dialog from Test screen
+                } else {
+                    showSkipDialog()
+                }
             }
             skipButton.setOnClickListener { showSkipDialog() }
             continueButton.setOnClickListener {
-                viewModel.confirmSelection()
+                viewModel.shareSelectedCheckIns()
             }
         }
 
@@ -55,9 +61,11 @@ class CheckInsConsentFragment : Fragment(R.layout.check_ins_consent_fragment), A
             .setTitle(R.string.trace_location_attendee_consent_dialog_title)
             .setMessage(R.string.trace_location_attendee_consent_dialog_message)
             .setPositiveButton(R.string.trace_location_attendee_consent_dialog_positive_button) { _, _ ->
-                viewModel.confirmSelection()
+                viewModel.shareSelectedCheckIns()
             }
-            .setNegativeButton(R.string.trace_location_attendee_consent_dialog_negative_button) { _, _ -> /*No-Op*/ }
+            .setNegativeButton(R.string.trace_location_attendee_consent_dialog_negative_button) { _, _ ->
+                viewModel.doNotShareCheckIns()
+            }
             .show()
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentFragment.kt
@@ -37,6 +37,9 @@ class CheckInsConsentFragment : Fragment(R.layout.check_ins_consent_fragment), A
                 showSkipDialog()
             }
             skipButton.setOnClickListener { showSkipDialog() }
+            continueButton.setOnClickListener {
+                viewModel.confirmSelection()
+            }
         }
 
         viewModel.checkIns.observe(viewLifecycleOwner) {
@@ -52,11 +55,9 @@ class CheckInsConsentFragment : Fragment(R.layout.check_ins_consent_fragment), A
             .setTitle(R.string.trace_location_attendee_consent_dialog_title)
             .setMessage(R.string.trace_location_attendee_consent_dialog_message)
             .setPositiveButton(R.string.trace_location_attendee_consent_dialog_positive_button) { _, _ ->
-                // TODO
+                viewModel.confirmSelection()
             }
-            .setNegativeButton(R.string.trace_location_attendee_consent_dialog_negative_button) { _, _ ->
-                // TODO
-            }
+            .setNegativeButton(R.string.trace_location_attendee_consent_dialog_negative_button) { _, _ -> /*No-Op*/ }
             .show()
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentFragment.kt
@@ -3,6 +3,7 @@ package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.View
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.CheckInsConsentFragmentBinding
 import de.rki.coronawarnapp.util.di.AutoInject
@@ -35,6 +36,7 @@ class CheckInsConsentFragment : Fragment(R.layout.check_ins_consent_fragment), A
             toolbar.setNavigationOnClickListener {
                 showSkipDialog()
             }
+            skipButton.setOnClickListener { showSkipDialog() }
         }
 
         viewModel.checkIns.observe(viewLifecycleOwner) {
@@ -46,6 +48,15 @@ class CheckInsConsentFragment : Fragment(R.layout.check_ins_consent_fragment), A
     }
 
     private fun showSkipDialog() {
-        // TODO
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.trace_location_attendee_consent_dialog_title)
+            .setMessage(R.string.trace_location_attendee_consent_dialog_message)
+            .setPositiveButton(R.string.trace_location_attendee_consent_dialog_positive_button) { _, _ ->
+                // TODO
+            }
+            .setNegativeButton(R.string.trace_location_attendee_consent_dialog_negative_button) { _, _ ->
+                // TODO
+            }
+            .show()
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentFragment.kt
@@ -39,6 +39,9 @@ class CheckInsConsentFragment : Fragment(R.layout.check_ins_consent_fragment), A
 
         viewModel.checkIns.observe(viewLifecycleOwner) {
             adapter.update(it)
+            binding.continueButton.isEnabled = it.any { item ->
+                item is SelectableCheckInVH.Item && item.checkIn.isSubmissionPermitted
+            }
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentFragment.kt
@@ -1,0 +1,48 @@
+package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.View
+import de.rki.coronawarnapp.R
+import de.rki.coronawarnapp.databinding.CheckInsConsentFragmentBinding
+import de.rki.coronawarnapp.util.di.AutoInject
+import de.rki.coronawarnapp.util.lists.diffutil.update
+import de.rki.coronawarnapp.util.ui.viewBindingLazy
+import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactoryProvider
+import de.rki.coronawarnapp.util.viewmodel.cwaViewModelsAssisted
+import javax.inject.Inject
+
+class CheckInsConsentFragment : Fragment(R.layout.check_ins_consent_fragment), AutoInject {
+
+    private val binding: CheckInsConsentFragmentBinding by viewBindingLazy()
+
+    @Inject lateinit var viewModelFactory: CWAViewModelFactoryProvider.Factory
+    private val viewModel: CheckInsConsentViewModel by cwaViewModelsAssisted(
+        factoryProducer = { viewModelFactory },
+        constructorCall = { factory, savedState ->
+            factory as CheckInsConsentViewModel.Factory
+            factory.create(
+                savedState = savedState
+            )
+        }
+    )
+
+    private val adapter = CheckInsConsentAdapter()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        with(binding) {
+            checkInsRecycler.adapter = adapter
+            toolbar.setNavigationOnClickListener {
+                showSkipDialog()
+            }
+        }
+
+        viewModel.checkIns.observe(viewLifecycleOwner) {
+            adapter.update(it)
+        }
+    }
+
+    private fun showSkipDialog() {
+        // TODO
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentFragmentModule.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentFragmentModule.kt
@@ -1,0 +1,19 @@
+package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent
+
+import dagger.Binds
+import dagger.Module
+import dagger.multibindings.IntoMap
+import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
+import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactory
+import de.rki.coronawarnapp.util.viewmodel.CWAViewModelKey
+
+@Module
+abstract class CheckInsConsentFragmentModule {
+
+    @Binds
+    @IntoMap
+    @CWAViewModelKey(CheckInsConsentViewModel::class)
+    abstract fun checkInsConsentFragment(
+        factory: CheckInsConsentViewModel.Factory
+    ): CWAViewModelFactory<out CWAViewModel>
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentItem.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentItem.kt
@@ -1,0 +1,5 @@
+package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent
+
+import de.rki.coronawarnapp.util.lists.HasStableId
+
+interface CheckInsConsentItem : HasStableId

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModel.kt
@@ -33,6 +33,10 @@ class CheckInsConsentViewModel @AssistedInject constructor(
         }
     }.asLiveData(context = dispatcherProvider.Default)
 
+    fun confirmSelection() {
+        // TODO
+    }
+
     private fun headerItem(checkIns: List<CheckIn>) = HeaderCheckInsVH.Item(
         selectAll = { selectedSetFlow.value = updateSet(checkIns) }
     )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModel.kt
@@ -11,7 +11,9 @@ import de.rki.coronawarnapp.eventregistration.checkins.CheckInRepository
 import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactory
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import timber.log.Timber
 
 class CheckInsConsentViewModel @AssistedInject constructor(
     @Assisted private val savedState: SavedStateHandle,
@@ -19,30 +21,58 @@ class CheckInsConsentViewModel @AssistedInject constructor(
     checkInRepository: CheckInRepository,
 ) : CWAViewModel(dispatcherProvider) {
 
-    val checkIns: LiveData<List<CheckInsConsentItem>> = checkInRepository
-        .checkInsWithinRetention
-        .map {
-            mutableListOf<CheckInsConsentItem>().apply {
-                add(
-                    HeaderCheckInsVH.Item(selectAll = {})
-                )
+    private val selectedSetFlow = MutableStateFlow(initialSet())
 
-                addAll(mapCheckIns(it))
-            }
-        }.asLiveData(context = dispatcherProvider.Default)
-
-    private fun mapCheckIns(checkIns: List<CheckIn>): List<CheckInsConsentItem> =
-        checkIns.filter { it.completed }.sortedByDescending { it.checkInEnd }.map { checkIn ->
-            SelectableCheckInVH.Item(
-                checkIn = checkIn,
-                onItemSelected = {}
-            )
+    val checkIns: LiveData<List<CheckInsConsentItem>> = combine(
+        checkInRepository.checkInsWithinRetention,
+        selectedSetFlow
+    ) { checkIns, ids ->
+        mutableListOf<CheckInsConsentItem>().apply {
+            add(headerItem(checkIns))
+            addAll(mapCheckIns(checkIns, ids))
         }
+    }.asLiveData(context = dispatcherProvider.Default)
+
+    private fun headerItem(checkIns: List<CheckIn>) = HeaderCheckInsVH.Item(
+        selectAll = { selectedSetFlow.value = updateSet(checkIns) }
+    )
+
+    private fun mapCheckIns(checkIns: List<CheckIn>, ids: Set<Long>): List<CheckInsConsentItem> =
+        checkIns.filter { it.completed }
+            .sortedByDescending { it.checkInEnd }
+            .map { checkIn ->
+                SelectableCheckInVH.Item(
+                    checkIn = checkIn.copy(isSubmissionPermitted = ids.contains(checkIn.id)),
+                    onItemSelected = { selectedSetFlow.value = updateSet(listOf(it)) }
+                )
+            }
+
+    private fun updateSet(checkIns: List<CheckIn>) =
+        mutableSetOf<Long>().apply {
+            val ids = checkIns.map { it.id }
+            if (!selectedSetFlow.value.containsAll(ids)) {
+                addAll(ids) // New Ids
+                addAll(selectedSetFlow.value) // Existing Ids
+            } else {
+                addAll(
+                    selectedSetFlow.value.toMutableSet().apply { removeAll(ids) }
+                )
+            }
+        }.also {
+            savedState.set(SET_KEY, it)
+            Timber.d("SelectedCheckIns=$it")
+        }
+
+    private fun initialSet(): Set<Long> = savedState.get(SET_KEY) ?: emptySet()
 
     @AssistedFactory
     interface Factory : CWAViewModelFactory<CheckInsConsentViewModel> {
         fun create(
             savedState: SavedStateHandle,
         ): CheckInsConsentViewModel
+    }
+
+    companion object {
+        private const val SET_KEY = "selected_checkIn_set"
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.asLiveData
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import de.rki.coronawarnapp.eventregistration.checkins.CheckIn
 import de.rki.coronawarnapp.eventregistration.checkins.CheckInRepository
 import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
@@ -25,8 +26,18 @@ class CheckInsConsentViewModel @AssistedInject constructor(
                 add(
                     HeaderCheckInsVH.Item(selectAll = {})
                 )
+
+                addAll(mapCheckIns(it))
             }
         }.asLiveData(context = dispatcherProvider.Default)
+
+    private fun mapCheckIns(checkIns: List<CheckIn>): List<CheckInsConsentItem> =
+        checkIns.filter { it.completed }.sortedByDescending { it.checkInEnd }.map { checkIn ->
+            SelectableCheckInVH.Item(
+                checkIn = checkIn,
+                onItemSelected = {}
+            )
+        }
 
     @AssistedFactory
     interface Factory : CWAViewModelFactory<CheckInsConsentViewModel> {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModel.kt
@@ -1,0 +1,37 @@
+package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import de.rki.coronawarnapp.eventregistration.checkins.CheckInRepository
+import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
+import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
+import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactory
+import kotlinx.coroutines.flow.map
+
+class CheckInsConsentViewModel @AssistedInject constructor(
+    @Assisted private val savedState: SavedStateHandle,
+    dispatcherProvider: DispatcherProvider,
+    checkInRepository: CheckInRepository,
+) : CWAViewModel(dispatcherProvider) {
+
+    val checkIns: LiveData<List<CheckInsConsentItem>> = checkInRepository
+        .checkInsWithinRetention
+        .map {
+            mutableListOf<CheckInsConsentItem>().apply {
+                add(
+                    HeaderCheckInsVH.Item(selectAll = {})
+                )
+            }
+        }.asLiveData(context = dispatcherProvider.Default)
+
+    @AssistedFactory
+    interface Factory : CWAViewModelFactory<CheckInsConsentViewModel> {
+        fun create(
+            savedState: SavedStateHandle,
+        ): CheckInsConsentViewModel
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModel.kt
@@ -42,7 +42,12 @@ class CheckInsConsentViewModel @AssistedInject constructor(
     }
 
     private fun headerItem(checkIns: List<CheckIn>) = HeaderCheckInsVH.Item(
-        selectAll = { selectedSetFlow.value = updateSet(checkIns) }
+        selectAll = {
+            val ids = checkIns.map { it.id }
+            if (!selectedSetFlow.value.containsAll(ids)) {
+                selectedSetFlow.value = updateSet(ids)
+            }
+        }
     )
 
     private fun mapCheckIns(checkIns: List<CheckIn>, ids: Set<Long>): List<CheckInsConsentItem> =
@@ -51,13 +56,12 @@ class CheckInsConsentViewModel @AssistedInject constructor(
             .map { checkIn ->
                 SelectableCheckInVH.Item(
                     checkIn = checkIn.copy(isSubmissionPermitted = ids.contains(checkIn.id)),
-                    onItemSelected = { selectedSetFlow.value = updateSet(listOf(it)) }
+                    onItemSelected = { selectedSetFlow.value = updateSet(listOf(it.id)) }
                 )
             }
 
-    private fun updateSet(checkIns: List<CheckIn>) =
+    private fun updateSet(ids: List<Long>) =
         mutableSetOf<Long>().apply {
-            val ids = checkIns.map { it.id }
             if (!selectedSetFlow.value.containsAll(ids)) {
                 addAll(ids) // New Ids
                 addAll(selectedSetFlow.value) // Existing Ids

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModel.kt
@@ -33,8 +33,12 @@ class CheckInsConsentViewModel @AssistedInject constructor(
         }
     }.asLiveData(context = dispatcherProvider.Default)
 
-    fun confirmSelection() {
-        // TODO
+    fun shareSelectedCheckIns() {
+        // TODO persist selection and proceed to submitting check-ins
+    }
+
+    fun doNotShareCheckIns() {
+        // TODO proceed to submitting keys only
     }
 
     private fun headerItem(checkIns: List<CheckIn>) = HeaderCheckInsVH.Item(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/HeaderCheckInsVH.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/HeaderCheckInsVH.kt
@@ -1,0 +1,28 @@
+package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent
+
+import android.view.ViewGroup
+import de.rki.coronawarnapp.R
+import de.rki.coronawarnapp.databinding.TraceLocationAttendeeConsentHeaderBinding
+
+class HeaderCheckInsVH(parent: ViewGroup) :
+    CheckInsConsentAdapter.ItemVH<HeaderCheckInsVH.Item, TraceLocationAttendeeConsentHeaderBinding>(
+        layoutRes = R.layout.trace_location_attendee_consent_header,
+        parent = parent
+    ) {
+
+    override val viewBinding: Lazy<TraceLocationAttendeeConsentHeaderBinding> = lazy {
+        TraceLocationAttendeeConsentHeaderBinding.bind(itemView)
+    }
+
+    override val onBindData: TraceLocationAttendeeConsentHeaderBinding.(
+        item: Item,
+        payloads: List<Any>
+    ) -> Unit = { item, _ ->
+    }
+
+    data class Item(
+        val selectAll: () -> Unit
+    ) : CheckInsConsentItem {
+        override val stableId: Long = Item::class.simpleName.hashCode().toLong()
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/HeaderCheckInsVH.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/HeaderCheckInsVH.kt
@@ -3,6 +3,7 @@ package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent
 import android.view.ViewGroup
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.TraceLocationAttendeeConsentHeaderBinding
+import de.rki.coronawarnapp.util.lists.diffutil.HasPayloadDiffer
 
 class HeaderCheckInsVH(parent: ViewGroup) :
     CheckInsConsentAdapter.ItemVH<HeaderCheckInsVH.Item, TraceLocationAttendeeConsentHeaderBinding>(
@@ -18,11 +19,13 @@ class HeaderCheckInsVH(parent: ViewGroup) :
         item: Item,
         payloads: List<Any>
     ) -> Unit = { item, _ ->
+        selectAllButton.setOnClickListener { item.selectAll() }
     }
 
     data class Item(
         val selectAll: () -> Unit
-    ) : CheckInsConsentItem {
+    ) : CheckInsConsentItem, HasPayloadDiffer {
         override val stableId: Long = Item::class.simpleName.hashCode().toLong()
+        override fun diffPayload(old: Any, new: Any): Any? = if (old::class == new::class) new else null
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/SelectableCheckInVH.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/SelectableCheckInVH.kt
@@ -1,0 +1,32 @@
+package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent
+
+import android.view.ViewGroup
+import de.rki.coronawarnapp.R
+import de.rki.coronawarnapp.databinding.TraceLocationAttendeeConsentSelectableCheckInBinding
+import de.rki.coronawarnapp.eventregistration.checkins.CheckIn
+import de.rki.coronawarnapp.util.lists.diffutil.HasPayloadDiffer
+
+class SelectableCheckInVH(parent: ViewGroup) :
+    CheckInsConsentAdapter.ItemVH<SelectableCheckInVH.Item, TraceLocationAttendeeConsentSelectableCheckInBinding>(
+        layoutRes = R.layout.trace_location_attendee_consent_selectable_check_in,
+        parent = parent
+    ) {
+
+    override val viewBinding: Lazy<TraceLocationAttendeeConsentSelectableCheckInBinding> = lazy {
+        TraceLocationAttendeeConsentSelectableCheckInBinding.bind(itemView)
+    }
+
+    override val onBindData: TraceLocationAttendeeConsentSelectableCheckInBinding.(
+        item: Item,
+        payloads: List<Any>
+    ) -> Unit = { item, payloads ->
+    }
+
+    data class Item(
+        val checkin: CheckIn,
+        val onItemSelected: (CheckIn) -> Unit
+    ) : CheckInsConsentItem, HasPayloadDiffer {
+        override val stableId: Long = checkin.id
+        override fun diffPayload(old: Any, new: Any): Any? = if (old::class == new::class) new else null
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/SelectableCheckInVH.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/SelectableCheckInVH.kt
@@ -4,6 +4,7 @@ import android.view.ViewGroup
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.TraceLocationAttendeeConsentSelectableCheckInBinding
 import de.rki.coronawarnapp.eventregistration.checkins.CheckIn
+import de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.common.checkoutInfo
 import de.rki.coronawarnapp.util.lists.diffutil.HasPayloadDiffer
 
 class SelectableCheckInVH(parent: ViewGroup) :
@@ -20,13 +21,24 @@ class SelectableCheckInVH(parent: ViewGroup) :
         item: Item,
         payloads: List<Any>
     ) -> Unit = { item, payloads ->
+        val curItem = payloads.filterIsInstance<Item>().singleOrNull() ?: item
+        val checkIn = curItem.checkIn
+        val imageResource = if (checkIn.isSubmissionPermitted) R.drawable.ic_selected else R.drawable.ic_unselected
+
+        checkbox.setImageResource(imageResource)
+        title.text = checkIn.description
+        subtitle.text = checkIn.address
+        checkoutInfo.text = checkIn.checkoutInfo
+
+        checkbox.setOnClickListener { item.onItemSelected(checkIn) }
+        itemView.setOnClickListener { item.onItemSelected(checkIn) }
     }
 
     data class Item(
-        val checkin: CheckIn,
+        val checkIn: CheckIn,
         val onItemSelected: (CheckIn) -> Unit
     ) : CheckInsConsentItem, HasPayloadDiffer {
-        override val stableId: Long = checkin.id
+        override val stableId: Long = checkIn.id
         override fun diffPayload(old: Any, new: Any): Any? = if (old::class == new::class) new else null
     }
 }

--- a/Corona-Warn-App/src/main/res/layout/check_ins_consent_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/check_ins_consent_fragment.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.presencetracing.attendee.checkins.consent.CheckInsConsentFragment">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/CWAToolbar.Close"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/trace_location_attendee_consent_title" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/checkInsRecycler"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginBottom="16dp"
+        android:orientation="vertical"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintBottom_toTopOf="@id/check_in_consent_continue_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar" />
+
+    <Button
+        android:id="@+id/check_in_consent_continue_button"
+        style="@style/buttonPrimary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="24dp"
+        android:layout_marginBottom="16dp"
+        android:text="@string/trace_location_attendee_consent_continue"
+        app:layout_constraintBottom_toTopOf="@id/check_in_consent_skip_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <Button
+        android:id="@+id/check_in_consent_skip_button"
+        style="@style/buttonPrimary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="24dp"
+        android:layout_marginBottom="24dp"
+        android:text="@string/trace_location_attendee_consent_skip"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Corona-Warn-App/src/main/res/layout/check_ins_consent_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/check_ins_consent_fragment.xml
@@ -26,7 +26,8 @@
         app:layout_constraintBottom_toTopOf="@id/continue_button"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/toolbar" />
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
+        tools:listitem="@layout/trace_location_attendee_consent_selectable_check_in" />
 
     <Button
         android:id="@+id/continue_button"

--- a/Corona-Warn-App/src/main/res/layout/check_ins_consent_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/check_ins_consent_fragment.xml
@@ -23,25 +23,25 @@
         android:layout_marginBottom="16dp"
         android:orientation="vertical"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-        app:layout_constraintBottom_toTopOf="@id/check_in_consent_continue_button"
+        app:layout_constraintBottom_toTopOf="@id/continue_button"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/toolbar" />
 
     <Button
-        android:id="@+id/check_in_consent_continue_button"
+        android:id="@+id/continue_button"
         style="@style/buttonPrimary"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="24dp"
         android:layout_marginBottom="16dp"
         android:text="@string/trace_location_attendee_consent_continue"
-        app:layout_constraintBottom_toTopOf="@id/check_in_consent_skip_button"
+        app:layout_constraintBottom_toTopOf="@id/skip_button"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
 
     <Button
-        android:id="@+id/check_in_consent_skip_button"
+        android:id="@+id/skip_button"
         style="@style/buttonPrimary"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/Corona-Warn-App/src/main/res/layout/trace_location_attendee_consent_header.xml
+++ b/Corona-Warn-App/src/main/res/layout/trace_location_attendee_consent_header.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:orientation="vertical"
     android:paddingStart="24dp"
     android:paddingTop="18dp"

--- a/Corona-Warn-App/src/main/res/layout/trace_location_attendee_consent_header.xml
+++ b/Corona-Warn-App/src/main/res/layout/trace_location_attendee_consent_header.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:paddingStart="24dp"
+    android:paddingTop="18dp"
+    android:paddingEnd="24dp"
+    android:paddingBottom="18dp">
+
+    <TextView
+        style="@style/subtitleMedium"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/trace_location_attendee_consent_header_description" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/select_all_button"
+        style="@style/materialTextButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_marginTop="24dp"
+        android:text="@string/trace_location_attendee_consent_header_button" />
+</LinearLayout>

--- a/Corona-Warn-App/src/main/res/layout/trace_location_attendee_consent_header.xml
+++ b/Corona-Warn-App/src/main/res/layout/trace_location_attendee_consent_header.xml
@@ -6,7 +6,7 @@
     android:paddingStart="24dp"
     android:paddingTop="18dp"
     android:paddingEnd="24dp"
-    android:paddingBottom="18dp">
+    android:paddingBottom="8dp">
 
     <TextView
         style="@style/subtitleMedium"
@@ -20,6 +20,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
-        android:layout_marginTop="24dp"
+        android:layout_marginTop="8dp"
         android:text="@string/trace_location_attendee_consent_header_button" />
 </LinearLayout>

--- a/Corona-Warn-App/src/main/res/layout/trace_location_attendee_consent_selectable_check_in.xml
+++ b/Corona-Warn-App/src/main/res/layout/trace_location_attendee_consent_selectable_check_in.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Corona-Warn-App/src/main/res/layout/trace_location_attendee_consent_selectable_check_in.xml
+++ b/Corona-Warn-App/src/main/res/layout/trace_location_attendee_consent_selectable_check_in.xml
@@ -2,7 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    style="@style/GreyCard.Ripple"
+    style="@style/contactDiaryCardRipple"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginHorizontal="16dp"

--- a/Corona-Warn-App/src/main/res/layout/trace_location_attendee_consent_selectable_check_in.xml
+++ b/Corona-Warn-App/src/main/res/layout/trace_location_attendee_consent_selectable_check_in.xml
@@ -1,6 +1,67 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent"
-    android:layout_height="match_parent">
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/GreyCard.Ripple"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="16dp"
+    android:layout_marginVertical="8dp"
+    android:focusable="true">
+
+    <ImageView
+        android:id="@+id/checkbox"
+        android:layout_width="@dimen/spacing_medium"
+        android:layout_height="@dimen/spacing_medium"
+        android:layout_marginStart="@dimen/spacing_small"
+        android:layout_marginTop="13dp"
+        android:background="?selectableItemBackgroundBorderless"
+        android:clickable="false"
+        android:focusable="false"
+        android:importantForAccessibility="no"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_unselected"
+        tools:srcCompat="@drawable/ic_selected" />
+
+    <TextView
+        android:id="@+id/title"
+        style="@style/materialSubtitleSixteen"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="15dp"
+        android:layout_marginTop="13dp"
+        android:layout_marginEnd="10dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/checkbox"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Hairdresser" />
+
+    <TextView
+        android:id="@+id/subtitle"
+        style="@style/body2"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="10dp"
+        android:textColor="@color/colorTextPrimary2"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@id/title"
+        app:layout_constraintTop_toBottomOf="@id/title"
+        tools:text="Berlin" />
+
+    <TextView
+        android:id="@+id/checkoutInfo"
+        style="@style/body2"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:layout_marginEnd="10dp"
+        android:layout_marginBottom="10dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@id/title"
+        app:layout_constraintTop_toBottomOf="@id/subtitle"
+        tools:text="21.01.21, 18:01 - 21:00 Uhr" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
+++ b/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
@@ -609,4 +609,15 @@
         android:name="de.rki.coronawarnapp.bugreporting.debuglog.ui.legal.DebugLogLegalFragment"
         android:label="DebugLogLegalFragment"
         tools:layout="@layout/bugreporting_legal_fragment" />
+
+    <fragment
+        android:id="@+id/checkInsConsentFragment"
+        android:name="de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent.CheckInsConsentFragment"
+        android:label="check_ins_consent_fragment"
+        tools:layout="@layout/check_ins_consent_fragment">
+        <argument
+            android:name="preConsentGiven"
+            android:defaultValue="false"
+            app:argType="boolean" />
+    </fragment>
 </navigation>

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -1974,4 +1974,10 @@
     <string name="trace_location_organiser_poster_share">"Teilen"</string>
     <!-- XHED: Trace location poster title -->
     <string name="trace_location_organiser_poster_title">"Druckversion"</string>
+
+    <string name="trace_location_attendee_consent_title">Check-ins teilen</string>
+    <string name="trace_location_attendee_consent_header_description">Teilen Sie Ihre Check-ins, um andere zu warnen, die auch dort waren. Ihre Identität bleibt geheim.</string>
+    <string name="trace_location_attendee_consent_header_button">Alle auswählen</string>
+    <string name="trace_location_attendee_consent_continue">Weiter</string>
+    <string name="trace_location_attendee_consent_skip">Überspringen</string>
 </resources>

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -303,13 +303,13 @@
     <!-- XHED: risk details - infection period logged headling, below behaviors -->
     <string name="risk_details_subtitle_period_logged">"Dieser Zeitraum wird berücksichtigt."</string>
     <!-- XHED: risk details - infection period logged information body, below behaviors -->
-    <!--    Dialog part 1-->
+<!--    Dialog part 1-->
     <string name="risk_details_information_body_period_logged">"Die Berechnung des Infektionsrisikos kann nur für die Zeiträume erfolgen, an denen die Risiko-Ermittlung aktiv war. Die Risiko- Ermittlung sollte daher dauerhaft aktiv sein. Für Ihre Risiko-Ermittlung wird der Zeitraum der letzten 14 Tage betrachtet."</string>
     <!-- XTXT: risk details - infection period logged information body, under 14 days -->
     <string name="risk_details_information_body_period_logged_assessment_under_14_days">"Die Corona-Warn-App ist seit %s Tagen installiert. Das Infektionsrisiko wird für Zeiträume berechnet, in denen die Risiko-Ermittlung aktiv ist. Wenn Sie andere Personen getroffen haben und die Risiko-Ermittlung aktiv war, wird Ihr Infektions-Risiko berechnet."</string>
     <!-- XTXT: risk details - infection period logged information body, over 14 days -->
     <string name="risk_details_information_body_period_logged_assessment_over_14_days">"Wenn die Risiko-Ermittlung zu Zeiten, in denen Sie andere Personen getroffen haben, aktiv war, kann die Berechnung des Infektionsrisikos für diesen Zeitraum erfolgen."</string>
-    <!-- XHED: risk details - infection period logged information body, below behaviors -->        <!-- XTXT: risk details - infection period logged information body, under 14 days -->
+    <!-- XHED: risk details - infection period logged information body, below behaviors -->	    <!-- XTXT: risk details - infection period logged information body, under 14 days -->
     <string name="risk_details_information_body_period_logged_assessment">"Ältere Tage werden automatisch gelöscht, da sie aus Sicht des Infektionsschutzes nicht mehr relevant sind."</string>
     <!-- XTXT: risk details - infection period days logged/14 -->
     <string name="risk_details_information_active_tracing_days_circle_progress">"%s/14"</string>

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -1977,7 +1977,7 @@
     <!-- XHED: Trace location check-ins consent screen title -->
     <string name="trace_location_attendee_consent_title">Check-ins für diese Orte teilen?</string>
     <!-- XTXT: Trace location check-ins consent screen header description -->
-    <string name="trace_location_attendee_consent_header_description">Teilen Sie Ihre Check-ins, um andere zu warnen, die auch in Ihrer Nähe waren. Ihre Identität bleibt geheim.</string>
+    <string name="trace_location_attendee_consent_header_description">Teilen Sie Ihre Check-ins, um andere zu warnen, die in Ihrer Nähe waren. Ihre Identität bleibt geheim.</string>
     <!-- XBUT: Trace location check-ins consent screen header button -->
     <string name="trace_location_attendee_consent_header_button">Alle auswählen</string>
     <!-- XBUT: Trace location check-ins consent screen continue button -->

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -303,13 +303,13 @@
     <!-- XHED: risk details - infection period logged headling, below behaviors -->
     <string name="risk_details_subtitle_period_logged">"Dieser Zeitraum wird berücksichtigt."</string>
     <!-- XHED: risk details - infection period logged information body, below behaviors -->
-<!--    Dialog part 1-->
+    <!--    Dialog part 1-->
     <string name="risk_details_information_body_period_logged">"Die Berechnung des Infektionsrisikos kann nur für die Zeiträume erfolgen, an denen die Risiko-Ermittlung aktiv war. Die Risiko- Ermittlung sollte daher dauerhaft aktiv sein. Für Ihre Risiko-Ermittlung wird der Zeitraum der letzten 14 Tage betrachtet."</string>
     <!-- XTXT: risk details - infection period logged information body, under 14 days -->
     <string name="risk_details_information_body_period_logged_assessment_under_14_days">"Die Corona-Warn-App ist seit %s Tagen installiert. Das Infektionsrisiko wird für Zeiträume berechnet, in denen die Risiko-Ermittlung aktiv ist. Wenn Sie andere Personen getroffen haben und die Risiko-Ermittlung aktiv war, wird Ihr Infektions-Risiko berechnet."</string>
     <!-- XTXT: risk details - infection period logged information body, over 14 days -->
     <string name="risk_details_information_body_period_logged_assessment_over_14_days">"Wenn die Risiko-Ermittlung zu Zeiten, in denen Sie andere Personen getroffen haben, aktiv war, kann die Berechnung des Infektionsrisikos für diesen Zeitraum erfolgen."</string>
-    <!-- XHED: risk details - infection period logged information body, below behaviors -->	    <!-- XTXT: risk details - infection period logged information body, under 14 days -->
+    <!-- XHED: risk details - infection period logged information body, below behaviors -->        <!-- XTXT: risk details - infection period logged information body, under 14 days -->
     <string name="risk_details_information_body_period_logged_assessment">"Ältere Tage werden automatisch gelöscht, da sie aus Sicht des Infektionsschutzes nicht mehr relevant sind."</string>
     <!-- XTXT: risk details - infection period days logged/14 -->
     <string name="risk_details_information_active_tracing_days_circle_progress">"%s/14"</string>
@@ -1974,10 +1974,22 @@
     <string name="trace_location_organiser_poster_share">"Teilen"</string>
     <!-- XHED: Trace location poster title -->
     <string name="trace_location_organiser_poster_title">"Druckversion"</string>
-
-    <string name="trace_location_attendee_consent_title">Check-ins teilen</string>
-    <string name="trace_location_attendee_consent_header_description">Teilen Sie Ihre Check-ins, um andere zu warnen, die auch dort waren. Ihre Identität bleibt geheim.</string>
+    <!-- XHED: Trace location check-ins consent screen title -->
+    <string name="trace_location_attendee_consent_title">Check-ins für diese Orte teilen?</string>
+    <!-- XTXT: Trace location check-ins consent screen header description -->
+    <string name="trace_location_attendee_consent_header_description">Teilen Sie Ihre Check-ins, um andere zu warnen, die auch in Ihrer Nähe waren. Ihre Identität bleibt geheim.</string>
+    <!-- XBUT: Trace location check-ins consent screen header button -->
     <string name="trace_location_attendee_consent_header_button">Alle auswählen</string>
+    <!-- XBUT: Trace location check-ins consent screen continue button -->
     <string name="trace_location_attendee_consent_continue">Weiter</string>
+    <!-- XBUT: Trace location check-ins consent screen skip button -->
     <string name="trace_location_attendee_consent_skip">Überspringen</string>
+    <!-- XHED: Trace location check-ins consent screen dialog title -->
+    <string name="trace_location_attendee_consent_dialog_title">Sind Sie sicher, dass Sie Ihre Check-Ins nicht teilen wollen?</string>
+    <!-- XTXT: Trace location check-ins consent screen dialog message -->
+    <string name="trace_location_attendee_consent_dialog_message">Dadurch werden andere, die in Ihrer Nähe waren, nicht gewarnt.</string>
+    <!-- XBUT: Trace location check-ins consent screen dialog positive button -->
+    <string name="trace_location_attendee_consent_dialog_positive_button">Teilen</string>
+    <!-- XBUT: Trace location check-ins consent screen dialog negative button -->
+    <string name="trace_location_attendee_consent_dialog_negative_button">Nicht teilen</string>
 </resources>

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -1982,4 +1982,10 @@
     <string name="trace_location_organiser_poster_share">"Share"</string>
     <!-- XHED: Trace location poster title -->
     <string name="trace_location_organiser_poster_title">"Print Version"</string>
+
+    <string name="trace_location_attendee_consent_title">Check-ins teilen</string>
+    <string name="trace_location_attendee_consent_header_description">Teilen Sie Ihre Check-ins, um andere zu warnen, die auch dort waren. Ihre Identität bleibt geheim.</string>
+    <string name="trace_location_attendee_consent_header_button">Alle auswählen</string>
+    <string name="trace_location_attendee_consent_continue">Weiter</string>
+    <string name="trace_location_attendee_consent_skip">Überspringen</string>
 </resources>

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -1982,10 +1982,22 @@
     <string name="trace_location_organiser_poster_share">"Share"</string>
     <!-- XHED: Trace location poster title -->
     <string name="trace_location_organiser_poster_title">"Print Version"</string>
-
-    <string name="trace_location_attendee_consent_title">Check-ins teilen</string>
-    <string name="trace_location_attendee_consent_header_description">Teilen Sie Ihre Check-ins, um andere zu warnen, die auch dort waren. Ihre Identität bleibt geheim.</string>
+    <!-- XHED: Trace location check-ins consent screen title -->
+    <string name="trace_location_attendee_consent_title">Check-ins für diese Orte teilen?</string>
+    <!-- XTXT: Trace location check-ins consent screen header description -->
+    <string name="trace_location_attendee_consent_header_description">Teilen Sie Ihre Check-ins, um andere zu warnen, die auch in Ihrer Nähe waren. Ihre Identität bleibt geheim.</string>
+    <!-- XBUT: Trace location check-ins consent screen header button -->
     <string name="trace_location_attendee_consent_header_button">Alle auswählen</string>
+    <!-- XBUT: Trace location check-ins consent screen continue button -->
     <string name="trace_location_attendee_consent_continue">Weiter</string>
+    <!-- XBUT: Trace location check-ins consent screen skip button -->
     <string name="trace_location_attendee_consent_skip">Überspringen</string>
+    <!-- XHED: Trace location check-ins consent screen dialog title -->
+    <string name="trace_location_attendee_consent_dialog_title">Sind Sie sicher, dass Sie Ihre Check-Ins nicht teilen wollen?</string>
+    <!-- XTXT: Trace location check-ins consent screen dialog message -->
+    <string name="trace_location_attendee_consent_dialog_message">Dadurch werden andere, die in Ihrer Nähe waren, nicht gewarnt.</string>
+    <!-- XBUT: Trace location check-ins consent screen dialog positive button -->
+    <string name="trace_location_attendee_consent_dialog_positive_button">Teilen</string>
+    <!-- XBUT: Trace location check-ins consent screen dialog negative button -->
+    <string name="trace_location_attendee_consent_dialog_negative_button">Nicht teilen</string>
 </resources>

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -1985,7 +1985,7 @@
     <!-- XHED: Trace location check-ins consent screen title -->
     <string name="trace_location_attendee_consent_title">Check-ins für diese Orte teilen?</string>
     <!-- XTXT: Trace location check-ins consent screen header description -->
-    <string name="trace_location_attendee_consent_header_description">Teilen Sie Ihre Check-ins, um andere zu warnen, die auch in Ihrer Nähe waren. Ihre Identität bleibt geheim.</string>
+    <string name="trace_location_attendee_consent_header_description">Teilen Sie Ihre Check-ins, um andere zu warnen, die in Ihrer Nähe waren. Ihre Identität bleibt geheim.</string>
     <!-- XBUT: Trace location check-ins consent screen header button -->
     <string name="trace_location_attendee_consent_header_button">Alle auswählen</string>
     <!-- XBUT: Trace location check-ins consent screen continue button -->

--- a/Corona-Warn-App/src/main/res/values/styles.xml
+++ b/Corona-Warn-App/src/main/res/values/styles.xml
@@ -293,9 +293,13 @@
         <item name="android:textColor">@color/colorTextPrimary1</item>
     </style>
 
-    <style name="subtitleBoldSixteen" parent="@style/TextAppearance.MaterialComponents.Subtitle1">
+
+    <style name="materialSubtitleSixteen" parent="@style/TextAppearance.MaterialComponents.Subtitle1">
         <item name="android:textColor">@color/colorTextPrimary1</item>
         <item name="android:textSize">16sp</item>
+    </style>
+
+    <style name="subtitleBoldSixteen" parent="materialSubtitleSixteen">
         <item name="android:textStyle">bold</item>
     </style>
 

--- a/Corona-Warn-App/src/main/res/values/styles.xml
+++ b/Corona-Warn-App/src/main/res/values/styles.xml
@@ -155,6 +155,10 @@
         <item name="android:textColor">@color/colorAccent</item>
     </style>
 
+    <style name="materialTextButton" parent="Widget.MaterialComponents.Button.TextButton.Dialog.Flush">
+        <item name="android:textColor">@color/colorAccent</item>
+    </style>
+
     <style name="buttonIcon">
         <item name="android:background">@drawable/circle_ripple</item>
         <item name="android:backgroundTint">@color/button_back</item>

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModelTest.kt
@@ -1,0 +1,215 @@
+package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent
+
+import androidx.lifecycle.SavedStateHandle
+import de.rki.coronawarnapp.eventregistration.checkins.CheckIn
+import de.rki.coronawarnapp.eventregistration.checkins.CheckInRepository
+import io.kotest.matchers.shouldBe
+import io.mockk.MockKAnnotations
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.just
+import kotlinx.coroutines.flow.flowOf
+import okio.ByteString.Companion.decodeBase64
+import okio.ByteString.Companion.encode
+import org.joda.time.Instant
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import testhelpers.BaseTest
+import testhelpers.TestDispatcherProvider
+import testhelpers.extensions.InstantExecutorExtension
+import testhelpers.extensions.getOrAwaitValue
+
+@ExtendWith(InstantExecutorExtension::class)
+class CheckInsConsentViewModelTest : BaseTest() {
+
+    @MockK lateinit var savedState: SavedStateHandle
+    @MockK lateinit var checkInRepository: CheckInRepository
+
+    private val checkIn1 = CheckIn(
+        id = 1L,
+        traceLocationId = "41da2115-eba2-49bd-bf17-adb3d635ddaf".decodeBase64()!!,
+        version = 1,
+        type = 2,
+        description = "brothers birthday",
+        address = "Malibu",
+        traceLocationStart = Instant.EPOCH,
+        traceLocationEnd = null,
+        defaultCheckInLengthInMinutes = null,
+        cryptographicSeed = "cryptographicSeed".encode(),
+        cnPublicKey = "cnPublicKey",
+        checkInStart = Instant.EPOCH,
+        checkInEnd = Instant.EPOCH,
+        completed = true,
+        createJournalEntry = false
+    )
+
+    private val checkIn2 = CheckIn(
+        id = 2L,
+        traceLocationId = "41da2115-eba2-49bd-bf17-adb3d635ddaf".decodeBase64()!!,
+        version = 1,
+        type = 2,
+        description = "brothers birthday",
+        address = "Malibu",
+        traceLocationStart = Instant.EPOCH,
+        traceLocationEnd = null,
+        defaultCheckInLengthInMinutes = null,
+        cryptographicSeed = "cryptographicSeed".encode(),
+        cnPublicKey = "cnPublicKey",
+        checkInStart = Instant.EPOCH,
+        checkInEnd = Instant.EPOCH,
+        completed = true,
+        createJournalEntry = false
+    )
+
+    private val checkIn3 = CheckIn(
+        id = 3L,
+        traceLocationId = "41da2115-eba2-49bd-bf17-adb3d635ddaf".decodeBase64()!!,
+        version = 1,
+        type = 2,
+        description = "brothers birthday",
+        address = "Malibu",
+        traceLocationStart = Instant.EPOCH,
+        traceLocationEnd = null,
+        defaultCheckInLengthInMinutes = null,
+        cryptographicSeed = "cryptographicSeed".encode(),
+        cnPublicKey = "cnPublicKey",
+        checkInStart = Instant.EPOCH,
+        checkInEnd = Instant.EPOCH,
+        completed = false,
+        createJournalEntry = false
+    )
+
+    @BeforeEach
+    fun setUp() {
+        MockKAnnotations.init(this)
+
+        every { checkInRepository.checkInsWithinRetention } returns flowOf(listOf(checkIn1, checkIn2, checkIn3))
+        every { savedState.set(any(), any<Set<Long>>()) } just Runs
+    }
+
+    @Test
+    fun `Nothing is selected initially`() {
+        every { savedState.get<Set<Long>>(any()) } returns emptySet()
+
+        val viewModel = createViewModel()
+        viewModel.checkIns.getOrAwaitValue().apply {
+            size shouldBe 3
+            get(0).apply {
+                this is HeaderCheckInsVH.Item
+            }
+
+            get(1).apply {
+                this as SelectableCheckInVH.Item
+                this.checkIn.isSubmissionPermitted shouldBe false
+            }
+
+            get(2).apply {
+                this as SelectableCheckInVH.Item
+                this.checkIn.isSubmissionPermitted shouldBe false
+            }
+        }
+    }
+
+    @Test
+    fun `Saved state is restored`() {
+        every { savedState.get<Set<Long>>(any()) } returns setOf(1L)
+        val viewModel = createViewModel()
+        viewModel.checkIns.getOrAwaitValue().apply {
+            size shouldBe 3
+            get(0).apply {
+                this is HeaderCheckInsVH.Item
+            }
+
+            get(1).apply {
+                this as SelectableCheckInVH.Item
+                this.checkIn.isSubmissionPermitted shouldBe true
+            }
+
+            get(2).apply {
+                this as SelectableCheckInVH.Item
+                this.checkIn.isSubmissionPermitted shouldBe false
+            }
+        }
+    }
+
+    @Test
+    fun `Select all`() {
+        every { savedState.get<Set<Long>>(any()) } returns emptySet()
+        val viewModel = createViewModel()
+        viewModel.checkIns.getOrAwaitValue().apply {
+            size shouldBe 3
+            get(0).apply {
+                this as HeaderCheckInsVH.Item
+                (get(1) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe false
+                (get(2) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe false
+
+                this.selectAll()
+
+                viewModel.checkIns.getOrAwaitValue().apply {
+                    (get(1) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe true
+                    (get(2) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe true
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `Single selection`() {
+        every { savedState.get<Set<Long>>(any()) } returns emptySet()
+        val viewModel = createViewModel()
+        viewModel.checkIns.getOrAwaitValue().apply {
+
+            (get(1) as SelectableCheckInVH.Item).apply {
+                checkIn.isSubmissionPermitted shouldBe false
+                onItemSelected(checkIn)
+            }
+
+            viewModel.checkIns.getOrAwaitValue().apply {
+                (get(1) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe true
+            }
+        }
+    }
+
+    @Test
+    fun `Single deselection`() {
+        every { savedState.get<Set<Long>>(any()) } returns emptySet()
+        val viewModel = createViewModel()
+        viewModel.checkIns.getOrAwaitValue().apply {
+            (get(1) as SelectableCheckInVH.Item).apply {
+                checkIn.isSubmissionPermitted shouldBe false
+                onItemSelected(checkIn)
+            }
+
+            viewModel.checkIns.getOrAwaitValue().apply {
+                (get(1) as SelectableCheckInVH.Item).apply {
+                    checkIn.isSubmissionPermitted shouldBe true
+                    onItemSelected(checkIn)
+                }
+            }
+
+            viewModel.checkIns.getOrAwaitValue().apply {
+                (get(1) as SelectableCheckInVH.Item).apply {
+                    checkIn.isSubmissionPermitted shouldBe false
+                }
+            }
+        }
+    }
+
+    @Test
+    fun shareSelectedCheckIns() {
+        // TODO test navigation
+    }
+
+    @Test
+    fun doNotShareCheckIns() {
+        // TODO test navigation
+    }
+
+    private fun createViewModel() = CheckInsConsentViewModel(
+        savedState = savedState,
+        dispatcherProvider = TestDispatcherProvider(),
+        checkInRepository = checkInRepository
+    )
+}

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModelTest.kt
@@ -156,6 +156,34 @@ class CheckInsConsentViewModelTest : BaseTest() {
     }
 
     @Test
+    fun `Select all does not un-select all`() {
+        every { savedState.get<Set<Long>>(any()) } returns emptySet()
+        val viewModel = createViewModel()
+        viewModel.checkIns.getOrAwaitValue().apply {
+            size shouldBe 3
+            get(0).apply {
+                this as HeaderCheckInsVH.Item
+                (get(1) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe false
+                (get(2) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe false
+
+                this.selectAll()
+
+                viewModel.checkIns.getOrAwaitValue().apply {
+                    (get(1) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe true
+                    (get(2) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe true
+                }
+
+                this.selectAll()
+
+                viewModel.checkIns.getOrAwaitValue().apply {
+                    (get(1) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe true
+                    (get(2) as SelectableCheckInVH.Item).checkIn.isSubmissionPermitted shouldBe true
+                }
+            }
+        }
+    }
+
+    @Test
     fun `Single selection`() {
         every { savedState.get<Set<Long>>(any()) } returns emptySet()
         val viewModel = createViewModel()


### PR DESCRIPTION
- Implements CheckIns consent screen

### TODO
- [x] Add unit tests
### Testing
- Add some completed check-ins  
- Go to testing menu -> presence tracing -> scroll to `Consent` button -> Open the new  consent screen
- Select - unselect items
- Check when activity is killed that state is reserved

Note: wiring the new screen will be done in a new PR 