### PR TITLE
Add missing "Uhr" indicator to check in duration (EXPOSUREAPP-6440)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/items/PastCheckInVH.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/items/PastCheckInVH.kt
@@ -36,7 +36,10 @@ class PastCheckInVH(parent: ViewGroup) :
         description.text = curItem.checkin.description
         address.text = curItem.checkin.address
 
-        checkoutInfo.text = context.getString(R.string.trace_location_attendee_past_event_duration, curItem.checkin.checkoutInfo)
+        checkoutInfo.text = context.getString(
+            R.string.trace_location_attendee_past_event_duration,
+            curItem.checkin.checkoutInfo
+        )
 
         menuAction.setupMenu(R.menu.menu_trace_location_attendee_checkin_item) {
             when (it.itemId) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/items/PastCheckInVH.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/items/PastCheckInVH.kt
@@ -36,7 +36,7 @@ class PastCheckInVH(parent: ViewGroup) :
         description.text = curItem.checkin.description
         address.text = curItem.checkin.address
 
-        checkoutInfo.text = curItem.checkin.checkoutInfo
+        checkoutInfo.text = context.getString(R.string.trace_location_attendee_past_event_duration, curItem.checkin.checkoutInfo)
 
         menuAction.setupMenu(R.menu.menu_trace_location_attendee_checkin_item) {
             when (it.itemId) {

--- a/Corona-Warn-App/src/main/res/values-de/event_registration_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/event_registration_strings.xml
@@ -211,6 +211,8 @@
     <string name="trace_location_organizer_detail_item_duration">"%1$s, %2$s - %3$s Uhr"</string>
     <!-- XTXT: Event organizer detail qr-code: duration with multiple date -->
     <string name="trace_location_organizer_detail_item_duration_multiple_days">"%1$s, %2$s - %3$s, %4$s Uhr"</string>
+    <!-- XTXT: Past Event Info duration -->
+    <string name="trace_location_attendee_past_event_duration">"%1$s"</string>
 
     <!-- XBUT: Event organiser list item: menu: information button  -->
     <string name="trace_location_organizer_list_item_menu_duplicate_btn">"Duplizieren"</string>

--- a/Corona-Warn-App/src/main/res/values/event_registration_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/event_registration_strings.xml
@@ -210,6 +210,8 @@
     <string name="trace_location_organizer_detail_item_duration">"%1$s, %2$s - %3$s"</string>
     <!-- XTXT: Event organizer detail qr-code: duration with multiple date -->
     <string name="trace_location_organizer_detail_item_duration_multiple_days">"%1$s, %2$s - %3$s, %4$s"</string>
+    <!-- XTXT: Past Event Info duration -->
+    <string name="trace_location_attendee_past_event_duration">"%1$s Uhr"</string>
 
     <!-- XBUT: Event organiser list item: menu: information button  -->
     <string name="trace_location_organizer_list_item_menu_duplicate_btn">"Duplicate"</string>


### PR DESCRIPTION
Small PR that adds the string "Uhr" to past events in my Check Ins.

![image](https://user-images.githubusercontent.com/75120552/119098796-83e80580-ba16-11eb-9bdb-8745a69b9f91.png)
