### PR TITLE
Adjust test polling behavior 21 days  after registration (EXPOSUREAPP-6882)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/CoronaTestExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/CoronaTestExtensions.kt
@@ -4,5 +4,5 @@ import org.joda.time.Duration
 import org.joda.time.Instant
 
 fun CoronaTest.isOlderThan21Days(nowUTC: Instant): Boolean {
-  return Duration(registeredAt, nowUTC).standardDays > 21
+    return Duration(registeredAt, nowUTC).standardDays > 21
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/CoronaTestExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/CoronaTestExtensions.kt
@@ -1,0 +1,8 @@
+package de.rki.coronawarnapp.coronatest.type
+
+import org.joda.time.Duration
+import org.joda.time.Instant
+
+fun CoronaTest.isOlderThan21Days(nowUTC: Instant): Boolean {
+  return Duration(registeredAt, nowUTC).standardDays > 21
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRProcessor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRProcessor.kt
@@ -139,7 +139,7 @@ class PCRProcessor @Inject constructor(
             }
 
             test.copy(
-                testResult = check60PlusDays(test, newTestResult),
+                testResult = check21PlusDays(test, newTestResult),
                 testResultReceivedAt = determineReceivedDate(test, newTestResult),
                 lastUpdatedAt = nowUTC,
                 lastError = null
@@ -153,10 +153,10 @@ class PCRProcessor @Inject constructor(
         }
     }
 
-    // After 60 days, the previously EXPIRED test is deleted from the server, and it will return pending again.
-    private fun check60PlusDays(test: CoronaTest, newResult: CoronaTestResult): CoronaTestResult {
+    // After 21 days, the previously EXPIRED test is deleted from the server, and it may return pending again.
+    private fun check21PlusDays(test: CoronaTest, newResult: CoronaTestResult): CoronaTestResult {
         val calculateDays = Duration(test.registeredAt, timeStamper.nowUTC).standardDays
-        Timber.tag(TAG).d("Calculated test age: %d days", calculateDays)
+        Timber.tag(TAG).d("Calculated test age: %d days, newResult=%s", calculateDays, newResult)
 
         return if (newResult == PCR_OR_RAT_PENDING && calculateDays >= BackgroundConstants.POLLING_VALIDITY_MAX_DAYS) {
             Timber.tag(TAG).d("$calculateDays is exceeding the maximum polling duration")

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRProcessor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRProcessor.kt
@@ -18,9 +18,11 @@ import de.rki.coronawarnapp.coronatest.tan.CoronaTestTAN
 import de.rki.coronawarnapp.coronatest.type.CoronaTest
 import de.rki.coronawarnapp.coronatest.type.CoronaTestProcessor
 import de.rki.coronawarnapp.coronatest.type.CoronaTestService
+import de.rki.coronawarnapp.coronatest.type.isOlderThan21Days
 import de.rki.coronawarnapp.datadonation.analytics.modules.keysubmission.AnalyticsKeySubmissionCollector
 import de.rki.coronawarnapp.datadonation.analytics.modules.registeredtest.TestResultDataCollector
 import de.rki.coronawarnapp.exception.ExceptionCategory
+import de.rki.coronawarnapp.exception.http.BadRequestException
 import de.rki.coronawarnapp.exception.http.CwaWebException
 import de.rki.coronawarnapp.exception.reporting.report
 import de.rki.coronawarnapp.util.TimeStamper
@@ -102,16 +104,35 @@ class PCRProcessor @Inject constructor(
             Timber.tag(TAG).v("pollServer(test=%s)", test)
             test as PCRCoronaTest
 
+
             if (test.isSubmitted) {
-                Timber.tag(TAG).w("Not refreshing, we have already submitted.")
+                Timber.tag(TAG).w("Not polling, we have already submitted.")
                 return test
             }
 
-            val newTestResult = submissionService.asyncRequestTestResult(test.registrationToken).let {
-                Timber.tag(TAG).d("Raw test result was %s", it)
-                testResultDataCollector.updatePendingTestResultReceivedTime(it)
+            val nowUTC = timeStamper.nowUTC
+            val isOlderThan21Days = test.isOlderThan21Days(nowUTC)
 
-                it.toValidatedResult()
+            if (isOlderThan21Days && test.testResult == PCR_REDEEMED) {
+                Timber.tag(TAG).w("Not polling, test is older than 21 days.")
+                return test
+            }
+
+            val newTestResult = try {
+                submissionService.asyncRequestTestResult(test.registrationToken).let {
+                    Timber.tag(TAG).d("Raw test result was %s", it)
+                    testResultDataCollector.updatePendingTestResultReceivedTime(it)
+
+                    it.toValidatedResult()
+                }
+            } catch (e: BadRequestException) {
+                if (isOlderThan21Days) {
+                    Timber.tag(TAG).w("HTTP 400 error after 21 days, remapping to PCR_REDEEMED.")
+                    PCR_REDEEMED
+                } else {
+                    Timber.tag(TAG).v("Unexpected HTTP 400 error, rethrowing...")
+                    throw e
+                }
             }
 
             if (newTestResult == PCR_POSITIVE) {
@@ -121,7 +142,7 @@ class PCRProcessor @Inject constructor(
             test.copy(
                 testResult = check60PlusDays(test, newTestResult),
                 testResultReceivedAt = determineReceivedDate(test, newTestResult),
-                lastUpdatedAt = timeStamper.nowUTC,
+                lastUpdatedAt = nowUTC,
                 lastError = null
             )
         } catch (e: Exception) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRProcessor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRProcessor.kt
@@ -104,7 +104,6 @@ class PCRProcessor @Inject constructor(
             Timber.tag(TAG).v("pollServer(test=%s)", test)
             test as PCRCoronaTest
 
-
             if (test.isSubmitted) {
                 Timber.tag(TAG).w("Not polling, we have already submitted.")
                 return test

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RapidAntigenProcessor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RapidAntigenProcessor.kt
@@ -112,7 +112,7 @@ class RapidAntigenProcessor @Inject constructor(
             }
 
             test.copy(
-                testResult = check60PlusDays(test, newTestResult),
+                testResult = check21PlusDays(test, newTestResult),
                 testResultReceivedAt = determineReceivedDate(test, newTestResult),
                 lastUpdatedAt = nowUTC,
                 lastError = null
@@ -126,10 +126,10 @@ class RapidAntigenProcessor @Inject constructor(
         }
     }
 
-    // After 60 days, the previously EXPIRED test is deleted from the server, and it will return pending again.
-    private fun check60PlusDays(test: CoronaTest, newResult: CoronaTestResult): CoronaTestResult {
+    // After 21 days, the previously EXPIRED test is deleted from the server, and it may return pending again.
+    private fun check21PlusDays(test: CoronaTest, newResult: CoronaTestResult): CoronaTestResult {
         val calculateDays = Duration(test.registeredAt, timeStamper.nowUTC).standardDays
-        Timber.tag(TAG).d("Calculated test age: %d days", calculateDays)
+        Timber.tag(TAG).d("Calculated test age: %d days, newResult=%s", calculateDays, newResult)
 
         return if (
             (newResult == PCR_OR_RAT_PENDING || newResult == RAT_PENDING) &&

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RapidAntigenProcessor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RapidAntigenProcessor.kt
@@ -17,7 +17,9 @@ import de.rki.coronawarnapp.coronatest.tan.CoronaTestTAN
 import de.rki.coronawarnapp.coronatest.type.CoronaTest
 import de.rki.coronawarnapp.coronatest.type.CoronaTestProcessor
 import de.rki.coronawarnapp.coronatest.type.CoronaTestService
+import de.rki.coronawarnapp.coronatest.type.isOlderThan21Days
 import de.rki.coronawarnapp.exception.ExceptionCategory
+import de.rki.coronawarnapp.exception.http.BadRequestException
 import de.rki.coronawarnapp.exception.http.CwaWebException
 import de.rki.coronawarnapp.exception.reporting.report
 import de.rki.coronawarnapp.util.TimeStamper
@@ -82,19 +84,37 @@ class RapidAntigenProcessor @Inject constructor(
             test as RACoronaTest
 
             if (test.isSubmitted) {
-                Timber.tag(TAG).w("Not refreshing, we have already submitted.")
+                Timber.tag(TAG).w("Not polling, we have already submitted.")
                 return test
             }
 
-            val newTestResult = submissionService.asyncRequestTestResult(test.registrationToken).let {
-                Timber.tag(TAG).v("Raw test result was %s", it)
-                it.toValidatedResult()
+            val nowUTC = timeStamper.nowUTC
+            val isOlderThan21Days = test.isOlderThan21Days(nowUTC)
+
+            if (isOlderThan21Days && test.testResult == RAT_REDEEMED) {
+                Timber.tag(TAG).w("Not polling, test is older than 21 days.")
+                return test
+            }
+
+            val newTestResult = try {
+                submissionService.asyncRequestTestResult(test.registrationToken).let {
+                    Timber.tag(TAG).v("Raw test result was %s", it)
+                    it.toValidatedResult()
+                }
+            } catch (e: BadRequestException) {
+                if (isOlderThan21Days) {
+                    Timber.tag(TAG).w("HTTP 400 error after 21 days, remapping to RAT_REDEEMED.")
+                    RAT_REDEEMED
+                } else {
+                    Timber.tag(TAG).v("Unexpected HTTP 400 error, rethrowing...")
+                    throw e
+                }
             }
 
             test.copy(
                 testResult = check60PlusDays(test, newTestResult),
                 testResultReceivedAt = determineReceivedDate(test, newTestResult),
-                lastUpdatedAt = timeStamper.nowUTC,
+                lastUpdatedAt = nowUTC,
                 lastError = null
             )
         } catch (e: Exception) {

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/CoronaTestExtensionsTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/CoronaTestExtensionsTest.kt
@@ -1,0 +1,34 @@
+package de.rki.coronawarnapp.coronatest.type
+
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.joda.time.Duration
+import org.joda.time.Instant
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class CoronaTestExtensionsTest : BaseTest() {
+
+    @Test
+    fun `is test older than 21 days - time changes`() {
+        val test = mockk<CoronaTest>().apply {
+            every { registeredAt } returns Instant.EPOCH
+        }
+
+        test.isOlderThan21Days(Instant.EPOCH.plus(Duration.standardDays(21))) shouldBe false
+        test.isOlderThan21Days(Instant.EPOCH.plus(Duration.standardDays(22))) shouldBe true
+    }
+
+    @Test
+    fun `is test older than 21 days - test changes`() {
+        val nowUTC = Instant.EPOCH.plus(Duration.standardDays(22))
+        mockk<CoronaTest>().apply {
+            every { registeredAt } returns Instant.EPOCH
+        }.isOlderThan21Days(nowUTC) shouldBe true
+
+        mockk<CoronaTest>().apply {
+            every { registeredAt } returns Instant.EPOCH.plus(Duration.standardDays(1))
+        }.isOlderThan21Days(nowUTC) shouldBe false
+    }
+}

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRProcessorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRProcessorTest.kt
@@ -17,6 +17,7 @@ import de.rki.coronawarnapp.coronatest.tan.CoronaTestTAN
 import de.rki.coronawarnapp.coronatest.type.CoronaTestService
 import de.rki.coronawarnapp.datadonation.analytics.modules.keysubmission.AnalyticsKeySubmissionCollector
 import de.rki.coronawarnapp.datadonation.analytics.modules.registeredtest.TestResultDataCollector
+import de.rki.coronawarnapp.exception.http.BadRequestException
 import de.rki.coronawarnapp.util.TimeStamper
 import io.kotest.matchers.shouldBe
 import io.mockk.MockKAnnotations
@@ -179,6 +180,57 @@ class PCRProcessorTest : BaseTest() {
 
         instance.create(CoronaTestQRCode.PCR(qrCodeGUID = "thisIsAQRCodeGUID")).apply {
             isResultAvailableNotificationSent shouldBe false
+        }
+    }
+
+    @Test
+    fun `polling is skipped if test is older than 21 days and state was already REDEEMED`() = runBlockingTest {
+        coEvery { submissionService.asyncRequestTestResult(any()) } answers { PCR_POSITIVE }
+
+        val instance = createInstance()
+
+        val pcrTest = PCRCoronaTest(
+            identifier = "identifier",
+            lastUpdatedAt = Instant.EPOCH,
+            registeredAt = nowUTC.minus(Duration.standardDays(22)),
+            registrationToken = "regtoken",
+            testResult = PCR_REDEEMED
+        )
+
+        // Older than 21 days and already redeemed
+        instance.pollServer(pcrTest) shouldBe pcrTest
+
+        // Older than 21 days but not in final state, we take value from server
+        instance.pollServer(
+            pcrTest.copy(testResult = PCR_NEGATIVE)
+        ).testResult shouldBe PCR_POSITIVE
+    }
+
+    @Test
+    fun `http 400 errors map to REDEEMED (EXPIRED) state after 21 days`() = runBlockingTest {
+        val ourBadRequest = BadRequestException("Who?")
+        coEvery { submissionService.asyncRequestTestResult(any()) } throws ourBadRequest
+
+        val instance = createInstance()
+
+        val pcrTest = PCRCoronaTest(
+            identifier = "identifier",
+            lastUpdatedAt = Instant.EPOCH,
+            registeredAt = nowUTC,
+            registrationToken = "regtoken",
+            testResult = PCR_POSITIVE
+        )
+
+        // Test is not older than 21 days, we want the error!
+        instance.pollServer(pcrTest).apply {
+            testResult shouldBe PCR_POSITIVE
+            lastError shouldBe ourBadRequest
+        }
+
+        // Test IS older than 21 days, we expected the error, and map it to REDEEMED (expired)
+        instance.pollServer(pcrTest.copy(registeredAt = nowUTC.minus(Duration.standardDays(22)))).apply {
+            testResult shouldBe PCR_REDEEMED
+            lastError shouldBe null
         }
     }
 }


### PR DESCRIPTION
* Map HTTP 400 errors to *_REDEEMED after 21 days (server has deleted data set).
* Stop test polling after 21 days if we are in a final state (*_REDEEMED).

* See ticket and related tech spec changes. 2.1.x hotfix target.
* Check test cases, right PCR/RAT results?
* Testable via mockserver and timetravel