### PR TITLE
Adjust test availability constant (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/server/VerificationServer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/server/VerificationServer.kt
@@ -6,6 +6,7 @@ import de.rki.coronawarnapp.util.PaddingTool.requestPadding
 import de.rki.coronawarnapp.util.security.HashHelper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.joda.time.Duration
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -113,6 +114,12 @@ class VerificationServer @Inject constructor(
         const val PADDING_LENGTH_BODY_TAN = 31 + VERIFICATION_BODY_FILL
         const val PADDING_LENGTH_BODY_TAN_FAKE = 31 + VERIFICATION_BODY_FILL
         const val DUMMY_REGISTRATION_TOKEN = "11111111-2222-4444-8888-161616161616"
+
+        /**
+         * Test is available for this long on the server.
+         * After this period the server will delete it and return PENDING if the regtoken is polled again.
+         */
+        val TEST_AVAILABLBILITY = Duration.standardDays(60)
 
         private const val TAG = "VerificationServer"
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRProcessor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRProcessor.kt
@@ -14,6 +14,7 @@ import de.rki.coronawarnapp.coronatest.server.CoronaTestResult.RAT_NEGATIVE
 import de.rki.coronawarnapp.coronatest.server.CoronaTestResult.RAT_PENDING
 import de.rki.coronawarnapp.coronatest.server.CoronaTestResult.RAT_POSITIVE
 import de.rki.coronawarnapp.coronatest.server.CoronaTestResult.RAT_REDEEMED
+import de.rki.coronawarnapp.coronatest.server.VerificationServer
 import de.rki.coronawarnapp.coronatest.tan.CoronaTestTAN
 import de.rki.coronawarnapp.coronatest.type.CoronaTest
 import de.rki.coronawarnapp.coronatest.type.CoronaTestProcessor
@@ -26,7 +27,6 @@ import de.rki.coronawarnapp.exception.http.BadRequestException
 import de.rki.coronawarnapp.exception.http.CwaWebException
 import de.rki.coronawarnapp.exception.reporting.report
 import de.rki.coronawarnapp.util.TimeStamper
-import de.rki.coronawarnapp.worker.BackgroundConstants
 import org.joda.time.Duration
 import org.joda.time.Instant
 import timber.log.Timber
@@ -139,7 +139,7 @@ class PCRProcessor @Inject constructor(
             }
 
             test.copy(
-                testResult = check21PlusDays(test, newTestResult),
+                testResult = check60Days(test, newTestResult),
                 testResultReceivedAt = determineReceivedDate(test, newTestResult),
                 lastUpdatedAt = nowUTC,
                 lastError = null
@@ -153,13 +153,13 @@ class PCRProcessor @Inject constructor(
         }
     }
 
-    // After 21 days, the previously EXPIRED test is deleted from the server, and it may return pending again.
-    private fun check21PlusDays(test: CoronaTest, newResult: CoronaTestResult): CoronaTestResult {
-        val calculateDays = Duration(test.registeredAt, timeStamper.nowUTC).standardDays
-        Timber.tag(TAG).d("Calculated test age: %d days, newResult=%s", calculateDays, newResult)
+    // After 60 days, the previously EXPIRED test is deleted from the server, and it may return pending again.
+    private fun check60Days(test: CoronaTest, newResult: CoronaTestResult): CoronaTestResult {
+        val calculateDays = Duration(test.registeredAt, timeStamper.nowUTC)
+        Timber.tag(TAG).d("Calculated test age: %d days, newResult=%s", calculateDays.standardDays, newResult)
 
-        return if (newResult == PCR_OR_RAT_PENDING && calculateDays >= BackgroundConstants.POLLING_VALIDITY_MAX_DAYS) {
-            Timber.tag(TAG).d("$calculateDays is exceeding the maximum polling duration")
+        return if (newResult == PCR_OR_RAT_PENDING && calculateDays > VerificationServer.TEST_AVAILABLBILITY) {
+            Timber.tag(TAG).d("$calculateDays is exceeding the test availability.")
             PCR_REDEEMED
         } else {
             newResult

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RapidAntigenProcessor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RapidAntigenProcessor.kt
@@ -19,7 +19,6 @@ import de.rki.coronawarnapp.coronatest.type.CoronaTest
 import de.rki.coronawarnapp.coronatest.type.CoronaTestProcessor
 import de.rki.coronawarnapp.coronatest.type.CoronaTestService
 import de.rki.coronawarnapp.coronatest.type.isOlderThan21Days
-import de.rki.coronawarnapp.coronatest.type.pcr.PCRProcessor
 import de.rki.coronawarnapp.exception.ExceptionCategory
 import de.rki.coronawarnapp.exception.http.BadRequestException
 import de.rki.coronawarnapp.exception.http.CwaWebException
@@ -130,13 +129,12 @@ class RapidAntigenProcessor @Inject constructor(
     // After 60 days, the previously EXPIRED test is deleted from the server, and it may return pending again.
     private fun check60Days(test: CoronaTest, newResult: CoronaTestResult): CoronaTestResult {
         val calculateDays = Duration(test.registeredAt, timeStamper.nowUTC)
-        Timber.tag(PCRProcessor.TAG)
-            .d("Calculated test age: %d days, newResult=%s", calculateDays.standardDays, newResult)
+        Timber.tag(TAG).d("Calculated test age: %d days, newResult=%s", calculateDays.standardDays, newResult)
 
         return if ((newResult == PCR_OR_RAT_PENDING || newResult == RAT_PENDING) &&
             calculateDays > VerificationServer.TEST_AVAILABLBILITY
         ) {
-            Timber.tag(PCRProcessor.TAG).d("$calculateDays is exceeding the test availability.")
+            Timber.tag(TAG).d("$calculateDays is exceeding the test availability.")
             RAT_REDEEMED
         } else {
             newResult

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/worker/BackgroundConstants.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/worker/BackgroundConstants.kt
@@ -20,13 +20,6 @@ object BackgroundConstants {
     const val WORKER_RETRY_COUNT_THRESHOLD = 2
 
     /**
-     * The maximum validity in days for keeping Background polling active
-     *
-     * @see TimeUnit.DAYS
-     */
-    const val POLLING_VALIDITY_MAX_DAYS = 21
-
-    /**
      * Backoff initial delay
      *
      * @see TimeUnit.MINUTES

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/server/VerificationServerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/server/VerificationServerTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.runBlocking
 import okhttp3.ConnectionSpec
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import org.joda.time.Duration
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -210,5 +211,10 @@ class VerificationServerTest : BaseIOTest() {
         requests.zipWithNext().forEach { (a, b) ->
             a.headerSizeIgnoringContentLength() shouldBe b.headerSizeIgnoringContentLength()
         }
+    }
+
+    @Test
+    fun `test availability constant`() {
+        VerificationServer.TEST_AVAILABLBILITY shouldBe Duration.standardDays(60)
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRProcessorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRProcessorTest.kt
@@ -94,7 +94,7 @@ class PCRProcessorTest : BaseTest() {
         instance.pollServer(pcrTest).testResult shouldBe PCR_OR_RAT_PENDING
 
         val past60DaysTest = pcrTest.copy(
-            registeredAt = nowUTC.minus(Duration.standardDays(21))
+            registeredAt = nowUTC.minus(Duration.standardDays(61))
         )
 
         instance.pollServer(past60DaysTest).testResult shouldBe PCR_REDEEMED

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RapidAntigenProcessorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RapidAntigenProcessorTest.kt
@@ -75,7 +75,7 @@ class RapidAntigenProcessorTest : BaseTest() {
         instance.pollServer(raTest).testResult shouldBe PCR_OR_RAT_PENDING
 
         val past60DaysTest = raTest.copy(
-            registeredAt = nowUTC.minus(Duration.standardDays(21))
+            registeredAt = nowUTC.minus(Duration.standardDays(61))
         )
 
         instance.pollServer(past60DaysTest).testResult shouldBe RAT_REDEEMED

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/worker/BackgroundConstantsTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/worker/BackgroundConstantsTest.kt
@@ -9,7 +9,6 @@ class BackgroundConstantsTest {
     fun allBackgroundConstants() {
         Assert.assertEquals(BackgroundConstants.KIND_DELAY, 1L)
         Assert.assertEquals(BackgroundConstants.WORKER_RETRY_COUNT_THRESHOLD, 2)
-        Assert.assertEquals(BackgroundConstants.POLLING_VALIDITY_MAX_DAYS, 21)
         Assert.assertEquals(BackgroundConstants.BACKOFF_INITIAL_DELAY, 8L)
     }
 }


### PR DESCRIPTION
The server returns a different result after 60, not 21 days.
This should currently only be able to happen when time traveling.