### PR TITLE
Hide spinner on scan screen by default (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/fragment_scan_qr_code.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_scan_qr_code.xml
@@ -48,6 +48,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/spacing_normal"
         android:indeterminate="true"
+        android:visibility="invisible"
         app:indicatorColor="@android:color/white"
         app:indicatorSize="64dp"
         app:trackColor="@android:color/transparent"


### PR DESCRIPTION
I broke this last week when I added the spinner. Needs to be hidden initially, so it does not show on the Check-in scan screen.
