### PR TITLE
Remove fitsSystemWindows from fragments (EXPOSUREAPP-7366,EXPOSUREAPP-7368)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/contact_diary_add_location_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/contact_diary_add_location_fragment.xml
@@ -4,7 +4,6 @@
     android:layout_height="match_parent"
     android:background="@color/colorBackground"
     android:fillViewport="true"
-    android:fitsSystemWindows="true"
     android:transitionName="contact_diary_shared_content">
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/Corona-Warn-App/src/main/res/layout/contact_diary_add_person_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/contact_diary_add_person_fragment.xml
@@ -2,9 +2,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fillViewport="true"
     android:background="@color/colorBackground"
-    android:fitsSystemWindows="true"
+    android:fillViewport="true"
     android:transitionName="contact_diary_shared_content">
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -20,9 +19,9 @@
             android:layout_marginTop="@dimen/spacing_tiny"
             android:contentDescription="@string/accessibility_close"
             android:padding="@dimen/spacing_mega_tiny"
-            app:srcCompat="@drawable/ic_close"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/ic_close" />
 
         <TextView
             android:id="@+id/contact_diary_person_title"
@@ -44,9 +43,9 @@
             android:layout_marginEnd="@dimen/spacing_tiny"
             android:contentDescription="@string/contact_diary_delete_icon_content_description"
             android:padding="@dimen/button_icon_padding"
-            app:srcCompat="@drawable/ic_baseline_delete"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/ic_baseline_delete" />
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/person_name_input_layout"
@@ -65,12 +64,12 @@
                 android:id="@+id/person_name_input"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:focusable="true"
                 android:imeOptions="actionNext"
                 android:inputType="textCapWords"
-                android:focusable="true"
                 android:maxLength="250" />
 
-            <requestFocus/>
+            <requestFocus />
 
         </com.google.android.material.textfield.TextInputLayout>
 

--- a/Corona-Warn-App/src/main/res/layout/fragment_confirm_check_in.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_confirm_check_in.xml
@@ -64,7 +64,6 @@
                     android:id="@+id/toolbar"
                     android:layout_width="match_parent"
                     android:layout_height="?attr/actionBarSize"
-                    android:fitsSystemWindows="true"
                     app:layout_collapseMode="pin"
                     app:layout_scrollFlags="scroll|enterAlways"
                     app:navigationIcon="@drawable/ic_close"

--- a/Corona-Warn-App/src/main/res/layout/fragment_edit_check_in.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_edit_check_in.xml
@@ -67,7 +67,6 @@
                     android:id="@+id/toolbar"
                     android:layout_width="match_parent"
                     android:layout_height="?attr/actionBarSize"
-                    android:fitsSystemWindows="true"
                     app:layout_collapseMode="pin"
                     app:layout_scrollFlags="scroll|enterAlways"
                     app:navigationIcon="@drawable/ic_close"


### PR DESCRIPTION
- Remove fitsSystemWindows from fragments, it is causing some overlay when keyboard is open
- this is flag is set now in the main activity layout and it should apply to all hosted fragments 
- One screen should have been fixed by @chiljamgossow  before , but it seems it is lost somehow 