### PR TITLE
Align Bluetooth incompatibility message with Google (COMMUNITY)

### DIFF
--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -2031,9 +2031,9 @@
     <!-- XHED: Incompitability card title -->
     <string name="incompatible_headline">"Incompatibility Warning"</string>
     <!-- XTXT: Incompitability card content -->
-    <string name="incompatible_advertising_not_supported">"Your smartphone can only receive COVID-19 notifications via Bluetooth, but not send them. This means you can be warned of exposures through this interface, but you cannot warn others of exposures yourself. You can send and receive warnings that result from check-ins."</string>
+    <string name="incompatible_advertising_not_supported">"Your smartphone can only receive COVID-19 Exposure Notifications via Bluetooth, but not send them. This means you can be warned of exposures through this interface, but you cannot warn others of exposures yourself. You can send and receive warnings that result from check-ins."</string>
     <!-- XTXT: Incompitability card content -->
-    <string name="incompatible_scanning_not_supported">"Your smartphone cannot send or receive COVID-19 notifications via Bluetooth. You can send and receive warnings that result from check-ins."</string>
+    <string name="incompatible_scanning_not_supported">"Your smartphone cannot send or receive COVID-19 Exposure Notifications via Bluetooth. You can send and receive warnings that result from check-ins."</string>
     <!-- XTXT: Incompatibility faq link for partial incompatibility -->
     <string name="incompatible_link_advertising_not_supported">"https://www.coronawarn.app/en/faq/#part_incompat"</string>
     <!-- XTXT: Incompatibility faq link for full incompatibility -->


### PR DESCRIPTION
This PR follows on from https://github.com/corona-warn-app/cwa-app-android/pull/3101#issuecomment-841121287 of @ralfgehrer to submit a separate PR on top of the merged PR https://github.com/corona-warn-app/cwa-app-android/pull/3101. It changes the term "COVID-19 notifications" in default strings `incompatible_advertising_not_supported` and  `incompatible_scanning_not_supported` to "COVID-19 Exposure Notifications" to match the term exactly, as used by the Google user interface.

`incompatible_scanning_not_supported` is changed to the following:

![Changed Incompatibility Warning](https://user-images.githubusercontent.com/66998419/118392480-4102e800-b63a-11eb-9265-b0913d0ba6aa.jpg)

`incompatible_advertising_not_supported`  is also changed correspondingly.

---
Reference text is from
Android Settings > Google which shows "COVID-19 Exposure Notifications" in the section "COVID-19 SUPPORT".

![Google COVID-19 Exposure Notifications](https://user-images.githubusercontent.com/66998419/118392559-8cb59180-b63a-11eb-9bb4-fdef2b0a3376.jpg)

---
The translation system should transfer this text to the EN instance of strings.xml. (https://github.com/corona-warn-app/cwa-app-android/blob/release/2.3.x/Corona-Warn-App/src/main/res/values-en/strings.xml).

Sanity check of change done through Pixel 3a Emulator on Android 10 (API 29), which has no Bluetooth support, and locale set to Español (Estados Unidos) with no other languages supported by CWA in the locale list.

CC: @fynngodau 

---
Internal Tracking ID: [EXPOSUREAPP-7118](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-7118)
