### PR TITLE
Fix codeowner setting for strings due to team name change (DEV)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,4 +8,4 @@
 * @corona-warn-app/cwa-app-android-maintainers
 
 # Code Onwer of all german texts
-/Corona-Warn-App/src/main/res/values-de/ @corona-warn-app/cwa-app-android-ua
+/Corona-Warn-App/src/main/res/values-de/ @corona-warn-app/cwa-app-user-assistance


### PR DESCRIPTION
:point_up: 