### PR TITLE
Adjust reference time for deadman notification (EXPOSUREAPP-7386)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/deadman/DeadmanNotificationTimeCalculation.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/deadman/DeadmanNotificationTimeCalculation.kt
@@ -2,6 +2,7 @@ package de.rki.coronawarnapp.deadman
 
 import dagger.Reusable
 import de.rki.coronawarnapp.diagnosiskeys.storage.KeyCacheRepository
+import de.rki.coronawarnapp.diagnosiskeys.storage.pkgDateTime
 import de.rki.coronawarnapp.util.TimeStamper
 import kotlinx.coroutines.flow.first
 import org.joda.time.DateTimeConstants
@@ -32,12 +33,12 @@ class DeadmanNotificationTimeCalculation @Inject constructor(
         val lastSuccess = keyCacheRepository.allCachedKeys()
             .first()
             .filter { it.info.isDownloadComplete }
-            .maxByOrNull { it.info.createdAt }
+            .maxByOrNull { it.info.pkgDateTime }
             ?.info
 
         Timber.d("Last successful diagnosis key package download: $lastSuccess")
         return if (lastSuccess != null) {
-            getHoursDiff(lastSuccess.createdAt).toLong()
+            getHoursDiff(lastSuccess.pkgDateTime.toInstant()).toLong()
         } else {
             (DEADMAN_NOTIFICATION_DELAY * DateTimeConstants.MINUTES_PER_HOUR).toLong()
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/deadman/DeadmanNotificationTimeCalculation.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/deadman/DeadmanNotificationTimeCalculation.kt
@@ -1,7 +1,7 @@
 package de.rki.coronawarnapp.deadman
 
 import dagger.Reusable
-import de.rki.coronawarnapp.nearby.ENFClient
+import de.rki.coronawarnapp.diagnosiskeys.storage.KeyCacheRepository
 import de.rki.coronawarnapp.util.TimeStamper
 import kotlinx.coroutines.flow.first
 import org.joda.time.DateTimeConstants
@@ -12,8 +12,8 @@ import javax.inject.Inject
 
 @Reusable
 class DeadmanNotificationTimeCalculation @Inject constructor(
-    val timeStamper: TimeStamper,
-    val enfClient: ENFClient
+    private val timeStamper: TimeStamper,
+    private val keyCacheRepository: KeyCacheRepository,
 ) {
 
     /**
@@ -29,10 +29,15 @@ class DeadmanNotificationTimeCalculation @Inject constructor(
      * If last success date time is null (eg: on application first start) - return [DEADMAN_NOTIFICATION_DELAY]
      */
     suspend fun getDelay(): Long {
-        val lastSuccess = enfClient.lastSuccessfulTrackedExposureDetection().first()?.finishedAt
-        Timber.d("enfClient.lastSuccessfulTrackedExposureDetection: $lastSuccess")
+        val lastSuccess = keyCacheRepository.allCachedKeys()
+            .first()
+            .filter { it.info.isDownloadComplete }
+            .maxByOrNull { it.info.createdAt }
+            ?.info
+
+        Timber.d("Last successful diagnosis key package download: $lastSuccess")
         return if (lastSuccess != null) {
-            getHoursDiff(lastSuccess).toLong()
+            getHoursDiff(lastSuccess.createdAt).toLong()
         } else {
             (DEADMAN_NOTIFICATION_DELAY * DateTimeConstants.MINUTES_PER_HOUR).toLong()
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/DayPackageSyncTool.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/DayPackageSyncTool.kt
@@ -9,6 +9,7 @@ import de.rki.coronawarnapp.diagnosiskeys.server.LocationCode
 import de.rki.coronawarnapp.diagnosiskeys.storage.CachedKey
 import de.rki.coronawarnapp.diagnosiskeys.storage.CachedKeyInfo.Type
 import de.rki.coronawarnapp.diagnosiskeys.storage.KeyCacheRepository
+import de.rki.coronawarnapp.diagnosiskeys.storage.pkgDateTime
 import de.rki.coronawarnapp.exception.http.CwaUnknownHostException
 import de.rki.coronawarnapp.storage.DeviceStorage
 import de.rki.coronawarnapp.util.TimeAndDateExtensions.toLocalDateUtc
@@ -81,7 +82,7 @@ class DayPackageSyncTool @Inject constructor(
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun expectNewDayPackages(cachedDays: List<CachedKey>): Boolean {
         val yesterday = timeStamper.nowUTC.toLocalDateUtc().minusDays(1)
-        val newestDay = cachedDays.map { it.info.toDateTime() }.maxOrNull()?.toLocalDate()
+        val newestDay = cachedDays.map { it.info.pkgDateTime }.maxOrNull()?.toLocalDate()
 
         return yesterday != newestDay
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/HourPackageSyncTool.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/HourPackageSyncTool.kt
@@ -9,6 +9,7 @@ import de.rki.coronawarnapp.diagnosiskeys.server.LocationCode
 import de.rki.coronawarnapp.diagnosiskeys.storage.CachedKey
 import de.rki.coronawarnapp.diagnosiskeys.storage.CachedKeyInfo.Type
 import de.rki.coronawarnapp.diagnosiskeys.storage.KeyCacheRepository
+import de.rki.coronawarnapp.diagnosiskeys.storage.pkgDateTime
 import de.rki.coronawarnapp.exception.http.CwaServerError
 import de.rki.coronawarnapp.exception.http.CwaUnknownHostException
 import de.rki.coronawarnapp.exception.http.NetworkConnectTimeoutException
@@ -126,7 +127,7 @@ class HourPackageSyncTool @Inject constructor(
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun expectNewHourPackages(cachedHours: List<CachedKey>, now: Instant): Boolean {
         val today = now.toDateTime(DateTimeZone.UTC)
-        val newestHour = cachedHours.map { it.info.toDateTime() }.maxOrNull()
+        val newestHour = cachedHours.map { it.info.pkgDateTime }.maxOrNull()
 
         return today.minusHours(1).hourOfDay != newestHour?.hourOfDay || today.toLocalDate() != newestHour.toLocalDate()
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/storage/CachedKeyInfo.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/storage/CachedKeyInfo.kt
@@ -50,11 +50,6 @@ data class CachedKeyInfo(
         isDownloadComplete = true
     )
 
-    fun toDateTime(): DateTime = when (type) {
-        Type.LOCATION_DAY -> day.toDateTimeAtStartOfDay(DateTimeZone.UTC)
-        Type.LOCATION_HOUR -> day.toDateTime(hour, DateTimeZone.UTC)
-    }
-
     companion object {
         fun calcluateId(
             location: LocationCode,
@@ -89,3 +84,9 @@ data class CachedKeyInfo(
         @ColumnInfo(name = "completed") val isDownloadComplete: Boolean
     )
 }
+
+val CachedKeyInfo.pkgDateTime: DateTime
+    get() = when (type) {
+        CachedKeyInfo.Type.LOCATION_DAY -> day.toDateTimeAtStartOfDay(DateTimeZone.UTC)
+        CachedKeyInfo.Type.LOCATION_HOUR -> day.toDateTime(hour, DateTimeZone.UTC)
+    }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelTask.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/RiskLevelTask.kt
@@ -7,6 +7,7 @@ import de.rki.coronawarnapp.appconfig.ExposureWindowRiskCalculationConfig
 import de.rki.coronawarnapp.coronatest.CoronaTestRepository
 import de.rki.coronawarnapp.datadonation.analytics.modules.exposurewindows.AnalyticsExposureWindowCollector
 import de.rki.coronawarnapp.diagnosiskeys.storage.KeyCacheRepository
+import de.rki.coronawarnapp.diagnosiskeys.storage.pkgDateTime
 import de.rki.coronawarnapp.exception.ExceptionCategory
 import de.rki.coronawarnapp.exception.reporting.report
 import de.rki.coronawarnapp.nearby.ENFClient
@@ -124,14 +125,14 @@ class RiskLevelTask @Inject constructor(
         Timber.tag(TAG).d("Evaluating areKeyPkgsOutDated(nowUTC=%s)", nowUTC)
 
         val latestDownload = keyCacheRepository.getAllCachedKeys().maxByOrNull {
-            it.info.toDateTime()
+            it.info.pkgDateTime
         }
         if (latestDownload == null) {
             Timber.w("areKeyPkgsOutDated(): No downloads available, why is the RiskLevelTask running? Aborting!")
             return true
         }
 
-        val downloadAge = Duration(latestDownload.info.toDateTime(), nowUTC).also {
+        val downloadAge = Duration(latestDownload.info.pkgDateTime, nowUTC).also {
             Timber.d("areKeyPkgsOutDated(): Age is %dh for latest key package: %s", it.standardHours, latestDownload)
         }
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/deadman/DeadmanNotificationTimeCalculationTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/deadman/DeadmanNotificationTimeCalculationTest.kt
@@ -1,8 +1,7 @@
 package de.rki.coronawarnapp.deadman
 
+import de.rki.coronawarnapp.diagnosiskeys.download.createMockCachedKeyInfo
 import de.rki.coronawarnapp.diagnosiskeys.storage.CachedKey
-import de.rki.coronawarnapp.diagnosiskeys.storage.CachedKeyInfo
-import de.rki.coronawarnapp.diagnosiskeys.storage.CachedKeyInfo.Type
 import de.rki.coronawarnapp.diagnosiskeys.storage.KeyCacheRepository
 import de.rki.coronawarnapp.util.TimeStamper
 import io.kotest.matchers.shouldBe
@@ -45,12 +44,11 @@ class DeadmanNotificationTimeCalculationTest : BaseTest() {
         keyHour: LocalTime? = null,
         isComplete: Boolean = true,
     ): CachedKey = mockk<CachedKey>().apply {
-        every { info } returns mockk<CachedKeyInfo>().apply {
-            every { type } returns if (keyHour != null) Type.LOCATION_HOUR else Type.LOCATION_DAY
-            every { day } returns keyDay
-            every { hour } returns keyHour
-            every { isDownloadComplete } returns isComplete
-        }
+        every { info } returns createMockCachedKeyInfo(
+            dayIdentifier = keyDay,
+            hourIdentifier = keyHour,
+            isComplete = isComplete,
+        )
     }
 
     @Test

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/DayPackageSyncToolTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/DayPackageSyncToolTest.kt
@@ -1,17 +1,13 @@
 package de.rki.coronawarnapp.diagnosiskeys.download
 
 import de.rki.coronawarnapp.appconfig.mapping.RevokedKeyPackage
-import de.rki.coronawarnapp.diagnosiskeys.storage.CachedKey
-import de.rki.coronawarnapp.diagnosiskeys.storage.CachedKeyInfo
 import de.rki.coronawarnapp.diagnosiskeys.storage.CachedKeyInfo.Type
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.coVerifySequence
 import io.mockk.every
-import io.mockk.mockk
 import kotlinx.coroutines.test.runBlockingTest
-import org.joda.time.DateTimeZone
 import org.joda.time.Instant
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -98,16 +94,12 @@ class DayPackageSyncToolTest : CommonSyncToolTest() {
 
     @Test
     fun `EXPECT_NEW_DAY_PACKAGES evaluation`() = runBlockingTest {
-        val cachedKey1 = mockk<CachedKey>().apply {
-            every { info } returns mockk<CachedKeyInfo>().apply {
-                every { toDateTime() } returns Instant.parse("2020-10-30T01:02:03.000Z").toDateTime(DateTimeZone.UTC)
-            }
-        }
-        val cachedKey2 = mockk<CachedKey>().apply {
-            every { info } returns mockk<CachedKeyInfo>().apply {
-                every { toDateTime() } returns Instant.parse("2020-10-31T01:02:03.000Z").toDateTime(DateTimeZone.UTC)
-            }
-        }
+        val cachedKey1 = mockCachedDay(
+            "EUR".loc, "2020-10-30".day
+        )
+        val cachedKey2 = mockCachedDay(
+            "EUR".loc, "2020-10-31".day
+        )
 
         val instance = createInstance()
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/DayPackageSyncToolTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/DayPackageSyncToolTest.kt
@@ -94,12 +94,8 @@ class DayPackageSyncToolTest : CommonSyncToolTest() {
 
     @Test
     fun `EXPECT_NEW_DAY_PACKAGES evaluation`() = runBlockingTest {
-        val cachedKey1 = mockCachedDay(
-            "EUR".loc, "2020-10-30".day
-        )
-        val cachedKey2 = mockCachedDay(
-            "EUR".loc, "2020-10-31".day
-        )
+        val cachedKey1 = mockCachedDay("EUR".loc, "2020-10-30".day)
+        val cachedKey2 = mockCachedDay("EUR".loc, "2020-10-31".day)
 
         val instance = createInstance()
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/HourPackageSyncToolTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/HourPackageSyncToolTest.kt
@@ -1,8 +1,6 @@
 package de.rki.coronawarnapp.diagnosiskeys.download
 
 import de.rki.coronawarnapp.appconfig.mapping.RevokedKeyPackage
-import de.rki.coronawarnapp.diagnosiskeys.storage.CachedKey
-import de.rki.coronawarnapp.diagnosiskeys.storage.CachedKeyInfo
 import de.rki.coronawarnapp.diagnosiskeys.storage.CachedKeyInfo.Type
 import de.rki.coronawarnapp.exception.http.NetworkConnectTimeoutException
 import io.kotest.matchers.shouldBe
@@ -10,9 +8,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.coVerifySequence
 import io.mockk.every
-import io.mockk.mockk
 import kotlinx.coroutines.test.runBlockingTest
-import org.joda.time.DateTimeZone
 import org.joda.time.Instant
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -184,16 +180,8 @@ class HourPackageSyncToolTest : CommonSyncToolTest() {
 
     @Test
     fun `EXPECT_NEW_HOUR_PACKAGES evaluation`() = runBlockingTest {
-        val cachedKey1 = mockk<CachedKey>().apply {
-            every { info } returns mockk<CachedKeyInfo>().apply {
-                every { toDateTime() } returns Instant.parse("2020-01-01T00:00:03.000Z").toDateTime(DateTimeZone.UTC)
-            }
-        }
-        val cachedKey2 = mockk<CachedKey>().apply {
-            every { info } returns mockk<CachedKeyInfo>().apply {
-                every { toDateTime() } returns Instant.parse("2020-01-01T01:00:03.000Z").toDateTime(DateTimeZone.UTC)
-            }
-        }
+        val cachedKey1 = mockCachedHour("EUR".loc, "2020-01-01".day, "00:00".hour)
+        val cachedKey2 = mockCachedHour("EUR".loc, "2020-01-01".day, "01:00".hour)
 
         val instance = createInstance()
 
@@ -207,11 +195,7 @@ class HourPackageSyncToolTest : CommonSyncToolTest() {
 
     @Test
     fun `EXPECT_NEW_HOUR_PACKAGES does not get confused by same hour on next day`() = runBlockingTest {
-        val cachedKey1 = mockk<CachedKey>().apply {
-            every { info } returns mockk<CachedKeyInfo>().apply {
-                every { toDateTime() } returns Instant.parse("2020-01-01T00:00:03.000Z").toDateTime(DateTimeZone.UTC)
-            }
-        }
+        val cachedKey1 = mockCachedHour("EUR".loc, "2020-01-01".day, "00:00".hour)
 
         val instance = createInstance()
 


### PR DESCRIPTION
This changes the reference time for the deadman scheduler to be the key package download timestamp.
Additionally it uses the keypackage day+hour identifier which are server based to prevent timetraveling from causing issues.