### PR TITLE
Fix button shadows (COMMUNITY)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/bugreporting_debuglog_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/bugreporting_debuglog_fragment.xml
@@ -97,6 +97,7 @@
         android:paddingTop="8dp"
         android:paddingEnd="24dp"
         android:paddingBottom="16dp"
+        android:clipToPadding="false"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent">

--- a/Corona-Warn-App/src/main/res/layout/home_create_trace_location_card.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_create_trace_location_card.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="@dimen/spacing_normal">
+    android:padding="@dimen/spacing_normal"
+    android:clipToPadding="false">
 
     <TextView
         android:id="@+id/create_trace_location_card_headline"

--- a/Corona-Warn-App/src/main/res/layout/home_reenable_risk_card_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_reenable_risk_card_layout.xml
@@ -7,6 +7,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:padding="@dimen/card_padding"
+        android:clipToPadding="false"
         tools:showIn="@layout/home_card_container_layout">
 
         <TextView

--- a/Corona-Warn-App/src/main/res/layout/home_submission_pcr_status_card_positive_not_shared.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_submission_pcr_status_card_positive_not_shared.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="@dimen/card_padding">
+    android:padding="@dimen/card_padding"
+    android:clipToPadding="false">
 
     <TextView
         android:id="@+id/title"

--- a/Corona-Warn-App/src/main/res/layout/home_submission_rapid_status_card_positive_not_shared.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_submission_rapid_status_card_positive_not_shared.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="@dimen/card_padding">
+    android:padding="@dimen/card_padding"
+    android:clipToPadding="false">
 
     <TextView
         android:id="@+id/title"

--- a/Corona-Warn-App/src/main/res/layout/include_interop_riskdetails_no_countries_infoview.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_interop_riskdetails_no_countries_infoview.xml
@@ -8,6 +8,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/spacing_normal"
         android:padding="@dimen/card_padding"
+        android:clipToPadding="false"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/country_barrier">

--- a/Corona-Warn-App/src/main/res/layout/include_tracing_status_card.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_tracing_status_card.xml
@@ -32,6 +32,7 @@
         style="@style/cardTracing"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:clipToPadding="false"
         android:focusable="true">
 
         <androidx.constraintlayout.widget.ConstraintLayout

--- a/Corona-Warn-App/src/main/res/layout/tracing_content_disabled_view.xml
+++ b/Corona-Warn-App/src/main/res/layout/tracing_content_disabled_view.xml
@@ -13,7 +13,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/colorSurface1"
-        android:padding="@dimen/card_padding">
+        android:padding="@dimen/card_padding"
+        android:clipToPadding="false">
 
         <TextView
             android:id="@+id/headline"

--- a/Corona-Warn-App/src/main/res/layout/tracing_details_fragment_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/tracing_details_fragment_layout.xml
@@ -47,6 +47,7 @@
             android:paddingTop="@dimen/spacing_small"
             android:paddingEnd="@dimen/spacing_normal"
             android:paddingBottom="@dimen/spacing_small"
+            android:clipToPadding="false"
             gone="@{!tracingDetailsState.isRiskLevelButtonGroupVisible()}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
This addresses the problem described in #2856.

Demonstration:

![Screenshot_1619264002](https://user-images.githubusercontent.com/16943720/115957284-abc07800-a501-11eb-902e-2aa31b44f116.png) | ![Screenshot_1619264011](https://user-images.githubusercontent.com/16943720/115957285-ae22d200-a501-11eb-8b62-1278a79e959f.png)
---|---

It works by telling parents not to clip their children to its padding through `clipToPadding="false"`. At first, I thought this would require restructuring each affected layout, and was happy to learn that this is not the case and that the fix is so simple.

---
 Internal Tracking ID: [EXPOSUREAPP-6543](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6543)
