### PR TITLE
Remove build tools (DEV)

### DIFF
--- a/Corona-Warn-App/build.gradle
+++ b/Corona-Warn-App/build.gradle
@@ -20,7 +20,6 @@ android {
     println("Current VERSION_BUILD: ${VERSION_BUILD}")
 
     compileSdkVersion 29
-    buildToolsVersion "29.0.3"
 
     defaultConfig {
         applicationId 'de.rki.coronawarnapp'


### PR DESCRIPTION
- As Android studio suggests already this is not needed anymore. 
- For internal release builds it will pick  `30.0.3` or `30.0.2`

I have built release locally and seems fine