### PR TITLE
Reduce Logs for production build (EXPOSUREAPP-6642)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/calculation/CheckInWarningMatcher.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/calculation/CheckInWarningMatcher.kt
@@ -5,6 +5,7 @@ import de.rki.coronawarnapp.presencetracing.checkins.CheckIn
 import de.rki.coronawarnapp.presencetracing.checkins.split.splitByMidnightUTC
 import de.rki.coronawarnapp.presencetracing.warning.storage.TraceWarningPackage
 import de.rki.coronawarnapp.server.protocols.internal.pt.TraceWarning
+import de.rki.coronawarnapp.util.CWADebug
 import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
 import de.rki.coronawarnapp.util.toOkioByteString
 import kotlinx.coroutines.CoroutineScope
@@ -106,6 +107,9 @@ internal suspend fun findMatches(
             checkIns
                 .mapNotNull { checkIn ->
                     checkIn.calculateOverlap(warning, warningPackage.packageId).also { overlap ->
+                        if (CWADebug.isDeviceForTestersBuild) {
+                            return@also
+                        }
                         if (overlap == null) {
                             Timber.tag(TAG).v("No match found for $checkIn and $warning")
                         } else {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/calculation/CheckInWarningMatcher.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/risk/calculation/CheckInWarningMatcher.kt
@@ -107,7 +107,7 @@ internal suspend fun findMatches(
             checkIns
                 .mapNotNull { checkIn ->
                     checkIn.calculateOverlap(warning, warningPackage.packageId).also { overlap ->
-                        if (CWADebug.isDeviceForTestersBuild) {
+                        if (!CWADebug.isDebugBuildOrMode) {
                             return@also
                         }
                         if (overlap == null) {


### PR DESCRIPTION
### Description
This PR removes some of the logging from `CheckinWarningMatcher` in builds for testers as this produces a huge amount of noise in their logs without much added value

### Steps to reproduce
1. Check into some event
2. Get an positive package submitted
3. Check if tester builds are logging lots of stuff about Matches
4. Check if there is still too much noise in the logs and if anything else should be disabled