### PR TITLE
Create QR code card - Overlapping views issue (EXPOSUREAPP-6544)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/home_create_trace_location_card.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_create_trace_location_card.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="@dimen/spacing_normal"
-    tools:showIn="@layout/home_card_container_layout">
+    android:padding="@dimen/spacing_normal">
 
     <TextView
         android:id="@+id/create_trace_location_card_headline"
@@ -30,26 +28,36 @@
         android:text="@string/create_trace_location_card_subtitle"
         app:layout_constraintEnd_toStartOf="@id/create_trace_location_card_icon"
         app:layout_constraintStart_toStartOf="@id/create_trace_location_card_headline"
-        app:layout_constraintTop_toBottomOf="@id/create_trace_location_card_headline" />
+        app:layout_constraintTop_toBottomOf="@id/create_trace_location_card_headline"
+        tools:text="@string/create_trace_location_card_subtitle" />
 
     <ImageView
         android:id="@+id/create_trace_location_card_icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:srcCompat="@drawable/ic_event_organizer"
         android:importantForAccessibility="no"
+        app:layout_constraintBottom_toTopOf="@+id/create_trace_location_card_button"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@id/create_trace_location_card_subtitle" />
+        app:layout_constraintTop_toTopOf="@+id/create_trace_location_card_headline"
+        app:srcCompat="@drawable/ic_event_organizer"
+        tools:src="@drawable/ic_event_organizer" />
+
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/button_barrier_event_card"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:barrierDirection="bottom"
+        app:constraint_referenced_ids="create_trace_location_card_icon,create_trace_location_card_subtitle" />
 
     <Button
         android:id="@+id/create_trace_location_card_button"
         style="@style/buttonPrimary"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/spacing_normal"
+        android:layout_marginTop="@dimen/spacing_small"
         android:text="@string/create_trace_location_card_button"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/create_trace_location_card_subtitle" />
+        app:layout_constraintTop_toBottomOf="@id/button_barrier_event_card" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Corona-Warn-App/src/main/res/layout/home_create_trace_location_card.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_create_trace_location_card.xml
@@ -31,7 +31,7 @@
         app:layout_constraintTop_toBottomOf="@id/create_trace_location_card_headline"
         tools:text="@string/create_trace_location_card_subtitle" />
 
-    <ImageView
+    <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/create_trace_location_card_icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
This PR addresses Exposureapp-6544. (TraceLocationCard - Overlapping views on small font sizes etc.)

How to Test:
- change the font size in your os settings to small, medium, big
- open the CWA App (MainFragment)
- Check the "Planing an Event Card" for overlapping issues

Screenshot (before):
![image](https://user-images.githubusercontent.com/46747780/115711337-ad5c3580-a373-11eb-96d9-68fbcf57c46e.png)

Screenshot (now, small & normal fontsize):
![now_normalsize](https://user-images.githubusercontent.com/46747780/115711568-f8764880-a373-11eb-86fe-4049e9f1b244.png)
![eventcard_nowsize_small](https://user-images.githubusercontent.com/46747780/115711573-f90edf00-a373-11eb-9f9d-79271642d752.png)




