### PR TITLE
Wire up new consent (EXPOSUREAPP-6532)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/submission/SubmissionTestResultAvailableFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/submission/SubmissionTestResultAvailableFragmentTest.kt
@@ -5,6 +5,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import dagger.Module
 import dagger.android.ContributesAndroidInjector
 import de.rki.coronawarnapp.datadonation.analytics.modules.keysubmission.AnalyticsKeySubmissionCollector
+import de.rki.coronawarnapp.eventregistration.checkins.CheckInRepository
 import de.rki.coronawarnapp.submission.SubmissionRepository
 import de.rki.coronawarnapp.submission.auto.AutoSubmission
 import de.rki.coronawarnapp.submission.data.tekhistory.TEKHistoryUpdater_Factory_Impl
@@ -39,6 +40,7 @@ class SubmissionTestResultAvailableFragmentTest : BaseUITest() {
     @MockK lateinit var autoSubmission: AutoSubmission
     @MockK lateinit var appShortcutsHelper: AppShortcutsHelper
     @MockK lateinit var analyticsKeySubmissionCollector: AnalyticsKeySubmissionCollector
+    @MockK lateinit var checkInRepository: CheckInRepository
 
     @Rule
     @JvmField
@@ -57,11 +59,12 @@ class SubmissionTestResultAvailableFragmentTest : BaseUITest() {
 
         viewModel = spyk(
             SubmissionTestResultAvailableViewModel(
-                TestDispatcherProvider(),
-                tekHistoryUpdaterFactory,
-                submissionRepository,
-                autoSubmission,
-                analyticsKeySubmissionCollector
+                dispatcherProvider = TestDispatcherProvider(),
+                tekHistoryUpdaterFactory = tekHistoryUpdaterFactory,
+                submissionRepository = submissionRepository,
+                autoSubmission = autoSubmission,
+                analyticsKeySubmissionCollector = analyticsKeySubmissionCollector,
+                checkInRepository = checkInRepository
             )
         )
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/eventregistration/checkins/CheckInRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/eventregistration/checkins/CheckInRepository.kt
@@ -65,7 +65,7 @@ class CheckInRepository @Inject constructor(
         checkInDao.updateEntityById(checkInId, update)
     }
 
-    suspend fun markCheckInAsSubmitted(checkInId: Long) {
+    suspend fun updatePostSubmissionFlags(checkInId: Long) {
         Timber.d("markCheckInAsSubmitted(checkInId=$checkInId)")
         checkInDao.updateEntity(
             TraceLocationCheckInEntity.SubmissionUpdate(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/checkins/common/CheckInRepositoryExtension.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/checkins/common/CheckInRepositoryExtension.kt
@@ -1,4 +1,4 @@
-package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.common
+package de.rki.coronawarnapp.presencetracing.checkins.common
 
 import de.rki.coronawarnapp.eventregistration.checkins.CheckIn
 import de.rki.coronawarnapp.eventregistration.checkins.CheckInRepository

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/task/SubmissionTask.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/task/SubmissionTask.kt
@@ -10,6 +10,7 @@ import de.rki.coronawarnapp.exception.NoRegistrationTokenSetException
 import de.rki.coronawarnapp.notification.ShareTestResultNotificationService
 import de.rki.coronawarnapp.notification.TestResultAvailableNotificationService
 import de.rki.coronawarnapp.playbook.Playbook
+import de.rki.coronawarnapp.presencetracing.checkins.common.completedCheckIns
 import de.rki.coronawarnapp.submission.SubmissionSettings
 import de.rki.coronawarnapp.submission.Symptoms
 import de.rki.coronawarnapp.submission.auto.AutoSubmission
@@ -143,8 +144,8 @@ class SubmissionTask @Inject constructor(
         )
         Timber.tag(TAG).d("Transformed keys with symptoms %s from %s to %s", symptoms, keys, transformedKeys)
 
-        val checkIns = checkInsRepository.checkInsWithinRetention.first().filter {
-            it.completed && it.hasSubmissionConsent && !it.isSubmitted
+        val checkIns = checkInsRepository.completedCheckIns.first().filter {
+            it.hasSubmissionConsent && !it.isSubmitted
         }
         val transformedCheckIns = checkInsTransformer.transform(checkIns, symptoms)
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/task/SubmissionTask.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/task/SubmissionTask.kt
@@ -174,7 +174,7 @@ class SubmissionTask @Inject constructor(
         Timber.tag(TAG).d("Marking %d submitted CheckIns.", checkIns.size)
         checkIns.forEach { checkIn ->
             try {
-                checkInsRepository.markCheckInAsSubmitted(checkIn.id)
+                checkInsRepository.updatePostSubmissionFlags(checkIn.id)
             } catch (e: Exception) {
                 e.reportProblem(TAG, "CheckIn $checkIn could not be marked as submitted")
             }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/common/CheckInRepositoryExtension.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/common/CheckInRepositoryExtension.kt
@@ -1,0 +1,13 @@
+package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.common
+
+import de.rki.coronawarnapp.eventregistration.checkins.CheckIn
+import de.rki.coronawarnapp.eventregistration.checkins.CheckInRepository
+import kotlinx.coroutines.flow.map
+
+/**
+ * Returns completed [CheckIn]s only
+ */
+val CheckInRepository.completedCheckIns
+    get() = checkInsWithinRetention.map { checkIns ->
+        checkIns.filter { checkIn -> checkIn.completed }
+    }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentFragment.kt
@@ -3,21 +3,22 @@ package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.View
-import androidx.navigation.fragment.navArgs
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.CheckInsConsentFragmentBinding
+import de.rki.coronawarnapp.util.DialogHelper
 import de.rki.coronawarnapp.util.di.AutoInject
 import de.rki.coronawarnapp.util.lists.diffutil.update
+import de.rki.coronawarnapp.util.ui.doNavigate
 import de.rki.coronawarnapp.util.ui.viewBindingLazy
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactoryProvider
 import de.rki.coronawarnapp.util.viewmodel.cwaViewModelsAssisted
+import timber.log.Timber
 import javax.inject.Inject
 
 class CheckInsConsentFragment : Fragment(R.layout.check_ins_consent_fragment), AutoInject {
 
     private val binding: CheckInsConsentFragmentBinding by viewBindingLazy()
-    private val navArgs by navArgs<CheckInsConsentFragmentArgs>()
 
     @Inject lateinit var viewModelFactory: CWAViewModelFactoryProvider.Factory
     private val viewModel: CheckInsConsentViewModel by cwaViewModelsAssisted(
@@ -36,22 +37,33 @@ class CheckInsConsentFragment : Fragment(R.layout.check_ins_consent_fragment), A
         with(binding) {
             checkInsRecycler.adapter = adapter
             toolbar.setNavigationOnClickListener {
-                if (navArgs.preConsentGiven) {
-                    // TODO show dialog from Test screen
-                } else {
-                    showSkipDialog()
-                }
+                viewModel.onCloseClick()
             }
-            skipButton.setOnClickListener { showSkipDialog() }
-            continueButton.setOnClickListener {
-                viewModel.shareSelectedCheckIns()
-            }
+            skipButton.setOnClickListener { viewModel.onSkipClick() }
+            continueButton.setOnClickListener { viewModel.shareSelectedCheckIns() }
         }
 
         viewModel.checkIns.observe(viewLifecycleOwner) {
             adapter.update(it)
             binding.continueButton.isEnabled = it.any { item ->
                 item is SelectableCheckInVH.Item && item.checkIn.isSubmissionPermitted
+            }
+        }
+
+        viewModel.events.observe(viewLifecycleOwner) {
+            when (it) {
+                CheckInsConsentNavigation.OpenCloseDialog -> showCloseDialog()
+                CheckInsConsentNavigation.OpenSkipDialog -> showSkipDialog()
+                CheckInsConsentNavigation.ToHomeFragment -> doNavigate(
+                    CheckInsConsentFragmentDirections.actionCheckInsConsentFragmentToMainFragment()
+                )
+                CheckInsConsentNavigation.ToSubmissionResultReadyFragment -> doNavigate(
+                    CheckInsConsentFragmentDirections.actionCheckInsConsentFragmentToSubmissionResultReadyFragment()
+                )
+                CheckInsConsentNavigation.ToSubmissionTestResultConsentGivenFragment -> doNavigate(
+                    CheckInsConsentFragmentDirections
+                        .actionCheckInsConsentFragmentToSubmissionTestResultConsentGivenFragment()
+                )
             }
         }
     }
@@ -61,11 +73,27 @@ class CheckInsConsentFragment : Fragment(R.layout.check_ins_consent_fragment), A
             .setTitle(R.string.trace_location_attendee_consent_dialog_title)
             .setMessage(R.string.trace_location_attendee_consent_dialog_message)
             .setPositiveButton(R.string.trace_location_attendee_consent_dialog_positive_button) { _, _ ->
-                viewModel.shareSelectedCheckIns()
+                Timber.d("showSkipDialog:Stay on CheckInsConsentFragment")
             }
             .setNegativeButton(R.string.trace_location_attendee_consent_dialog_negative_button) { _, _ ->
                 viewModel.doNotShareCheckIns()
             }
             .show()
+    }
+
+    private fun showCloseDialog() {
+        val closeDialogInstance = DialogHelper.DialogInstance(
+            context = requireActivity(),
+            title = R.string.submission_test_result_available_close_dialog_title_consent_given,
+            message = R.string.submission_test_result_available_close_dialog_body_consent_given,
+            positiveButton = R.string.submission_test_result_available_close_dialog_continue_button,
+            negativeButton = R.string.submission_test_result_available_close_dialog_cancel_button,
+            cancelable = true,
+            positiveButtonFunction = {
+                Timber.d("showCloseDialog:Stay on CheckInsConsentFragment")
+            },
+            negativeButtonFunction = { viewModel.onCancelConfirmed() }
+        )
+        DialogHelper.showDialog(closeDialogInstance)
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentFragment.kt
@@ -3,6 +3,7 @@ package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.View
+import androidx.activity.OnBackPressedCallback
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.CheckInsConsentFragmentBinding
@@ -34,6 +35,12 @@ class CheckInsConsentFragment : Fragment(R.layout.check_ins_consent_fragment), A
     private val adapter = CheckInsConsentAdapter()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+
+        val backCallback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() = viewModel.onCloseClick()
+        }
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, backCallback)
+
         with(binding) {
             checkInsRecycler.adapter = adapter
             toolbar.setNavigationOnClickListener {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentNavigation.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentNavigation.kt
@@ -1,0 +1,9 @@
+package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent
+
+sealed class CheckInsConsentNavigation {
+    object OpenCloseDialog : CheckInsConsentNavigation()
+    object OpenSkipDialog : CheckInsConsentNavigation()
+    object ToHomeFragment : CheckInsConsentNavigation()
+    object ToSubmissionTestResultConsentGivenFragment : CheckInsConsentNavigation()
+    object ToSubmissionResultReadyFragment : CheckInsConsentNavigation()
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModel.kt
@@ -53,35 +53,38 @@ class CheckInsConsentViewModel @AssistedInject constructor(
             consent = true,
         )
 
-        if (submissionRepository.hasViewedTestResult.first()) {
+        val event = if (submissionRepository.hasViewedTestResult.first()) {
             Timber.d("Navigate to SubmissionResultReadyFragment")
-            events.postValue(CheckInsConsentNavigation.ToSubmissionResultReadyFragment)
+            CheckInsConsentNavigation.ToSubmissionResultReadyFragment
         } else {
             Timber.d("Navigate to SubmissionTestResultConsentGivenFragment")
-            events.postValue(CheckInsConsentNavigation.ToSubmissionTestResultConsentGivenFragment)
+            CheckInsConsentNavigation.ToSubmissionTestResultConsentGivenFragment
         }
+        events.postValue(event)
     }
 
     fun doNotShareCheckIns() = launch {
         Timber.d("Navigate to doNotShareCheckIns")
         autoSubmission.updateMode(AutoSubmission.Mode.MONITOR)
-        if (submissionRepository.hasViewedTestResult.first()) {
+        val event = if (submissionRepository.hasViewedTestResult.first()) {
             Timber.d("Navigate to SubmissionResultReadyFragment")
-            events.postValue(CheckInsConsentNavigation.ToSubmissionResultReadyFragment)
+            CheckInsConsentNavigation.ToSubmissionResultReadyFragment
         } else {
             Timber.d("Navigate to SubmissionTestResultConsentGivenFragment")
-            events.postValue(CheckInsConsentNavigation.ToSubmissionTestResultConsentGivenFragment)
+            CheckInsConsentNavigation.ToSubmissionTestResultConsentGivenFragment
         }
+        events.postValue(event)
     }
 
     fun onCloseClick() = launch {
-        if (submissionRepository.hasViewedTestResult.first()) {
+        val event = if (submissionRepository.hasViewedTestResult.first()) {
             Timber.d("openSkipDialog")
-            events.postValue(CheckInsConsentNavigation.OpenSkipDialog)
+            CheckInsConsentNavigation.OpenSkipDialog
         } else {
             Timber.d("openCloseDialog")
-            events.postValue(CheckInsConsentNavigation.OpenCloseDialog)
+            CheckInsConsentNavigation.OpenCloseDialog
         }
+        events.postValue(event)
     }
 
     fun onCancelConfirmed() {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModel.kt
@@ -10,7 +10,7 @@ import de.rki.coronawarnapp.eventregistration.checkins.CheckIn
 import de.rki.coronawarnapp.eventregistration.checkins.CheckInRepository
 import de.rki.coronawarnapp.submission.SubmissionRepository
 import de.rki.coronawarnapp.submission.auto.AutoSubmission
-import de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.common.completedCheckIns
+import de.rki.coronawarnapp.presencetracing.checkins.common.completedCheckIns
 import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
 import de.rki.coronawarnapp.util.ui.SingleLiveEvent
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModel

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModel.kt
@@ -45,7 +45,14 @@ class CheckInsConsentViewModel @AssistedInject constructor(
     fun shareSelectedCheckIns() = launch {
         Timber.d("Navigate to shareSelectedCheckIns")
         autoSubmission.updateMode(AutoSubmission.Mode.MONITOR)
-        // TODO checkInRepository.updateCheckIns(selectedSetFlow.value)
+
+        // Update CheckIns for submission
+        val idsWithConsent = selectedSetFlow.value
+        checkInRepository.updateSubmissionConsents(
+            checkInIds = idsWithConsent,
+            consent = true,
+        )
+
         if (submissionRepository.hasViewedTestResult.first()) {
             Timber.d("Navigate to SubmissionResultReadyFragment")
             events.postValue(CheckInsConsentNavigation.ToSubmissionResultReadyFragment)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/resultavailable/SubmissionTestResultAvailableViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/resultavailable/SubmissionTestResultAvailableViewModel.kt
@@ -14,7 +14,7 @@ import de.rki.coronawarnapp.exception.reporting.report
 import de.rki.coronawarnapp.submission.SubmissionRepository
 import de.rki.coronawarnapp.submission.auto.AutoSubmission
 import de.rki.coronawarnapp.submission.data.tekhistory.TEKHistoryUpdater
-import de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.common.completedCheckIns
+import de.rki.coronawarnapp.presencetracing.checkins.common.completedCheckIns
 import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
 import de.rki.coronawarnapp.util.ui.SingleLiveEvent
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModel

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/resultavailable/SubmissionTestResultAvailableViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/resultavailable/SubmissionTestResultAvailableViewModel.kt
@@ -8,11 +8,13 @@ import com.google.android.gms.nearby.exposurenotification.TemporaryExposureKey
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import de.rki.coronawarnapp.datadonation.analytics.modules.keysubmission.AnalyticsKeySubmissionCollector
+import de.rki.coronawarnapp.eventregistration.checkins.CheckInRepository
 import de.rki.coronawarnapp.exception.ExceptionCategory
 import de.rki.coronawarnapp.exception.reporting.report
 import de.rki.coronawarnapp.submission.SubmissionRepository
 import de.rki.coronawarnapp.submission.auto.AutoSubmission
 import de.rki.coronawarnapp.submission.data.tekhistory.TEKHistoryUpdater
+import de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.common.completedCheckIns
 import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
 import de.rki.coronawarnapp.util.ui.SingleLiveEvent
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
@@ -24,13 +26,14 @@ class SubmissionTestResultAvailableViewModel @AssistedInject constructor(
     dispatcherProvider: DispatcherProvider,
     tekHistoryUpdaterFactory: TEKHistoryUpdater.Factory,
     submissionRepository: SubmissionRepository,
+    private val checkInRepository: CheckInRepository,
     private val autoSubmission: AutoSubmission,
     private val analyticsKeySubmissionCollector: AnalyticsKeySubmissionCollector
 ) : CWAViewModel(dispatcherProvider = dispatcherProvider) {
 
     val routeToScreen = SingleLiveEvent<NavDirections>()
 
-    val consentFlow = submissionRepository.hasGivenConsentToSubmission
+    private val consentFlow = submissionRepository.hasGivenConsentToSubmission
     val consent = consentFlow.asLiveData(dispatcherProvider.Default)
     val showPermissionRequest = SingleLiveEvent<(Activity) -> Unit>()
     val showCloseDialog = SingleLiveEvent<Unit>()
@@ -39,14 +42,21 @@ class SubmissionTestResultAvailableViewModel @AssistedInject constructor(
 
     private val tekHistoryUpdater = tekHistoryUpdaterFactory.create(
         object : TEKHistoryUpdater.Callback {
-            override fun onTEKAvailable(teks: List<TemporaryExposureKey>) {
-                Timber.d("onTEKAvailable(teks.size=%d)", teks.size)
-                autoSubmission.updateMode(AutoSubmission.Mode.MONITOR)
+            override fun onTEKAvailable(teks: List<TemporaryExposureKey>) = launch {
+                Timber.tag(TAG).d("onTEKAvailable(teks.size=%d)", teks.size)
                 showKeysRetrievalProgress.postValue(false)
-                routeToScreen.postValue(
+                val completedCheckInsExist = checkInRepository.completedCheckIns.first().isNotEmpty()
+                val navDirections = if (completedCheckInsExist) {
+                    Timber.tag(TAG).d("Navigate to CheckInsConsentFragment")
+                    SubmissionTestResultAvailableFragmentDirections
+                        .actionSubmissionTestResultAvailableFragmentToCheckInsConsentFragment()
+                } else {
+                    autoSubmission.updateMode(AutoSubmission.Mode.MONITOR)
+                    Timber.tag(TAG).d("Navigate to SubmissionTestResultConsentGivenFragment")
                     SubmissionTestResultAvailableFragmentDirections
                         .actionSubmissionTestResultAvailableFragmentToSubmissionTestResultConsentGivenFragment()
-                )
+                }
+                routeToScreen.postValue(navDirections)
             }
 
             override fun onTEKPermissionDeclined() {
@@ -59,13 +69,13 @@ class SubmissionTestResultAvailableViewModel @AssistedInject constructor(
             }
 
             override fun onTracingConsentRequired(onConsentResult: (given: Boolean) -> Unit) {
-                Timber.d("onTracingConsentRequired")
+                Timber.tag(TAG).d("onTracingConsentRequired")
                 showKeysRetrievalProgress.postValue(false)
                 showTracingConsentDialog.postValue(onConsentResult)
             }
 
             override fun onPermissionRequired(permissionRequest: (Activity) -> Unit) {
-                Timber.d("onPermissionRequired")
+                Timber.tag(TAG).d("onPermissionRequired")
                 showKeysRetrievalProgress.postValue(false)
                 showPermissionRequest.postValue(permissionRequest)
             }
@@ -109,10 +119,10 @@ class SubmissionTestResultAvailableViewModel @AssistedInject constructor(
         showKeysRetrievalProgress.value = true
         launch {
             if (consentFlow.first()) {
-                Timber.d("tekHistoryUpdater.updateTEKHistoryOrRequestPermission")
+                Timber.tag(TAG).d("tekHistoryUpdater.updateTEKHistoryOrRequestPermission")
                 tekHistoryUpdater.updateTEKHistoryOrRequestPermission()
             } else {
-                Timber.d("routeToScreen:SubmissionTestResultNoConsentFragment")
+                Timber.tag(TAG).d("routeToScreen:SubmissionTestResultNoConsentFragment")
                 analyticsKeySubmissionCollector.reportConsentWithdrawn()
                 showKeysRetrievalProgress.postValue(false)
                 routeToScreen.postValue(
@@ -130,4 +140,8 @@ class SubmissionTestResultAvailableViewModel @AssistedInject constructor(
 
     @AssistedFactory
     interface Factory : SimpleCWAViewModelFactory<SubmissionTestResultAvailableViewModel>
+
+    companion object {
+        private const val TAG = "TestAvailableViewModel"
+    }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/warnothers/SubmissionResultPositiveOtherWarningNoConsentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/warnothers/SubmissionResultPositiveOtherWarningNoConsentViewModel.kt
@@ -9,6 +9,7 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import de.rki.coronawarnapp.datadonation.analytics.modules.keysubmission.AnalyticsKeySubmissionCollector
 import de.rki.coronawarnapp.datadonation.analytics.modules.keysubmission.Screen
+import de.rki.coronawarnapp.eventregistration.checkins.CheckInRepository
 import de.rki.coronawarnapp.exception.ExceptionCategory
 import de.rki.coronawarnapp.exception.reporting.report
 import de.rki.coronawarnapp.nearby.ENFClient
@@ -16,6 +17,7 @@ import de.rki.coronawarnapp.storage.interoperability.InteroperabilityRepository
 import de.rki.coronawarnapp.submission.SubmissionRepository
 import de.rki.coronawarnapp.submission.auto.AutoSubmission
 import de.rki.coronawarnapp.submission.data.tekhistory.TEKHistoryUpdater
+import de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.common.completedCheckIns
 import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
 import de.rki.coronawarnapp.util.ui.SingleLiveEvent
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
@@ -30,6 +32,7 @@ class SubmissionResultPositiveOtherWarningNoConsentViewModel @AssistedInject con
     tekHistoryUpdaterFactory: TEKHistoryUpdater.Factory,
     interoperabilityRepository: InteroperabilityRepository,
     private val submissionRepository: SubmissionRepository,
+    private val checkInRepository: CheckInRepository,
     private val analyticsKeySubmissionCollector: AnalyticsKeySubmissionCollector
 ) : CWAViewModel(dispatcherProvider = dispatcherProvider) {
 
@@ -48,36 +51,44 @@ class SubmissionResultPositiveOtherWarningNoConsentViewModel @AssistedInject con
 
     private val tekHistoryUpdater = tekHistoryUpdaterFactory.create(
         object : TEKHistoryUpdater.Callback {
-            override fun onTEKAvailable(teks: List<TemporaryExposureKey>) {
-                Timber.d("onTEKAvailable(tek.size=%d)", teks.size)
-                autoSubmission.updateMode(AutoSubmission.Mode.MONITOR)
+            override fun onTEKAvailable(teks: List<TemporaryExposureKey>) = launch {
+                Timber.tag(TAG).d("onTEKAvailable(tek.size=%d)", teks.size)
                 showKeysRetrievalProgress.postValue(false)
-                routeToScreen.postValue(
+
+                val completedCheckInsExist = checkInRepository.completedCheckIns.first().isNotEmpty()
+                val navDirections = if (completedCheckInsExist) {
+                    Timber.tag(TAG).d("Navigate to CheckInsConsentFragment")
+                    SubmissionResultPositiveOtherWarningNoConsentFragmentDirections
+                        .actionSubmissionResultPositiveOtherWarningNoConsentFragmentToCheckInsConsentFragment()
+                } else {
+                    autoSubmission.updateMode(AutoSubmission.Mode.MONITOR)
+                    Timber.tag(TAG).d("Navigate to SubmissionResultReadyFragment")
                     SubmissionResultPositiveOtherWarningNoConsentFragmentDirections
                         .actionSubmissionResultPositiveOtherWarningNoConsentFragmentToSubmissionResultReadyFragment()
-                )
+                }
+                routeToScreen.postValue(navDirections)
             }
 
             override fun onTEKPermissionDeclined() {
-                Timber.d("onTEKPermissionDeclined")
+                Timber.tag(TAG).d("onTEKPermissionDeclined")
                 showKeysRetrievalProgress.postValue(false)
                 // stay on screen
             }
 
             override fun onTracingConsentRequired(onConsentResult: (given: Boolean) -> Unit) {
-                Timber.d("onTracingConsentRequired")
+                Timber.tag(TAG).d("onTracingConsentRequired")
                 showKeysRetrievalProgress.postValue(false)
                 showTracingConsentDialog.postValue(onConsentResult)
             }
 
             override fun onPermissionRequired(permissionRequest: (Activity) -> Unit) {
-                Timber.d("onPermissionRequired")
+                Timber.tag(TAG).d("onPermissionRequired")
                 showKeysRetrievalProgress.postValue(false)
                 showPermissionRequest.postValue(permissionRequest)
             }
 
             override fun onError(error: Throwable) {
-                Timber.e(error, "Couldn't access temporary exposure key history.")
+                Timber.tag(TAG).e(error, "Couldn't access temporary exposure key history.")
                 showKeysRetrievalProgress.postValue(false)
                 error.report(ExceptionCategory.EXPOSURENOTIFICATION, "Failed to obtain TEKs.")
             }
@@ -96,10 +107,10 @@ class SubmissionResultPositiveOtherWarningNoConsentViewModel @AssistedInject con
         submissionRepository.giveConsentToSubmission()
         launch {
             if (enfClient.isTracingEnabled.first()) {
-                Timber.d("tekHistoryUpdater.updateTEKHistoryOrRequestPermission()")
+                Timber.tag(TAG).d("tekHistoryUpdater.updateTEKHistoryOrRequestPermission()")
                 tekHistoryUpdater.updateTEKHistoryOrRequestPermission()
             } else {
-                Timber.d("showEnableTracingEvent:Unit")
+                Timber.tag(TAG).d("showEnableTracingEvent:Unit")
                 showKeysRetrievalProgress.postValue(false)
                 showEnableTracingEvent.postValue(Unit)
             }
@@ -107,6 +118,7 @@ class SubmissionResultPositiveOtherWarningNoConsentViewModel @AssistedInject con
     }
 
     fun onDataPrivacyClick() {
+        Timber.tag(TAG).d("onDataPrivacyClick")
         routeToScreen.postValue(
             SubmissionResultPositiveOtherWarningNoConsentFragmentDirections
                 .actionSubmissionResultPositiveOtherWarningNoConsentFragmentToInformationPrivacyFragment()
@@ -114,6 +126,7 @@ class SubmissionResultPositiveOtherWarningNoConsentViewModel @AssistedInject con
     }
 
     fun handleActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        Timber.tag(TAG).d("handleActivityResult($resultCode)")
         showKeysRetrievalProgress.value = true
         tekHistoryUpdater.handleActivityResult(requestCode, resultCode, data)
     }
@@ -125,5 +138,9 @@ class SubmissionResultPositiveOtherWarningNoConsentViewModel @AssistedInject con
     @AssistedFactory
     interface Factory : CWAViewModelFactory<SubmissionResultPositiveOtherWarningNoConsentViewModel> {
         fun create(): SubmissionResultPositiveOtherWarningNoConsentViewModel
+    }
+
+    companion object {
+        private const val TAG = "WarnNoConsentViewModel"
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/warnothers/SubmissionResultPositiveOtherWarningNoConsentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/warnothers/SubmissionResultPositiveOtherWarningNoConsentViewModel.kt
@@ -17,7 +17,7 @@ import de.rki.coronawarnapp.storage.interoperability.InteroperabilityRepository
 import de.rki.coronawarnapp.submission.SubmissionRepository
 import de.rki.coronawarnapp.submission.auto.AutoSubmission
 import de.rki.coronawarnapp.submission.data.tekhistory.TEKHistoryUpdater
-import de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.common.completedCheckIns
+import de.rki.coronawarnapp.presencetracing.checkins.common.completedCheckIns
 import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
 import de.rki.coronawarnapp.util.ui.SingleLiveEvent
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModel

--- a/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
+++ b/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
@@ -278,6 +278,11 @@
             app:destination="@id/submissionResultReadyFragment"
             app:popUpTo="@id/mainFragment"
             app:popUpToInclusive="false" />
+        <action
+            android:id="@+id/action_submissionResultPositiveOtherWarningNoConsentFragment_to_checkInsConsentFragment"
+            app:destination="@id/checkInsConsentFragment"
+            app:popUpTo="@id/mainFragment"
+            app:popUpToInclusive="false" />
     </fragment>
     <fragment
         android:id="@+id/submissionTestResultPendingFragment"
@@ -489,6 +494,11 @@
             app:popUpTo="@id/mainFragment"
             app:popUpToInclusive="false" />
         <action
+            android:id="@+id/action_submissionTestResultAvailableFragment_to_checkInsConsentFragment"
+            app:destination="@id/checkInsConsentFragment"
+            app:popUpTo="@id/mainFragment"
+            app:popUpToInclusive="false" />
+        <action
             android:id="@+id/action_submissionTestResultAvailableFragment_to_submissionTestResultNoConsentFragment"
             app:destination="@id/submissionTestResultNoConsentFragment"
             app:popUpTo="@id/mainFragment"
@@ -615,9 +625,22 @@
         android:name="de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent.CheckInsConsentFragment"
         android:label="check_ins_consent_fragment"
         tools:layout="@layout/check_ins_consent_fragment">
-        <argument
-            android:name="preConsentGiven"
-            android:defaultValue="false"
-            app:argType="boolean" />
+        <action
+            android:id="@+id/action_checkInsConsentFragment_to_mainFragment"
+            app:destination="@id/mainFragment"
+            app:popUpTo="@id/nav_graph"
+            app:popUpToInclusive="true" />
+
+        <action
+            android:id="@+id/action_checkInsConsentFragment_to_submissionResultReadyFragment"
+            app:destination="@id/submissionResultReadyFragment"
+            app:popUpTo="@id/mainFragment"
+            app:popUpToInclusive="false" />
+
+        <action
+            android:id="@+id/action_checkInsConsentFragment_to_submissionTestResultConsentGivenFragment"
+            app:destination="@id/submissionTestResultConsentGivenFragment"
+            app:popUpTo="@id/mainFragment"
+            app:popUpToInclusive="false" />
     </fragment>
 </navigation>

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/submission/task/SubmissionTaskTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/submission/task/SubmissionTaskTest.kt
@@ -140,7 +140,10 @@ class SubmissionTaskTest : BaseTest() {
 
         every { checkInRepository.checkInsWithinRetention } returns flowOf(
             listOf(
-                validCheckIn, invalidCheckIn1, invalidCheckIn2, invalidCheckIn3
+                validCheckIn,
+                invalidCheckIn1,
+                invalidCheckIn2,
+                invalidCheckIn3
             )
         )
         coEvery { checkInsTransformer.transform(any(), any()) } returns emptyList()

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/submission/task/SubmissionTaskTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/submission/task/SubmissionTaskTest.kt
@@ -200,7 +200,7 @@ class SubmissionTaskTest : BaseTest() {
             submissionSettings.symptoms
             settingSymptomsPreference.update(match { it.invoke(mockk()) == null })
 
-            checkInRepository.markCheckInAsSubmitted(testCheckIn1.id)
+            checkInRepository.updatePostSubmissionFlags(testCheckIn1.id)
 
             autoSubmission.updateMode(AutoSubmission.Mode.DISABLED)
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/submission/task/SubmissionTaskTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/submission/task/SubmissionTaskTest.kt
@@ -74,7 +74,7 @@ class SubmissionTaskTest : BaseTest() {
 
     private val settingLastUserActivityUTC: FlowPreference<Instant> = mockFlowPreference(Instant.EPOCH.plus(1))
 
-    private val testCheckIn1 = CheckIn(
+    private val validCheckIn = CheckIn(
         id = 1L,
         traceLocationId = mockk(),
         version = 1,
@@ -93,6 +93,10 @@ class SubmissionTaskTest : BaseTest() {
         isSubmitted = false,
         hasSubmissionConsent = true
     )
+
+    private val invalidCheckIn1 = validCheckIn.copy(id = 2L, completed = false)
+    private val invalidCheckIn2 = validCheckIn.copy(id = 3L, isSubmitted = true)
+    private val invalidCheckIn3 = validCheckIn.copy(id = 4L, hasSubmissionConsent = false)
 
     @BeforeEach
     fun setup() {
@@ -134,7 +138,11 @@ class SubmissionTaskTest : BaseTest() {
 
         every { timeStamper.nowUTC } returns Instant.EPOCH.plus(Duration.standardHours(1))
 
-        every { checkInRepository.checkInsWithinRetention } returns flowOf(listOf(testCheckIn1))
+        every { checkInRepository.checkInsWithinRetention } returns flowOf(
+            listOf(
+                validCheckIn, invalidCheckIn1, invalidCheckIn2, invalidCheckIn3
+            )
+        )
         coEvery { checkInsTransformer.transform(any(), any()) } returns emptyList()
     }
 
@@ -200,7 +208,7 @@ class SubmissionTaskTest : BaseTest() {
             submissionSettings.symptoms
             settingSymptomsPreference.update(match { it.invoke(mockk()) == null })
 
-            checkInRepository.updatePostSubmissionFlags(testCheckIn1.id)
+            checkInRepository.updatePostSubmissionFlags(validCheckIn.id)
 
             autoSubmission.updateMode(AutoSubmission.Mode.DISABLED)
 
@@ -210,6 +218,12 @@ class SubmissionTaskTest : BaseTest() {
 
             shareTestResultNotificationService.cancelSharePositiveTestResultNotification()
             testResultAvailableNotificationService.cancelTestResultAvailableNotification()
+        }
+
+        coVerify(exactly = 0) {
+            checkInRepository.updatePostSubmissionFlags(invalidCheckIn1.id)
+            checkInRepository.updatePostSubmissionFlags(invalidCheckIn2.id)
+            checkInRepository.updatePostSubmissionFlags(invalidCheckIn3.id)
         }
     }
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModelTest.kt
@@ -13,7 +13,6 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.just
-import io.mockk.verify
 import kotlinx.coroutines.flow.flowOf
 import okio.ByteString.Companion.decodeBase64
 import okio.ByteString.Companion.encode

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModelTest.kt
@@ -3,6 +3,8 @@ package de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent
 import androidx.lifecycle.SavedStateHandle
 import de.rki.coronawarnapp.eventregistration.checkins.CheckIn
 import de.rki.coronawarnapp.eventregistration.checkins.CheckInRepository
+import de.rki.coronawarnapp.submission.SubmissionRepository
+import de.rki.coronawarnapp.submission.auto.AutoSubmission
 import io.kotest.matchers.shouldBe
 import io.mockk.MockKAnnotations
 import io.mockk.Runs
@@ -26,6 +28,8 @@ class CheckInsConsentViewModelTest : BaseTest() {
 
     @MockK lateinit var savedState: SavedStateHandle
     @MockK lateinit var checkInRepository: CheckInRepository
+    @MockK lateinit var submissionRepository: SubmissionRepository
+    @MockK lateinit var autoSubmission: AutoSubmission
 
     private val checkIn1 = CheckIn(
         id = 1L,
@@ -87,6 +91,8 @@ class CheckInsConsentViewModelTest : BaseTest() {
 
         every { checkInRepository.checkInsWithinRetention } returns flowOf(listOf(checkIn1, checkIn2, checkIn3))
         every { savedState.set(any(), any<Set<Long>>()) } just Runs
+        every { autoSubmission.updateMode(any()) } just Runs
+        every { submissionRepository.hasViewedTestResult } returns flowOf(false)
     }
 
     @Test
@@ -238,6 +244,8 @@ class CheckInsConsentViewModelTest : BaseTest() {
     private fun createViewModel() = CheckInsConsentViewModel(
         savedState = savedState,
         dispatcherProvider = TestDispatcherProvider(),
-        checkInRepository = checkInRepository
+        checkInRepository = checkInRepository,
+        submissionRepository = submissionRepository,
+        autoSubmission = autoSubmission
     )
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModelTest.kt
@@ -8,9 +8,12 @@ import de.rki.coronawarnapp.submission.auto.AutoSubmission
 import io.kotest.matchers.shouldBe
 import io.mockk.MockKAnnotations
 import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.just
+import io.mockk.verify
 import kotlinx.coroutines.flow.flowOf
 import okio.ByteString.Companion.decodeBase64
 import okio.ByteString.Companion.encode
@@ -90,9 +93,11 @@ class CheckInsConsentViewModelTest : BaseTest() {
         MockKAnnotations.init(this)
 
         every { checkInRepository.checkInsWithinRetention } returns flowOf(listOf(checkIn1, checkIn2, checkIn3))
+        coEvery { checkInRepository.updateSubmissionConsents(any(), true) } just Runs
         every { savedState.set(any(), any<Set<Long>>()) } just Runs
         every { autoSubmission.updateMode(any()) } just Runs
         every { submissionRepository.hasViewedTestResult } returns flowOf(false)
+        every { savedState.get<Set<Long>>(any()) } returns emptySet()
     }
 
     @Test
@@ -232,13 +237,87 @@ class CheckInsConsentViewModelTest : BaseTest() {
     }
 
     @Test
-    fun shareSelectedCheckIns() {
-        // TODO test navigation
+    fun `Confirming cancel goes to home screen`() {
+        val viewModel = createViewModel()
+        viewModel.onCancelConfirmed()
+
+        viewModel.events.getOrAwaitValue() shouldBe CheckInsConsentNavigation.ToHomeFragment
     }
 
     @Test
-    fun doNotShareCheckIns() {
-        // TODO test navigation
+    fun `Skip opens skipDialog`() {
+        val viewModel = createViewModel()
+        viewModel.onSkipClick()
+
+        viewModel.events.getOrAwaitValue() shouldBe CheckInsConsentNavigation.OpenSkipDialog
+    }
+
+    @Test
+    fun `Close opens skipDialog when test result has been shown`() {
+        every { submissionRepository.hasViewedTestResult } returns flowOf(true)
+        val viewModel = createViewModel()
+        viewModel.onCloseClick()
+
+        viewModel.events.getOrAwaitValue() shouldBe CheckInsConsentNavigation.OpenSkipDialog
+    }
+
+    @Test
+    fun `Close opens closeDialog when test result has not been shown`() {
+        every { submissionRepository.hasViewedTestResult } returns flowOf(false)
+        val viewModel = createViewModel()
+        viewModel.onCloseClick()
+
+        viewModel.events.getOrAwaitValue() shouldBe CheckInsConsentNavigation.OpenCloseDialog
+    }
+
+    @Test
+    fun `shareSelectedCheckIns when test result has been shown`() {
+        every { submissionRepository.hasViewedTestResult } returns flowOf(true)
+        val viewModel = createViewModel()
+        viewModel.shareSelectedCheckIns()
+
+        viewModel.events.getOrAwaitValue() shouldBe CheckInsConsentNavigation.ToSubmissionResultReadyFragment
+        coVerify {
+            autoSubmission.updateMode(AutoSubmission.Mode.MONITOR)
+            checkInRepository.updateSubmissionConsents(any(), true)
+        }
+    }
+
+    @Test
+    fun `shareSelectedCheckIns when test result has not been shown`() {
+        every { submissionRepository.hasViewedTestResult } returns flowOf(false)
+        val viewModel = createViewModel()
+        viewModel.shareSelectedCheckIns()
+
+        viewModel.events.getOrAwaitValue() shouldBe CheckInsConsentNavigation.ToSubmissionTestResultConsentGivenFragment
+        coVerify {
+            autoSubmission.updateMode(AutoSubmission.Mode.MONITOR)
+            checkInRepository.updateSubmissionConsents(any(), true)
+        }
+    }
+
+    @Test
+    fun `doNotShareCheckIns when test result has been shown`() {
+        every { submissionRepository.hasViewedTestResult } returns flowOf(true)
+        val viewModel = createViewModel()
+        viewModel.doNotShareCheckIns()
+
+        viewModel.events.getOrAwaitValue() shouldBe CheckInsConsentNavigation.ToSubmissionResultReadyFragment
+        coVerify {
+            autoSubmission.updateMode(AutoSubmission.Mode.MONITOR)
+        }
+    }
+
+    @Test
+    fun `doNotShareCheckIns when test result has not been shown`() {
+        every { submissionRepository.hasViewedTestResult } returns flowOf(false)
+        val viewModel = createViewModel()
+        viewModel.doNotShareCheckIns()
+
+        viewModel.events.getOrAwaitValue() shouldBe CheckInsConsentNavigation.ToSubmissionTestResultConsentGivenFragment
+        coVerify {
+            autoSubmission.updateMode(AutoSubmission.Mode.MONITOR)
+        }
     }
 
     private fun createViewModel() = CheckInsConsentViewModel(

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModelTest.kt
@@ -237,45 +237,46 @@ class CheckInsConsentViewModelTest : BaseTest() {
 
     @Test
     fun `Confirming cancel goes to home screen`() {
-        val viewModel = createViewModel()
-        viewModel.onCancelConfirmed()
-
-        viewModel.events.getOrAwaitValue() shouldBe CheckInsConsentNavigation.ToHomeFragment
+        createViewModel().apply {
+            onCancelConfirmed()
+            events.getOrAwaitValue() shouldBe CheckInsConsentNavigation.ToHomeFragment
+        }
     }
 
     @Test
     fun `Skip opens skipDialog`() {
-        val viewModel = createViewModel()
-        viewModel.onSkipClick()
-
-        viewModel.events.getOrAwaitValue() shouldBe CheckInsConsentNavigation.OpenSkipDialog
+        createViewModel().apply {
+            onSkipClick()
+            events.getOrAwaitValue() shouldBe CheckInsConsentNavigation.OpenSkipDialog
+        }
     }
 
     @Test
     fun `Close opens skipDialog when test result has been shown`() {
         every { submissionRepository.hasViewedTestResult } returns flowOf(true)
-        val viewModel = createViewModel()
-        viewModel.onCloseClick()
-
-        viewModel.events.getOrAwaitValue() shouldBe CheckInsConsentNavigation.OpenSkipDialog
+        createViewModel().apply {
+            onCloseClick()
+            events.getOrAwaitValue() shouldBe CheckInsConsentNavigation.OpenSkipDialog
+        }
     }
 
     @Test
     fun `Close opens closeDialog when test result has not been shown`() {
         every { submissionRepository.hasViewedTestResult } returns flowOf(false)
-        val viewModel = createViewModel()
-        viewModel.onCloseClick()
-
-        viewModel.events.getOrAwaitValue() shouldBe CheckInsConsentNavigation.OpenCloseDialog
+        createViewModel().apply {
+            onCloseClick()
+            events.getOrAwaitValue() shouldBe CheckInsConsentNavigation.OpenCloseDialog
+        }
     }
 
     @Test
     fun `shareSelectedCheckIns when test result has been shown`() {
         every { submissionRepository.hasViewedTestResult } returns flowOf(true)
-        val viewModel = createViewModel()
-        viewModel.shareSelectedCheckIns()
+        createViewModel().apply {
+            shareSelectedCheckIns()
+            events.getOrAwaitValue() shouldBe CheckInsConsentNavigation.ToSubmissionResultReadyFragment
+        }
 
-        viewModel.events.getOrAwaitValue() shouldBe CheckInsConsentNavigation.ToSubmissionResultReadyFragment
         coVerify {
             autoSubmission.updateMode(AutoSubmission.Mode.MONITOR)
             checkInRepository.updateSubmissionConsents(any(), true)
@@ -285,10 +286,11 @@ class CheckInsConsentViewModelTest : BaseTest() {
     @Test
     fun `shareSelectedCheckIns when test result has not been shown`() {
         every { submissionRepository.hasViewedTestResult } returns flowOf(false)
-        val viewModel = createViewModel()
-        viewModel.shareSelectedCheckIns()
+        createViewModel().apply {
+            shareSelectedCheckIns()
+            events.getOrAwaitValue() shouldBe CheckInsConsentNavigation.ToSubmissionTestResultConsentGivenFragment
+        }
 
-        viewModel.events.getOrAwaitValue() shouldBe CheckInsConsentNavigation.ToSubmissionTestResultConsentGivenFragment
         coVerify {
             autoSubmission.updateMode(AutoSubmission.Mode.MONITOR)
             checkInRepository.updateSubmissionConsents(any(), true)
@@ -298,10 +300,11 @@ class CheckInsConsentViewModelTest : BaseTest() {
     @Test
     fun `doNotShareCheckIns when test result has been shown`() {
         every { submissionRepository.hasViewedTestResult } returns flowOf(true)
-        val viewModel = createViewModel()
-        viewModel.doNotShareCheckIns()
+        createViewModel().apply {
+            doNotShareCheckIns()
+            events.getOrAwaitValue() shouldBe CheckInsConsentNavigation.ToSubmissionResultReadyFragment
+        }
 
-        viewModel.events.getOrAwaitValue() shouldBe CheckInsConsentNavigation.ToSubmissionResultReadyFragment
         coVerify {
             autoSubmission.updateMode(AutoSubmission.Mode.MONITOR)
         }
@@ -310,10 +313,11 @@ class CheckInsConsentViewModelTest : BaseTest() {
     @Test
     fun `doNotShareCheckIns when test result has not been shown`() {
         every { submissionRepository.hasViewedTestResult } returns flowOf(false)
-        val viewModel = createViewModel()
-        viewModel.doNotShareCheckIns()
+        createViewModel().apply {
+            doNotShareCheckIns()
+            events.getOrAwaitValue() shouldBe CheckInsConsentNavigation.ToSubmissionTestResultConsentGivenFragment
+        }
 
-        viewModel.events.getOrAwaitValue() shouldBe CheckInsConsentNavigation.ToSubmissionTestResultConsentGivenFragment
         coVerify {
             autoSubmission.updateMode(AutoSubmission.Mode.MONITOR)
         }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/testavailable/SubmissionTestResultAvailableViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/testavailable/SubmissionTestResultAvailableViewModelTest.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.ui.submission.testavailable
 
 import de.rki.coronawarnapp.datadonation.analytics.modules.keysubmission.AnalyticsKeySubmissionCollector
+import de.rki.coronawarnapp.eventregistration.checkins.CheckInRepository
 import de.rki.coronawarnapp.submission.SubmissionRepository
 import de.rki.coronawarnapp.submission.auto.AutoSubmission
 import de.rki.coronawarnapp.submission.data.tekhistory.TEKHistoryUpdater
@@ -31,6 +32,7 @@ class SubmissionTestResultAvailableViewModelTest : BaseTest() {
     @MockK lateinit var tekHistoryUpdater: TEKHistoryUpdater
     @MockK lateinit var tekHistoryUpdaterFactory: TEKHistoryUpdater.Factory
     @MockK lateinit var analyticsKeySubmissionCollector: AnalyticsKeySubmissionCollector
+    @MockK lateinit var checkInRepository: CheckInRepository
 
     @BeforeEach
     fun setUp() {
@@ -49,7 +51,8 @@ class SubmissionTestResultAvailableViewModelTest : BaseTest() {
         dispatcherProvider = TestDispatcherProvider(),
         tekHistoryUpdaterFactory = tekHistoryUpdaterFactory,
         autoSubmission = autoSubmission,
-        analyticsKeySubmissionCollector = analyticsKeySubmissionCollector
+        analyticsKeySubmissionCollector = analyticsKeySubmissionCollector,
+        checkInRepository = checkInRepository
     )
 
     @Test

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/warnothers/SubmissionResultPositiveOtherWarningNoConsentViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/warnothers/SubmissionResultPositiveOtherWarningNoConsentViewModelTest.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.ui.submission.warnothers
 
 import de.rki.coronawarnapp.datadonation.analytics.modules.keysubmission.AnalyticsKeySubmissionCollector
+import de.rki.coronawarnapp.eventregistration.checkins.CheckInRepository
 import de.rki.coronawarnapp.nearby.ENFClient
 import de.rki.coronawarnapp.storage.interoperability.InteroperabilityRepository
 import de.rki.coronawarnapp.submission.SubmissionRepository
@@ -33,6 +34,7 @@ class SubmissionResultPositiveOtherWarningNoConsentViewModelTest : BaseTest() {
     @MockK lateinit var interoperabilityRepository: InteroperabilityRepository
     @MockK lateinit var enfClient: ENFClient
     @MockK lateinit var analyticsKeySubmissionCollector: AnalyticsKeySubmissionCollector
+    @MockK lateinit var checkInRepository: CheckInRepository
 
     @BeforeEach
     fun setUp() {
@@ -53,7 +55,8 @@ class SubmissionResultPositiveOtherWarningNoConsentViewModelTest : BaseTest() {
         enfClient = enfClient,
         interoperabilityRepository = interoperabilityRepository,
         submissionRepository = submissionRepository,
-        analyticsKeySubmissionCollector = analyticsKeySubmissionCollector
+        analyticsKeySubmissionCollector = analyticsKeySubmissionCollector,
+        checkInRepository = checkInRepository
     )
 
     @Test


### PR DESCRIPTION
## Important Notes
- CheckIns screen should not be displayed if there are no completed check-ins , meaning the flow should be like as it is at the moment
- Android back action should behave as `X` button and the behaviour is explained below

## Case 1: User has given CWA submission consent (this is not the access TEKs ENS Consent)
* Start at `SubmissionTestResultAvailableFragment`
* Press NEXT, If TEK consent is available
	* From `SubmissionTestResultAvailableFragment` go to `CheckInsConsentFragment`
* Press NEXT, If TEK consent is not available
	* Get TEK consent on this screen (TEKHistoryUpdater)
	* If user shared TEKS then go to `CheckInsConsentFragment`
	* If user didn't share TEKs, stay
* On `CheckInsConsentFragment` and (`SubmissionRepository.hasViewedTestResult==false`)
	* If the user presses X
		* Show the same abort dialog as on `SubmissionTestResultAvailableFragment`
			* If the user choses "don't show test result" -> go to home screen
			* If the user choses "show test result" -> user stays on the same screen (so they can give consent) (to advance to the test result screen, the user has to either press NEXT or SKIP)
	* If the user presses NEXT
		* (because at least 1 entry is selected) we update the checkins in the database
		* We set `AutoSubmission.updateMode(MONITOR)`
		* We navigate to `SubmissionTestResultConsentGivenFragment`
	* If the user presses SKIP
		* We show a confirmation dialog 
			* If user chooses "Share" we stay on the same screen
			* If the user choses don't share go to the `SubmissionTestResultConsentGivenFragment`
				* We set `AutoSubmission.updateMode(MONITOR)`

## Case 2: User has not given CWA submission consent
 * Start at `SubmissionResultPositiveOtherWarningNoConsentFragment`
 * Press AGREE, If TEK consent is available
 	* We go to `CheckInsConsentFragment`
 * Press AGREE, if TEK is not available
 	* Get TEK consent on this screen (TEKHistoryUpdater)
 	* Then go to `CheckInsConsentFragment` if user shared TEKs
 	* If user didn't share TEKs, stay on screen
* On `CheckInsConsentFragment` and (`SubmissionRepository.hasViewedTestResult==true`)
	* If the user presses X
		* Show same dialog as SKIP option
	* If the user presses NEXT
		* (because at least 1 entry is selected) we update the checkins database
		* We set `AutoSubmission.updateMode(MONITOR)`
		* We go to `SubmissionResultReadyFragment`
	* If we press SKIP
		* We show a confirmation dialog 
			* If the user presses "DONT SHARE"
				* We set `AutoSubmission.updateMode(MONITOR)`
				* Go to `SubmissionResultReadyFragment`
			* If the user presses "SHARE" we stay on the screen