### PR TITLE
Use wild path pattern

### DIFF
--- a/Corona-Warn-App/src/main/AndroidManifest.xml
+++ b/Corona-Warn-App/src/main/AndroidManifest.xml
@@ -85,6 +85,7 @@
 
                 <data
                     android:host="e.coronawarn.app"
+                    android:pathPattern=".*"
                     android:scheme="https" />
             </intent-filter>
         </activity>


### PR DESCRIPTION
- Xiaomi devices does not open the link without. Thanks to @chiljamgossow who discovered this issue on her device 