### PR TITLE
Removed bold Description in Event Creation (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/trace_location_create_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/trace_location_create_fragment.xml
@@ -51,8 +51,7 @@
                     android:layout_height="wrap_content"
                     android:imeOptions="actionNext"
                     android:inputType="textCapWords"
-                    android:maxLength="100"
-                    android:textStyle="bold" />
+                    android:maxLength="100" />
 
             </com.google.android.material.textfield.TextInputLayout>
 


### PR DESCRIPTION
Removed bold description in even creation description is not the only mandatory field anymore and therefore the bold text makes no sense anymore. 

_-> Figma is not updated yet, but it is discussed with UX._

**Before**: 

<img width="282" alt="image" src="https://user-images.githubusercontent.com/75120552/117402566-eb765f00-af06-11eb-8346-9097f7a97a41.png">

**After**:

<img width="417" alt="image" src="https://user-images.githubusercontent.com/75120552/117402710-2ed0cd80-af07-11eb-8199-486c66c56cc7.png">
