### PR TITLE
Added missing Dark Mode Icons (EXPOSUREAPP-7399)

### DIFF
--- a/Corona-Warn-App/src/main/res/drawable-night/ic_hourglass.xml
+++ b/Corona-Warn-App/src/main/res/drawable-night/ic_hourglass.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="40dp"
+    android:height="40dp"
+    android:viewportWidth="40"
+    android:viewportHeight="40">
+  <path
+      android:pathData="M20,20m-20,0a20,20 0,1 1,40 0a20,20 0,1 1,-40 0"
+      android:fillColor="#434445"/>
+  <path
+      android:pathData="M14,10V16H14.01L14,16.01L18,20L14,24L14.01,24.01H14V30H26V24.01H25.99L26,24L22,20L26,16.01L25.99,16H26V10H14ZM24,24.5V28H16V24.5L20,20.5L24,24.5ZM16,12V15.5L20,19.5L24,15.5V12H16Z"
+      android:fillColor="#83D2F2"
+      android:fillType="evenOdd"/>
+</vector>

--- a/Corona-Warn-App/src/main/res/drawable-night/ic_test_result_step_deletion.xml
+++ b/Corona-Warn-App/src/main/res/drawable-night/ic_test_result_step_deletion.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="40dp"
+    android:height="40dp"
+    android:viewportWidth="40"
+    android:viewportHeight="40">
+  <path
+      android:pathData="M20,20m-20,0a20,20 0,1 1,40 0a20,20 0,1 1,-40 0"
+      android:fillColor="#434445"/>
+  <path
+      android:pathData="M24,17V27H16V17H24ZM22.5,11H17.5L16.5,12H13V14H27V12H23.5L22.5,11ZM26,15H14V27C14,28.1 14.9,29 16,29H24C25.1,29 26,28.1 26,27V15Z"
+      android:fillColor="#83D2F2"/>
+</vector>


### PR DESCRIPTION
Adds two dark mode items, one for InvalidTestResult and one for PendingTestResult

![image](https://user-images.githubusercontent.com/75120552/119125723-6de83e00-ba32-11eb-9d82-f0901293a601.png)
![image](https://user-images.githubusercontent.com/75120552/119126337-34640280-ba33-11eb-982f-5f00423833d6.png)
