### PR TITLE
Connection Reset error handling (EXPOSUREAPP-6784)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/ui/homecards/SubmissionStateProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/ui/homecards/SubmissionStateProvider.kt
@@ -1,7 +1,7 @@
 package de.rki.coronawarnapp.submission.ui.homecards
 
 import dagger.Reusable
-import de.rki.coronawarnapp.exception.http.CwaServerError
+import de.rki.coronawarnapp.exception.http.CwaClientError
 import de.rki.coronawarnapp.submission.SubmissionRepository
 import de.rki.coronawarnapp.submission.SubmissionSettings
 import de.rki.coronawarnapp.util.CWADebug
@@ -101,7 +101,7 @@ class SubmissionStateProvider @Inject constructor(
 
         fun isInvalid(): Boolean =
             isDeviceRegistered && when (deviceUiState) {
-                is NetworkRequestWrapper.RequestFailed -> deviceUiState.error !is CwaServerError
+                is NetworkRequestWrapper.RequestFailed -> deviceUiState.error is CwaClientError
                 is NetworkRequestWrapper.RequestSuccessful -> deviceUiState.data == DeviceUIState.PAIRED_REDEEMED
                 else -> false
             }


### PR DESCRIPTION
A test is invalid on 40X errors (client errors), instead of checking for  `!is CwaServerError`, we check for `is CwaClientError`.
This causes the error case for `SocketException` to be mapped to PENDING.

### Testing
Test the behavior by either playing with your firewall, or throwing an exception here:

![Screenshot from 2021-04-27 13-40-14](https://user-images.githubusercontent.com/1439229/116235686-75336900-a75e-11eb-8363-63e15b19c757.png)
