### PR TITLE
NFC

### DIFF
--- a/Corona-Warn-App/src/main/AndroidManifest.xml
+++ b/Corona-Warn-App/src/main/AndroidManifest.xml
@@ -79,6 +79,7 @@
 
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
+                <action android:name="android.nfc.action.NDEF_DISCOVERED"/>
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />


### PR DESCRIPTION
Changed the AndroidManifest.xml to support the possibility to scan an NFC-Tag with a CheckIn-URL to open the app directly like in the iOS version.
