### PR TITLE
Display risk calculated at on risk cards (DEV)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/main/home/HomeData.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/main/home/HomeData.kt
@@ -42,7 +42,7 @@ object HomeData {
             state = LowRisk(
                 riskState = RiskState.LOW_RISK,
                 isInDetailsMode = false,
-                lastExposureDetectionTime = Instant.now(),
+                calculatedAt = Instant.now(),
                 lastEncounterAt = null,
                 allowManualUpdate = false,
                 daysWithEncounters = 0,
@@ -56,7 +56,7 @@ object HomeData {
             state = LowRisk(
                 riskState = RiskState.LOW_RISK,
                 isInDetailsMode = false,
-                lastExposureDetectionTime = todayAtNineFiftyFive,
+                calculatedAt = todayAtNineFiftyFive,
                 lastEncounterAt = null,
                 allowManualUpdate = false,
                 daysWithEncounters = 0,
@@ -70,7 +70,7 @@ object HomeData {
             state = LowRisk(
                 riskState = RiskState.LOW_RISK,
                 isInDetailsMode = false,
-                lastExposureDetectionTime = todayAtNineFiftyFive,
+                calculatedAt = todayAtNineFiftyFive,
                 lastEncounterAt = todayAtNineFiftyFive.toLocalDateUtc(),
                 allowManualUpdate = false,
                 daysWithEncounters = 1,
@@ -84,7 +84,7 @@ object HomeData {
             state = IncreasedRisk(
                 riskState = RiskState.INCREASED_RISK,
                 isInDetailsMode = false,
-                lastExposureDetectionTime = todayAtNineFiftyFive,
+                calculatedAt = todayAtNineFiftyFive,
                 allowManualUpdate = false,
                 daysWithEncounters = 1,
                 lastEncounterAt = todayAtNineFiftyFive.toLocalDateUtc()
@@ -97,7 +97,7 @@ object HomeData {
             state = TracingDisabled(
                 riskState = RiskState.LOW_RISK,
                 isInDetailsMode = false,
-                lastExposureDetectionTime = todayAtNineFiftyFive
+                calculatedAt = todayAtNineFiftyFive
             ),
             onCardClick = {},
             onEnableTracingClick = {}
@@ -116,7 +116,7 @@ object HomeData {
             state = TracingFailed(
                 riskState = RiskState.CALCULATION_FAILED,
                 isInDetailsMode = false,
-                lastExposureDetectionTime = todayAtNineFiftyFive
+                calculatedAt = todayAtNineFiftyFive
             ),
             onCardClick = {},
             onRetryClick = {}

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/tracing/TracingData.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/tracing/TracingData.kt
@@ -36,7 +36,7 @@ object TracingData {
                 state = TracingDisabled(
                     riskState = RiskState.LOW_RISK,
                     isInDetailsMode = true,
-                    lastExposureDetectionTime = todayAtNineFiftyFive
+                    calculatedAt = todayAtNineFiftyFive
                 )
             ),
             BehaviorNormalRiskBox.Item(
@@ -63,7 +63,7 @@ object TracingData {
                 state = LowRisk(
                     riskState = RiskState.LOW_RISK,
                     isInDetailsMode = true,
-                    lastExposureDetectionTime = todayAtNineFiftyFive,
+                    calculatedAt = todayAtNineFiftyFive,
                     allowManualUpdate = false,
                     daysWithEncounters = 0,
                     daysSinceInstallation = 4,
@@ -94,7 +94,7 @@ object TracingData {
                 state = LowRisk(
                     riskState = RiskState.LOW_RISK,
                     isInDetailsMode = true,
-                    lastExposureDetectionTime = todayAtNineFiftyFive,
+                    calculatedAt = todayAtNineFiftyFive,
                     allowManualUpdate = false,
                     daysWithEncounters = 1,
                     daysSinceInstallation = 4,
@@ -125,7 +125,7 @@ object TracingData {
                 state = LowRisk(
                     riskState = RiskState.LOW_RISK,
                     isInDetailsMode = true,
-                    lastExposureDetectionTime = todayAtNineFiftyFive,
+                    calculatedAt = todayAtNineFiftyFive,
                     allowManualUpdate = false,
                     daysWithEncounters = 2,
                     daysSinceInstallation = 4,
@@ -156,7 +156,7 @@ object TracingData {
                 state = IncreasedRisk(
                     riskState = RiskState.INCREASED_RISK,
                     isInDetailsMode = true,
-                    lastExposureDetectionTime = todayAtNineFiftyFive,
+                    calculatedAt = todayAtNineFiftyFive,
                     allowManualUpdate = false,
                     daysWithEncounters = 1,
                     lastEncounterAt = todayAtNineFiftyFive.toLocalDateUtc()
@@ -185,7 +185,7 @@ object TracingData {
                 state = TracingFailed(
                     riskState = RiskState.CALCULATION_FAILED,
                     isInDetailsMode = true,
-                    lastExposureDetectionTime = null
+                    calculatedAt = null
                 )
             ),
             BehaviorNormalRiskBox.Item(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/states/TracingState.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/states/TracingState.kt
@@ -29,7 +29,7 @@ sealed class TracingState {
 data class IncreasedRisk(
     override val riskState: RiskState,
     override val isInDetailsMode: Boolean,
-    val lastExposureDetectionTime: Instant?,
+    val calculatedAt: Instant?,
     val lastEncounterAt: LocalDate?,
     val allowManualUpdate: Boolean,
     val daysWithEncounters: Int
@@ -37,10 +37,10 @@ data class IncreasedRisk(
 
     val showUpdateButton: Boolean = allowManualUpdate && !isInDetailsMode
 
-    fun getTimeFetched(context: Context): String = if (lastExposureDetectionTime != null) {
+    fun getTimeFetched(context: Context): String = if (calculatedAt != null) {
         context.getString(
             R.string.risk_card_body_time_fetched,
-            formatRelativeDateTimeString(context, lastExposureDetectionTime)
+            formatRelativeDateTimeString(context, calculatedAt)
         )
     } else {
         context.getString(R.string.risk_card_body_not_yet_fetched)
@@ -90,7 +90,7 @@ data class IncreasedRisk(
 data class LowRisk(
     override val riskState: RiskState,
     override val isInDetailsMode: Boolean,
-    val lastExposureDetectionTime: Instant?,
+    val calculatedAt: Instant?,
     val lastEncounterAt: LocalDate?,
     val allowManualUpdate: Boolean,
     val daysWithEncounters: Int,
@@ -99,10 +99,10 @@ data class LowRisk(
 
     val showUpdateButton: Boolean = allowManualUpdate && !isInDetailsMode
 
-    fun getTimeFetched(context: Context): String = if (lastExposureDetectionTime != null) {
+    fun getTimeFetched(context: Context): String = if (calculatedAt != null) {
         context.getString(
             R.string.risk_card_body_time_fetched,
-            formatRelativeDateTimeString(context, lastExposureDetectionTime)
+            formatRelativeDateTimeString(context, calculatedAt)
         )
     } else {
         context.getString(R.string.risk_card_body_not_yet_fetched)
@@ -163,15 +163,15 @@ data class LowRisk(
 data class TracingFailed(
     override val riskState: RiskState, // Here it's the latest successful
     override val isInDetailsMode: Boolean,
-    val lastExposureDetectionTime: Instant?
+    val calculatedAt: Instant?
 ) : TracingState() {
 
     val showRestartButton: Boolean = !isInDetailsMode
 
-    fun getTimeFetched(context: Context): String = if (lastExposureDetectionTime != null) {
+    fun getTimeFetched(context: Context): String = if (calculatedAt != null) {
         context.getString(
             R.string.risk_card_body_time_fetched,
-            formatRelativeDateTimeString(context, lastExposureDetectionTime)
+            formatRelativeDateTimeString(context, calculatedAt)
         )
     } else {
         context.getString(R.string.risk_card_body_not_yet_fetched)
@@ -193,15 +193,15 @@ data class TracingFailed(
 data class TracingDisabled(
     override val riskState: RiskState, // Here it's the latest successful
     override val isInDetailsMode: Boolean,
-    val lastExposureDetectionTime: Instant?
+    val calculatedAt: Instant?
 ) : TracingState() {
 
     val showEnableTracingButton: Boolean = !isInDetailsMode
 
-    fun getTimeFetched(c: Context): String = if (lastExposureDetectionTime != null) {
+    fun getTimeFetched(c: Context): String = if (calculatedAt != null) {
         c.getString(
             R.string.risk_card_body_time_fetched,
-            formatRelativeDateTimeString(c, lastExposureDetectionTime)
+            formatRelativeDateTimeString(c, calculatedAt)
         )
     } else {
         c.getString(R.string.risk_card_body_not_yet_fetched)

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/tracing/states/IncreasedRiskTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/tracing/states/IncreasedRiskTest.kt
@@ -59,7 +59,7 @@ internal class IncreasedRiskTest {
     private val defaultRisk = IncreasedRisk(
         riskState = RiskState.INCREASED_RISK,
         isInDetailsMode = false,
-        lastExposureDetectionTime = Instant.now(),
+        calculatedAt = Instant.now(),
         allowManualUpdate = false,
         daysWithEncounters = 1,
         lastEncounterAt = Instant.now().toLocalDateUtc()

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/tracing/states/LowRiskTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/tracing/states/LowRiskTest.kt
@@ -30,7 +30,7 @@ internal class LowRiskTest {
     private val defaultRisk = LowRisk(
         riskState = RiskState.LOW_RISK,
         isInDetailsMode = false,
-        lastExposureDetectionTime = Instant.now(),
+        calculatedAt = Instant.now(),
         allowManualUpdate = false,
         daysWithEncounters = 0,
         daysSinceInstallation = 4,


### PR DESCRIPTION
To prevent confusion, the timestamp shown is changed to the one from the in-app calculation.
