### PR TITLE
Catch debug log FileNotFoundExceptions (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/debuglog/internal/LogWriter.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/debuglog/internal/LogWriter.kt
@@ -52,7 +52,10 @@ class LogWriter @Inject constructor(val logFile: File) {
                 logFile.parentFile?.mkdirs()
                 logFile.createNewFile()
                 logFile.writeText("Logfile was deleted.\n")
+
                 performWrite()
+
+                updateLogSize()
             } catch (e: Exception) {
                 Log.e(TAG, "LogWrite retry failed, something is just wrong...", e)
                 return@withLock

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/debuglog/internal/LogWriter.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/debuglog/internal/LogWriter.kt
@@ -1,12 +1,17 @@
 package de.rki.coronawarnapp.bugreporting.debuglog.internal
 
+import android.annotation.SuppressLint
+import android.util.Log
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import timber.log.Timber
 import java.io.File
+import java.io.FileNotFoundException
 import javax.inject.Inject
 
+@Suppress("BlockingMethodInNonBlockingContext")
+@SuppressLint("LogNotTimber")
 class LogWriter @Inject constructor(val logFile: File) {
     private var ioLimiter = 0
     private val mutex = Mutex()
@@ -34,12 +39,34 @@ class LogWriter @Inject constructor(val logFile: File) {
     }
 
     suspend fun write(formattedLine: String): Unit = mutex.withLock {
-        logFile.appendText(formattedLine + "\n", Charsets.UTF_8)
+        val performWrite = {
+            logFile.appendText(formattedLine + "\n", Charsets.UTF_8)
+        }
+
+        try {
+            performWrite()
+        } catch (e: FileNotFoundException) {
+            Log.e(TAG, "Log file didn't exist when we tried to write, retry.")
+
+            try {
+                logFile.parentFile?.mkdirs()
+                logFile.createNewFile()
+                logFile.writeText("Logfile was deleted.\n")
+                performWrite()
+            } catch (e: Exception) {
+                Log.e(TAG, "LogWrite retry failed, something is just wrong...", e)
+                return@withLock
+            }
+        }
 
         if (ioLimiter % 10 == 0) {
             updateLogSize()
             ioLimiter = 0
         }
         ioLimiter++
+    }
+
+    companion object {
+        private const val TAG = "LogWriter"
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/debuglog/internal/LogWriterTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/debuglog/internal/LogWriterTest.kt
@@ -45,4 +45,23 @@ class LogWriterTest : BaseIOTest() {
             logSize.value shouldBe 0L
         }
     }
+
+    /**
+     * e.g. System cache cleaning interferring
+     */
+    @Test
+    fun `if the file is deleted after setup we try to recreate it and do not crash`() = runBlockingTest {
+        createInstance().apply {
+            setup()
+            write("ABC")
+            logFile.readText() shouldBe "ABC\n"
+
+            logFile.delete()
+            logFile.parentFile!!.delete()
+            logFile.exists() shouldBe false
+
+            write("DEF")
+            logFile.readText() shouldBe "Logfile was deleted.\nDEF\n"
+        }
+    }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/debuglog/internal/LogWriterTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/debuglog/internal/LogWriterTest.kt
@@ -56,12 +56,16 @@ class LogWriterTest : BaseIOTest() {
             write("ABC")
             logFile.readText() shouldBe "ABC\n"
 
+            logSize.value shouldBe 4L
+
             logFile.delete()
             logFile.parentFile!!.delete()
             logFile.exists() shouldBe false
 
             write("DEF")
             logFile.readText() shouldBe "Logfile was deleted.\nDEF\n"
+
+            logSize.value shouldBe 25L
         }
     }
 }


### PR DESCRIPTION
* On low storage, the system may clean caches without asking.
* If the parent dir of the debuglog is deleted, writing will fail with an exception.
* Catch that exception, and try to recreate the path+file.
* Write an initial log line that the log was deleted, then continue.
* If all fails, log the error to logcat and just skip.