### PR TITLE
Fix rat wrong birthdate format (EXPOSUREAPP-7069)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/ui/testresults/negative/RATResultNegativeFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/ui/testresults/negative/RATResultNegativeFragment.kt
@@ -74,6 +74,6 @@ class RATResultNegativeFragment : Fragment(R.layout.fragment_submission_antigen_
     }
 
     companion object {
-        private const val DATE_FORMAT = "dd.MM.yy"
+        private const val DATE_FORMAT = "dd.MM.yyyy"
     }
 }


### PR DESCRIPTION
Small PR that fixes the date format on the negative RAT result screen.