### PR TITLE
Fix potentially failing background RiskLevel calculation on slow devices (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/ExposureStateUpdateWorker.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/ExposureStateUpdateWorker.kt
@@ -12,6 +12,7 @@ import de.rki.coronawarnapp.exception.reporting.report
 import de.rki.coronawarnapp.risk.RiskLevelTask
 import de.rki.coronawarnapp.task.TaskController
 import de.rki.coronawarnapp.task.common.DefaultTaskRequest
+import de.rki.coronawarnapp.task.submitBlocking
 import de.rki.coronawarnapp.util.worker.InjectedWorkerFactory
 import timber.log.Timber
 
@@ -23,7 +24,7 @@ class ExposureStateUpdateWorker @AssistedInject constructor(
 
     override suspend fun doWork(): Result {
         try {
-            taskController.submit(
+            taskController.submitBlocking(
                 DefaultTaskRequest(RiskLevelTask::class, originTag = "ExposureStateUpdateWorker")
             )
             Timber.tag(TAG).v("Risk level calculation triggered")


### PR DESCRIPTION
Run the RiskLevelTask within the `ExposureStateUpdateWorker` via `submitBlocking` to retain elevated priority by keeping the worker running, otherwise the system may kill our process while the RiskLevelTask is still running, because the worker isn't.

This came up while debugging #2880.
It is not the cause for the weird ENS log entries reported by @vaubaehn , but may be the cause for seeing the error card on the home screen: The risk level task didn't run reliably as on his device the risk level task takes longer than the system giving us time, due to the worker waiting for the task.

### Testing
* Get an ExposureStateUpdateReceiver that causes the RiskLevelTask to execute while the app is in the background, i.e. get one risklevel calculation while the app was not open.