### PR TITLE
Improve log censoring mechanics (EXPOSUREAPP-7455, EXPOSUREAPP-7196, EXPOSUREAPP-7514)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/BugCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/BugCensor.kt
@@ -35,7 +35,7 @@ interface BugCensor {
             val start = this.string.indexOf(orig)
             if (start == -1) return null
 
-            val end = start + orig.length
+            val end = this.string.lastIndexOf(orig) + orig.length
             return CensoredString(
                 string = this.string.replace(orig, replacement),
                 range = start..end

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/BugCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/BugCensor.kt
@@ -2,9 +2,6 @@ package de.rki.coronawarnapp.bugreporting.censors
 
 interface BugCensor {
 
-    /**
-     * If there is something to censor a new log line is returned, otherwise returns null
-     */
     suspend fun checkLog(message: String): CensorContainer?
 
     data class CensorContainer(
@@ -32,11 +29,11 @@ interface BugCensor {
             val ranges = actions.map { it.range }
             if (ranges.isEmpty()) return null
 
-            val isIntersecting = ranges.any { outter ->
+            val isIntersecting = ranges.any { outer ->
                 ranges.any { inner ->
-                    outter != inner &&
-                        (inner.contains(outter.first) || inner.contains(outter.last)) &&
-                        (inner.last != outter.first && inner.first != outter.last)
+                    outer != inner &&
+                        (inner.contains(outer.first) || inner.contains(outer.last)) &&
+                        (inner.last != outer.first && inner.first != outer.last)
                 }
             }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/BugCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/BugCensor.kt
@@ -43,7 +43,7 @@ interface BugCensor {
 
             return if (isIntersecting) {
                 CensoredString(
-                    censored = original.replaceRange(minMin, maxMax, "<internal-censor-collision>"),
+                    censored = original.replaceRange(minMin, maxMax, COLLISION_STRING),
                     range = minMin..maxMax
                 )
             } else {
@@ -60,9 +60,7 @@ interface BugCensor {
         )
 
         companion object {
-            fun fromOriginal(original: String): CensorContainer = CensorContainer(
-                original = original
-            )
+            const val COLLISION_STRING = "<censor-collision>"
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/BugCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/BugCensor.kt
@@ -34,7 +34,9 @@ interface BugCensor {
 
             val isIntersecting = ranges.any { outter ->
                 ranges.any { inner ->
-                    outter != inner && (inner.contains(outter.first) || inner.contains(outter.last))
+                    outter != inner &&
+                        (inner.contains(outter.first) || inner.contains(outter.last)) &&
+                        (inner.last != outter.first && inner.first != outter.last)
                 }
             }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/BugCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/BugCensor.kt
@@ -148,5 +148,22 @@ interface BugCensor {
             action(zipCode)
             return true
         }
+
+        fun containerForError(
+            censor: BugCensor,
+            original: String,
+            error: Exception
+        ): CensorContainer = CensorContainer(
+            original = original,
+            actions = setOf(
+                CensorContainer.Action(
+                    range = 0..original.length,
+                    modifier = CensorContainer.Action.SimpleReplace(
+                        original,
+                        "<censor-error>Module ${censor.javaClass.simpleName}: $error</censor-error>"
+                    )
+                )
+            )
+        )
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/BugCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/BugCensor.kt
@@ -38,8 +38,8 @@ interface BugCensor {
             }
 
             return if (isIntersecting) {
-                val minMin = ranges.minOf { it.first }.coerceAtLeast(0).coerceAtMost(original.length)
-                val maxMax = ranges.maxOf { it.last }.coerceAtLeast(0).coerceAtMost(original.length)
+                val minMin = ranges.minOf { it.first }
+                val maxMax = ranges.maxOf { it.last }
                 CensoredString(
                     censored = original.replaceRange(minMin, maxMax, COLLISION_STRING),
                     ranges = listOf(minMin..maxMax)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryEncounterCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryEncounterCensor.kt
@@ -35,7 +35,7 @@ class DiaryEncounterCensor @Inject constructor(
 
         if (encounterHistory.isEmpty()) return null
 
-        val newMessage = encounterHistory.fold(CensorContainer.fromOriginal(message)) { orig, encounter ->
+        val newMessage = encounterHistory.fold(CensorContainer(message)) { orig, encounter ->
             var wip = orig
 
             withValidComment(encounter.circumstances) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryEncounterCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryEncounterCensor.kt
@@ -38,7 +38,7 @@ class DiaryEncounterCensor @Inject constructor(
 
         if (encounterHistory.isEmpty()) return null
 
-        val newMessage = encounterHistory.fold(CensoredString(message)) { orig, encounter ->
+        val newMessage = encounterHistory.fold(CensoredString.fromOriginal(message)) { orig, encounter ->
             var wip = orig
 
             withValidComment(encounter.circumstances) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryEncounterCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryEncounterCensor.kt
@@ -31,7 +31,7 @@ class DiaryEncounterCensor @Inject constructor(
             .launchIn(debugScope)
     }
 
-    override suspend fun checkLog(message: String): BugCensor.CensoredString? = mutex.withLock {
+    override suspend fun checkLog(message: String): CensorContainer? = mutex.withLock {
 
         if (encounterHistory.isEmpty()) return null
 
@@ -45,6 +45,6 @@ class DiaryEncounterCensor @Inject constructor(
             wip
         }
 
-        return newMessage.compile()
+        return newMessage.nullIfEmpty()
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryLocationCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryLocationCensor.kt
@@ -32,7 +32,7 @@ class DiaryLocationCensor @Inject constructor(
             .launchIn(debugScope)
     }
 
-    override suspend fun checkLog(message: String): BugCensor.CensoredString? = mutex.withLock {
+    override suspend fun checkLog(message: String): CensorContainer? = mutex.withLock {
 
         if (locationHistory.isEmpty()) return null
 
@@ -52,6 +52,6 @@ class DiaryLocationCensor @Inject constructor(
             wip
         }
 
-        return newMessage.compile()
+        return newMessage.nullIfEmpty()
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryLocationCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryLocationCensor.kt
@@ -36,7 +36,7 @@ class DiaryLocationCensor @Inject constructor(
 
         if (locationHistory.isEmpty()) return null
 
-        val newMessage = locationHistory.fold(CensorContainer.fromOriginal(message)) { orig, location ->
+        val newMessage = locationHistory.fold(CensorContainer(message)) { orig, location ->
             var wip = orig
 
             withValidName(location.locationName) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryLocationCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryLocationCensor.kt
@@ -39,7 +39,7 @@ class DiaryLocationCensor @Inject constructor(
 
         if (locationHistory.isEmpty()) return null
 
-        val newMessage = locationHistory.fold(CensoredString(message)) { orig, location ->
+        val newMessage = locationHistory.fold(CensoredString.fromOriginal(message)) { orig, location ->
             var wip = orig
 
             withValidName(location.locationName) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryPersonCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryPersonCensor.kt
@@ -2,10 +2,7 @@ package de.rki.coronawarnapp.bugreporting.censors.contactdiary
 
 import dagger.Reusable
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.CensoredString
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.censor
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.plus
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.toNullIfUnmodified
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.CensorContainer
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidEmail
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidName
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidPhoneNumber
@@ -36,26 +33,26 @@ class DiaryPersonCensor @Inject constructor(
             .launchIn(debugScope)
     }
 
-    override suspend fun checkLog(message: String): CensoredString? = mutex.withLock {
+    override suspend fun checkLog(message: String): BugCensor.CensoredString? = mutex.withLock {
 
         if (personHistory.isEmpty()) return null
 
-        val newMessage = personHistory.fold(CensoredString.fromOriginal(message)) { orig, person ->
+        val newMessage = personHistory.fold(CensorContainer.fromOriginal(message)) { orig, person ->
             var wip = orig
 
             withValidName(person.fullName) {
-                wip += wip.censor(it, "Person#${person.personId}/Name")
+                wip = wip.censor(it, "Person#${person.personId}/Name")
             }
             withValidEmail(person.emailAddress) {
-                wip += wip.censor(it, "Person#${person.personId}/EMail")
+                wip = wip.censor(it, "Person#${person.personId}/EMail")
             }
             withValidPhoneNumber(person.phoneNumber) {
-                wip += wip.censor(it, "Person#${person.personId}/PhoneNumber")
+                wip = wip.censor(it, "Person#${person.personId}/PhoneNumber")
             }
 
             wip
         }
 
-        return newMessage.toNullIfUnmodified()
+        return newMessage.compile()
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryPersonCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryPersonCensor.kt
@@ -40,7 +40,7 @@ class DiaryPersonCensor @Inject constructor(
 
         if (personHistory.isEmpty()) return null
 
-        val newMessage = personHistory.fold(CensoredString(message)) { orig, person ->
+        val newMessage = personHistory.fold(CensoredString.fromOriginal(message)) { orig, person ->
             var wip = orig
 
             withValidName(person.fullName) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryPersonCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryPersonCensor.kt
@@ -33,7 +33,7 @@ class DiaryPersonCensor @Inject constructor(
             .launchIn(debugScope)
     }
 
-    override suspend fun checkLog(message: String): BugCensor.CensoredString? = mutex.withLock {
+    override suspend fun checkLog(message: String): CensorContainer? = mutex.withLock {
 
         if (personHistory.isEmpty()) return null
 
@@ -53,6 +53,6 @@ class DiaryPersonCensor @Inject constructor(
             wip
         }
 
-        return newMessage.compile()
+        return newMessage.nullIfEmpty()
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryPersonCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryPersonCensor.kt
@@ -37,7 +37,7 @@ class DiaryPersonCensor @Inject constructor(
 
         if (personHistory.isEmpty()) return null
 
-        val newMessage = personHistory.fold(CensorContainer.fromOriginal(message)) { orig, person ->
+        val newMessage = personHistory.fold(CensorContainer(message)) { orig, person ->
             var wip = orig
 
             withValidName(person.fullName) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryVisitCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryVisitCensor.kt
@@ -34,7 +34,7 @@ class DiaryVisitCensor @Inject constructor(
             .launchIn(debugScope)
     }
 
-    override suspend fun checkLog(message: String): BugCensor.CensoredString? = mutex.withLock {
+    override suspend fun checkLog(message: String): CensorContainer? = mutex.withLock {
 
         if (visitsHistory.isEmpty()) return null
 
@@ -48,6 +48,6 @@ class DiaryVisitCensor @Inject constructor(
             wip
         }
 
-        return newMessage.compile()
+        return newMessage.nullIfEmpty()
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryVisitCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryVisitCensor.kt
@@ -41,7 +41,7 @@ class DiaryVisitCensor @Inject constructor(
 
         if (visitsHistory.isEmpty()) return null
 
-        val newMessage = visitsHistory.fold(CensoredString(message)) { orig, visit ->
+        val newMessage = visitsHistory.fold(CensoredString.fromOriginal(message)) { orig, visit ->
             var wip = orig
 
             BugCensor.withValidComment(visit.circumstances) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryVisitCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryVisitCensor.kt
@@ -38,7 +38,7 @@ class DiaryVisitCensor @Inject constructor(
 
         if (visitsHistory.isEmpty()) return null
 
-        val newMessage = visitsHistory.fold(CensorContainer.fromOriginal(message)) { orig, visit ->
+        val newMessage = visitsHistory.fold(CensorContainer(message)) { orig, visit ->
             var wip = orig
 
             BugCensor.withValidComment(visit.circumstances) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryVisitCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/DiaryVisitCensor.kt
@@ -2,10 +2,7 @@ package de.rki.coronawarnapp.bugreporting.censors.contactdiary
 
 import dagger.Reusable
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.CensoredString
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.censor
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.plus
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.toNullIfUnmodified
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.CensorContainer
 import de.rki.coronawarnapp.bugreporting.debuglog.internal.DebuggerScope
 import de.rki.coronawarnapp.contactdiary.model.ContactDiaryLocationVisit
 import de.rki.coronawarnapp.contactdiary.storage.repo.ContactDiaryRepository
@@ -37,20 +34,20 @@ class DiaryVisitCensor @Inject constructor(
             .launchIn(debugScope)
     }
 
-    override suspend fun checkLog(message: String): CensoredString? = mutex.withLock {
+    override suspend fun checkLog(message: String): BugCensor.CensoredString? = mutex.withLock {
 
         if (visitsHistory.isEmpty()) return null
 
-        val newMessage = visitsHistory.fold(CensoredString.fromOriginal(message)) { orig, visit ->
+        val newMessage = visitsHistory.fold(CensorContainer.fromOriginal(message)) { orig, visit ->
             var wip = orig
 
             BugCensor.withValidComment(visit.circumstances) {
-                wip += wip.censor(it, "Visit#${visit.id}/Circumstances")
+                wip = wip.censor(it, "Visit#${visit.id}/Circumstances")
             }
 
             wip
         }
 
-        return newMessage.toNullIfUnmodified()
+        return newMessage.compile()
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/presencetracing/CheckInsCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/presencetracing/CheckInsCensor.kt
@@ -38,7 +38,7 @@ class CheckInsCensor @Inject constructor(
 
         if (checkInsHistory.isEmpty()) return null
 
-        val newLogMsg = checkInsHistory.fold(CensoredString(message)) { initial, checkIn ->
+        val newLogMsg = checkInsHistory.fold(CensoredString.fromOriginal(message)) { initial, checkIn ->
 
             var acc = initial
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/presencetracing/CheckInsCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/presencetracing/CheckInsCensor.kt
@@ -2,10 +2,7 @@ package de.rki.coronawarnapp.bugreporting.censors.presencetracing
 
 import dagger.Reusable
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.CensoredString
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.censor
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.plus
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.toNullIfUnmodified
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.CensorContainer
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidAddress
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidDescription
 import de.rki.coronawarnapp.bugreporting.debuglog.internal.DebuggerScope
@@ -34,25 +31,25 @@ class CheckInsCensor @Inject constructor(
             .launchIn(debugScope)
     }
 
-    override suspend fun checkLog(message: String): CensoredString? = mutex.withLock {
+    override suspend fun checkLog(message: String): BugCensor.CensoredString? = mutex.withLock {
 
         if (checkInsHistory.isEmpty()) return null
 
-        val newLogMsg = checkInsHistory.fold(CensoredString.fromOriginal(message)) { initial, checkIn ->
+        val newLogMsg = checkInsHistory.fold(CensorContainer.fromOriginal(message)) { initial, checkIn ->
 
             var acc = initial
 
             withValidDescription(checkIn.description) { description ->
-                acc += acc.censor(description, "CheckIn#${checkIn.id}/Description")
+                acc = acc.censor(description, "CheckIn#${checkIn.id}/Description")
             }
 
             withValidAddress(checkIn.address) { address ->
-                acc += acc.censor(address, "CheckIn#${checkIn.id}/Address")
+                acc = acc.censor(address, "CheckIn#${checkIn.id}/Address")
             }
 
             acc
         }
 
-        return newLogMsg.toNullIfUnmodified()
+        return newLogMsg.compile()
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/presencetracing/CheckInsCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/presencetracing/CheckInsCensor.kt
@@ -35,7 +35,7 @@ class CheckInsCensor @Inject constructor(
 
         if (checkInsHistory.isEmpty()) return null
 
-        val newLogMsg = checkInsHistory.fold(CensorContainer.fromOriginal(message)) { initial, checkIn ->
+        val newLogMsg = checkInsHistory.fold(CensorContainer(message)) { initial, checkIn ->
 
             var acc = initial
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/presencetracing/CheckInsCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/presencetracing/CheckInsCensor.kt
@@ -31,7 +31,7 @@ class CheckInsCensor @Inject constructor(
             .launchIn(debugScope)
     }
 
-    override suspend fun checkLog(message: String): BugCensor.CensoredString? = mutex.withLock {
+    override suspend fun checkLog(message: String): CensorContainer? = mutex.withLock {
 
         if (checkInsHistory.isEmpty()) return null
 
@@ -50,6 +50,6 @@ class CheckInsCensor @Inject constructor(
             acc
         }
 
-        return newLogMsg.compile()
+        return newLogMsg.nullIfEmpty()
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/presencetracing/TraceLocationCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/presencetracing/TraceLocationCensor.kt
@@ -40,7 +40,7 @@ class TraceLocationCensor @Inject constructor(
             .launchIn(debugScope)
     }
 
-    override suspend fun checkLog(message: String): BugCensor.CensoredString? = mutex.withLock {
+    override suspend fun checkLog(message: String): CensorContainer? = mutex.withLock {
 
         var newLogMsg = traceLocationHistory.fold(CensorContainer(message)) { initial, traceLocation ->
             var acc = initial
@@ -71,7 +71,7 @@ class TraceLocationCensor @Inject constructor(
             }
         }
 
-        return newLogMsg.compile()
+        return newLogMsg.nullIfEmpty()
     }
 
     companion object {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/presencetracing/TraceLocationCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/presencetracing/TraceLocationCensor.kt
@@ -45,7 +45,7 @@ class TraceLocationCensor @Inject constructor(
 
     override suspend fun checkLog(message: String): CensoredString? = mutex.withLock {
 
-        var newLogMsg = traceLocationHistory.fold(CensoredString(message)) { initial, traceLocation ->
+        var newLogMsg = traceLocationHistory.fold(CensoredString.fromOriginal(message)) { initial, traceLocation ->
             var acc = initial
 
             acc += acc.censor(traceLocation.type.name, "TraceLocation#${traceLocation.id}/Type")

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/presencetracing/TraceLocationCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/presencetracing/TraceLocationCensor.kt
@@ -2,10 +2,7 @@ package de.rki.coronawarnapp.bugreporting.censors.presencetracing
 
 import dagger.Reusable
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.CensoredString
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.censor
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.plus
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.toNullIfUnmodified
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.CensorContainer
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidAddress
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidDescription
 import de.rki.coronawarnapp.bugreporting.debuglog.internal.DebuggerScope
@@ -43,19 +40,19 @@ class TraceLocationCensor @Inject constructor(
             .launchIn(debugScope)
     }
 
-    override suspend fun checkLog(message: String): CensoredString? = mutex.withLock {
+    override suspend fun checkLog(message: String): BugCensor.CensoredString? = mutex.withLock {
 
-        var newLogMsg = traceLocationHistory.fold(CensoredString.fromOriginal(message)) { initial, traceLocation ->
+        var newLogMsg = traceLocationHistory.fold(CensorContainer.fromOriginal(message)) { initial, traceLocation ->
             var acc = initial
 
-            acc += acc.censor(traceLocation.type.name, "TraceLocation#${traceLocation.id}/Type")
+            acc = acc.censor(traceLocation.type.name, "TraceLocation#${traceLocation.id}/Type")
 
             withValidDescription(traceLocation.description) { description ->
-                acc += acc.censor(description, "TraceLocation#${traceLocation.id}/Description")
+                acc = acc.censor(description, "TraceLocation#${traceLocation.id}/Description")
             }
 
             withValidAddress(traceLocation.address) { address ->
-                acc += acc.censor(address, "TraceLocation#${traceLocation.id}/Address")
+                acc = acc.censor(address, "TraceLocation#${traceLocation.id}/Address")
             }
 
             acc
@@ -63,18 +60,18 @@ class TraceLocationCensor @Inject constructor(
 
         val inputDataToCensor = dataToCensor
         if (inputDataToCensor != null) {
-            newLogMsg += newLogMsg.censor(inputDataToCensor.type.name, "TraceLocationUserInput#Type")
+            newLogMsg = newLogMsg.censor(inputDataToCensor.type.name, "TraceLocationUserInput#Type")
 
             withValidDescription(inputDataToCensor.description) {
-                newLogMsg += newLogMsg.censor(inputDataToCensor.description, "TraceLocationUserInput#Description")
+                newLogMsg = newLogMsg.censor(inputDataToCensor.description, "TraceLocationUserInput#Description")
             }
 
             withValidAddress(inputDataToCensor.address) {
-                newLogMsg += newLogMsg.censor(inputDataToCensor.address, "TraceLocationUserInput#Address")
+                newLogMsg = newLogMsg.censor(inputDataToCensor.address, "TraceLocationUserInput#Address")
             }
         }
 
-        return newLogMsg.toNullIfUnmodified()
+        return newLogMsg.compile()
     }
 
     companion object {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/presencetracing/TraceLocationCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/presencetracing/TraceLocationCensor.kt
@@ -42,7 +42,7 @@ class TraceLocationCensor @Inject constructor(
 
     override suspend fun checkLog(message: String): BugCensor.CensoredString? = mutex.withLock {
 
-        var newLogMsg = traceLocationHistory.fold(CensorContainer.fromOriginal(message)) { initial, traceLocation ->
+        var newLogMsg = traceLocationHistory.fold(CensorContainer(message)) { initial, traceLocation ->
             var acc = initial
 
             acc = acc.censor(traceLocation.type.name, "TraceLocation#${traceLocation.id}/Type")

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/CoronaTestCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/CoronaTestCensor.kt
@@ -42,7 +42,7 @@ class CoronaTestCensor @Inject constructor(
 
     override suspend fun checkLog(message: String): CensoredString? = mutex.withLock {
 
-        var newMessage = CensoredString(message)
+        var newMessage = CensoredString.fromOriginal(message)
 
         for (token in tokenHistory) {
             if (!message.contains(token)) continue

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/CoronaTestCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/CoronaTestCensor.kt
@@ -37,7 +37,7 @@ class CoronaTestCensor @Inject constructor(
             }.launchIn(debugScope)
     }
 
-    override suspend fun checkLog(message: String): BugCensor.CensoredString? = mutex.withLock {
+    override suspend fun checkLog(message: String): CensorContainer? = mutex.withLock {
 
         var newMessage = CensorContainer(message)
 
@@ -53,7 +53,7 @@ class CoronaTestCensor @Inject constructor(
                 newMessage = newMessage.censor(it, "${it.take(11)}CoronaTest/Identifier")
             }
 
-        return newMessage.compile()
+        return newMessage.nullIfEmpty()
     }
 
     companion object {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/CoronaTestCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/CoronaTestCensor.kt
@@ -39,7 +39,7 @@ class CoronaTestCensor @Inject constructor(
 
     override suspend fun checkLog(message: String): BugCensor.CensoredString? = mutex.withLock {
 
-        var newMessage = CensorContainer.fromOriginal(message)
+        var newMessage = CensorContainer(message)
 
         for (token in tokenHistory) {
             if (!message.contains(token)) continue

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/PcrQrCodeCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/PcrQrCodeCensor.kt
@@ -13,7 +13,7 @@ class PcrQrCodeCensor @Inject constructor() : BugCensor {
         val guid = lastGUID ?: return null
         if (!message.contains(guid)) return null
 
-        return CensoredString(message).censor(guid, PLACEHOLDER + guid.takeLast(4))
+        return CensoredString.fromOriginal(message).censor(guid, PLACEHOLDER + guid.takeLast(4))
     }
 
     companion object {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/PcrQrCodeCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/PcrQrCodeCensor.kt
@@ -8,11 +8,11 @@ import javax.inject.Inject
 @Reusable
 class PcrQrCodeCensor @Inject constructor() : BugCensor {
 
-    override suspend fun checkLog(message: String): BugCensor.CensoredString? {
+    override suspend fun checkLog(message: String): CensorContainer? {
         val guid = lastGUID ?: return null
         if (!message.contains(guid)) return null
 
-        return CensorContainer(message).censor(guid, PLACEHOLDER + guid.takeLast(4)).compile()
+        return CensorContainer(message).censor(guid, PLACEHOLDER + guid.takeLast(4)).nullIfEmpty()
     }
 
     companion object {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/PcrQrCodeCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/PcrQrCodeCensor.kt
@@ -2,18 +2,17 @@ package de.rki.coronawarnapp.bugreporting.censors.submission
 
 import dagger.Reusable
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.CensoredString
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.censor
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.CensorContainer
 import javax.inject.Inject
 
 @Reusable
 class PcrQrCodeCensor @Inject constructor() : BugCensor {
 
-    override suspend fun checkLog(message: String): CensoredString? {
+    override suspend fun checkLog(message: String): BugCensor.CensoredString? {
         val guid = lastGUID ?: return null
         if (!message.contains(guid)) return null
 
-        return CensoredString.fromOriginal(message).censor(guid, PLACEHOLDER + guid.takeLast(4))
+        return CensorContainer.fromOriginal(message).censor(guid, PLACEHOLDER + guid.takeLast(4)).compile()
     }
 
     companion object {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/PcrQrCodeCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/PcrQrCodeCensor.kt
@@ -12,7 +12,7 @@ class PcrQrCodeCensor @Inject constructor() : BugCensor {
         val guid = lastGUID ?: return null
         if (!message.contains(guid)) return null
 
-        return CensorContainer.fromOriginal(message).censor(guid, PLACEHOLDER + guid.takeLast(4)).compile()
+        return CensorContainer(message).censor(guid, PLACEHOLDER + guid.takeLast(4)).compile()
     }
 
     companion object {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RACoronaTestCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RACoronaTestCensor.kt
@@ -1,10 +1,7 @@
 package de.rki.coronawarnapp.bugreporting.censors.submission
 
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.CensoredString
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.censor
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.plus
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.toNullIfUnmodified
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.CensorContainer
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidName
 import de.rki.coronawarnapp.bugreporting.debuglog.internal.DebuggerScope
 import de.rki.coronawarnapp.coronatest.CoronaTestRepository
@@ -38,24 +35,24 @@ class RACoronaTestCensor @Inject constructor(
             .launchIn(debugScope)
     }
 
-    override suspend fun checkLog(message: String): CensoredString? = mutex.withLock {
+    override suspend fun checkLog(message: String): BugCensor.CensoredString? = mutex.withLock {
 
-        var newMessage = CensoredString.fromOriginal(message)
+        var newMessage = CensorContainer.fromOriginal(message)
 
         ratCoronaTestHistory.forEach { ratCoronaTest ->
             withValidName(ratCoronaTest.firstName) { firstName ->
-                newMessage += newMessage.censor(firstName, "RATest/FirstName")
+                newMessage = newMessage.censor(firstName, "RATest/FirstName")
             }
 
             withValidName(ratCoronaTest.lastName) { lastName ->
-                newMessage += newMessage.censor(lastName, "RATest/LastName")
+                newMessage = newMessage.censor(lastName, "RATest/LastName")
             }
 
             ratCoronaTest.dateOfBirth?.toString(dayOfBirthFormatter)?.let { dateOfBirthString ->
-                newMessage += newMessage.censor(dateOfBirthString, "RATest/DateOfBirth")
+                newMessage = newMessage.censor(dateOfBirthString, "RATest/DateOfBirth")
             }
         }
 
-        return newMessage.toNullIfUnmodified()
+        return newMessage.compile()
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RACoronaTestCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RACoronaTestCensor.kt
@@ -40,7 +40,7 @@ class RACoronaTestCensor @Inject constructor(
 
     override suspend fun checkLog(message: String): CensoredString? = mutex.withLock {
 
-        var newMessage = CensoredString(message)
+        var newMessage = CensoredString.fromOriginal(message)
 
         ratCoronaTestHistory.forEach { ratCoronaTest ->
             withValidName(ratCoronaTest.firstName) { firstName ->

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RACoronaTestCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RACoronaTestCensor.kt
@@ -37,7 +37,7 @@ class RACoronaTestCensor @Inject constructor(
 
     override suspend fun checkLog(message: String): BugCensor.CensoredString? = mutex.withLock {
 
-        var newMessage = CensorContainer.fromOriginal(message)
+        var newMessage = CensorContainer(message)
 
         ratCoronaTestHistory.forEach { ratCoronaTest ->
             withValidName(ratCoronaTest.firstName) { firstName ->

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RACoronaTestCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RACoronaTestCensor.kt
@@ -35,7 +35,7 @@ class RACoronaTestCensor @Inject constructor(
             .launchIn(debugScope)
     }
 
-    override suspend fun checkLog(message: String): BugCensor.CensoredString? = mutex.withLock {
+    override suspend fun checkLog(message: String): CensorContainer? = mutex.withLock {
 
         var newMessage = CensorContainer(message)
 
@@ -53,6 +53,6 @@ class RACoronaTestCensor @Inject constructor(
             }
         }
 
-        return newMessage.compile()
+        return newMessage.nullIfEmpty()
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RatProfileCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RatProfileCensor.kt
@@ -34,7 +34,7 @@ class RatProfileCensor @Inject constructor(
             ratProfileHistory.add(ratProfile)
         }
 
-        var newMessage = CensoredString(message)
+        var newMessage = CensoredString.fromOriginal(message)
 
         ratProfileHistory.forEach { profile ->
             with(profile) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RatProfileCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RatProfileCensor.kt
@@ -1,10 +1,7 @@
 package de.rki.coronawarnapp.bugreporting.censors.submission
 
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.CensoredString
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.censor
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.plus
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.toNullIfUnmodified
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.CensorContainer
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidAddress
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidCity
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidName
@@ -26,7 +23,7 @@ class RatProfileCensor @Inject constructor(
     private val dayOfBirthFormatter = DateTimeFormat.forPattern("yyyy-MM-dd")
     private val ratProfileHistory = mutableSetOf<RATProfile>()
 
-    override suspend fun checkLog(message: String): CensoredString? = mutex.withLock {
+    override suspend fun checkLog(message: String): BugCensor.CensoredString? = mutex.withLock {
         val ratProfile = ratProfileSettings.profile.flow.first()
 
         // store the profile in a property so we still have a reference after it was deleted by the user
@@ -34,46 +31,46 @@ class RatProfileCensor @Inject constructor(
             ratProfileHistory.add(ratProfile)
         }
 
-        var newMessage = CensoredString.fromOriginal(message)
+        var newMessage = CensorContainer.fromOriginal(message)
 
         ratProfileHistory.forEach { profile ->
             with(profile) {
                 withValidName(firstName) { firstName ->
-                    newMessage += newMessage.censor(firstName, "RAT-Profile/FirstName")
+                    newMessage = newMessage.censor(firstName, "RAT-Profile/FirstName")
                 }
 
                 withValidName(lastName) { lastName ->
-                    newMessage += newMessage.censor(lastName, "RAT-Profile/LastName")
+                    newMessage = newMessage.censor(lastName, "RAT-Profile/LastName")
                 }
 
                 val dateOfBirthString = birthDate?.toString(dayOfBirthFormatter)
 
                 if (dateOfBirthString != null) {
-                    newMessage += newMessage.censor(dateOfBirthString, "RAT-Profile/DateOfBirth")
+                    newMessage = newMessage.censor(dateOfBirthString, "RAT-Profile/DateOfBirth")
                 }
 
                 withValidAddress(street) { street ->
-                    newMessage += newMessage.censor(street, "RAT-Profile/Street")
+                    newMessage = newMessage.censor(street, "RAT-Profile/Street")
                 }
 
                 withValidCity(city) { city ->
-                    newMessage += newMessage.censor(city, "RAT-Profile/City")
+                    newMessage = newMessage.censor(city, "RAT-Profile/City")
                 }
 
                 withValidZipCode(zipCode) { zipCode ->
-                    newMessage += newMessage.censor(zipCode, "RAT-Profile/Zip-Code")
+                    newMessage = newMessage.censor(zipCode, "RAT-Profile/Zip-Code")
                 }
 
                 withValidPhoneNumber(phone) { phone ->
-                    newMessage += newMessage.censor(phone, "RAT-Profile/Phone")
+                    newMessage = newMessage.censor(phone, "RAT-Profile/Phone")
                 }
 
                 withValidPhoneNumber(email) { phone ->
-                    newMessage += newMessage.censor(phone, "RAT-Profile/eMail")
+                    newMessage = newMessage.censor(phone, "RAT-Profile/eMail")
                 }
             }
         }
 
-        return newMessage.toNullIfUnmodified()
+        return newMessage.compile()
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RatProfileCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RatProfileCensor.kt
@@ -23,7 +23,7 @@ class RatProfileCensor @Inject constructor(
     private val dayOfBirthFormatter = DateTimeFormat.forPattern("yyyy-MM-dd")
     private val ratProfileHistory = mutableSetOf<RATProfile>()
 
-    override suspend fun checkLog(message: String): BugCensor.CensoredString? = mutex.withLock {
+    override suspend fun checkLog(message: String): CensorContainer? = mutex.withLock {
         val ratProfile = ratProfileSettings.profile.flow.first()
 
         // store the profile in a property so we still have a reference after it was deleted by the user
@@ -71,6 +71,6 @@ class RatProfileCensor @Inject constructor(
             }
         }
 
-        return newMessage.compile()
+        return newMessage.nullIfEmpty()
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RatProfileCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RatProfileCensor.kt
@@ -31,7 +31,7 @@ class RatProfileCensor @Inject constructor(
             ratProfileHistory.add(ratProfile)
         }
 
-        var newMessage = CensorContainer.fromOriginal(message)
+        var newMessage = CensorContainer(message)
 
         ratProfileHistory.forEach { profile ->
             with(profile) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RatQrCodeCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RatQrCodeCensor.kt
@@ -14,7 +14,7 @@ class RatQrCodeCensor @Inject constructor() : BugCensor {
 
     private val dayOfBirthFormatter = DateTimeFormat.forPattern("yyyy-MM-dd")
 
-    override suspend fun checkLog(message: String): BugCensor.CensoredString? {
+    override suspend fun checkLog(message: String): CensorContainer? {
 
         val dataToCensor = dataToCensor ?: return null
 
@@ -38,7 +38,7 @@ class RatQrCodeCensor @Inject constructor() : BugCensor {
             newMessage = newMessage.censor(dateOfBirthString, "RATest/DateOfBirth")
         }
 
-        return newMessage.compile()
+        return newMessage.nullIfEmpty()
     }
 
     companion object {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RatQrCodeCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RatQrCodeCensor.kt
@@ -18,7 +18,7 @@ class RatQrCodeCensor @Inject constructor() : BugCensor {
 
         val dataToCensor = dataToCensor ?: return null
 
-        var newMessage = CensorContainer.fromOriginal(message)
+        var newMessage = CensorContainer(message)
 
         with(dataToCensor) {
             newMessage = newMessage.censor(rawString, "RatQrCode/ScannedRawString")

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RatQrCodeCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RatQrCodeCensor.kt
@@ -2,10 +2,7 @@ package de.rki.coronawarnapp.bugreporting.censors.submission
 
 import dagger.Reusable
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.CensoredString
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.censor
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.plus
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.toNullIfUnmodified
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.CensorContainer
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.withValidName
 import de.rki.coronawarnapp.coronatest.qrcode.RapidAntigenHash
 import org.joda.time.LocalDate
@@ -17,31 +14,31 @@ class RatQrCodeCensor @Inject constructor() : BugCensor {
 
     private val dayOfBirthFormatter = DateTimeFormat.forPattern("yyyy-MM-dd")
 
-    override suspend fun checkLog(message: String): CensoredString? {
+    override suspend fun checkLog(message: String): BugCensor.CensoredString? {
 
         val dataToCensor = dataToCensor ?: return null
 
-        var newMessage = CensoredString.fromOriginal(message)
+        var newMessage = CensorContainer.fromOriginal(message)
 
         with(dataToCensor) {
-            newMessage += newMessage.censor(rawString, "RatQrCode/ScannedRawString")
+            newMessage = newMessage.censor(rawString, "RatQrCode/ScannedRawString")
 
-            newMessage += newMessage.censor(hash, PLACEHOLDER + hash.takeLast(4))
+            newMessage = newMessage.censor(hash, PLACEHOLDER + hash.takeLast(4))
 
             withValidName(firstName) { firstName ->
-                newMessage += newMessage.censor(firstName, "RATest/FirstName")
+                newMessage = newMessage.censor(firstName, "RATest/FirstName")
             }
 
             withValidName(lastName) { lastName ->
-                newMessage += newMessage.censor(lastName, "RATest/LastName")
+                newMessage = newMessage.censor(lastName, "RATest/LastName")
             }
 
             val dateOfBirthString = dateOfBirth?.toString(dayOfBirthFormatter) ?: return@with
 
-            newMessage += newMessage.censor(dateOfBirthString, "RATest/DateOfBirth")
+            newMessage = newMessage.censor(dateOfBirthString, "RATest/DateOfBirth")
         }
 
-        return newMessage.toNullIfUnmodified()
+        return newMessage.compile()
     }
 
     companion object {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RatQrCodeCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/RatQrCodeCensor.kt
@@ -21,7 +21,7 @@ class RatQrCodeCensor @Inject constructor() : BugCensor {
 
         val dataToCensor = dataToCensor ?: return null
 
-        var newMessage = CensoredString(message)
+        var newMessage = CensoredString.fromOriginal(message)
 
         with(dataToCensor) {
             newMessage += newMessage.censor(rawString, "RatQrCode/ScannedRawString")

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/vaccination/CertificateQrCodeCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/vaccination/CertificateQrCodeCensor.kt
@@ -12,7 +12,7 @@ import javax.inject.Inject
 class CertificateQrCodeCensor @Inject constructor() : BugCensor {
 
     override suspend fun checkLog(message: String): BugCensor.CensoredString? {
-        var newMessage = CensorContainer.fromOriginal(message)
+        var newMessage = CensorContainer(message)
 
         synchronized(qrCodeStringsToCensor) { qrCodeStringsToCensor.toList() }.forEach {
             newMessage = newMessage.censor(it, PLACEHOLDER + it.takeLast(4))

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/vaccination/CertificateQrCodeCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/vaccination/CertificateQrCodeCensor.kt
@@ -15,7 +15,7 @@ import javax.inject.Inject
 class CertificateQrCodeCensor @Inject constructor() : BugCensor {
 
     override suspend fun checkLog(message: String): CensoredString? {
-        var newMessage = CensoredString(message)
+        var newMessage = CensoredString.fromOriginal(message)
 
         synchronized(qrCodeStringsToCensor) { qrCodeStringsToCensor.toList() }.forEach {
             newMessage += newMessage.censor(it, PLACEHOLDER + it.takeLast(4))

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/vaccination/CertificateQrCodeCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/vaccination/CertificateQrCodeCensor.kt
@@ -2,10 +2,7 @@ package de.rki.coronawarnapp.bugreporting.censors.vaccination
 
 import dagger.Reusable
 import de.rki.coronawarnapp.bugreporting.censors.BugCensor
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.CensoredString
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.censor
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.plus
-import de.rki.coronawarnapp.bugreporting.censors.BugCensor.Companion.toNullIfUnmodified
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor.CensorContainer
 import de.rki.coronawarnapp.vaccination.core.certificate.VaccinationDGCV1
 import de.rki.coronawarnapp.vaccination.core.qrcode.VaccinationCertificateData
 import java.util.LinkedList
@@ -14,83 +11,83 @@ import javax.inject.Inject
 @Reusable
 class CertificateQrCodeCensor @Inject constructor() : BugCensor {
 
-    override suspend fun checkLog(message: String): CensoredString? {
-        var newMessage = CensoredString.fromOriginal(message)
+    override suspend fun checkLog(message: String): BugCensor.CensoredString? {
+        var newMessage = CensorContainer.fromOriginal(message)
 
         synchronized(qrCodeStringsToCensor) { qrCodeStringsToCensor.toList() }.forEach {
-            newMessage += newMessage.censor(it, PLACEHOLDER + it.takeLast(4))
+            newMessage = newMessage.censor(it, PLACEHOLDER + it.takeLast(4))
         }
 
         synchronized(certsToCensor) { certsToCensor.toList() }.forEach {
             it.certificate.apply {
-                newMessage += newMessage.censor(
+                newMessage = newMessage.censor(
                     dob,
                     "vaccinationCertificate/dob"
                 )
 
-                newMessage += newMessage.censor(
+                newMessage = newMessage.censor(
                     dateOfBirth.toString(),
                     "vaccinationCertificate/dateOfBirth"
                 )
 
-                newMessage += censorNameData(nameData, newMessage)
+                newMessage = censorNameData(nameData, newMessage)
 
                 vaccinationDatas.forEach { data ->
-                    newMessage += censorVaccinationData(data, newMessage)
+                    newMessage = censorVaccinationData(data, newMessage)
                 }
             }
         }
 
-        return newMessage.toNullIfUnmodified()
+        return newMessage.compile()
     }
 
     private fun censorVaccinationData(
         vaccinationData: VaccinationDGCV1.VaccinationData,
-        message: CensoredString
-    ): CensoredString {
+        message: CensorContainer
+    ): CensorContainer {
         var newMessage = message
 
-        newMessage += newMessage.censor(
+        newMessage = newMessage.censor(
             vaccinationData.dt,
             "vaccinationData/dt"
         )
 
-        newMessage += newMessage.censor(
+        newMessage = newMessage.censor(
             vaccinationData.marketAuthorizationHolderId,
             "vaccinationData/marketAuthorizationHolderId"
         )
 
-        newMessage += newMessage.censor(
+        newMessage = newMessage.censor(
             vaccinationData.medicalProductId,
             "vaccinationData/medicalProductId"
         )
 
-        newMessage += newMessage.censor(
+        newMessage = newMessage.censor(
             vaccinationData.targetId,
             "vaccinationData/targetId"
         )
 
-        newMessage += newMessage.censor(
+        newMessage = newMessage.censor(
             vaccinationData.certificateIssuer,
             "vaccinationData/certificateIssuer"
         )
 
-        newMessage += newMessage.censor(
+        newMessage = newMessage.censor(
             vaccinationData.uniqueCertificateIdentifier,
             "vaccinationData/uniqueCertificateIdentifier"
         )
 
-        newMessage += newMessage.censor(
+        newMessage = newMessage.censor(
             vaccinationData.countryOfVaccination,
             "vaccinationData/countryOfVaccination"
         )
 
-        newMessage += newMessage.censor(
+        newMessage = newMessage.censor(
             vaccinationData.vaccineId,
             "vaccinationData/vaccineId"
         )
 
-        newMessage += newMessage.censor(
+        newMessage = newMessage.censor(
             vaccinationData.vaccinatedAt.toString(),
             "vaccinationData/vaccinatedAt"
         )
@@ -98,30 +95,30 @@ class CertificateQrCodeCensor @Inject constructor() : BugCensor {
         return newMessage
     }
 
-    private fun censorNameData(nameData: VaccinationDGCV1.NameData, message: CensoredString): CensoredString {
+    private fun censorNameData(nameData: VaccinationDGCV1.NameData, message: CensorContainer): CensorContainer {
         var newMessage = message
 
         nameData.familyName?.let { fName ->
-            newMessage += newMessage.censor(
+            newMessage = newMessage.censor(
                 fName,
                 "nameData/familyName"
             )
         }
 
-        newMessage += newMessage.censor(
+        newMessage = newMessage.censor(
             nameData.familyNameStandardized,
             "nameData/familyNameStandardized"
         )
 
         nameData.givenName?.let { gName ->
-            newMessage += newMessage.censor(
+            newMessage = newMessage.censor(
                 gName,
                 "nameData/givenName"
             )
         }
 
         nameData.givenNameStandardized?.let { gName ->
-            newMessage += newMessage.censor(
+            newMessage = newMessage.censor(
                 gName,
                 "nameData/givenNameStandardized"
             )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/vaccination/CertificateQrCodeCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/vaccination/CertificateQrCodeCensor.kt
@@ -11,7 +11,7 @@ import javax.inject.Inject
 @Reusable
 class CertificateQrCodeCensor @Inject constructor() : BugCensor {
 
-    override suspend fun checkLog(message: String): BugCensor.CensoredString? {
+    override suspend fun checkLog(message: String): CensorContainer? {
         var newMessage = CensorContainer(message)
 
         synchronized(qrCodeStringsToCensor) { qrCodeStringsToCensor.toList() }.forEach {
@@ -38,7 +38,7 @@ class CertificateQrCodeCensor @Inject constructor() : BugCensor {
             }
         }
 
-        return newMessage.compile()
+        return newMessage.nullIfEmpty()
     }
 
     private fun censorVaccinationData(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/vaccination/CertificateQrCodeCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/vaccination/CertificateQrCodeCensor.kt
@@ -20,15 +20,18 @@ class CertificateQrCodeCensor @Inject constructor() : BugCensor {
 
         synchronized(certsToCensor) { certsToCensor.toList() }.forEach {
             it.certificate.apply {
-                newMessage = newMessage.censor(
-                    dob,
-                    "vaccinationCertificate/dob"
-                )
+                val dobFormatted = dateOfBirth.toString()
 
                 newMessage = newMessage.censor(
-                    dateOfBirth.toString(),
+                    dobFormatted,
                     "vaccinationCertificate/dateOfBirth"
                 )
+                if (dobFormatted != dob) {
+                    newMessage = newMessage.censor(
+                        dob,
+                        "vaccinationCertificate/dob"
+                    )
+                }
 
                 newMessage = censorNameData(nameData, newMessage)
 
@@ -46,11 +49,6 @@ class CertificateQrCodeCensor @Inject constructor() : BugCensor {
         message: CensorContainer
     ): CensorContainer {
         var newMessage = message
-
-        newMessage = newMessage.censor(
-            vaccinationData.dt,
-            "vaccinationData/dt"
-        )
 
         newMessage = newMessage.censor(
             vaccinationData.marketAuthorizationHolderId,
@@ -87,10 +85,17 @@ class CertificateQrCodeCensor @Inject constructor() : BugCensor {
             "vaccinationData/vaccineId"
         )
 
+        val vaccinatedAt = vaccinationData.vaccinatedAt.toString()
         newMessage = newMessage.censor(
-            vaccinationData.vaccinatedAt.toString(),
+            vaccinatedAt,
             "vaccinationData/vaccinatedAt"
         )
+        if (vaccinatedAt != vaccinationData.dt) {
+            newMessage = newMessage.censor(
+                vaccinationData.dt,
+                "vaccinationData/dt"
+            )
+        }
 
         return newMessage
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/debuglog/DebugLogger.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/debuglog/DebugLogger.kt
@@ -172,7 +172,7 @@ class DebugLogger(
                                     it.checkLog(formattedMessage)
                                 } catch (e: Exception) {
                                     Log.e(TAG, "Error in censor module $it", e)
-                                    null
+                                    BugCensor.containerForError(it, formattedMessage, e)
                                 }
                             }
                         }
@@ -192,7 +192,7 @@ class DebugLogger(
                                 combinedContainer.compile()?.censored ?: formattedMessage
                             } catch (e: Exception) {
                                 Log.e(TAG, "Censoring collision fail.", e)
-                                "<censor-error>Global combination: $e</censor-error"
+                                "<censor-error>Global combination: $e</censor-error>"
                             }
                     }
                     logWriter.write(rawLine.formatFinal(toWrite))

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/debuglog/DebugLogger.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/debuglog/DebugLogger.kt
@@ -186,7 +186,7 @@ class DebugLogger(
                             try {
                                 val combinedContainer = BugCensor.CensorContainer(
                                     original = formattedMessage,
-                                    actions = censored.flatMap { it.actions }
+                                    actions = censored.flatMap { it.actions }.toSet()
                                 )
 
                                 combinedContainer.compile()?.censored ?: formattedMessage

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/debuglog/DebugLogger.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/debuglog/DebugLogger.kt
@@ -177,7 +177,7 @@ class DebugLogger(
 
                     val toWrite: String = when (censored.size) {
                         0 -> formattedMessage
-                        1 -> censored.single().string
+                        1 -> censored.single().let { it.censored ?: it.original }
                         else -> {
                             try {
                                 // Lowest censoring range, within original msg bounds

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/debuglog/DebugLogger.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/debuglog/DebugLogger.kt
@@ -182,17 +182,18 @@ class DebugLogger(
                     val toWrite: String = when (censored.size) {
                         0 -> formattedMessage
                         1 -> censored.single().compile()?.censored ?: formattedMessage
-                        else -> try {
-                            val combinedContainer = BugCensor.CensorContainer(
-                                original = formattedMessage,
-                                actions = censored.flatMap { it.actions }
-                            )
+                        else ->
+                            try {
+                                val combinedContainer = BugCensor.CensorContainer(
+                                    original = formattedMessage,
+                                    actions = censored.flatMap { it.actions }
+                                )
 
-                            combinedContainer.compile()?.censored ?: formattedMessage
-                        } catch (e: Exception) {
-                            Log.e(TAG, "Censoring collision fail.", e)
-                            "<censor-error>Global combination: $e</censor-error"
-                        }
+                                combinedContainer.compile()?.censored ?: formattedMessage
+                            } catch (e: Exception) {
+                                Log.e(TAG, "Censoring collision fail.", e)
+                                "<censor-error>Global combination: $e</censor-error"
+                            }
                     }
                     logWriter.write(toWrite)
                 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/debuglog/DebugLogger.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/debuglog/DebugLogger.kt
@@ -195,7 +195,7 @@ class DebugLogger(
                                 "<censor-error>Global combination: $e</censor-error"
                             }
                     }
-                    logWriter.write(toWrite)
+                    logWriter.write(rawLine.formatFinal(toWrite))
                 }
             }
         } catch (e: CancellationException) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/debuglog/LogLine.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/debuglog/LogLine.kt
@@ -13,16 +13,15 @@ data class LogLine(
     val throwable: Throwable?
 ) {
 
-    fun format(): String {
+    fun format(): String = if (throwable != null) {
+        message + "\n" + getStackTraceString(throwable)
+    } else {
+        message
+    }
+
+    fun formatFinal(formattedLogLine: String): String {
         val time = Instant.ofEpochMilli(timestamp)
-
-        val baseLine = "$time ${priorityLabel(priority)}/$tag: $message"
-
-        return if (throwable != null) {
-            baseLine + "\n" + getStackTraceString(throwable)
-        } else {
-            baseLine
-        }
+        return "$time ${priorityLabel(priority)}/$tag: $formattedLogLine"
     }
 
     companion object {

--- a/Corona-Warn-App/src/test/java/android/util/Log.java
+++ b/Corona-Warn-App/src/test/java/android/util/Log.java
@@ -1,0 +1,39 @@
+package android.util;
+
+public class Log {
+
+    public static final int VERBOSE = 2;
+    public static final int DEBUG = 3;
+    public static final int INFO = 4;
+    public static final int WARN = 5;
+    public static final int ERROR = 6;
+    public static final int ASSERT = 7;
+
+    public static int d(String tag, String msg) {
+        System.out.println("D: " + tag + ": " + msg);
+        return 0;
+    }
+
+    public static int i(String tag, String msg) {
+        System.out.println("I/: " + tag + ": " + msg);
+        return 0;
+    }
+
+    public static int w(String tag, String msg) {
+        System.out.println("W/: " + tag + ": " + msg);
+        return 0;
+    }
+
+    public static int e(String tag, String msg) {
+        return e(tag, msg, null);
+    }
+
+    public static int e(String tag, String msg, Throwable error) {
+        if (error != null) {
+            System.out.println("E/: " + tag + ": " + msg + "Error: " + error.toString());
+        } else {
+            System.out.println("E/: " + tag + ": " + msg);
+        }
+        return 0;
+    }
+}

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/BugCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/BugCensorTest.kt
@@ -170,7 +170,8 @@ class BugCensorTest : BaseTest() {
         BugCensor.CensorContainer("#abcdefg*")
             .censor("abc", "123")
             .censor("efg", "567")
-            .compile()!!.apply {
+            .compile()!!
+            .apply {
                 censored shouldBe "#123d567*"
                 ranges shouldBe listOf(1..4, 5..8)
             }
@@ -181,7 +182,8 @@ class BugCensorTest : BaseTest() {
         BugCensor.CensorContainer("#abcefg*")
             .censor("abc", "123")
             .censor("efg", "567")
-            .compile()!!.apply {
+            .compile()!!
+            .apply {
                 censored shouldBe "#123567*"
                 ranges shouldBe listOf(1..4, 4..7)
             }
@@ -192,7 +194,8 @@ class BugCensorTest : BaseTest() {
         BugCensor.CensorContainer("#abcdefg*")
             .censor("abcd", "1234")
             .censor("defg", "4567")
-            .compile()!!.apply {
+            .compile()!!
+            .apply {
                 censored shouldBe "#<censor-collision/>*"
                 ranges shouldBe listOf(1..8)
             }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/BugCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/BugCensorTest.kt
@@ -102,98 +102,98 @@ class BugCensorTest : BaseTest() {
 
     @Test
     fun `censor string is nulled if not modified`() {
-        BugCensor.CensoredString("abc", 1..2).toNullIfUnmodified() shouldNotBe null
-        BugCensor.CensoredString("abc", null).toNullIfUnmodified() shouldBe null
+        BugCensor.CensoredString("abc", "abc", 1..2).toNullIfUnmodified() shouldNotBe null
+        BugCensor.CensoredString("abc", "abc", null).toNullIfUnmodified() shouldBe null
     }
 
     @Test
     fun `censoring range determination`() {
         val input = "1234567890ABCDEFG"
-        val one = BugCensor.CensoredString(input, null)
+        val one = BugCensor.CensoredString.fromOriginal(input)
 
         one.censor("1234", "")!!.apply {
-            string shouldBe "567890ABCDEFG"
+            censored shouldBe "567890ABCDEFG"
             range shouldBe 0..4
         }
 
         one.censor("1234", "....")!!.apply {
-            string shouldBe "....567890ABCDEFG"
+            censored shouldBe "....567890ABCDEFG"
             range shouldBe 0..4
         }
 
         one.censor("DEFG", "....")!!.apply {
-            string shouldBe "1234567890ABC...."
+            censored shouldBe "1234567890ABC...."
             range shouldBe 13..(13 + 4)
         }
 
         one.censor("1234567890ABCDEFG", "...")!!.apply {
-            string shouldBe "..."
+            censored shouldBe "..."
             range shouldBe 0..(0 + 17)
         }
 
         one.censor("#", "...") shouldBe null
 
         one.censor("1234567890ABCDEFG", "1234567890ABCDEFG###")!!.apply {
-            string shouldBe "1234567890ABCDEFG###"
+            censored shouldBe "1234567890ABCDEFG###"
             range shouldBe 0..(0 + 17)
         }
 
         one.censor("", " ")!!.apply {
-            string shouldBe " 1 2 3 4 5 6 7 8 9 0 A B C D E F G "
+            censored shouldBe " 1 2 3 4 5 6 7 8 9 0 A B C D E F G "
             range shouldBe 0..16
         }
     }
 
     @Test
     fun `censoring range combination`() {
-        (BugCensor.CensoredString("abc", 1..2) + BugCensor.CensoredString("abc", 1..2)).apply {
-            string shouldBe "abc"
+        (BugCensor.CensoredString("abc", "abc", 1..2) + BugCensor.CensoredString("abc", "abc", 1..2)).apply {
+            censored shouldBe "abc"
             range shouldBe 1..2
         }
 
-        (BugCensor.CensoredString("abc", 0..2) + BugCensor.CensoredString("abc", 1..2)).apply {
+        (BugCensor.CensoredString("abc", "abc", 0..2) + BugCensor.CensoredString("abc", "abc", 1..2)).apply {
             range shouldBe 0..2
         }
-        (BugCensor.CensoredString("abc", 0..3) + BugCensor.CensoredString("abc", 1..2)).apply {
+        (BugCensor.CensoredString("abc", "abc", 0..3) + BugCensor.CensoredString("abc", "abc", 1..2)).apply {
             range shouldBe 0..3
         }
-        (BugCensor.CensoredString("abc", 1..2) + BugCensor.CensoredString("abc", 0..2)).apply {
+        (BugCensor.CensoredString("abc", "abc", 1..2) + BugCensor.CensoredString("abc", "abc", 0..2)).apply {
             range shouldBe 0..2
         }
-        (BugCensor.CensoredString("abc", 1..2) + BugCensor.CensoredString("abc", 0..3)).apply {
+        (BugCensor.CensoredString("abc", "abc", 1..2) + BugCensor.CensoredString("abc", "abc", 0..3)).apply {
             range shouldBe 0..3
         }
 
-        (BugCensor.CensoredString("abc", 1..2) + BugCensor.CensoredString("abc", 3..4)).apply {
+        (BugCensor.CensoredString("abc", "abc", 1..2) + BugCensor.CensoredString("abc", "abc", 3..4)).apply {
             range shouldBe 1..4
         }
-        (BugCensor.CensoredString("abc", 1..2) + BugCensor.CensoredString("abc", 4..5)).apply {
+        (BugCensor.CensoredString("abc", "abc", 1..2) + BugCensor.CensoredString("abc", "abc", 4..5)).apply {
             range shouldBe 1..5
         }
-        (BugCensor.CensoredString("abc", 1..1) + BugCensor.CensoredString("abc", 2..2)).apply {
+        (BugCensor.CensoredString("abc", "abc", 1..1) + BugCensor.CensoredString("abc", "abc", 2..2)).apply {
             range shouldBe 1..2
         }
 
-        (BugCensor.CensoredString("abc", 1..2) + BugCensor.CensoredString("abc", 0..2)).apply {
+        (BugCensor.CensoredString("abc", "abc", 1..2) + BugCensor.CensoredString("abc", "abc", 0..2)).apply {
             range shouldBe 0..2
         }
-        (BugCensor.CensoredString("abc", 1..2) + BugCensor.CensoredString("abc", 0..3)).apply {
+        (BugCensor.CensoredString("abc", "abc", 1..2) + BugCensor.CensoredString("abc", "abc", 0..3)).apply {
             range shouldBe 0..3
         }
-        (BugCensor.CensoredString("abc", 0..2) + BugCensor.CensoredString("abc", 1..2)).apply {
+        (BugCensor.CensoredString("abc", "abc", 0..2) + BugCensor.CensoredString("abc", "abc", 1..2)).apply {
             range shouldBe 0..2
         }
-        (BugCensor.CensoredString("abc", 0..3) + BugCensor.CensoredString("abc", 1..2)).apply {
+        (BugCensor.CensoredString("abc", "abc", 0..3) + BugCensor.CensoredString("abc", "abc", 1..2)).apply {
             range shouldBe 0..3
         }
 
-        (BugCensor.CensoredString("abc", 3..4) + BugCensor.CensoredString("abc", 1..2)).apply {
+        (BugCensor.CensoredString("abc", "abc", 3..4) + BugCensor.CensoredString("abc", "abc", 1..2)).apply {
             range shouldBe 1..4
         }
-        (BugCensor.CensoredString("abc", 4..5) + BugCensor.CensoredString("abc", 1..2)).apply {
+        (BugCensor.CensoredString("abc", "abc", 4..5) + BugCensor.CensoredString("abc", "abc", 1..2)).apply {
             range shouldBe 1..5
         }
-        (BugCensor.CensoredString("abc", 2..2) + BugCensor.CensoredString("abc", 1..1)).apply {
+        (BugCensor.CensoredString("abc", "abc", 2..2) + BugCensor.CensoredString("abc", "abc", 1..1)).apply {
             range shouldBe 1..2
         }
     }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/BugCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/BugCensorTest.kt
@@ -172,7 +172,18 @@ class BugCensorTest : BaseTest() {
             .censor("efg", "567")
             .compile()!!.apply {
                 censored shouldBe "#123d567*"
-                ranges shouldBe 1..8
+                ranges shouldBe listOf(1..4, 5..8)
+            }
+    }
+
+    @Test
+    fun `censoring disjoint - touching`() {
+        BugCensor.CensorContainer("#abcefg*")
+            .censor("abc", "123")
+            .censor("efg", "567")
+            .compile()!!.apply {
+                censored shouldBe "#123567*"
+                ranges shouldBe listOf(1..4, 4..7)
             }
     }
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/BugCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/BugCensorTest.kt
@@ -140,8 +140,14 @@ class BugCensorTest : BaseTest() {
 
         one.censor("", " ")!!.apply {
             string shouldBe " 1 2 3 4 5 6 7 8 9 0 A B C D E F G "
-            range shouldBe 0..13
+            range shouldBe 0..16
         }
+
+        // TODO if we use the original string
+//        one.censor("", " ")!!.apply {
+//            string shouldBe " 1 2 3 4 5 6 7 8 9 0 A B C D E F G "
+//            range shouldBe 0..13
+//        }
     }
 
     @Test

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/BugCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/BugCensorTest.kt
@@ -164,4 +164,26 @@ class BugCensorTest : BaseTest() {
         container3.actions[0].range shouldBe 2..5
         container3.actions[1].range shouldBe 0..2
     }
+
+    @Test
+    fun `censoring disjoint`() {
+        BugCensor.CensorContainer("#abcdefg*")
+            .censor("abc", "123")
+            .censor("efg", "567")
+            .compile()!!.apply {
+                censored shouldBe "#123d567*"
+                ranges shouldBe 1..8
+            }
+    }
+
+    @Test
+    fun `censoring overlap`() {
+        BugCensor.CensorContainer("#abcdefg*")
+            .censor("abcd", "1234")
+            .censor("defg", "4567")
+            .compile()!!.apply {
+                censored shouldBe "#<censor-collision/>*"
+                ranges shouldBe listOf(1..8)
+            }
+    }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/BugCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/BugCensorTest.kt
@@ -142,12 +142,6 @@ class BugCensorTest : BaseTest() {
             string shouldBe " 1 2 3 4 5 6 7 8 9 0 A B C D E F G "
             range shouldBe 0..16
         }
-
-        // TODO if we use the original string
-//        one.censor("", " ")!!.apply {
-//            string shouldBe " 1 2 3 4 5 6 7 8 9 0 A B C D E F G "
-//            range shouldBe 0..13
-//        }
     }
 
     @Test

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/CensorInjectionTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/CensorInjectionTest.kt
@@ -69,7 +69,7 @@ class MockProvider {
 
     @Singleton
     @Provides
-    fun diary(): ContactDiaryRepository = mockk() {
+    fun diary(): ContactDiaryRepository = mockk {
         every { people } returns flowOf(emptyList())
         every { personEncounters } returns flowOf(emptyList())
         every { locations } returns flowOf(emptyList())
@@ -82,19 +82,19 @@ class MockProvider {
 
     @Singleton
     @Provides
-    fun coronaTestRepository(): CoronaTestRepository = mockk() {
+    fun coronaTestRepository(): CoronaTestRepository = mockk {
         every { coronaTests } returns flowOf(emptySet())
     }
 
     @Singleton
     @Provides
-    fun checkInRepository(): CheckInRepository = mockk() {
+    fun checkInRepository(): CheckInRepository = mockk {
         every { allCheckIns } returns flowOf(emptyList())
     }
 
     @Singleton
     @Provides
-    fun traceLocationRepository(): TraceLocationRepository = mockk() {
+    fun traceLocationRepository(): TraceLocationRepository = mockk {
         every { allTraceLocations } returns flowOf(emptyList())
     }
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/CheckInsCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/CheckInsCensorTest.kt
@@ -65,7 +65,7 @@ internal class CheckInsCensorTest : BaseTest() {
             Who needs the Kwik-E-Mart in Some Street, 12345 Springfield? I doooo!
             """.trimIndent()
 
-        censor.checkLog(logLineToCensor)!!.string shouldBe """
+        censor.checkLog(logLineToCensor)!!.censored shouldBe """
             Let's go to CheckIn#1/Description in CheckIn#1/Address.
             Who needs the CheckIn#2/Description in CheckIn#2/Address? I doooo!
         """.trimIndent()
@@ -108,7 +108,7 @@ internal class CheckInsCensorTest : BaseTest() {
             Who needs the Kwik-E-Mart in Some Street, 12345 Springfield? I doooo!
             """.trimIndent()
 
-        censor.checkLog(logLineToCensor)!!.string shouldBe """
+        censor.checkLog(logLineToCensor)!!.censored shouldBe """
             Let's go to CheckIn#1/Description in CheckIn#1/Address.
             Who needs the CheckIn#2/Description in CheckIn#2/Address? I doooo!
         """.trimIndent()

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/CheckInsCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/CheckInsCensorTest.kt
@@ -92,11 +92,11 @@ internal class CheckInsCensorTest : BaseTest() {
                     checkInDescription = "Moe's Tavern",
                     checkInAddress = "Near 742 Evergreen Terrace, 12345 Springfield"
                 ),
-                            /* deleted: mockCheckIn(
-                    checkInId = 2,
-                    checkInDescription = "Kwik-E-Mart",
-                    checkInAddress = "Some Street, 12345 Springfield"
-                )*/
+                /* deleted: mockCheckIn(
+        checkInId = 2,
+        checkInDescription = "Kwik-E-Mart",
+        checkInAddress = "Some Street, 12345 Springfield"
+    )*/
             )
         )
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/CheckInsCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/CheckInsCensorTest.kt
@@ -65,7 +65,7 @@ internal class CheckInsCensorTest : BaseTest() {
             Who needs the Kwik-E-Mart in Some Street, 12345 Springfield? I doooo!
             """.trimIndent()
 
-        censor.checkLog(logLineToCensor)!!.censored shouldBe """
+        censor.checkLog(logLineToCensor)!!.compile()!!.censored shouldBe """
             Let's go to CheckIn#1/Description in CheckIn#1/Address.
             Who needs the CheckIn#2/Description in CheckIn#2/Address? I doooo!
         """.trimIndent()
@@ -108,7 +108,7 @@ internal class CheckInsCensorTest : BaseTest() {
             Who needs the Kwik-E-Mart in Some Street, 12345 Springfield? I doooo!
             """.trimIndent()
 
-        censor.checkLog(logLineToCensor)!!.censored shouldBe """
+        censor.checkLog(logLineToCensor)!!.compile()!!.censored shouldBe """
             Let's go to CheckIn#1/Description in CheckIn#1/Address.
             Who needs the CheckIn#2/Description in CheckIn#2/Address? I doooo!
         """.trimIndent()

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/CoronaTestCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/CoronaTestCensorTest.kt
@@ -54,7 +54,8 @@ class CoronaTestCensorTest : BaseTest() {
     fun `censoring replaces the logline message`() = runBlockingTest {
         val instance = createInstance()
         val filterMe = "I'm a shy registration token: $testToken and we are extrovert $pcrIdentifier and $ratIdentifier"
-        instance.checkLog(filterMe)!!.censored shouldBe "I'm a shy registration token: ########-####-####-####-########3a2f and we are extrovert qrcode-pcr-CoronaTest/Identifier and qrcode-rat-CoronaTest/Identifier"
+        instance.checkLog(filterMe)!!
+            .compile()!!.censored shouldBe "I'm a shy registration token: ########-####-####-####-########3a2f and we are extrovert qrcode-pcr-CoronaTest/Identifier and qrcode-rat-CoronaTest/Identifier"
 
         verify { coronaTestRepository.coronaTests }
     }
@@ -83,11 +84,13 @@ class CoronaTestCensorTest : BaseTest() {
 
         val filterMe = "I'm a shy registration token: $testToken and we are extrovert $pcrIdentifier and $ratIdentifier"
 
-        censor.checkLog(filterMe)!!.censored shouldBe "I'm a shy registration token: ########-####-####-####-########3a2f and we are extrovert qrcode-pcr-CoronaTest/Identifier and qrcode-rat-CoronaTest/Identifier"
+        censor.checkLog(filterMe)!!
+            .compile()!!.censored shouldBe "I'm a shy registration token: ########-####-####-####-########3a2f and we are extrovert qrcode-pcr-CoronaTest/Identifier and qrcode-rat-CoronaTest/Identifier"
 
         // delete all tests
         coronaTests.value = emptySet()
 
-        censor.checkLog(filterMe)!!.censored shouldBe "I'm a shy registration token: ########-####-####-####-########3a2f and we are extrovert qrcode-pcr-CoronaTest/Identifier and qrcode-rat-CoronaTest/Identifier"
+        censor.checkLog(filterMe)!!
+            .compile()!!.censored shouldBe "I'm a shy registration token: ########-####-####-####-########3a2f and we are extrovert qrcode-pcr-CoronaTest/Identifier and qrcode-rat-CoronaTest/Identifier"
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/CoronaTestCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/CoronaTestCensorTest.kt
@@ -54,7 +54,7 @@ class CoronaTestCensorTest : BaseTest() {
     fun `censoring replaces the logline message`() = runBlockingTest {
         val instance = createInstance()
         val filterMe = "I'm a shy registration token: $testToken and we are extrovert $pcrIdentifier and $ratIdentifier"
-        instance.checkLog(filterMe)!!.string shouldBe "I'm a shy registration token: ########-####-####-####-########3a2f and we are extrovert qrcode-pcr-CoronaTest/Identifier and qrcode-rat-CoronaTest/Identifier"
+        instance.checkLog(filterMe)!!.censored shouldBe "I'm a shy registration token: ########-####-####-####-########3a2f and we are extrovert qrcode-pcr-CoronaTest/Identifier and qrcode-rat-CoronaTest/Identifier"
 
         verify { coronaTestRepository.coronaTests }
     }
@@ -83,11 +83,11 @@ class CoronaTestCensorTest : BaseTest() {
 
         val filterMe = "I'm a shy registration token: $testToken and we are extrovert $pcrIdentifier and $ratIdentifier"
 
-        censor.checkLog(filterMe)!!.string shouldBe "I'm a shy registration token: ########-####-####-####-########3a2f and we are extrovert qrcode-pcr-CoronaTest/Identifier and qrcode-rat-CoronaTest/Identifier"
+        censor.checkLog(filterMe)!!.censored shouldBe "I'm a shy registration token: ########-####-####-####-########3a2f and we are extrovert qrcode-pcr-CoronaTest/Identifier and qrcode-rat-CoronaTest/Identifier"
 
         // delete all tests
         coronaTests.value = emptySet()
 
-        censor.checkLog(filterMe)!!.string shouldBe "I'm a shy registration token: ########-####-####-####-########3a2f and we are extrovert qrcode-pcr-CoronaTest/Identifier and qrcode-rat-CoronaTest/Identifier"
+        censor.checkLog(filterMe)!!.censored shouldBe "I'm a shy registration token: ########-####-####-####-########3a2f and we are extrovert qrcode-pcr-CoronaTest/Identifier and qrcode-rat-CoronaTest/Identifier"
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryEncounterCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryEncounterCensorTest.kt
@@ -57,7 +57,7 @@ class DiaryEncounterCensorTest : BaseTest() {
             everyone disliked that.
             """.trimIndent()
 
-        instance.checkLog(censorMe)!!.censored shouldBe
+        instance.checkLog(censorMe)!!.compile()!!.censored shouldBe
             """
             On Encounter#2/Circumstances,
             two persons Encounter#3/Circumstances,
@@ -88,7 +88,7 @@ class DiaryEncounterCensorTest : BaseTest() {
             everyone disliked that.
             """.trimIndent()
 
-        instance.checkLog(censorMe)!!.censored shouldBe
+        instance.checkLog(censorMe)!!.compile()!!.censored shouldBe
             """
             On Encounter#2/Circumstances,
             two persons Encounter#3/Circumstances,

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryEncounterCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryEncounterCensorTest.kt
@@ -57,7 +57,7 @@ class DiaryEncounterCensorTest : BaseTest() {
             everyone disliked that.
             """.trimIndent()
 
-        instance.checkLog(censorMe)!!.string shouldBe
+        instance.checkLog(censorMe)!!.censored shouldBe
             """
             On Encounter#2/Circumstances,
             two persons Encounter#3/Circumstances,
@@ -88,7 +88,7 @@ class DiaryEncounterCensorTest : BaseTest() {
             everyone disliked that.
             """.trimIndent()
 
-        instance.checkLog(censorMe)!!.string shouldBe
+        instance.checkLog(censorMe)!!.censored shouldBe
             """
             On Encounter#2/Circumstances,
             two persons Encounter#3/Circumstances,

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryLocationCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryLocationCensorTest.kt
@@ -59,7 +59,7 @@ class DiaryLocationCensorTest : BaseTest() {
             Both agreed that their emails (bürgermeister@münchen.de|karl@aachen.de) are awesome,
             and that Bielefeld doesn't exist as it has neither phonenumber (null) nor email (null).
             """.trimIndent()
-        instance.checkLog(censorMe)!!.string shouldBe
+        instance.checkLog(censorMe)!!.censored shouldBe
             """
             Bürgermeister of Location#1/Name (Location#1/PhoneNumber) and Karl of Location#3/Name [Location#3/PhoneNumber] called each other.
             Both agreed that their emails (Location#1/EMail|Location#3/EMail) are awesome,
@@ -89,7 +89,7 @@ class DiaryLocationCensorTest : BaseTest() {
             Both agreed that their emails (bürgermeister@münchen.de|karl@aachen.de) are awesome,
             and that Bielefeld doesn't exist as it has neither phonenumber (null) nor email (null).
             """.trimIndent()
-        instance.checkLog(censorMe)!!.string shouldBe
+        instance.checkLog(censorMe)!!.censored shouldBe
             """
             Bürgermeister of Location#1/Name (Location#1/PhoneNumber) and Karl of Location#3/Name [Location#3/PhoneNumber] called each other.
             Both agreed that their emails (Location#1/EMail|Location#3/EMail) are awesome,

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryLocationCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryLocationCensorTest.kt
@@ -59,7 +59,7 @@ class DiaryLocationCensorTest : BaseTest() {
             Both agreed that their emails (bürgermeister@münchen.de|karl@aachen.de) are awesome,
             and that Bielefeld doesn't exist as it has neither phonenumber (null) nor email (null).
             """.trimIndent()
-        instance.checkLog(censorMe)!!.censored shouldBe
+        instance.checkLog(censorMe)!!.compile()!!.censored shouldBe
             """
             Bürgermeister of Location#1/Name (Location#1/PhoneNumber) and Karl of Location#3/Name [Location#3/PhoneNumber] called each other.
             Both agreed that their emails (Location#1/EMail|Location#3/EMail) are awesome,
@@ -89,7 +89,7 @@ class DiaryLocationCensorTest : BaseTest() {
             Both agreed that their emails (bürgermeister@münchen.de|karl@aachen.de) are awesome,
             and that Bielefeld doesn't exist as it has neither phonenumber (null) nor email (null).
             """.trimIndent()
-        instance.checkLog(censorMe)!!.censored shouldBe
+        instance.checkLog(censorMe)!!.compile()!!.censored shouldBe
             """
             Bürgermeister of Location#1/Name (Location#1/PhoneNumber) and Karl of Location#3/Name [Location#3/PhoneNumber] called each other.
             Both agreed that their emails (Location#1/EMail|Location#3/EMail) are awesome,

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryPersonCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryPersonCensorTest.kt
@@ -60,7 +60,7 @@ class DiaryPersonCensorTest : BaseTest() {
             but Matthias thought he had enough has had enough for today.
             A quick mail to luka@sap.com confirmed this.
             """.trimIndent()
-        instance.checkLog(censorMe)!!.string shouldBe
+        instance.checkLog(censorMe)!!.censored shouldBe
             """
             Person#2/Name requested more coffee from Person#1/PhoneNumber,
             but Person#3/Name thought he had enough has had enough for today.
@@ -91,7 +91,7 @@ class DiaryPersonCensorTest : BaseTest() {
             A quick mail to luka@sap.com confirmed this.
             """.trimIndent()
 
-        instance.checkLog(censorMe)!!.string shouldBe
+        instance.checkLog(censorMe)!!.censored shouldBe
             """
             Person#2/Name requested more coffee from Person#1/PhoneNumber,
             but Person#3/Name thought he had enough has had enough for today.

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryPersonCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryPersonCensorTest.kt
@@ -60,7 +60,7 @@ class DiaryPersonCensorTest : BaseTest() {
             but Matthias thought he had enough has had enough for today.
             A quick mail to luka@sap.com confirmed this.
             """.trimIndent()
-        instance.checkLog(censorMe)!!.censored shouldBe
+        instance.checkLog(censorMe)!!.compile()!!.censored shouldBe
             """
             Person#2/Name requested more coffee from Person#1/PhoneNumber,
             but Person#3/Name thought he had enough has had enough for today.
@@ -91,7 +91,7 @@ class DiaryPersonCensorTest : BaseTest() {
             A quick mail to luka@sap.com confirmed this.
             """.trimIndent()
 
-        instance.checkLog(censorMe)!!.censored shouldBe
+        instance.checkLog(censorMe)!!.compile()!!.censored shouldBe
             """
             Person#2/Name requested more coffee from Person#1/PhoneNumber,
             but Person#3/Name thought he had enough has had enough for today.

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryVisitCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryVisitCensorTest.kt
@@ -55,7 +55,7 @@ class DiaryVisitCensorTest : BaseTest() {
             I got my beard shaved without mask,
             only to find out the supermarket was out of toiletpaper.
             """.trimIndent()
-        instance.checkLog(censorMe)!!.string shouldBe
+        instance.checkLog(censorMe)!!.censored shouldBe
             """
             After having a Visit#1/Circumstances,
             I got my Visit#2/Circumstances,
@@ -84,7 +84,7 @@ class DiaryVisitCensorTest : BaseTest() {
             I got my beard shaved without mask,
             only to find out the supermarket was out of toiletpaper.
             """.trimIndent()
-        instance.checkLog(censorMe)!!.string shouldBe
+        instance.checkLog(censorMe)!!.censored shouldBe
             """
             After having a Visit#1/Circumstances,
             I got my Visit#2/Circumstances,

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryVisitCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/DiaryVisitCensorTest.kt
@@ -55,7 +55,7 @@ class DiaryVisitCensorTest : BaseTest() {
             I got my beard shaved without mask,
             only to find out the supermarket was out of toiletpaper.
             """.trimIndent()
-        instance.checkLog(censorMe)!!.censored shouldBe
+        instance.checkLog(censorMe)!!.compile()!!.censored shouldBe
             """
             After having a Visit#1/Circumstances,
             I got my Visit#2/Circumstances,
@@ -84,7 +84,7 @@ class DiaryVisitCensorTest : BaseTest() {
             I got my beard shaved without mask,
             only to find out the supermarket was out of toiletpaper.
             """.trimIndent()
-        instance.checkLog(censorMe)!!.censored shouldBe
+        instance.checkLog(censorMe)!!.compile()!!.censored shouldBe
             """
             After having a Visit#1/Circumstances,
             I got my Visit#2/Circumstances,

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/PcrQrCodeCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/PcrQrCodeCensorTest.kt
@@ -30,7 +30,8 @@ class PcrQrCodeCensorTest : BaseTest() {
         PcrQrCodeCensor.lastGUID = testGUID
         val instance = createInstance()
         val censored = "I'm a shy qrcode: $testGUID"
-        instance.checkLog(censored)!!.censored shouldBe "I'm a shy qrcode: ########-####-####-####-########3a2f"
+        instance.checkLog(censored)!!
+            .compile()!!.censored shouldBe "I'm a shy qrcode: ########-####-####-####-########3a2f"
     }
 
     @Test

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/PcrQrCodeCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/PcrQrCodeCensorTest.kt
@@ -30,7 +30,7 @@ class PcrQrCodeCensorTest : BaseTest() {
         PcrQrCodeCensor.lastGUID = testGUID
         val instance = createInstance()
         val censored = "I'm a shy qrcode: $testGUID"
-        instance.checkLog(censored)!!.string shouldBe "I'm a shy qrcode: ########-####-####-####-########3a2f"
+        instance.checkLog(censored)!!.censored shouldBe "I'm a shy qrcode: ########-####-####-####-########3a2f"
     }
 
     @Test

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/RACoronaTestCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/RACoronaTestCensorTest.kt
@@ -50,7 +50,7 @@ internal class RACoronaTestCensorTest : BaseTest() {
             Hello! My name is John. My friends call me Mister Doe and I was born on 2020-01-01.
             """.trimIndent()
 
-        censor.checkLog(logLineToCensor)!!.censored shouldBe
+        censor.checkLog(logLineToCensor)!!.compile()!!.censored shouldBe
             """
             Hello! My name is RATest/FirstName. My friends call me Mister RATest/LastName and I was born on RATest/DateOfBirth.
             """.trimIndent()
@@ -77,7 +77,7 @@ internal class RACoronaTestCensorTest : BaseTest() {
             Hello! My name is John. My friends call me Mister Doe and I was born on 2020-01-01.
             """.trimIndent()
 
-        censor.checkLog(logLineToCensor)!!.censored shouldBe
+        censor.checkLog(logLineToCensor)!!.compile()!!.censored shouldBe
             """
             Hello! My name is RATest/FirstName. My friends call me Mister RATest/LastName and I was born on RATest/DateOfBirth.
             """.trimIndent()

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/RACoronaTestCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/RACoronaTestCensorTest.kt
@@ -50,7 +50,7 @@ internal class RACoronaTestCensorTest : BaseTest() {
             Hello! My name is John. My friends call me Mister Doe and I was born on 2020-01-01.
             """.trimIndent()
 
-        censor.checkLog(logLineToCensor)!!.string shouldBe
+        censor.checkLog(logLineToCensor)!!.censored shouldBe
             """
             Hello! My name is RATest/FirstName. My friends call me Mister RATest/LastName and I was born on RATest/DateOfBirth.
             """.trimIndent()
@@ -77,7 +77,7 @@ internal class RACoronaTestCensorTest : BaseTest() {
             Hello! My name is John. My friends call me Mister Doe and I was born on 2020-01-01.
             """.trimIndent()
 
-        censor.checkLog(logLineToCensor)!!.string shouldBe
+        censor.checkLog(logLineToCensor)!!.censored shouldBe
             """
             Hello! My name is RATest/FirstName. My friends call me Mister RATest/LastName and I was born on RATest/DateOfBirth.
             """.trimIndent()

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/RatQrCodeCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/RatQrCodeCensorTest.kt
@@ -41,7 +41,7 @@ internal class RatQrCodeCensorTest {
         val logLineToCensor =
             "Here comes the hash: $testHash of the rat test of Milhouse Van Houten. He was born on 1980-07-01"
 
-        censor.checkLog(logLineToCensor)!!.string shouldBe "Here comes the hash: SHA256HASH-ENDING-WITH-15ad of the rat test of RATest/FirstName RATest/LastName. He was born on RATest/DateOfBirth"
+        censor.checkLog(logLineToCensor)!!.censored shouldBe "Here comes the hash: SHA256HASH-ENDING-WITH-15ad of the rat test of RATest/FirstName RATest/LastName. He was born on RATest/DateOfBirth"
     }
 
     @Test

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/RatQrCodeCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/RatQrCodeCensorTest.kt
@@ -41,7 +41,8 @@ internal class RatQrCodeCensorTest {
         val logLineToCensor =
             "Here comes the hash: $testHash of the rat test of Milhouse Van Houten. He was born on 1980-07-01"
 
-        censor.checkLog(logLineToCensor)!!.censored shouldBe "Here comes the hash: SHA256HASH-ENDING-WITH-15ad of the rat test of RATest/FirstName RATest/LastName. He was born on RATest/DateOfBirth"
+        censor.checkLog(logLineToCensor)!!
+            .compile()!!.censored shouldBe "Here comes the hash: SHA256HASH-ENDING-WITH-15ad of the rat test of RATest/FirstName RATest/LastName. He was born on RATest/DateOfBirth"
     }
 
     @Test

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/TraceLocationCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/TraceLocationCensorTest.kt
@@ -51,38 +51,39 @@ internal class TraceLocationCensorTest : BaseTest() {
     }
 
     @Test
-    fun `checkLog() should return LogLine with censored trace location information from repository`() = runBlockingTest {
-        every { traceLocationRepo.allTraceLocations } returns flowOf(
-            listOf(
-                mockTraceLocation(
-                    traceLocationId = 1,
-                    traceLocationType = TraceLocationOuterClass.TraceLocationType.LOCATION_TYPE_PERMANENT_FOOD_SERVICE,
-                    traceLocationDescription = "Sushi Place",
-                    traceLocationAddress = "Sushi Street 123, 12345 Fish Town"
-                ),
-                mockTraceLocation(
-                    traceLocationId = 2,
-                    traceLocationType = TraceLocationOuterClass.TraceLocationType.LOCATION_TYPE_TEMPORARY_CULTURAL_EVENT,
-                    traceLocationDescription = "Rick Astley Concert",
-                    traceLocationAddress = "Never gonna give you up street 1, 12345 RickRoll City"
+    fun `checkLog() should return LogLine with censored trace location information from repository`() =
+        runBlockingTest {
+            every { traceLocationRepo.allTraceLocations } returns flowOf(
+                listOf(
+                    mockTraceLocation(
+                        traceLocationId = 1,
+                        traceLocationType = TraceLocationOuterClass.TraceLocationType.LOCATION_TYPE_PERMANENT_FOOD_SERVICE,
+                        traceLocationDescription = "Sushi Place",
+                        traceLocationAddress = "Sushi Street 123, 12345 Fish Town"
+                    ),
+                    mockTraceLocation(
+                        traceLocationId = 2,
+                        traceLocationType = TraceLocationOuterClass.TraceLocationType.LOCATION_TYPE_TEMPORARY_CULTURAL_EVENT,
+                        traceLocationDescription = "Rick Astley Concert",
+                        traceLocationAddress = "Never gonna give you up street 1, 12345 RickRoll City"
+                    )
                 )
             )
-        )
 
-        val censor = createInstance(this)
+            val censor = createInstance(this)
 
-        val logLineToCensor =
-            """
+            val logLineToCensor =
+                """
             The type is LOCATION_TYPE_TEMPORARY_CULTURAL_EVENT. Yesterday we went to the Rick Astley Concert. The spectacle took place in Never gonna give you up street 1, 12345 RickRoll City. 
             Afterwards we had some food in Sushi Place in Sushi Street 123, 12345 Fish Town. It a nice LOCATION_TYPE_PERMANENT_FOOD_SERVICE.
             """.trimIndent()
 
-        censor.checkLog(logLineToCensor)!!.censored shouldBe
-            """
+            censor.checkLog(logLineToCensor)!!.censored shouldBe
+                """
             The type is TraceLocation#2/Type. Yesterday we went to the TraceLocation#2/Description. The spectacle took place in TraceLocation#2/Address. 
             Afterwards we had some food in TraceLocation#1/Description in TraceLocation#1/Address. It a nice TraceLocation#1/Type.
             """.trimIndent()
-    }
+        }
 
     @Test
     fun `censoring should still work after the user deletes his trace locations`() = runBlockingTest {

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/TraceLocationCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/TraceLocationCensorTest.kt
@@ -77,7 +77,7 @@ internal class TraceLocationCensorTest : BaseTest() {
             Afterwards we had some food in Sushi Place in Sushi Street 123, 12345 Fish Town. It a nice LOCATION_TYPE_PERMANENT_FOOD_SERVICE.
             """.trimIndent()
 
-        censor.checkLog(logLineToCensor)!!.string shouldBe
+        censor.checkLog(logLineToCensor)!!.censored shouldBe
             """
             The type is TraceLocation#2/Type. Yesterday we went to the TraceLocation#2/Description. The spectacle took place in TraceLocation#2/Address. 
             Afterwards we had some food in TraceLocation#1/Description in TraceLocation#1/Address. It a nice TraceLocation#1/Type.
@@ -126,7 +126,7 @@ internal class TraceLocationCensorTest : BaseTest() {
             Afterwards we had some food in Sushi Place in Sushi Street 123, 12345 Fish Town. It a nice LOCATION_TYPE_PERMANENT_FOOD_SERVICE.
             """.trimIndent()
 
-        censor.checkLog(logLineToCensor)!!.string shouldBe
+        censor.checkLog(logLineToCensor)!!.censored shouldBe
             """
             The type is TraceLocation#2/Type. Yesterday we went to the TraceLocation#2/Description. The spectacle took place in TraceLocation#2/Address. 
             Afterwards we had some food in TraceLocation#1/Description in TraceLocation#1/Address. It a nice TraceLocation#1/Type.
@@ -154,7 +154,7 @@ internal class TraceLocationCensorTest : BaseTest() {
                 top secret address as the address. The type is LOCATION_TYPE_TEMPORARY_PRIVATE_EVENT. 
                 """.trimIndent()
 
-            censor.checkLog(logLineToCensor)!!.string shouldBe
+            censor.checkLog(logLineToCensor)!!.censored shouldBe
                 """
                 The user just created a new traceLocation with TraceLocationUserInput#Description as the description and
                 TraceLocationUserInput#Address as the address. The type is TraceLocationUserInput#Type. 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/TraceLocationCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/TraceLocationCensorTest.kt
@@ -78,7 +78,7 @@ internal class TraceLocationCensorTest : BaseTest() {
             Afterwards we had some food in Sushi Place in Sushi Street 123, 12345 Fish Town. It a nice LOCATION_TYPE_PERMANENT_FOOD_SERVICE.
             """.trimIndent()
 
-            censor.checkLog(logLineToCensor)!!.censored shouldBe
+            censor.checkLog(logLineToCensor)!!.compile()!!.censored shouldBe
                 """
             The type is TraceLocation#2/Type. Yesterday we went to the TraceLocation#2/Description. The spectacle took place in TraceLocation#2/Address. 
             Afterwards we had some food in TraceLocation#1/Description in TraceLocation#1/Address. It a nice TraceLocation#1/Type.
@@ -127,7 +127,7 @@ internal class TraceLocationCensorTest : BaseTest() {
             Afterwards we had some food in Sushi Place in Sushi Street 123, 12345 Fish Town. It a nice LOCATION_TYPE_PERMANENT_FOOD_SERVICE.
             """.trimIndent()
 
-        censor.checkLog(logLineToCensor)!!.censored shouldBe
+        censor.checkLog(logLineToCensor)!!.compile()!!.censored shouldBe
             """
             The type is TraceLocation#2/Type. Yesterday we went to the TraceLocation#2/Description. The spectacle took place in TraceLocation#2/Address. 
             Afterwards we had some food in TraceLocation#1/Description in TraceLocation#1/Address. It a nice TraceLocation#1/Type.
@@ -155,7 +155,7 @@ internal class TraceLocationCensorTest : BaseTest() {
                 top secret address as the address. The type is LOCATION_TYPE_TEMPORARY_PRIVATE_EVENT. 
                 """.trimIndent()
 
-            censor.checkLog(logLineToCensor)!!.censored shouldBe
+            censor.checkLog(logLineToCensor)!!.compile()!!.censored shouldBe
                 """
                 The user just created a new traceLocation with TraceLocationUserInput#Description as the description and
                 TraceLocationUserInput#Address as the address. The type is TraceLocationUserInput#Type. 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/TraceLocationCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/TraceLocationCensorTest.kt
@@ -74,15 +74,15 @@ internal class TraceLocationCensorTest : BaseTest() {
 
             val logLineToCensor =
                 """
-            The type is LOCATION_TYPE_TEMPORARY_CULTURAL_EVENT. Yesterday we went to the Rick Astley Concert. The spectacle took place in Never gonna give you up street 1, 12345 RickRoll City. 
-            Afterwards we had some food in Sushi Place in Sushi Street 123, 12345 Fish Town. It a nice LOCATION_TYPE_PERMANENT_FOOD_SERVICE.
-            """.trimIndent()
+                The type is LOCATION_TYPE_TEMPORARY_CULTURAL_EVENT. Yesterday we went to the Rick Astley Concert. The spectacle took place in Never gonna give you up street 1, 12345 RickRoll City. 
+                Afterwards we had some food in Sushi Place in Sushi Street 123, 12345 Fish Town. It a nice LOCATION_TYPE_PERMANENT_FOOD_SERVICE.
+                """.trimIndent()
 
             censor.checkLog(logLineToCensor)!!.compile()!!.censored shouldBe
                 """
-            The type is TraceLocation#2/Type. Yesterday we went to the TraceLocation#2/Description. The spectacle took place in TraceLocation#2/Address. 
-            Afterwards we had some food in TraceLocation#1/Description in TraceLocation#1/Address. It a nice TraceLocation#1/Type.
-            """.trimIndent()
+                The type is TraceLocation#2/Type. Yesterday we went to the TraceLocation#2/Description. The spectacle took place in TraceLocation#2/Address. 
+                Afterwards we had some food in TraceLocation#1/Description in TraceLocation#1/Address. It a nice TraceLocation#1/Type.
+                """.trimIndent()
         }
 
     @Test

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/submission/RatProfileCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/submission/RatProfileCensorTest.kt
@@ -59,7 +59,7 @@ internal class RatProfileCensorTest : BaseTest() {
             "Mister First name who is also known as Last name and is born on 1950-08-01 lives in Main street, " +
                 "12132 in the beautiful city of London. You can reach him by phone: 111111111 or email: email@example.com"
 
-        censor.checkLog(logLine)!!.string shouldBe
+        censor.checkLog(logLine)!!.censored shouldBe
             "Mister RAT-Profile/FirstName who is also known as RAT-Profile/LastName and is born on RAT-Profile/DateOfBirth lives in RAT-Profile/Street, " +
             "RAT-Profile/Zip-Code in the beautiful city of RAT-Profile/City. You can reach him by phone: RAT-Profile/Phone or email: RAT-Profile/eMail"
     }
@@ -74,7 +74,7 @@ internal class RatProfileCensorTest : BaseTest() {
             "Mister First name who is also known as Last name and is born on 1950-08-01 lives in Main street, " +
                 "12132 in the beautiful city of London. You can reach him by phone: 111111111 or email: email@example.com"
 
-        censor.checkLog(logLine)!!.string shouldBe
+        censor.checkLog(logLine)!!.censored shouldBe
             "Mister RAT-Profile/FirstName who is also known as RAT-Profile/LastName and is born on RAT-Profile/DateOfBirth lives in RAT-Profile/Street, " +
             "RAT-Profile/Zip-Code in the beautiful city of RAT-Profile/City. You can reach him by phone: RAT-Profile/Phone or email: RAT-Profile/eMail"
     }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/submission/RatProfileCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/submission/RatProfileCensorTest.kt
@@ -79,6 +79,24 @@ internal class RatProfileCensorTest : BaseTest() {
             "RAT-Profile/Zip-Code in the beautiful city of RAT-Profile/City. You can reach him by phone: RAT-Profile/Phone or email: RAT-Profile/eMail"
     }
 
+    @Test
+    fun `self overlap`() = runBlockingTest {
+        val selfOverlap = profile.copy(
+            lastName = "Berlin",
+            city = "Berlin Kreuzberg"
+        )
+        every { ratProfileSettings.profile.flow } returns flowOf(selfOverlap, null)
+
+        val censor = createInstance()
+
+        val logLine =
+            "Mister First name who is also known as Last name and is born on 1950-08-01 lives in Main street, " +
+                "12132 in the beautiful city of Berlin Kreuzberg. You can reach him by phone: 111111111 or email: email@example.com, " +
+                "NotCensored"
+
+        censor.checkLog(logLine)!!.censored shouldBe "Mister <internal-censor-collision>, NotCensored"
+    }
+
     private val formatter = DateTimeFormat.forPattern("yyyy-MM-dd")
 
     private val profile = RATProfile(

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/submission/RatProfileCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/submission/RatProfileCensorTest.kt
@@ -59,7 +59,7 @@ internal class RatProfileCensorTest : BaseTest() {
             "Mister First name who is also known as Last name and is born on 1950-08-01 lives in Main street, " +
                 "12132 in the beautiful city of London. You can reach him by phone: 111111111 or email: email@example.com"
 
-        censor.checkLog(logLine)!!.censored shouldBe
+        censor.checkLog(logLine)!!.compile()!!.censored shouldBe
             "Mister RAT-Profile/FirstName who is also known as RAT-Profile/LastName and is born on RAT-Profile/DateOfBirth lives in RAT-Profile/Street, " +
             "RAT-Profile/Zip-Code in the beautiful city of RAT-Profile/City. You can reach him by phone: RAT-Profile/Phone or email: RAT-Profile/eMail"
     }
@@ -74,7 +74,7 @@ internal class RatProfileCensorTest : BaseTest() {
             "Mister First name who is also known as Last name and is born on 1950-08-01 lives in Main street, " +
                 "12132 in the beautiful city of London. You can reach him by phone: 111111111 or email: email@example.com"
 
-        censor.checkLog(logLine)!!.censored shouldBe
+        censor.checkLog(logLine)!!.compile()!!.censored shouldBe
             "Mister RAT-Profile/FirstName who is also known as RAT-Profile/LastName and is born on RAT-Profile/DateOfBirth lives in RAT-Profile/Street, " +
             "RAT-Profile/Zip-Code in the beautiful city of RAT-Profile/City. You can reach him by phone: RAT-Profile/Phone or email: RAT-Profile/eMail"
     }
@@ -94,7 +94,7 @@ internal class RatProfileCensorTest : BaseTest() {
                 "12132 in the beautiful city of Berlin Kreuzberg. You can reach him by phone: 111111111 or email: email@example.com, " +
                 "NotCensored"
 
-        censor.checkLog(logLine)!!.censored shouldBe "Mister <internal-censor-collision>, NotCensored"
+        censor.checkLog(logLine)!!.compile()!!.censored shouldBe "Mister <censor-collision/>, NotCensored"
     }
 
     private val formatter = DateTimeFormat.forPattern("yyyy-MM-dd")

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/vaccination/CertificateQrCodeCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/vaccination/CertificateQrCodeCensorTest.kt
@@ -64,13 +64,13 @@ internal class CertificateQrCodeCensorTest {
 
         val logLineToCensor = "Here comes the rawString: $testRawString of the vaccine certificate"
 
-        censor.checkLog(logLineToCensor)!!.string shouldBe "Here comes the rawString: ########-####-####-####-########C\$AH of the vaccine certificate"
+        censor.checkLog(logLineToCensor)!!.censored shouldBe "Here comes the rawString: ########-####-####-####-########C\$AH of the vaccine certificate"
 
         val certDataToCensor = "Hello my name is Kevin Bob, i was born at 1969-11-16, i have been " +
             "vaccinated with: 12345 1214765 aaEd/easd ASD-2312 1969-04-20 DE Herbert" +
             " urn:uvci:01:NL:PlA8UWS60Z4RZXVALl6GAZ"
 
-        censor.checkLog(certDataToCensor)!!.string shouldBe "Hello my name is nameData/familyName nameData/givenName, i was born at " +
+        censor.checkLog(certDataToCensor)!!.censored shouldBe "Hello my name is nameData/familyName nameData/givenName, i was born at " +
             "vaccinationCertificate/dob, i have been vaccinated with: vaccinationData/targetId " +
             "vaccinationData/vaccineId vaccinationData/medicalProductId" +
             " vaccinationData/marketAuthorizationHolderId vaccinationData/dt" +

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/vaccination/CertificateQrCodeCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/vaccination/CertificateQrCodeCensorTest.kt
@@ -20,9 +20,9 @@ internal class CertificateQrCodeCensorTest {
             version = "1",
             nameData = VaccinationDGCV1.NameData(
                 familyName = "Kevin",
-                familyNameStandardized = "Kevin2",
+                familyNameStandardized = "KEVIN",
                 givenName = "Bob",
-                givenNameStandardized = "Bob2"
+                givenNameStandardized = "BOB"
             ),
             dob = "1969-11-16",
             vaccinationDatas = listOf(
@@ -73,9 +73,9 @@ internal class CertificateQrCodeCensorTest {
 
         censor.checkLog(certDataToCensor)!!
             .compile()!!.censored shouldBe "Hello my name is nameData/familyName nameData/givenName, i was born at " +
-            "vaccinationCertificate/dob, i have been vaccinated with: vaccinationData/targetId " +
+            "vaccinationCertificate/dateOfBirth, i have been vaccinated with: vaccinationData/targetId " +
             "vaccinationData/vaccineId vaccinationData/medicalProductId" +
-            " vaccinationData/marketAuthorizationHolderId vaccinationData/dt" +
+            " vaccinationData/marketAuthorizationHolderId vaccinationData/vaccinatedAt" +
             " vaccinationData/countryOfVaccination vaccinationData/certificateIssuer" +
             " vaccinationData/uniqueCertificateIdentifier"
     }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/vaccination/CertificateQrCodeCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/vaccination/CertificateQrCodeCensorTest.kt
@@ -64,13 +64,15 @@ internal class CertificateQrCodeCensorTest {
 
         val logLineToCensor = "Here comes the rawString: $testRawString of the vaccine certificate"
 
-        censor.checkLog(logLineToCensor)!!.censored shouldBe "Here comes the rawString: ########-####-####-####-########C\$AH of the vaccine certificate"
+        censor.checkLog(logLineToCensor)!!
+            .compile()!!.censored shouldBe "Here comes the rawString: ########-####-####-####-########C\$AH of the vaccine certificate"
 
         val certDataToCensor = "Hello my name is Kevin Bob, i was born at 1969-11-16, i have been " +
             "vaccinated with: 12345 1214765 aaEd/easd ASD-2312 1969-04-20 DE Herbert" +
             " urn:uvci:01:NL:PlA8UWS60Z4RZXVALl6GAZ"
 
-        censor.checkLog(certDataToCensor)!!.censored shouldBe "Hello my name is nameData/familyName nameData/givenName, i was born at " +
+        censor.checkLog(certDataToCensor)!!
+            .compile()!!.censored shouldBe "Hello my name is nameData/familyName nameData/givenName, i was born at " +
             "vaccinationCertificate/dob, i have been vaccinated with: vaccinationData/targetId " +
             "vaccinationData/vaccineId vaccinationData/medicalProductId" +
             " vaccinationData/marketAuthorizationHolderId vaccinationData/dt" +

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/debuglog/DebugLoggerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/debuglog/DebugLoggerTest.kt
@@ -355,7 +355,7 @@ class DebugLoggerTest : BaseIOTest() {
             val msg = arg<String>(0)
             var orig = BugCensor.CensorContainer(msg)
 
-            orig = orig.censor("ort", "thisReallyIsNotShortAnymore")
+            orig = orig.censor("ortBef", "thisReallyIsNotShortAnymore")
             orig = orig.censor("Anymore", "Nevermore")
             orig
         }
@@ -413,19 +413,20 @@ class DebugLoggerTest : BaseIOTest() {
 
     @Test
     fun `censoring collision without overlap`() = runBlockingTest {
-        val before = "StrawBerryrawCake" // Without timestamp
+        val before = "StrawBerryCakeWithCream" // Without timestamp
 
         coEvery { coronaTestCensor1.checkLog(any()) } answers {
             val msg = arg<String>(0)
-            BugCensor.CensorContainer(msg).censor("Straw", "Pipe")
+            BugCensor.CensorContainer(msg)
+                .censor("Straw", "Strap")
+                .censor("With", "More")
 
         }
         coEvery { coronaTestCensor2.checkLog(any()) } answers {
             val msg = arg<String>(0)
-            var orig = BugCensor.CensorContainer(msg)
-
-            orig = orig.censor("Cake", "Fruit")
-            orig
+            BugCensor.CensorContainer(msg)
+                .censor("Berry", "Barry")
+                .censor("Cream", "Sugar")
         }
 
         val instance = createInstance(scope = this).apply {
@@ -440,7 +441,7 @@ class DebugLoggerTest : BaseIOTest() {
 
         runningLog.readLines()
             .last()
-            .substring(25) shouldBe "V/Test: PipeBerryFruit"
+            .substring(25) shouldBe "V/Test: StrapBarryCakeMoreSugar"
 
         instance.stop()
         advanceUntilIdle()

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/debuglog/DebugLoggerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/debuglog/DebugLoggerTest.kt
@@ -294,15 +294,15 @@ class DebugLoggerTest : BaseIOTest() {
                 testResult=RAT_POSITIVE(7),
                 testedAt=2021-05-25T10:17:51.000Z,
                 firstName=Rüdiger, lastName=Müller,
-                dateOfBirth=1994-05-18, isProcessing=true,
+                dateOfBirth=1994-05-18, isProcessing=false,
                 lastError=IOException()
             )
         """.trimIndent()
         val after = """
             RACoronaTest(
                 identifier=<censoring-collision>,
-                dateOfBirth=1994-05-18, isProcessing=true,
-                lastError=null
+                dateOfBirth=1994-05-18, isProcessing=false,
+                lastError=IOException()
             )
         """.trimIndent()
 
@@ -336,7 +336,7 @@ class DebugLoggerTest : BaseIOTest() {
         val rawWritten = runningLog.readText()
         val cleanedWritten = rawWritten.substring(rawWritten.indexOf("RACoronaTest"))
 
-        cleanedWritten shouldBe after
+        cleanedWritten shouldBe after + "\n"
 
         instance.stop()
         advanceUntilIdle()

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/debuglog/DebugLoggerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/debuglog/DebugLoggerTest.kt
@@ -8,6 +8,8 @@ import de.rki.coronawarnapp.util.CWADebug
 import de.rki.coronawarnapp.util.di.ApplicationComponent
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldEndWith
+import io.kotest.matchers.string.shouldStartWith
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.every
@@ -467,7 +469,10 @@ class DebugLoggerTest : BaseIOTest() {
 
         runningLog.readLines()
             .last()
-            .substring(25) shouldBe "V/Test: <censor-error>Module BugCensor\$Subclass1: java.lang.IllegalArgumentException: I give up</censor-error>"
+            .substring(25).apply {
+                this shouldStartWith "V/Test: <censor-error>Module BugCensor"
+                this shouldEndWith "lang.IllegalArgumentException: I give up</censor-error>"
+            }
 
         instance.stop()
         advanceUntilIdle()

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/debuglog/DebugLoggerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/debuglog/DebugLoggerTest.kt
@@ -241,7 +241,7 @@ class DebugLoggerTest : BaseIOTest() {
 
         coEvery { coronaTestCensor1.checkLog(any()) } answers {
             val msg = arg<String>(0)
-            BugCensor.CensoredString(msg).censor("says: A hot coffee", "says: A hot tea")
+            BugCensor.CensoredString.fromOriginal(msg).censor("says: A hot coffee", "says: A hot tea")
         }
 
         instance.start()
@@ -253,7 +253,7 @@ class DebugLoggerTest : BaseIOTest() {
 
         coEvery { coronaTestCensor2.checkLog(any()) } answers {
             val msg = arg<String>(0)
-            BugCensor.CensoredString(msg).censor("says:", "sings:")
+            BugCensor.CensoredString.fromOriginal(msg).censor("says:", "sings:")
         }
 
         Timber.tag("Test").v(logMsg)
@@ -309,7 +309,7 @@ class DebugLoggerTest : BaseIOTest() {
 
         coEvery { coronaTestCensor1.checkLog(any()) } answers {
             val msg = arg<String>(0)
-            BugCensor.CensoredString(msg).censor(
+            BugCensor.CensoredString.fromOriginal(msg).censor(
                 "firstName=Rüdiger, lastName=Müller",
                 "firstName=FIRSTNAME, lastName=LASTNAME"
             )
@@ -317,7 +317,7 @@ class DebugLoggerTest : BaseIOTest() {
         }
         coEvery { coronaTestCensor2.checkLog(any()) } answers {
             val msg = arg<String>(0)
-            BugCensor.CensoredString(msg).censor(
+            BugCensor.CensoredString.fromOriginal(msg).censor(
                 "qrcode-RAPID_ANTIGEN-9a9a35fa1cf3261be3349fc50a37b58280634bf42487c8e4eca060c48f259eb7",
                 "IDENTIFIER"
             )
@@ -348,12 +348,12 @@ class DebugLoggerTest : BaseIOTest() {
 
         coEvery { coronaTestCensor1.checkLog(any()) } answers {
             val msg = arg<String>(0)
-            BugCensor.CensoredString(msg).censor("Before", "After")
+            BugCensor.CensoredString.fromOriginal(msg).censor("Before", "After")
 
         }
         coEvery { coronaTestCensor2.checkLog(any()) } answers {
             val msg = arg<String>(0)
-            var orig = BugCensor.CensoredString(msg)
+            var orig = BugCensor.CensoredString.fromOriginal(msg)
 
             orig += orig.censor("ort", "thisReallyIsNotShortAnymore")
             orig += orig.censor("Anymore", "Nevermore")

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/debuglog/DebugLoggerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/debuglog/DebugLoggerTest.kt
@@ -267,7 +267,8 @@ class DebugLoggerTest : BaseIOTest() {
 
     @Test
     fun `censoring collision handling for multiple values in the same string`() = runBlockingTest {
-        val before = """
+        val before =
+            """
             RACoronaTest(
                 identifier=qrcode-RAPID_ANTIGEN-9a9a35fa1cf3261be3349fc50a37b58280634bf42487c8e4eca060c48f259eb7,
                 registeredAt=2021-05-25T10:18:05.275Z,
@@ -297,15 +298,15 @@ class DebugLoggerTest : BaseIOTest() {
                 dateOfBirth=1994-05-18, isProcessing=false,
                 lastError=IOException()
             )
-        """.trimIndent()
-        val after = """
+            """.trimIndent()
+        val after =
+            """
             RACoronaTest(
                 identifier=<censor-collision/>,
                 dateOfBirth=1994-05-18, isProcessing=false,
                 lastError=IOException()
             )
-        """.trimIndent()
-
+            """.trimIndent()
 
         coEvery { coronaTestCensor1.checkLog(any()) } answers {
             val msg = arg<String>(0)
@@ -313,7 +314,6 @@ class DebugLoggerTest : BaseIOTest() {
                 "firstName=Rüdiger, lastName=Müller",
                 "firstName=FIRSTNAME, lastName=LASTNAME"
             )
-
         }
         coEvery { coronaTestCensor2.checkLog(any()) } answers {
             val msg = arg<String>(0)
@@ -349,7 +349,6 @@ class DebugLoggerTest : BaseIOTest() {
         coEvery { coronaTestCensor1.checkLog(any()) } answers {
             val msg = arg<String>(0)
             BugCensor.CensorContainer(msg).censor("Before", "After")
-
         }
         coEvery { coronaTestCensor2.checkLog(any()) } answers {
             val msg = arg<String>(0)
@@ -384,7 +383,6 @@ class DebugLoggerTest : BaseIOTest() {
         coEvery { coronaTestCensor1.checkLog(any()) } answers {
             val msg = arg<String>(0)
             BugCensor.CensorContainer(msg).censor("Berry", "Banana")
-
         }
         coEvery { coronaTestCensor2.checkLog(any()) } answers {
             val msg = arg<String>(0)
@@ -420,7 +418,6 @@ class DebugLoggerTest : BaseIOTest() {
             BugCensor.CensorContainer(msg)
                 .censor("Straw", "Strap")
                 .censor("With", "More")
-
         }
         coEvery { coronaTestCensor2.checkLog(any()) } answers {
             val msg = arg<String>(0)

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/debuglog/DebugLoggerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/debuglog/DebugLoggerTest.kt
@@ -239,7 +239,7 @@ class DebugLoggerTest : BaseIOTest() {
 
         coEvery { coronaTestCensor1.checkLog(any()) } answers {
             val msg = arg<String>(0)
-            BugCensor.CensorContainer(msg).censor("says: A hot coffee", "says: A hot tea").compile()
+            BugCensor.CensorContainer(msg).censor("says: A hot coffee", "says: A hot tea")
         }
 
         instance.start()
@@ -253,13 +253,13 @@ class DebugLoggerTest : BaseIOTest() {
 
         coEvery { coronaTestCensor2.checkLog(any()) } answers {
             val msg = arg<String>(0)
-            BugCensor.CensorContainer(msg).censor("says:", "sings:").compile()
+            BugCensor.CensorContainer(msg).censor("says:", "sings:")
         }
 
         Timber.tag("Test").v(logMsg)
         advanceTimeBy(2000L)
 
-        runningLog.readLines().last().substring(25) shouldBe "V/Test: Lukas <censoring-collision> is really nice!"
+        runningLog.readLines().last().substring(25) shouldBe "V/Test: Lukas <censor-collision/> is really nice!"
 
         instance.stop()
         advanceUntilIdle()
@@ -300,7 +300,7 @@ class DebugLoggerTest : BaseIOTest() {
         """.trimIndent()
         val after = """
             RACoronaTest(
-                identifier=<censoring-collision>,
+                identifier=<censor-collision/>,
                 dateOfBirth=1994-05-18, isProcessing=false,
                 lastError=IOException()
             )
@@ -312,7 +312,7 @@ class DebugLoggerTest : BaseIOTest() {
             BugCensor.CensorContainer(msg).censor(
                 "firstName=Rüdiger, lastName=Müller",
                 "firstName=FIRSTNAME, lastName=LASTNAME"
-            ).compile()
+            )
 
         }
         coEvery { coronaTestCensor2.checkLog(any()) } answers {
@@ -320,7 +320,7 @@ class DebugLoggerTest : BaseIOTest() {
             BugCensor.CensorContainer(msg).censor(
                 "qrcode-RAPID_ANTIGEN-9a9a35fa1cf3261be3349fc50a37b58280634bf42487c8e4eca060c48f259eb7",
                 "IDENTIFIER"
-            ).compile()
+            )
         }
 
         val instance = createInstance(scope = this).apply {
@@ -348,7 +348,7 @@ class DebugLoggerTest : BaseIOTest() {
 
         coEvery { coronaTestCensor1.checkLog(any()) } answers {
             val msg = arg<String>(0)
-            BugCensor.CensorContainer(msg).censor("Before", "After").compile()
+            BugCensor.CensorContainer(msg).censor("Before", "After")
 
         }
         coEvery { coronaTestCensor2.checkLog(any()) } answers {
@@ -357,7 +357,7 @@ class DebugLoggerTest : BaseIOTest() {
 
             orig = orig.censor("ort", "thisReallyIsNotShortAnymore")
             orig = orig.censor("Anymore", "Nevermore")
-            orig.compile()
+            orig
         }
 
         val instance = createInstance(scope = this).apply {
@@ -370,7 +370,7 @@ class DebugLoggerTest : BaseIOTest() {
         Timber.tag("Test").v(before)
         advanceTimeBy(2000L)
 
-        runningLog.readLines().last().substring(25) shouldBe "V/Test: sh<censoring-collision>"
+        runningLog.readLines().last().substring(25) shouldBe "V/Test: sh<censor-collision/>"
 
         instance.stop()
         advanceUntilIdle()
@@ -383,7 +383,7 @@ class DebugLoggerTest : BaseIOTest() {
 
         coEvery { coronaTestCensor1.checkLog(any()) } answers {
             val msg = arg<String>(0)
-            BugCensor.CensorContainer(msg).censor("Berry", "Banana").compile()
+            BugCensor.CensorContainer(msg).censor("Berry", "Banana")
 
         }
         coEvery { coronaTestCensor2.checkLog(any()) } answers {
@@ -392,7 +392,7 @@ class DebugLoggerTest : BaseIOTest() {
 
             orig = orig.censor("StrawBerry", "StrawBerryBananaPie")
             orig = orig.censor("StrawBerryBananaPie", "Apple")
-            orig.compile()
+            orig
         }
 
         val instance = createInstance(scope = this).apply {
@@ -405,7 +405,7 @@ class DebugLoggerTest : BaseIOTest() {
         Timber.tag("Test").v(before)
         advanceTimeBy(2000L)
 
-        runningLog.readLines().last().substring(25) shouldBe "V/Test: <censoring-collision>Cake"
+        runningLog.readLines().last().substring(25) shouldBe "V/Test: <censor-collision/>Cake"
 
         instance.stop()
         advanceUntilIdle()
@@ -417,7 +417,7 @@ class DebugLoggerTest : BaseIOTest() {
 
         coEvery { coronaTestCensor1.checkLog(any()) } answers {
             val msg = arg<String>(0)
-            BugCensor.CensorContainer(msg).censor("Straw", "Pipe").compile()
+            BugCensor.CensorContainer(msg).censor("Straw", "Pipe")
 
         }
         coEvery { coronaTestCensor2.checkLog(any()) } answers {
@@ -425,7 +425,7 @@ class DebugLoggerTest : BaseIOTest() {
             var orig = BugCensor.CensorContainer(msg)
 
             orig = orig.censor("Cake", "Fruit")
-            orig.compile()
+            orig
         }
 
         val instance = createInstance(scope = this).apply {

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/debuglog/LogLineTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/debuglog/LogLineTest.kt
@@ -17,9 +17,14 @@ class LogLineTest : BaseTest() {
             tag = "IamATag",
             message = "Low storage check failed.",
             throwable = null
-        ).format() shouldBe """
-            1970-01-01T00:00:00.123Z E/IamATag: Low storage check failed.
-        """.trimIndent()
+        ).apply {
+            format() shouldBe """
+                Low storage check failed.
+            """.trimIndent()
+            formatFinal("abc") shouldBe """
+                1970-01-01T00:00:00.123Z E/IamATag: abc
+            """.trimIndent()
+        }
     }
 
     @Test
@@ -30,10 +35,15 @@ class LogLineTest : BaseTest() {
             tag = "IamATag",
             message = "Low storage check failed.",
             throwable = IOException()
-        ).format().trimToLength(182) shouldBe """
-            1970-01-01T00:00:00.123Z E/IamATag: Low storage check failed.
-            java.io.IOException
-            	at de.rki.coronawarnapp.bugreporting.debuglog.LogLineTest.log formatting with error(LogLineTest.kt:
-        """.trimIndent()
+        ).apply {
+            format().trimToLength(146) shouldBe """
+                Low storage check failed.
+                java.io.IOException
+                	at de.rki.coronawarnapp.bugreporting.debuglog.LogLineTest.log formatting with error(LogLineTest.kt:
+            """.trimIndent()
+            formatFinal("abc") shouldBe """
+                1970-01-01T00:00:00.123Z E/IamATag: abc
+            """.trimIndent()
+        }
     }
 }


### PR DESCRIPTION
This PR fixes multiple bugs caused by censoring multiple elements within the same log message. This PR fixes it by changing the censoring to work with lazy evaluated replacements:

### Idea

* Each `BugCensor` now produces a `CensorContainer` which is a combination of all "censorings" it wanted to do called `CensorAction`.
* Each `CensorAction` has an `CensorAction.range: IntRange` of what it wants to censor, and a `CensorAction.execute: (String) -> String` to actually do it.
* `CensorContainer.compile` creates what we previously knew as `CensoredString`, if there is a collision, it will replace the overlapping ranges with `<censor-collision/>` if there is none, if will apply all `CensorAction.execute` calls to the string and produce the final result.
* `DebugLogger`
    * Calls `compile` directly if there is only a single `BugCensor` that produced a `CensorContainer` and the others produced `null` (nothing to censor)
    * If there are multiple container produced by `BugCensor` it will combine them all into a single container and call `compile` on that.

### Fixes

* Fixes: Crash due to IndexOutOfBounds exception. Start+end index of the censored range was from the message after it has already been censored multiple times within one censor (and the replacements caused the string to be longer than the original). ( EXPOSUREAPP-7455)
* Fixes: Log message could contain uncensored elements if the logline contains the same `toCensor` element multiple times and there is a collision. Because the replacement range for the collision text was `firstIndex+length`, but it needs to be `firstIndex+lastIndex+length` (EXPOSUREAPP-7514, EXPOSUREAPP-7196)
* Fixes: Only partially censored entries if there is an overlap within the same censoring module, i.e. "John Berlin" who lives in "Berlin Kreuzberg".
* Improves: Partial censoring, if there no overlap texts be censored without collision.
* Improves: Censoring performance, if there is a collision we don't need to do individual string replacements, and just had to do `indexOf`.
* Improves: Censoring performance, we only work on the core logline, not the logline metadata data (e.g. timestamp)


Pandoras box of censoring :roll_eyes: :dizzy_face: 
