### PR TITLE
Contact Diary data is written in clear text into error log on data deletion (EXPOSUREAPP-7408)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryEncounterCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryEncounterCensor.kt
@@ -1,6 +1,5 @@
 package de.rki.coronawarnapp.bugreporting.censors.contactdiary
 
-import com.google.common.collect.ImmutableSet
 import dagger.Reusable
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.CensoredString
@@ -39,9 +38,7 @@ class DiaryEncounterCensor @Inject constructor(
 
         if (encounterHistory.isEmpty()) return null
 
-        val immutableHistory = ImmutableSet.copyOf(encounterHistory)
-
-        val newMessage = immutableHistory.fold(CensoredString(message)) { orig, encounter ->
+        val newMessage = encounterHistory.fold(CensoredString(message)) { orig, encounter ->
             var wip = orig
 
             withValidComment(encounter.circumstances) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryEncounterCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryEncounterCensor.kt
@@ -8,12 +8,11 @@ import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.plus
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.toNullIfUnmodified
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidComment
 import de.rki.coronawarnapp.bugreporting.debuglog.internal.DebuggerScope
+import de.rki.coronawarnapp.contactdiary.model.ContactDiaryPersonEncounter
 import de.rki.coronawarnapp.contactdiary.storage.repo.ContactDiaryRepository
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
 @Reusable
@@ -22,20 +21,18 @@ class DiaryEncounterCensor @Inject constructor(
     diary: ContactDiaryRepository
 ) : BugCensor {
 
-    private val encounters by lazy {
-        diary.personEncounters.stateIn(
-            scope = debugScope,
-            started = SharingStarted.Lazily,
-            initialValue = null
-        ).filterNotNull()
+    // We keep a history of all encounters so that we can censor them even after they got deleted
+    private val encounterHistory = mutableSetOf<ContactDiaryPersonEncounter>()
+
+    init {
+        diary.personEncounters.onEach { encounterHistory.addAll(it) }.launchIn(debugScope)
     }
 
     override suspend fun checkLog(message: String): CensoredString? {
-        val encountersNow = encounters.first().filter { !it.circumstances.isNullOrBlank() }
 
-        if (encountersNow.isEmpty()) return null
+        if (encounterHistory.isEmpty()) return null
 
-        val newMessage = encountersNow.fold(CensoredString(message)) { orig, encounter ->
+        val newMessage = encounterHistory.fold(CensoredString(message)) { orig, encounter ->
             var wip = orig
 
             withValidComment(encounter.circumstances) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryLocationCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryLocationCensor.kt
@@ -30,7 +30,9 @@ class DiaryLocationCensor @Inject constructor(
     private var locationHistory = mutableSetOf<ContactDiaryLocation>()
 
     init {
-        diary.locations.onEach { locationHistory.addAll(it) }.launchIn(debugScope)
+        diary.locations
+            .onEach { mutex.withLock { locationHistory.addAll(it) } }
+            .launchIn(debugScope)
     }
 
     override suspend fun checkLog(message: String): CensoredString? = mutex.withLock {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryLocationCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryLocationCensor.kt
@@ -10,12 +10,13 @@ import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidEm
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidName
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidPhoneNumber
 import de.rki.coronawarnapp.bugreporting.debuglog.internal.DebuggerScope
+import de.rki.coronawarnapp.contactdiary.model.ContactDiaryLocation
 import de.rki.coronawarnapp.contactdiary.storage.repo.ContactDiaryRepository
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 
 @Reusable
@@ -24,20 +25,19 @@ class DiaryLocationCensor @Inject constructor(
     diary: ContactDiaryRepository
 ) : BugCensor {
 
-    private val locations by lazy {
-        diary.locations.stateIn(
-            scope = debugScope,
-            started = SharingStarted.Lazily,
-            initialValue = null
-        ).filterNotNull()
+    private val mutex = Mutex()
+
+    private var locationHistory = mutableSetOf<ContactDiaryLocation>()
+
+    init {
+        diary.locations.onEach { locationHistory.addAll(it) }.launchIn(debugScope)
     }
 
-    override suspend fun checkLog(message: String): CensoredString? {
-        val locationsNow = locations.first()
+    override suspend fun checkLog(message: String): CensoredString? = mutex.withLock {
 
-        if (locationsNow.isEmpty()) return null
+        if (locationHistory.isEmpty()) return null
 
-        val newMessage = locationsNow.fold(CensoredString(message)) { orig, location ->
+        val newMessage = locationHistory.fold(CensoredString(message)) { orig, location ->
             var wip = orig
 
             withValidName(location.locationName) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryPersonCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryPersonCensor.kt
@@ -31,7 +31,9 @@ class DiaryPersonCensor @Inject constructor(
     private val personHistory = mutableSetOf<ContactDiaryPerson>()
 
     init {
-        diary.people.onEach { personHistory.addAll(it) }.launchIn(debugScope)
+        diary.people
+            .onEach { mutex.withLock { personHistory.addAll(it) } }
+            .launchIn(debugScope)
     }
 
     override suspend fun checkLog(message: String): CensoredString? = mutex.withLock {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryPersonCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryPersonCensor.kt
@@ -23,7 +23,7 @@ class DiaryPersonCensor @Inject constructor(
     diary: ContactDiaryRepository
 ) : BugCensor {
 
-    // We keep a history of all stored persons so that we can censor them even after they got deleted
+    // We keep a history of all persons so that we can censor them even after they got deleted
     private val personHistory = mutableSetOf<ContactDiaryPerson>()
 
     init {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryVisitCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryVisitCensor.kt
@@ -30,7 +30,9 @@ class DiaryVisitCensor @Inject constructor(
         diary.locationVisits
             .onEach { locationVisitList ->
                 val visitsWithCircumstances = locationVisitList.filterNot { it.circumstances.isNullOrBlank() }
-                visitsHistory.addAll(visitsWithCircumstances)
+                mutex.withLock {
+                    visitsHistory.addAll(visitsWithCircumstances)
+                }
             }
             .launchIn(debugScope)
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/presencetracing/CheckInsCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/presencetracing/CheckInsCensor.kt
@@ -9,35 +9,34 @@ import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.toNullIfUnm
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidAddress
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidDescription
 import de.rki.coronawarnapp.bugreporting.debuglog.internal.DebuggerScope
+import de.rki.coronawarnapp.presencetracing.checkins.CheckIn
 import de.rki.coronawarnapp.presencetracing.checkins.CheckInRepository
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 
 @Reusable
 class CheckInsCensor @Inject constructor(
     @DebuggerScope debugScope: CoroutineScope,
-    private val checkInRepository: CheckInRepository
+    checkInRepository: CheckInRepository
 ) : BugCensor {
 
-    private val checkInsFlow by lazy {
-        checkInRepository.allCheckIns.stateIn(
-            scope = debugScope,
-            started = SharingStarted.Lazily,
-            initialValue = null
-        ).filterNotNull()
+    private val mutex = Mutex()
+
+    private val checkInsHistory = mutableSetOf<CheckIn>()
+
+    init {
+        checkInRepository.allCheckIns.onEach { checkInsHistory.addAll(it) }.launchIn(debugScope)
     }
 
-    override suspend fun checkLog(message: String): CensoredString? {
+    override suspend fun checkLog(message: String): CensoredString? = mutex.withLock {
 
-        val checkIns = checkInsFlow.first()
+        if (checkInsHistory.isEmpty()) return null
 
-        if (checkIns.isEmpty()) return null
-
-        val newLogMsg = checkIns.fold(CensoredString(message)) { initial, checkIn ->
+        val newLogMsg = checkInsHistory.fold(CensoredString(message)) { initial, checkIn ->
 
             var acc = initial
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/presencetracing/CheckInsCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/presencetracing/CheckInsCensor.kt
@@ -29,7 +29,9 @@ class CheckInsCensor @Inject constructor(
     private val checkInsHistory = mutableSetOf<CheckIn>()
 
     init {
-        checkInRepository.allCheckIns.onEach { checkInsHistory.addAll(it) }.launchIn(debugScope)
+        checkInRepository.allCheckIns
+            .onEach { mutex.withLock { checkInsHistory.addAll(it) } }
+            .launchIn(debugScope)
     }
 
     override suspend fun checkLog(message: String): CensoredString? = mutex.withLock {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/CoronaTestCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/CoronaTestCensor.kt
@@ -11,7 +11,6 @@ import de.rki.coronawarnapp.coronatest.CoronaTestRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.sync.Mutex
@@ -43,7 +42,6 @@ class CoronaTestCensor @Inject constructor(
     }
 
     override suspend fun checkLog(message: String): CensoredString? = mutex.withLock {
-        coronaTestFlow.first()
 
         var newMessage = CensoredString(message)
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RACoronaTestCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RACoronaTestCensor.kt
@@ -38,7 +38,7 @@ class RACoronaTestCensor @Inject constructor(
             .launchIn(debugScope)
     }
 
-    override suspend fun checkLog(message: String): CensoredString? {
+    override suspend fun checkLog(message: String): CensoredString? = mutex.withLock {
 
         var newMessage = CensoredString(message)
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RACoronaTestCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RACoronaTestCensor.kt
@@ -1,5 +1,6 @@
 package de.rki.coronawarnapp.bugreporting.censors.submission
 
+import com.google.common.collect.ImmutableSet
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.CensoredString
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.censor
@@ -10,48 +11,48 @@ import de.rki.coronawarnapp.bugreporting.debuglog.internal.DebuggerScope
 import de.rki.coronawarnapp.coronatest.CoronaTestRepository
 import de.rki.coronawarnapp.coronatest.type.rapidantigen.RACoronaTest
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.onEach
 import org.joda.time.format.DateTimeFormat
 import javax.inject.Inject
 
 class RACoronaTestCensor @Inject constructor(
     @DebuggerScope debugScope: CoroutineScope,
-    private val coronaTestRepository: CoronaTestRepository
+    coronaTestRepository: CoronaTestRepository
 ) : BugCensor {
 
     private val dayOfBirthFormatter = DateTimeFormat.forPattern("yyyy-MM-dd")
 
-    private val coronaTestFlow by lazy {
-        coronaTestRepository.coronaTests.stateIn(
-            scope = debugScope,
-            started = SharingStarted.Lazily,
-            initialValue = null
-        ).filterNotNull()
+    // We keep a history of rat corona test so that we are able to censor even after they got deleted
+    private val ratCoronaTestHistory = mutableSetOf<RACoronaTest>()
+
+    init {
+        coronaTestRepository
+            .coronaTests
+            .map { it.filterIsInstance<RACoronaTest>() }
+            .onEach { ratCoronaTestHistory.addAll(it) }
+            .launchIn(debugScope)
     }
 
     override suspend fun checkLog(message: String): CensoredString? {
 
-        val raCoronaTestFlow = coronaTestFlow.map { tests -> tests.filterIsInstance<RACoronaTest>() }.first()
-        val raCoronaTest = raCoronaTestFlow.firstOrNull() ?: return null
+        val immutableHistory = ImmutableSet.copyOf(ratCoronaTestHistory)
 
         var newMessage = CensoredString(message)
 
-        with(raCoronaTest) {
-            withValidName(firstName) { firstName ->
+        immutableHistory.forEach { ratCoronaTest ->
+            withValidName(ratCoronaTest.firstName) { firstName ->
                 newMessage += newMessage.censor(firstName, "RATest/FirstName")
             }
 
-            withValidName(lastName) { lastName ->
+            withValidName(ratCoronaTest.lastName) { lastName ->
                 newMessage += newMessage.censor(lastName, "RATest/LastName")
             }
 
-            val dateOfBirthString = dateOfBirth?.toString(dayOfBirthFormatter) ?: return@with
-
-            newMessage += newMessage.censor(dateOfBirthString, "RATest/DateOfBirth")
+            ratCoronaTest.dateOfBirth?.toString(dayOfBirthFormatter)?.let { dateOfBirthString ->
+                newMessage += newMessage.censor(dateOfBirthString, "RATest/DateOfBirth")
+            }
         }
 
         return newMessage.toNullIfUnmodified()

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/CensorInjectionTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/CensorInjectionTest.kt
@@ -13,7 +13,9 @@ import de.rki.coronawarnapp.submission.SubmissionSettings
 import io.github.classgraph.ClassGraph
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.shouldBe
+import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import timber.log.Timber
@@ -67,7 +69,12 @@ class MockProvider {
 
     @Singleton
     @Provides
-    fun diary(): ContactDiaryRepository = mockk()
+    fun diary(): ContactDiaryRepository = mockk() {
+        every { people } returns flowOf(emptyList())
+        every { personEncounters } returns flowOf(emptyList())
+        every { locations } returns flowOf(emptyList())
+        every { locationVisits } returns flowOf(emptyList())
+    }
 
     @Singleton
     @Provides
@@ -75,15 +82,21 @@ class MockProvider {
 
     @Singleton
     @Provides
-    fun coronaTestRepository(): CoronaTestRepository = mockk()
+    fun coronaTestRepository(): CoronaTestRepository = mockk() {
+        every { coronaTests } returns flowOf(emptySet())
+    }
 
     @Singleton
     @Provides
-    fun checkInRepository(): CheckInRepository = mockk()
+    fun checkInRepository(): CheckInRepository = mockk() {
+        every { allCheckIns } returns flowOf(emptyList())
+    }
 
     @Singleton
     @Provides
-    fun traceLocationRepository(): TraceLocationRepository = mockk()
+    fun traceLocationRepository(): TraceLocationRepository = mockk() {
+        every { allTraceLocations } returns flowOf(emptyList())
+    }
 
     @Singleton
     @Provides

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/CheckInsCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/CheckInsCensorTest.kt
@@ -85,13 +85,14 @@ internal class CheckInsCensorTest : BaseTest() {
                     checkInDescription = "Kwik-E-Mart",
                     checkInAddress = "Some Street, 12345 Springfield"
                 )
-            ), listOf(
+            ),
+            listOf(
                 mockCheckIn(
                     checkInId = 1,
                     checkInDescription = "Moe's Tavern",
                     checkInAddress = "Near 742 Evergreen Terrace, 12345 Springfield"
                 ),
-                /* deleted: mockCheckIn(
+                            /* deleted: mockCheckIn(
                     checkInId = 2,
                     checkInDescription = "Kwik-E-Mart",
                     checkInAddress = "Some Street, 12345 Springfield"

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/CheckInsCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/CheckInsCensorTest.kt
@@ -41,7 +41,7 @@ internal class CheckInsCensorTest : BaseTest() {
     }
 
     @Test
-    fun `checkLog() should return LogLine with censored check-in information`() = runBlocking {
+    fun `checkLog() should return LogLine with censored check-in information`() = runBlockingTest {
         every { checkInsRepo.allCheckIns } returns flowOf(
             listOf(
                 mockCheckIn(

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryEncounterCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryEncounterCensorTest.kt
@@ -63,9 +63,31 @@ class DiaryEncounterCensorTest : BaseTest() {
             two persons Encounter#3/Circumstances,
             everyone disliked that.
             """.trimIndent()
+    }
 
-        // censoring should still work after encounters are deleted
-        every { diaryRepo.personEncounters } returns flowOf(emptyList())
+    @Test
+    fun `censoring should still work after encounters are deleted`() = runBlockingTest {
+        every { diaryRepo.personEncounters } returns flowOf(
+            listOf(
+                mockEncounter(1, _circumstances = ""),
+                mockEncounter(2, _circumstances = "A rainy day"),
+                mockEncounter(3, "Spilled coffee on each others laptops")
+            ),
+            listOf(
+                mockEncounter(1, _circumstances = ""),
+               // "a rainy day" was deleted
+                mockEncounter(3, "Spilled coffee on each others laptops")
+            )
+        )
+
+        val instance = createInstance(this)
+        val censorMe =
+            """
+            On A rainy day,
+            two persons Spilled coffee on each others laptops,
+            everyone disliked that.
+            """.trimIndent()
+
         instance.checkLog(censorMe)!!.string shouldBe
             """
             On Encounter#2/Circumstances,

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryEncounterCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryEncounterCensorTest.kt
@@ -75,7 +75,7 @@ class DiaryEncounterCensorTest : BaseTest() {
             ),
             listOf(
                 mockEncounter(1, _circumstances = ""),
-               // "a rainy day" was deleted
+                // "a rainy day" was deleted
                 mockEncounter(3, "Spilled coffee on each others laptops")
             )
         )

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryPersonCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryPersonCensorTest.kt
@@ -66,9 +66,31 @@ class DiaryPersonCensorTest : BaseTest() {
             but Person#3/Name thought he had enough has had enough for today.
             A quick mail to Person#1/EMail confirmed this.
             """.trimIndent()
+    }
 
-        // censoring should still work after people are deleted
-        every { diaryRepo.people } returns flowOf(emptyList())
+    @Test
+    fun `censoring should still work after people are deleted`() = runBlockingTest {
+        every { diaryRepo.people } returns flowOf(
+            listOf(
+                mockPerson(1, "Luka", phone = "+49 1234 7777", mail = "luka@sap.com"),
+                mockPerson(2, "Ralf", phone = null, mail = null),
+                mockPerson(3, "Matthias", phone = null, mail = "matthias@sap.com")
+            ),
+            listOf(
+                mockPerson(1, "Luka", phone = "+49 1234 7777", mail = "luka@sap.com"),
+                mockPerson(2, "Ralf", phone = null, mail = null),
+                // Matthias was deleted
+            )
+        )
+
+        val instance = createInstance(this)
+        val censorMe =
+            """
+            Ralf requested more coffee from +49 1234 7777,
+            but Matthias thought he had enough has had enough for today.
+            A quick mail to luka@sap.com confirmed this.
+            """.trimIndent()
+
         instance.checkLog(censorMe)!!.string shouldBe
             """
             Person#2/Name requested more coffee from Person#1/PhoneNumber,

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryVisitCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryVisitCensorTest.kt
@@ -61,9 +61,29 @@ class DiaryVisitCensorTest : BaseTest() {
             I got my Visit#2/Circumstances,
             only to find out the supermarket was Visit#3/Circumstances.
             """.trimIndent()
+    }
 
-        // censoring should still work even after visits are deleted
-        every { diaryRepo.locationVisits } returns flowOf(emptyList())
+    @Test
+    fun `censor should still work even after visits are deleted`() = runBlockingTest {
+        every { diaryRepo.locationVisits } returns flowOf(
+            listOf(
+                mockVisit(1, _circumstances = "Döner that was too spicy"),
+                mockVisit(2, _circumstances = "beard shaved without mask"),
+                mockVisit(3, _circumstances = "out of toiletpaper")
+            ),
+            listOf(
+                mockVisit(1, _circumstances = "Döner that was too spicy"),
+                // mockVisit(2, _circumstances = "beard shaved without mask"), => deleted
+                mockVisit(3, _circumstances = "out of toiletpaper")
+            )
+        )
+        val instance = createInstance(this)
+        val censorMe =
+            """
+            After having a Döner that was too spicy,
+            I got my beard shaved without mask,
+            only to find out the supermarket was out of toiletpaper.
+            """.trimIndent()
         instance.checkLog(censorMe)!!.string shouldBe
             """
             After having a Visit#1/Circumstances,

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/TraceLocationCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/TraceLocationCensorTest.kt
@@ -51,7 +51,7 @@ internal class TraceLocationCensorTest : BaseTest() {
     }
 
     @Test
-    fun `checkLog() should return LogLine with censored trace location information from repository`() = runBlocking {
+    fun `checkLog() should return LogLine with censored trace location information from repository`() = runBlockingTest {
         every { traceLocationRepo.allTraceLocations } returns flowOf(
             listOf(
                 mockTraceLocation(
@@ -82,9 +82,49 @@ internal class TraceLocationCensorTest : BaseTest() {
             The type is TraceLocation#2/Type. Yesterday we went to the TraceLocation#2/Description. The spectacle took place in TraceLocation#2/Address. 
             Afterwards we had some food in TraceLocation#1/Description in TraceLocation#1/Address. It a nice TraceLocation#1/Type.
             """.trimIndent()
+    }
 
-        // censoring should still work after the user deletes his trace locations
-        every { traceLocationRepo.allTraceLocations } returns flowOf(emptyList())
+    @Test
+    fun `censoring should still work after the user deletes his trace locations`() = runBlockingTest {
+
+        every { traceLocationRepo.allTraceLocations } returns flowOf(
+            listOf(
+                mockTraceLocation(
+                    traceLocationId = 1,
+                    traceLocationType = TraceLocationOuterClass.TraceLocationType.LOCATION_TYPE_PERMANENT_FOOD_SERVICE,
+                    traceLocationDescription = "Sushi Place",
+                    traceLocationAddress = "Sushi Street 123, 12345 Fish Town"
+                ),
+                mockTraceLocation(
+                    traceLocationId = 2,
+                    traceLocationType = TraceLocationOuterClass.TraceLocationType.LOCATION_TYPE_TEMPORARY_CULTURAL_EVENT,
+                    traceLocationDescription = "Rick Astley Concert",
+                    traceLocationAddress = "Never gonna give you up street 1, 12345 RickRoll City"
+                )
+            ),
+            listOf(
+                mockTraceLocation(
+                    traceLocationId = 1,
+                    traceLocationType = TraceLocationOuterClass.TraceLocationType.LOCATION_TYPE_PERMANENT_FOOD_SERVICE,
+                    traceLocationDescription = "Sushi Place",
+                    traceLocationAddress = "Sushi Street 123, 12345 Fish Town"
+                ),
+                /* deleted: mockTraceLocation(
+                    traceLocationId = 2,
+                    traceLocationType = TraceLocationOuterClass.TraceLocationType.LOCATION_TYPE_TEMPORARY_CULTURAL_EVENT,
+                    traceLocationDescription = "Rick Astley Concert",
+                    traceLocationAddress = "Never gonna give you up street 1, 12345 RickRoll City"
+                )*/
+            )
+        )
+
+        val censor = createInstance(this)
+
+        val logLineToCensor =
+            """
+            The type is LOCATION_TYPE_TEMPORARY_CULTURAL_EVENT. Yesterday we went to the Rick Astley Concert. The spectacle took place in Never gonna give you up street 1, 12345 RickRoll City. 
+            Afterwards we had some food in Sushi Place in Sushi Street 123, 12345 Fish Town. It a nice LOCATION_TYPE_PERMANENT_FOOD_SERVICE.
+            """.trimIndent()
 
         censor.checkLog(logLineToCensor)!!.string shouldBe
             """

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/submission/RatProfileCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/submission/RatProfileCensorTest.kt
@@ -8,6 +8,7 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runBlockingTest
 import org.joda.time.format.DateTimeFormat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -61,9 +62,17 @@ internal class RatProfileCensorTest : BaseTest() {
         censor.checkLog(logLine)!!.string shouldBe
             "Mister RAT-Profile/FirstName who is also known as RAT-Profile/LastName and is born on RAT-Profile/DateOfBirth lives in RAT-Profile/Street, " +
             "RAT-Profile/Zip-Code in the beautiful city of RAT-Profile/City. You can reach him by phone: RAT-Profile/Phone or email: RAT-Profile/eMail"
+        }
 
-        // censoring should still work after the user deletes his profile
-        every { ratProfileSettings.profile.flow } returns flowOf(null)
+    @Test
+    fun `censoring should still work after the user deletes his profile`() = runBlockingTest {
+        every { ratProfileSettings.profile.flow } returns flowOf(profile, null)
+
+        val censor = createInstance()
+
+        val logLine =
+            "Mister First name who is also known as Last name and is born on 1950-08-01 lives in Main street, " +
+                "12132 in the beautiful city of London. You can reach him by phone: 111111111 or email: email@example.com"
 
         censor.checkLog(logLine)!!.string shouldBe
             "Mister RAT-Profile/FirstName who is also known as RAT-Profile/LastName and is born on RAT-Profile/DateOfBirth lives in RAT-Profile/Street, " +

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/submission/RatProfileCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/submission/RatProfileCensorTest.kt
@@ -62,7 +62,7 @@ internal class RatProfileCensorTest : BaseTest() {
         censor.checkLog(logLine)!!.string shouldBe
             "Mister RAT-Profile/FirstName who is also known as RAT-Profile/LastName and is born on RAT-Profile/DateOfBirth lives in RAT-Profile/Street, " +
             "RAT-Profile/Zip-Code in the beautiful city of RAT-Profile/City. You can reach him by phone: RAT-Profile/Phone or email: RAT-Profile/eMail"
-        }
+    }
 
     @Test
     fun `censoring should still work after the user deletes his profile`() = runBlockingTest {


### PR DESCRIPTION
### Description
We have this problem that some of our censors read the data that needs to be censored directly from the database. However, when something is logged after the respective data is already removed, the censor can't censor anymore. 

This PR now updates these censors so that they keep the data in memory. Then, even after the data is removed from the database, we can still censor correctly. 

Actually, we had some tests that covered these scenarios, however, they were incorrect (false positive). 

### How to test
Delete
- Single Persons in the Contact Diary
- Single Locations in the Contact Diary
- CheckIns
- TraceLocations
=> Then export the error logs and check if all data got censored appropriately. 
