### PR TITLE
Invalid QR dialog wrong button functions (EXPOSUREAPP-7341)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/scan/SubmissionQRCodeScanFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/scan/SubmissionQRCodeScanFragment.kt
@@ -150,7 +150,7 @@ class SubmissionQRCodeScanFragment : Fragment(R.layout.fragment_submission_qr_co
                 R.string.submission_qr_code_scan_invalid_dialog_button_negative,
                 true,
                 { startDecode() },
-                ::navigateToDispatchScreen
+                { viewModel.onBackPressed() }
             )
             is CwaClientError, is CwaServerError -> DialogHelper.DialogInstance(
                 requireActivity(),

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/scan/SubmissionQRCodeScanFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/scan/SubmissionQRCodeScanFragment.kt
@@ -82,7 +82,7 @@ class SubmissionQRCodeScanFragment : Fragment(R.layout.fragment_submission_qr_co
 
         viewModel.qrCodeValidationState.observe2(this) {
             if (QrCodeRegistrationStateProcessor.ValidationState.INVALID == it) {
-                DialogHelper.showDialog(showInvalidScanDialog())
+                DialogHelper.showDialog(createInvalidScanDialog())
             }
         }
 
@@ -142,7 +142,7 @@ class SubmissionQRCodeScanFragment : Fragment(R.layout.fragment_submission_qr_co
 
     private fun buildErrorDialog(exception: CwaWebException): DialogHelper.DialogInstance {
         return when (exception) {
-            is BadRequestException -> showInvalidScanDialog()
+            is BadRequestException -> createInvalidScanDialog()
             is CwaClientError, is CwaServerError -> DialogHelper.DialogInstance(
                 requireActivity(),
                 R.string.submission_error_dialog_web_generic_error_title,
@@ -168,7 +168,7 @@ class SubmissionQRCodeScanFragment : Fragment(R.layout.fragment_submission_qr_co
         SubmissionQRCodeScanFragmentDirections.actionSubmissionQRCodeScanFragmentToSubmissionDispatcherFragment()
     )
 
-    private fun showInvalidScanDialog() = DialogHelper.DialogInstance(
+    private fun createInvalidScanDialog() = DialogHelper.DialogInstance(
         requireActivity(),
         R.string.submission_qr_code_scan_invalid_dialog_headline,
         R.string.submission_qr_code_scan_invalid_dialog_body,

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/scan/SubmissionQRCodeScanFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/scan/SubmissionQRCodeScanFragment.kt
@@ -82,8 +82,12 @@ class SubmissionQRCodeScanFragment : Fragment(R.layout.fragment_submission_qr_co
 
         viewModel.qrCodeValidationState.observe2(this) {
             if (QrCodeRegistrationStateProcessor.ValidationState.INVALID == it) {
-                showInvalidScanDialog()
+                DialogHelper.showDialog(showInvalidScanDialog())
             }
+        }
+
+        viewModel.registrationError.observe2(this) {
+            DialogHelper.showDialog(buildErrorDialog(it))
         }
         viewModel.showRedeemedTokenWarning.observe2(this) {
             val dialog = DialogHelper.DialogInstance(
@@ -128,10 +132,6 @@ class SubmissionQRCodeScanFragment : Fragment(R.layout.fragment_submission_qr_co
                 }
             }.run { doNavigate(this) }
         }
-
-        viewModel.registrationError.observe2(this) {
-            DialogHelper.showDialog(buildErrorDialog(it))
-        }
     }
 
     private fun startDecode() {
@@ -142,17 +142,7 @@ class SubmissionQRCodeScanFragment : Fragment(R.layout.fragment_submission_qr_co
 
     private fun buildErrorDialog(exception: CwaWebException): DialogHelper.DialogInstance {
         return when (exception) {
-            is BadRequestException -> DialogHelper.DialogInstance(
-                requireActivity(),
-                R.string.submission_qr_code_scan_invalid_dialog_headline,
-                R.string.submission_qr_code_scan_invalid_dialog_body,
-                R.string.submission_qr_code_scan_invalid_dialog_button_positive,
-                R.string.submission_qr_code_scan_invalid_dialog_button_negative,
-                true,
-                { startDecode() },
-                { viewModel.onBackPressed() },
-                { viewModel.onBackPressed() }
-            )
+            is BadRequestException -> showInvalidScanDialog()
             is CwaClientError, is CwaServerError -> DialogHelper.DialogInstance(
                 requireActivity(),
                 R.string.submission_error_dialog_web_generic_error_title,
@@ -178,20 +168,17 @@ class SubmissionQRCodeScanFragment : Fragment(R.layout.fragment_submission_qr_co
         SubmissionQRCodeScanFragmentDirections.actionSubmissionQRCodeScanFragmentToSubmissionDispatcherFragment()
     )
 
-    private fun showInvalidScanDialog() {
-        val invalidScanDialogInstance = DialogHelper.DialogInstance(
-            requireActivity(),
-            R.string.submission_qr_code_scan_invalid_dialog_headline,
-            R.string.submission_qr_code_scan_invalid_dialog_body,
-            R.string.submission_qr_code_scan_invalid_dialog_button_positive,
-            R.string.submission_qr_code_scan_invalid_dialog_button_negative,
-            true,
-            ::startDecode,
-            ::navigateToDispatchScreen
-        )
-
-        DialogHelper.showDialog(invalidScanDialogInstance)
-    }
+    private fun showInvalidScanDialog() = DialogHelper.DialogInstance(
+        requireActivity(),
+        R.string.submission_qr_code_scan_invalid_dialog_headline,
+        R.string.submission_qr_code_scan_invalid_dialog_body,
+        R.string.submission_qr_code_scan_invalid_dialog_button_positive,
+        R.string.submission_qr_code_scan_invalid_dialog_button_negative,
+        true,
+        { startDecode() },
+        { viewModel.onBackPressed() },
+        { viewModel.onBackPressed() }
+    )
 
     override fun onRequestPermissionsResult(
         requestCode: Int,

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/scan/SubmissionQRCodeScanFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/scan/SubmissionQRCodeScanFragment.kt
@@ -150,6 +150,7 @@ class SubmissionQRCodeScanFragment : Fragment(R.layout.fragment_submission_qr_co
                 R.string.submission_qr_code_scan_invalid_dialog_button_negative,
                 true,
                 { startDecode() },
+                { viewModel.onBackPressed() },
                 { viewModel.onBackPressed() }
             )
             is CwaClientError, is CwaServerError -> DialogHelper.DialogInstance(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/DialogHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/DialogHelper.kt
@@ -23,7 +23,8 @@ object DialogHelper {
         val cancelable: Boolean? = true,
         val isTextSelectable: Boolean = false,
         val positiveButtonFunction: () -> Unit? = {},
-        val negativeButtonFunction: () -> Unit? = {}
+        val negativeButtonFunction: () -> Unit? = {},
+        val cancelFunction: () -> Unit? = {}
     ) {
         constructor(
             context: Context,
@@ -33,7 +34,8 @@ object DialogHelper {
             negativeButton: Int? = null,
             cancelable: Boolean? = true,
             positiveButtonFunction: () -> Unit? = {},
-            negativeButtonFunction: () -> Unit? = {}
+            negativeButtonFunction: () -> Unit? = {},
+            cancelFunction: () -> Unit? = {}
         ) : this(
             context = context,
             title = context.resources.getString(title),
@@ -42,7 +44,8 @@ object DialogHelper {
             negativeButton = negativeButton?.let { context.resources.getString(it) },
             cancelable = cancelable,
             positiveButtonFunction = positiveButtonFunction,
-            negativeButtonFunction = negativeButtonFunction
+            negativeButtonFunction = negativeButtonFunction,
+            cancelFunction = cancelFunction
         )
 
         constructor(
@@ -92,7 +95,9 @@ object DialogHelper {
                     ) { _, _ ->
                         dialogInstance.negativeButtonFunction()
                     }
-                    setOnCancelListener { dialogInstance.negativeButtonFunction() }
+                }
+                if(dialogInstance.cancelFunction != null) {
+                    setOnCancelListener { dialogInstance.cancelFunction() }
                 }
             }
             builder.create()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/DialogHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/DialogHelper.kt
@@ -56,7 +56,8 @@ object DialogHelper {
             negativeButton: Int? = null,
             cancelable: Boolean? = true,
             positiveButtonFunction: () -> Unit? = {},
-            negativeButtonFunction: () -> Unit? = {}
+            negativeButtonFunction: () -> Unit? = {},
+            cancelFunction: () -> Unit? = {}
         ) : this(
             context = context,
             title = context.resources.getString(title),
@@ -65,7 +66,8 @@ object DialogHelper {
             negativeButton = negativeButton?.let { context.resources.getString(it) },
             cancelable = cancelable,
             positiveButtonFunction = positiveButtonFunction,
-            negativeButtonFunction = negativeButtonFunction
+            negativeButtonFunction = negativeButtonFunction,
+            cancelFunction = cancelFunction
         )
     }
 
@@ -96,9 +98,7 @@ object DialogHelper {
                         dialogInstance.negativeButtonFunction()
                     }
                 }
-                if (dialogInstance.cancelFunction != null) {
-                    setOnCancelListener { dialogInstance.cancelFunction() }
-                }
+                setOnCancelListener { dialogInstance.cancelFunction() }
             }
             builder.create()
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/DialogHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/DialogHelper.kt
@@ -92,6 +92,7 @@ object DialogHelper {
                     ) { _, _ ->
                         dialogInstance.negativeButtonFunction()
                     }
+                    setOnCancelListener { dialogInstance.negativeButtonFunction() }
                 }
             }
             builder.create()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/DialogHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/DialogHelper.kt
@@ -96,7 +96,7 @@ object DialogHelper {
                         dialogInstance.negativeButtonFunction()
                     }
                 }
-                if(dialogInstance.cancelFunction != null) {
+                if (dialogInstance.cancelFunction != null) {
                     setOnCancelListener { dialogInstance.cancelFunction() }
                 }
             }


### PR DESCRIPTION
Fixes an issue where the back button dismissed the dialog but the cancel button on the dialog would navigate you back to the previous screen. 
Now pressing the back button or the cancel button on the dialog will have the same effect.

Test by scanning an invalid corona test QR code.