### PR TITLE
Correct typo in SettingsTracingFragment log message (COMMUNITY)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/TracingPermissionHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/TracingPermissionHelper.kt
@@ -54,7 +54,7 @@ class TracingPermissionHelper @AssistedInject constructor(
 
     fun handleActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
         Timber.v(
-            "handleActivityResult(requesutCode=%d, resultCode=%d, data=%s)",
+            "handleActivityResult(requestCode=%d, resultCode=%d, data=%s)",
             requestCode,
             resultCode,
             data


### PR DESCRIPTION
### Description

This PR corrects a typo of a message which may be output in a user visible Error Report, for example
`2021-05-25T09:21:15.389Z  V/SettingsTracingFragment: handleActivityResult(requesutCode=3010, resultCode=-1, data=null)`

The text "requesutCode" is changed to "requestCode".