### PR TITLE
Refactor Contact Diary Work Scheduler (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/CoronaWarnApplication.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/CoronaWarnApplication.kt
@@ -31,7 +31,6 @@ import de.rki.coronawarnapp.presencetracing.risk.execution.PresenceTracingRiskWo
 import de.rki.coronawarnapp.presencetracing.storage.retention.TraceLocationDbCleanUpScheduler
 import de.rki.coronawarnapp.risk.RiskLevelChangeDetector
 import de.rki.coronawarnapp.risk.execution.ExposureWindowRiskWorkScheduler
-import de.rki.coronawarnapp.storage.OnboardingSettings
 import de.rki.coronawarnapp.submission.auto.AutoSubmission
 import de.rki.coronawarnapp.task.TaskController
 import de.rki.coronawarnapp.util.CWADebug
@@ -68,7 +67,6 @@ class CoronaWarnApplication : Application(), HasAndroidInjector {
     @Inject lateinit var deviceTimeHandler: DeviceTimeHandler
     @Inject lateinit var autoSubmission: AutoSubmission
     @Inject lateinit var coronaTestRepository: CoronaTestRepository
-    @Inject lateinit var onboardingSettings: OnboardingSettings
     @Inject lateinit var autoCheckOut: AutoCheckOut
     @Inject lateinit var traceLocationDbCleanupScheduler: TraceLocationDbCleanUpScheduler
     @Inject lateinit var shareTestResultNotificationService: ShareTestResultNotificationService
@@ -111,9 +109,8 @@ class CoronaWarnApplication : Application(), HasAndroidInjector {
             .onEach { isAppInForeground = it }
             .launchIn(GlobalScope)
 
-        if (onboardingSettings.isOnboarded) {
-            contactDiaryWorkScheduler.schedulePeriodic()
-        }
+        Timber.v("Setting up contact diary work scheduler")
+        contactDiaryWorkScheduler.setup()
 
         Timber.v("Setting up deadman notification scheduler")
         deadmanNotificationScheduler.setup()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/retention/ContactDiaryWorkScheduler.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/retention/ContactDiaryWorkScheduler.kt
@@ -1,22 +1,39 @@
 package de.rki.coronawarnapp.contactdiary.retention
 
+import androidx.annotation.VisibleForTesting
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.WorkManager
 import dagger.Reusable
+import de.rki.coronawarnapp.storage.OnboardingSettings
+import de.rki.coronawarnapp.util.coroutine.AppScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import timber.log.Timber
 import javax.inject.Inject
 
 @Reusable
 class ContactDiaryWorkScheduler @Inject constructor(
-    val workManager: WorkManager,
-    private val workBuilder: ContactDiaryWorkBuilder
+    @AppScope val appScope: CoroutineScope,
+    private val workManager: WorkManager,
+    private val workBuilder: ContactDiaryWorkBuilder,
+    private val onboardingSettings: OnboardingSettings
 ) {
+
+    fun setup() {
+        onboardingSettings.isOnboardedFlow.onEach { isOnboarded ->
+            if (isOnboarded) {
+                schedulePeriodic()
+            }
+        }.launchIn(appScope)
+    }
 
     /**
      * Enqueue background contact diary clean periodic worker
      * Replace with new if older work exists.
      */
-    fun schedulePeriodic() {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun schedulePeriodic() {
         Timber.d("ContactDiaryWorkScheduler schedulePeriodic()")
         // Create unique work and enqueue
         workManager.enqueueUniquePeriodicWork(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainActivity.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainActivity.kt
@@ -193,7 +193,6 @@ class MainActivity : AppCompatActivity(), HasAndroidInjector {
     override fun onResume() {
         super.onResume()
         vm.doBackgroundNoiseCheck()
-        contactDiaryWorkScheduler.schedulePeriodic()
         dataDonationAnalyticsScheduler.schedulePeriodic()
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainActivity.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainActivity.kt
@@ -18,7 +18,6 @@ import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector
 import de.rki.coronawarnapp.NavGraphDirections
 import de.rki.coronawarnapp.R
-import de.rki.coronawarnapp.contactdiary.retention.ContactDiaryWorkScheduler
 import de.rki.coronawarnapp.contactdiary.ui.overview.ContactDiaryOverviewFragmentDirections
 import de.rki.coronawarnapp.databinding.ActivityMainBinding
 import de.rki.coronawarnapp.datadonation.analytics.worker.DataDonationAnalyticsScheduler
@@ -75,7 +74,6 @@ class MainActivity : AppCompatActivity(), HasAndroidInjector {
     private val navController by lazy { supportFragmentManager.findNavController(R.id.nav_host_fragment) }
 
     @Inject lateinit var powerManagement: PowerManagement
-    @Inject lateinit var contactDiaryWorkScheduler: ContactDiaryWorkScheduler
     @Inject lateinit var dataDonationAnalyticsScheduler: DataDonationAnalyticsScheduler
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/contactdiary/retention/ContactDiaryWorkSchedulerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/contactdiary/retention/ContactDiaryWorkSchedulerTest.kt
@@ -4,13 +4,18 @@ import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.Operation
 import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager
+import de.rki.coronawarnapp.storage.OnboardingSettings
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import io.mockk.verifySequence
+import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runBlockingTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import testhelpers.coroutines.runBlockingTest2
 
 class ContactDiaryWorkSchedulerTest : BaseTest() {
 
@@ -18,6 +23,7 @@ class ContactDiaryWorkSchedulerTest : BaseTest() {
     @MockK lateinit var operation: Operation
     @MockK lateinit var workBuilder: ContactDiaryWorkBuilder
     @MockK lateinit var periodicWorkRequest: PeriodicWorkRequest
+    @MockK lateinit var onBoardingSettings: OnboardingSettings
 
     @BeforeEach
     fun setup() {
@@ -32,16 +38,32 @@ class ContactDiaryWorkSchedulerTest : BaseTest() {
         } returns operation
     }
 
-    private fun createScheduler() = ContactDiaryWorkScheduler(
+    private fun createScheduler(scope: CoroutineScope) = ContactDiaryWorkScheduler(
+        appScope = scope,
         workManager = workManager,
-        workBuilder = workBuilder
+        workBuilder = workBuilder,
+        onboardingSettings = onBoardingSettings
     )
 
     @Test
-    fun `test periodic work was scheduled`() {
-        createScheduler().schedulePeriodic()
+    fun `test periodic work was scheduled`() = runBlockingTest {
+        createScheduler(this).schedulePeriodic()
+        verifyIfWorkWasScheduled()
+    }
 
-        verifySequence {
+    @Test
+    fun `periodic work should be scheduled after onboaring`() = runBlockingTest2(ignoreActive = true) {
+        val onboardingFlow = MutableStateFlow(false)
+        every { onBoardingSettings.isOnboardedFlow } returns onboardingFlow
+        createScheduler(this).setup()
+        verifyIfWorkWasScheduled(exactly = 0)
+
+        onboardingFlow.value = true
+        verifyIfWorkWasScheduled(exactly = 1)
+    }
+
+    private fun verifyIfWorkWasScheduled(exactly: Int = 1) {
+        verify(exactly = exactly) {
             workManager.enqueueUniquePeriodicWork(
                 ContactDiaryWorkScheduler.PERIODIC_WORK_NAME,
                 ExistingPeriodicWorkPolicy.REPLACE,


### PR DESCRIPTION
Work is now scheduled in the same way as for other workers. 

Now only `.setup()` is called at app start and the scheduler now observes changes of the onboarding status on its own and so we don't have to schedule the work from other places within the app. 