### PR TITLE
Update privacy_de.html (COMMUNITY)

### DIFF
--- a/Corona-Warn-App/src/main/assets/privacy_de.html
+++ b/Corona-Warn-App/src/main/assets/privacy_de.html
@@ -457,7 +457,7 @@
     Hierzu ruft die App vom Serversystem mehrmals täglich eine aktuelle Positiv-Liste mit den
     Angaben von Nutzern, die über die offizielle Corona-App eines am länderübergreifenden Warnsystem
     teilnehmenden Landes (siehe hierzu Punkt 7) eine Warnung ausgelöst haben ab. Diese Positiv-Liste
-    enthält die Zufalls-IDs der warnenden Nutzer sowie eventuelle Angaben zum Symptombeginn.. Falls
+    enthält die Zufalls-IDs der warnenden Nutzer sowie eventuelle Angaben zum Symptombeginn. Falls
     die warnenden Nutzer bei einem Event eingecheckt waren, enthält die Positiv-Liste auch die
     betreffenden Event-IDs und die Dauer des Check-ins (Eincheck- und Auscheck-Zeit).
 </p>


### PR DESCRIPTION
fixed little typeos from Issue#https://github.com/corona-warn-app/cwa-app-android/issues/2841#issue-859037936 (
Additionally, I found this small typo in the German privacy policy in number 6 (Wofür werden Ihre Daten verarbeitet), letter a (Risiko-Ermittlung), second paragraph, second sentence:
 teilnehmenden Landes (siehe hierzu Punkt 7) eine Warnung ausgelöst haben ab. Diese Positiv-Liste 
 enthält die Zufalls-IDs der warnenden Nutzer sowie eventuelle Angaben zum Symptombeginn.. Falls 

There's two dots there.
I wanted to change the other thing(s) from the Issue#https://github.com/corona-warn-app/cwa-app-android/issues/2841#issue-859037936 too, but don't know if the thing he wanted to be changed, really has to be changed. Other wise I would also have done that to close the Issue. ;D
)