### PR TITLE
Set build tools to 30.0.3

### DIFF
--- a/Corona-Warn-App/build.gradle
+++ b/Corona-Warn-App/build.gradle
@@ -20,7 +20,7 @@ android {
     println("Current VERSION_BUILD: ${VERSION_BUILD}")
 
     compileSdkVersion 29
-
+    buildToolsVersion "30.0.3"
     defaultConfig {
         applicationId 'de.rki.coronawarnapp'
         minSdkVersion 23


### PR DESCRIPTION
Internal release build fails ,because it does not have `30.0.2`