### PR TITLE
Refresh the right test types, remove hardcoded PCR (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/SubmissionRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/SubmissionRepository.kt
@@ -75,7 +75,7 @@ class SubmissionRepository @Inject constructor(
         }
     }
 
-    fun refreshTest(type: CoronaTest.Type) {
+    fun refreshTest(type: CoronaTest.Type? = null) {
         Timber.tag(TAG).v("refreshTest(type=%s)", type)
 
         scope.launch {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragmentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragmentViewModel.kt
@@ -367,7 +367,7 @@ class HomeFragmentViewModel @AssistedInject constructor(
 
     fun refreshRequiredData() {
         launch {
-            submissionRepository.refreshTest(type = CoronaTest.Type.PCR)
+            submissionRepository.refreshTest()
             tracingRepository.refreshRiskLevel()
         }
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/resultavailable/SubmissionTestResultAvailableViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/resultavailable/SubmissionTestResultAvailableViewModel.kt
@@ -98,7 +98,7 @@ class SubmissionTestResultAvailableViewModel @AssistedInject constructor(
     )
 
     init {
-        submissionRepository.refreshTest(type = CoronaTest.Type.PCR)
+        submissionRepository.refreshTest(type = testType)
     }
 
     fun goBack() {


### PR DESCRIPTION
Noticed during review of #2935

On the homescreen we want to refresh both test types, on the other screens it should be the type passed via navArgs, not hardcoded PCR.