### PR TITLE
Allow user locale to be passed manually for vacc certs to fix flaky test (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/vaccination/core/repository/storage/VaccinationContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/vaccination/core/repository/storage/VaccinationContainer.kt
@@ -51,7 +51,10 @@ data class VaccinationContainer internal constructor(
     val personIdentifier: VaccinatedPersonIdentifier
         get() = certificate.personIdentifier
 
-    fun toVaccinationCertificate(valueSet: VaccinationValueSet?) = object : VaccinationCertificate {
+    fun toVaccinationCertificate(
+        valueSet: VaccinationValueSet?,
+        userLocale: Locale = Locale.getDefault(),
+    ) = object : VaccinationCertificate {
         override val personIdentifier: VaccinatedPersonIdentifier
             get() = certificate.personIdentifier
 
@@ -83,9 +86,10 @@ data class VaccinationContainer internal constructor(
             get() = vaccination.certificateIssuer
         override val certificateCountry: String
             get() = Locale(
-                Locale.getDefault().language,
+                userLocale.language,
                 vaccination.countryOfVaccination.uppercase()
-            ).displayCountry
+            ).getDisplayCountry(userLocale)
+
         override val certificateId: String
             get() = vaccination.uniqueCertificateIdentifier
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/vaccination/core/repository/storage/VaccinationContainerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/vaccination/core/repository/storage/VaccinationContainerTest.kt
@@ -7,7 +7,6 @@ import de.rki.coronawarnapp.vaccination.core.server.valueset.VaccinationValueSet
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkObject
 import org.joda.time.Instant
 import org.joda.time.LocalDate
 import org.junit.jupiter.api.BeforeEach
@@ -23,7 +22,6 @@ class VaccinationContainerTest : BaseTest() {
     @BeforeEach
     fun setup() {
         DaggerVaccinationTestComponent.factory().create().inject(this)
-        mockkObject(Locale.getDefault())
     }
 
     @Test
@@ -62,8 +60,7 @@ class VaccinationContainerTest : BaseTest() {
 
     @Test
     fun `mapping to user facing data - valueset is null`() {
-        every { Locale.getDefault().language } returns "de"
-        testData.personAVac1Container.toVaccinationCertificate(null).apply {
+        testData.personAVac1Container.toVaccinationCertificate(null, userLocale = Locale.GERMAN).apply {
             firstName shouldBe "Andreas"
             lastName shouldBe "Astrá Eins"
             dateOfBirth shouldBe LocalDate.parse("1966-11-11")
@@ -110,9 +107,8 @@ class VaccinationContainerTest : BaseTest() {
             every { mp } returns vpMockk
             every { ma } returns vpMockk
         }
-        every { Locale.getDefault().language } returns "de"
 
-        testData.personAVac1Container.toVaccinationCertificate(valueSet).apply {
+        testData.personAVac1Container.toVaccinationCertificate(valueSet, userLocale = Locale.GERMAN).apply {
             firstName shouldBe "Andreas"
             lastName shouldBe "Astrá Eins"
             dateOfBirth shouldBe LocalDate.parse("1966-11-11")


### PR DESCRIPTION
Pass locale in test to avoid flaky test due to problematic mocking of Locale.getDefault().
