### PR TITLE
Align menu text in contact diary to event registration (closes #2944) (COMMUNITY)

### DIFF
--- a/Corona-Warn-App/src/main/res/values-de/contact_diary_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/contact_diary_strings.xml
@@ -52,7 +52,7 @@
 
 
     <!-- XTXT: Menu information entry for contact diary overview screen -->
-    <string name="menu_contact_diary_information">"Information"</string>
+    <string name="menu_contact_diary_information">"Informationen"</string>
     <!-- XTXT: Menu export entry for contact diary overview screen -->
     <string name="menu_contact_export_entries">"Einträge exportieren"</string>
     <!-- XTXT: Menu edit persons entry for contact diary overview screen -->


### PR DESCRIPTION
### Description
Closes issue #2944

### Steps to reproduce
See #2944 

See also https://github.com/corona-warn-app/cwa-app-ios/issues/2543 and https://github.com/corona-warn-app/cwa-app-ios/pull/2544 