### PR TITLE
Fix typos in TraceWarningPackageSyncTool module (COMMUNITY)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/warning/download/TraceWarningPackageSyncTool.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/warning/download/TraceWarningPackageSyncTool.kt
@@ -75,7 +75,7 @@ class TraceWarningPackageSyncTool @Inject constructor(
         cleanUpIrrelevantPackages(location, firstRelevantInterval)
 
         if (firstRelevantInterval > intervalDiscovery.latest) {
-            Timber.tag(TAG).d("Known server IDs are older then ours newest, aborting early.")
+            Timber.tag(TAG).d("Known server IDs are older than our newest, aborting early.")
             return SyncResult(successful = true)
         }
 


### PR DESCRIPTION
### Description

A log message may be output in the user selected Error Report function such as:
`2021-05-14T12:55:15.742Z  D/TraceWarningSyncTool: Known server IDs are older then ours newest, aborting early.`

This PR fixes the typos in the above message, which originate from TraceWarningPackageSyncTool.kt.

`Timber.tag(TAG).d("Known server IDs are older then ours newest, aborting early.")`
is changed to
`Timber.tag(TAG).d("Known server IDs are older than our newest, aborting early.")`

### Steps to reproduce

Unfortunately I am unable to verify this fix, except by code-inspection, since I do not have an allowlisted Google account and therefore I cannot successfully activate exposure logging on a test build from Android Studio.

With an allowlisted account, the following may work:

1. Open CWA in Pixel 3a emulator, Android 11 using a debug build from Android Studio
2. In Android Studio open Logcat. Select test device, de.rki.coronawarnapp.test app, Debug level and search for TraceWarningSyncTool
3. Back in CWA, in Start Screen, tap three-dot icon
4. Tap "App Information"
5. Tap "Error Reports"
6. Tap "START" if the display does not already show "Recording Active" 