### PR TITLE
Reduce config check timeout for the update checker (EXPOSUREAPP-6101)

### DIFF
--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/update/UpdateCheckerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/update/UpdateCheckerTest.kt
@@ -126,6 +126,5 @@ class UpdateCheckerTest : BaseTest() {
             isUpdateNeeded shouldBe false
             updateIntent shouldBe null
         }
-
     }
 }


### PR DESCRIPTION
By 50% to reduce app blocking on launch due to bad internet or firewalls.