### PR TITLE
Auto-Cleanup Contact Journal(coronatests) after 16 days (EXPOSUREAPP-6043)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/contactdiary/storage/ContactDiaryDatabaseTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/contactdiary/storage/ContactDiaryDatabaseTest.kt
@@ -266,4 +266,27 @@ class ContactDiaryDatabaseTest : BaseTestInstrumentation() {
         coronaTestsDao.insertTest(newTest)
         coronaTestsFlow.first().containsAll(listOf(coronaTest, newTest)) shouldBe true
     }
+
+    @Test
+    fun deletingCoronaTests(): Unit = runBlocking {
+        val coronaTestFlow = coronaTestsDao.allTests()
+        val coronaTest2 = coronaTest.copy(id = "Test #2")
+        val coronaTest3 = coronaTest.copy(id = "Test #3")
+
+        coronaTestFlow.first() shouldBe emptyList()
+
+        coronaTestsDao.run {
+            insertTest(coronaTest)
+            insertTest(coronaTest2)
+            insertTest(coronaTest3)
+        }
+
+        coronaTestFlow.first() shouldBe listOf(coronaTest, coronaTest2, coronaTest3)
+
+        coronaTestsDao.delete(listOf(coronaTest2))
+        coronaTestFlow.first() shouldBe listOf(coronaTest, coronaTest3)
+
+        coronaTestsDao.delete(listOf(coronaTest, coronaTest3))
+        coronaTestFlow.first() shouldBe emptyList()
+    }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/retention/ContactDiaryCleanTask.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/retention/ContactDiaryCleanTask.kt
@@ -24,14 +24,19 @@ class ContactDiaryCleanTask @Inject constructor(
     override suspend fun run(arguments: Task.Arguments) = try {
         Timber.d("Running with arguments=%s", arguments)
 
-        retentionCalculation.clearObsoleteContactDiaryLocationVisits()
-        Timber.tag(TAG).d("Obsolete contact diary location visits cleaned up")
+        retentionCalculation.run {
+            clearObsoleteContactDiaryLocationVisits()
+            Timber.tag(TAG).d("Obsolete contact diary location visits cleaned up")
 
-        retentionCalculation.clearObsoleteContactDiaryPersonEncounters()
-        Timber.tag(TAG).d("Obsolete contact diary person encounters cleaned up")
+            clearObsoleteContactDiaryPersonEncounters()
+            Timber.tag(TAG).d("Obsolete contact diary person encounters cleaned up")
 
-        retentionCalculation.clearObsoleteRiskPerDate()
-        Timber.tag(TAG).d("Obsolete Aggregated Risk Per Date Results cleaned up")
+            clearObsoleteRiskPerDate()
+            Timber.tag(TAG).d("Obsolete Aggregated Risk Per Date Results cleaned up")
+
+            clearObsoleteCoronaTests()
+            Timber.tag(TAG).d("Obsolete Contact Diary Corona Tests cleaned up")
+        }
 
         object : Task.Result {}
     } catch (error: Exception) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/storage/dao/ContactDiaryCoronaTestDao.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/storage/dao/ContactDiaryCoronaTestDao.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.contactdiary.storage.dao
 
 import androidx.room.Dao
+import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
@@ -18,4 +19,7 @@ interface ContactDiaryCoronaTestDao {
 
     @Query("DELETE FROM corona_tests")
     suspend fun deleteAll()
+
+    @Delete
+    suspend fun delete(contactDiaryCoronaTestEntities: List<ContactDiaryCoronaTestEntity>)
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/storage/repo/ContactDiaryRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/storage/repo/ContactDiaryRepository.kt
@@ -58,6 +58,7 @@ interface ContactDiaryRepository {
     // Tests
     val testResults: Flow<List<ContactDiaryCoronaTestEntity>>
     suspend fun updateTests(tests: Map<CoronaTestGUID, CoronaTest>)
+    suspend fun deleteTests(tests: List<ContactDiaryCoronaTestEntity>)
 
     // Clean
     suspend fun clear()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/storage/repo/DefaultContactDiaryRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/storage/repo/DefaultContactDiaryRepository.kt
@@ -263,6 +263,11 @@ class DefaultContactDiaryRepository @Inject constructor(
             .forEach { contactDiaryCoronaTestDao.insertTest(it) }
     }
 
+    override suspend fun deleteTests(tests: List<ContactDiaryCoronaTestEntity>) {
+        Timber.d("deleteTests(tests=%s)", tests)
+        contactDiaryCoronaTestDao.delete(tests)
+    }
+
     private suspend fun executeWhenIdNotDefault(id: Long, action: (suspend () -> Unit) = { }) {
         if (id != 0L) {
             action()

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/contactdiary/retention/ContactDiaryCleanTaskTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/contactdiary/retention/ContactDiaryCleanTaskTest.kt
@@ -4,7 +4,7 @@ import io.kotest.matchers.shouldNotBe
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.coVerifyOrder
+import io.mockk.coVerifySequence
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import kotlinx.coroutines.test.runBlockingTest
@@ -24,6 +24,7 @@ class ContactDiaryCleanTaskTest : BaseTest() {
         coEvery { retentionCalculation.clearObsoleteContactDiaryPersonEncounters() } returns Unit
         coEvery { retentionCalculation.clearObsoleteContactDiaryLocationVisits() } returns Unit
         coEvery { retentionCalculation.clearObsoleteRiskPerDate() } returns Unit
+        coEvery { retentionCalculation.clearObsoleteCoronaTests() } returns Unit
     }
 
     private fun createInstance() = ContactDiaryCleanTask(
@@ -34,10 +35,13 @@ class ContactDiaryCleanTaskTest : BaseTest() {
     fun `no errors`() = runBlockingTest {
         val result = createInstance().run(mockk())
 
-        coVerifyOrder {
-            retentionCalculation.clearObsoleteContactDiaryLocationVisits()
-            retentionCalculation.clearObsoleteContactDiaryPersonEncounters()
-            retentionCalculation.clearObsoleteRiskPerDate()
+        coVerifySequence {
+            retentionCalculation.run {
+                clearObsoleteContactDiaryLocationVisits()
+                clearObsoleteContactDiaryPersonEncounters()
+                clearObsoleteRiskPerDate()
+                clearObsoleteCoronaTests()
+            }
         }
         result shouldNotBe null
     }
@@ -50,8 +54,11 @@ class ContactDiaryCleanTaskTest : BaseTest() {
 
         coVerify(exactly = 1) { retentionCalculation.clearObsoleteContactDiaryLocationVisits() }
         coVerify(exactly = 0) {
-            retentionCalculation.clearObsoleteContactDiaryPersonEncounters()
-            retentionCalculation.clearObsoleteRiskPerDate()
+            retentionCalculation.run {
+                clearObsoleteContactDiaryPersonEncounters()
+                clearObsoleteRiskPerDate()
+                clearObsoleteCoronaTests()
+            }
         }
         result shouldNotBe null
     }
@@ -66,7 +73,12 @@ class ContactDiaryCleanTaskTest : BaseTest() {
             retentionCalculation.clearObsoleteContactDiaryLocationVisits()
             retentionCalculation.clearObsoleteContactDiaryPersonEncounters()
         }
-        coVerify(exactly = 0) { retentionCalculation.clearObsoleteRiskPerDate() }
+        coVerify(exactly = 0) {
+            retentionCalculation.run {
+                clearObsoleteRiskPerDate()
+                clearObsoleteCoronaTests()
+            }
+        }
 
         result shouldNotBe null
     }
@@ -83,6 +95,28 @@ class ContactDiaryCleanTaskTest : BaseTest() {
             retentionCalculation.clearObsoleteRiskPerDate()
         }
 
+        coVerify(exactly = 0) {
+            retentionCalculation.clearObsoleteCoronaTests()
+        }
+
+        result shouldNotBe null
+    }
+
+    @Test
+    fun `corona tests fails`() = runBlockingTest {
+        coEvery { retentionCalculation.clearObsoleteCoronaTests() } throws Exception()
+
+        val result = assertThrows<Exception> { createInstance().run(mockk()) }
+
+        coVerify(exactly = 1) {
+            retentionCalculation.run {
+                clearObsoleteContactDiaryLocationVisits()
+                clearObsoleteContactDiaryPersonEncounters()
+                clearObsoleteRiskPerDate()
+                clearObsoleteCoronaTests()
+            }
+        }
+
         result shouldNotBe null
     }
 
@@ -95,8 +129,11 @@ class ContactDiaryCleanTaskTest : BaseTest() {
 
         coVerify(exactly = 1) { retentionCalculation.clearObsoleteContactDiaryLocationVisits() }
         coVerify(exactly = 0) {
-            retentionCalculation.clearObsoleteContactDiaryPersonEncounters()
-            retentionCalculation.clearObsoleteRiskPerDate()
+            retentionCalculation.run {
+                clearObsoleteContactDiaryPersonEncounters()
+                clearObsoleteRiskPerDate()
+                clearObsoleteCoronaTests()
+            }
         }
         result shouldNotBe null
     }


### PR DESCRIPTION
This PR addresses ExposureApp-6043.
- Automatic Deletion of Contact-Journal-Entries (Corona-Tests) after 16 Days (DB Clean-Up).
- Adjusted tests
