### PR TITLE
Fix crashing PCR test result update worker (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/CoronaTestRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/CoronaTestRepository.kt
@@ -188,7 +188,7 @@ class CoronaTestRepository @Inject constructor(
             }
         }
 
-        return refreshedData.values.toSet()
+        return refreshedData.values.filter { toRefresh.contains(it.identifier) }.toSet()
     }
 
     suspend fun clear() {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/pcr/execution/PCRResultRetrievalWorker.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/pcr/execution/PCRResultRetrievalWorker.kt
@@ -9,7 +9,6 @@ import dagger.assisted.AssistedInject
 import de.rki.coronawarnapp.coronatest.CoronaTestRepository
 import de.rki.coronawarnapp.coronatest.latestPCRT
 import de.rki.coronawarnapp.coronatest.type.CoronaTest
-import de.rki.coronawarnapp.coronatest.type.pcr.PCRCoronaTest
 import de.rki.coronawarnapp.util.worker.InjectedWorkerFactory
 import de.rki.coronawarnapp.worker.BackgroundConstants
 import kotlinx.coroutines.flow.first
@@ -42,12 +41,9 @@ class PCRResultRetrievalWorker @AssistedInject constructor(
                 return Result.success()
             }
 
-            Timber.tag(TAG).d(" $id Running task.")
-            val coronaTest = coronaTestRepository.refresh(
-                type = CoronaTest.Type.PCR
-            ).single() as PCRCoronaTest
-            val testResult = coronaTest.testResult
-            Timber.tag(TAG).d("$id: Test result retrieved is $testResult")
+            Timber.tag(TAG).v(" $id Running PCR test result refresh.")
+            coronaTestRepository.refresh(type = CoronaTest.Type.PCR)
+            Timber.tag(TAG).d("$id: PCR test result refreshed.")
 
             return Result.success()
         } catch (e: Exception) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/pcr/execution/PCRResultRetrievalWorker.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/pcr/execution/PCRResultRetrievalWorker.kt
@@ -41,7 +41,7 @@ class PCRResultRetrievalWorker @AssistedInject constructor(
                 return Result.success()
             }
 
-            Timber.tag(TAG).v(" $id Running PCR test result refresh.")
+            Timber.tag(TAG).v("$id Running PCR test result refresh.")
             coronaTestRepository.refresh(type = CoronaTest.Type.PCR)
             Timber.tag(TAG).d("$id: PCR test result refreshed.")
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/execution/RAResultRetrievalWorker.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/execution/RAResultRetrievalWorker.kt
@@ -46,8 +46,9 @@ class RAResultRetrievalWorker @AssistedInject constructor(
                 Timber.tag(TAG).w("There is no RapidAntigen test available!?")
                 return Result.success()
             }
-
+            Timber.tag(TAG).v(" $id Running RA test result refresh.")
             coronaTestRepository.refresh(CoronaTest.Type.RAPID_ANTIGEN)
+            Timber.tag(TAG).d("$id: RA test result refreshed.")
 
             val nowUTC = timeStamper.nowUTC
             val days = Duration(rat.registeredAt, nowUTC).standardDays

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/execution/RAResultRetrievalWorker.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/execution/RAResultRetrievalWorker.kt
@@ -46,7 +46,7 @@ class RAResultRetrievalWorker @AssistedInject constructor(
                 Timber.tag(TAG).w("There is no RapidAntigen test available!?")
                 return Result.success()
             }
-            Timber.tag(TAG).v(" $id Running RA test result refresh.")
+            Timber.tag(TAG).v("$id Running RA test result refresh.")
             coronaTestRepository.refresh(CoronaTest.Type.RAPID_ANTIGEN)
             Timber.tag(TAG).d("$id: RA test result refreshed.")
 


### PR DESCRIPTION
The filtering for `coronaTestRepo.refresh(...)` did not work and the updated results contained all registered tests.
The worker which used `.single()` (because there should only be one PCR test) threw an exception after the update.
This caused it to retry despite success and may lead to inconsistent test result behavior.
Other callers of `refresh()` may also have experienced issues.

Conditions:
* Have two tests registered
* Wait for refresh via worker 