### PR TITLE
Fix sporadic crash due to IllegalArgumentException on quick navigation (EXPOSUREAPP-6610)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ui/ViewBindingExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ui/ViewBindingExtensions.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.viewbinding.ViewBinding
+import timber.log.Timber
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
@@ -43,26 +44,41 @@ class ViewBindingProperty<ComponentT : LifecycleOwner, BindingT : ViewBinding>(
     private val onDestroyObserver = object : DefaultLifecycleObserver {
         // Called right before Fragment.onDestroyView
         override fun onDestroy(owner: LifecycleOwner) {
-            val ref = localRef ?: return
-            ref.lifecycle.removeObserver(this)
+            localRef?.lifecycle?.removeObserver(this) ?: return
+
             localRef = null
-            // Otherwise the binding is null before Fragment.onDestroyView
-            uiHandler.post { viewBinding = null }
+
+            uiHandler.post {
+                Timber.v("Resetting viewBinding")
+                viewBinding = null
+            }
         }
     }
 
     @MainThread
     override fun getValue(thisRef: ComponentT, property: KProperty<*>): BindingT {
+        val lifecycle = lifecycleOwnerProvider(thisRef).lifecycle
+
+        if (localRef == null && viewBinding != null) {
+            Timber.w("Fragment.onDestroyView() was called, but the handler didn't execute our delayed reset.")
+            /**
+             * There is a fragment racecondition if you navigate to another fragment and quickly popBackStack().
+             * Our uiHandler.post { } will not have executed for some reason.
+             * In that case we manually null the old viewBinding, to allow for clean recreation.
+             */
+            viewBinding = null
+        }
+
         viewBinding?.let {
             // Only accessible from within the same component
             require(localRef === thisRef)
             return@getValue it
         }
 
-        localRef = thisRef
-
-        lifecycleOwnerProvider(thisRef).lifecycle.addObserver(onDestroyObserver)
-
-        return bindingProvider(thisRef).also { viewBinding = it }
+        return bindingProvider(thisRef).also {
+            viewBinding = it
+            localRef = thisRef
+            lifecycle.addObserver(onDestroyObserver)
+        }
     }
 }


### PR DESCRIPTION
There is a fragment racecondition if you navigate to another fragment and quickly popBackStack().
Our uiHandler.post { } will not have executed for some reason.
In that case we manually null the old viewBinding, to allow for clean recreation.

Can be reproduced by adding "popBackStack()" to the target fragment in onResume or onCreate.

```
java.lang.IllegalArgumentException: 
  at de.rki.coronawarnapp.util.ui.ViewBindingProperty.getValue (ViewBindingExtensions.kt:2)
  at de.rki.coronawarnapp.ui.main.home.HomeFragment.getBinding (HomeFragment.kt)
  at de.rki.coronawarnapp.ui.main.home.HomeFragment.onViewCreated (HomeFragment.kt:2)
```