### PR TITLE
Fix flaky "onTestOpened" PPA unit-test (DEV)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/submission/SubmissionTestResultNoConsentGivenFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/submission/SubmissionTestResultNoConsentGivenFragmentTest.kt
@@ -27,6 +27,7 @@ import org.junit.runner.RunWith
 import testhelpers.BaseUITest
 import testhelpers.Screenshot
 import testhelpers.SystemUIDemoModeRule
+import testhelpers.TestDispatcherProvider
 import testhelpers.captureScreenshot
 import tools.fastlane.screengrab.locale.LocaleTestRule
 
@@ -55,6 +56,7 @@ class SubmissionTestResultNoConsentGivenFragmentTest : BaseUITest() {
         viewModel =
             spyk(
                 SubmissionTestResultNoConsentViewModel(
+                    TestDispatcherProvider(),
                     submissionRepository,
                     testResultAvailableNotificationService,
                     analyticsKeySubmissionCollector,

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/testresult/positive/SubmissionTestResultNoConsentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/testresult/positive/SubmissionTestResultNoConsentViewModel.kt
@@ -12,6 +12,7 @@ import de.rki.coronawarnapp.datadonation.analytics.modules.keysubmission.Analyti
 import de.rki.coronawarnapp.datadonation.analytics.modules.keysubmission.Screen
 import de.rki.coronawarnapp.submission.SubmissionRepository
 import de.rki.coronawarnapp.ui.submission.testresult.TestResultUIState
+import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactory
 import kotlinx.coroutines.Dispatchers
@@ -20,11 +21,12 @@ import kotlinx.coroutines.flow.map
 import timber.log.Timber
 
 class SubmissionTestResultNoConsentViewModel @AssistedInject constructor(
+    dispatcherProvider: DispatcherProvider,
     private val submissionRepository: SubmissionRepository,
     private val testResultAvailableNotificationService: PCRTestResultAvailableNotificationService,
     private val analyticsKeySubmissionCollector: AnalyticsKeySubmissionCollector,
     @Assisted private val testType: CoronaTest.Type
-) : CWAViewModel() {
+) : CWAViewModel(dispatcherProvider = dispatcherProvider) {
     init {
         Timber.v("init() coronaTestType=%s", testType)
     }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/testresult/positive/SubmissionTestResultNoConsentViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/testresult/positive/SubmissionTestResultNoConsentViewModelTest.kt
@@ -13,6 +13,7 @@ import io.mockk.verify
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import testhelpers.TestDispatcherProvider
 
 internal class SubmissionTestResultNoConsentViewModelTest : BaseTest() {
 
@@ -26,6 +27,7 @@ internal class SubmissionTestResultNoConsentViewModelTest : BaseTest() {
     }
 
     private fun createInstance(testType: Type) = SubmissionTestResultNoConsentViewModel(
+        TestDispatcherProvider(),
         submissionRepository,
         testResultAvailableNotificationService,
         analyticsKeySubmissionCollector,


### PR DESCRIPTION
Pass dispatcher provider explicitly and run synchronously in unit tests.

The test was flaky due to race condition between "scope.launch" and "verify".