### PR TITLE
Rapid Antigen Tests: Retrieve Test Result Timestamp from Verification Server (EXPOSUREAPP-6865)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/server/CoronaTestResult.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/server/CoronaTestResult.kt
@@ -3,7 +3,21 @@ package de.rki.coronawarnapp.coronatest.server
 import com.google.gson.TypeAdapter
 import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonWriter
+import org.joda.time.Instant
 import org.json.JSONObject
+
+data class CoronaTestResultResponse(
+    val coronaTestResult: CoronaTestResult,
+    val sampleCollectedAt: Instant?
+) {
+    companion object {
+        fun fromResponse(response: VerificationApiV1.TestResultResponse) =
+            CoronaTestResultResponse(
+                coronaTestResult = CoronaTestResult.fromInt(response.testResult),
+                sampleCollectedAt = response.sampleCollectedAt?.toLong()?.let { Instant.ofEpochSecond(it) }
+            )
+    }
+}
 
 enum class CoronaTestResult(val value: Int) {
     /**

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/server/VerificationApiV1.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/server/VerificationApiV1.kt
@@ -31,7 +31,7 @@ interface VerificationApiV1 {
 
     data class TestResultResponse(
         @SerializedName("testResult") val testResult: Int,
-        @SerializedName("sc") val sc: Int?
+        @SerializedName("sc") val sampleCollectedAt: Int?
     )
 
     @POST("version/v1/testresult")

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/server/VerificationApiV1.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/server/VerificationApiV1.kt
@@ -30,7 +30,8 @@ interface VerificationApiV1 {
     )
 
     data class TestResultResponse(
-        @SerializedName("testResult") val testResult: Int
+        @SerializedName("testResult") val testResult: Int,
+        @SerializedName("sc") val sc: Int?
     )
 
     @POST("version/v1/testresult")

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/server/VerificationServer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/server/VerificationServer.kt
@@ -7,6 +7,7 @@ import de.rki.coronawarnapp.util.security.HashHelper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.joda.time.Duration
+import org.joda.time.Instant
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -51,7 +52,7 @@ class VerificationServer @Inject constructor(
 
     suspend fun pollTestResult(
         token: RegistrationToken
-    ): CoronaTestResult = withContext(Dispatchers.IO) {
+    ): Pair<CoronaTestResult, Instant?> = withContext(Dispatchers.IO) {
         Timber.tag(TAG).v("retrieveTestResults(token=%s)", token)
         val response = api.getTestResult(
             fake = "0",
@@ -63,7 +64,7 @@ class VerificationServer @Inject constructor(
         )
 
         Timber.tag(TAG).d("retrieveTestResults(token=%s) -> %s", token, response)
-        CoronaTestResult.fromInt(response.testResult)
+        CoronaTestResult.fromInt(response.testResult) to response.sc?.toLong()?.let { Instant.ofEpochSecond(it) }
     }
 
     suspend fun retrieveTan(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/server/VerificationServer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/server/VerificationServer.kt
@@ -7,7 +7,6 @@ import de.rki.coronawarnapp.util.security.HashHelper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.joda.time.Duration
-import org.joda.time.Instant
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -52,7 +51,7 @@ class VerificationServer @Inject constructor(
 
     suspend fun pollTestResult(
         token: RegistrationToken
-    ): Pair<CoronaTestResult, Instant?> = withContext(Dispatchers.IO) {
+    ): CoronaTestResultResponse = withContext(Dispatchers.IO) {
         Timber.tag(TAG).v("retrieveTestResults(token=%s)", token)
         val response = api.getTestResult(
             fake = "0",
@@ -65,8 +64,7 @@ class VerificationServer @Inject constructor(
 
         Timber.tag(TAG).d("retrieveTestResults(token=%s) -> %s", token, response)
 
-        CoronaTestResult.fromInt(response.testResult) to
-            response.sampleCollectedAt?.toLong()?.let { Instant.ofEpochSecond(it) }
+        CoronaTestResultResponse.fromResponse(response)
     }
 
     suspend fun retrieveTan(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/server/VerificationServer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/server/VerificationServer.kt
@@ -64,7 +64,9 @@ class VerificationServer @Inject constructor(
         )
 
         Timber.tag(TAG).d("retrieveTestResults(token=%s) -> %s", token, response)
-        CoronaTestResult.fromInt(response.testResult) to response.sc?.toLong()?.let { Instant.ofEpochSecond(it) }
+
+        CoronaTestResult.fromInt(response.testResult) to
+            response.sampleCollectedAt?.toLong()?.let { Instant.ofEpochSecond(it) }
     }
 
     suspend fun retrieveTan(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/CoronaTestService.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/CoronaTestService.kt
@@ -1,11 +1,10 @@
 package de.rki.coronawarnapp.coronatest.type
 
-import de.rki.coronawarnapp.coronatest.server.CoronaTestResult
+import de.rki.coronawarnapp.coronatest.server.CoronaTestResultResponse
 import de.rki.coronawarnapp.coronatest.server.VerificationKeyType
 import de.rki.coronawarnapp.deniability.NoiseScheduler
 import de.rki.coronawarnapp.playbook.Playbook
 import de.rki.coronawarnapp.worker.BackgroundConstants
-import org.joda.time.Instant
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -14,7 +13,7 @@ class CoronaTestService @Inject constructor(
     private val noiseScheduler: NoiseScheduler,
 ) {
 
-    suspend fun asyncRequestTestResult(registrationToken: String): Pair<CoronaTestResult, Instant?> {
+    suspend fun asyncRequestTestResult(registrationToken: String): CoronaTestResultResponse {
         return playbook.testResult(registrationToken)
     }
 
@@ -52,6 +51,6 @@ class CoronaTestService @Inject constructor(
 
     data class RegistrationData(
         val registrationToken: String,
-        val testResult: Pair<CoronaTestResult, Instant?>
+        val testResultResponse: CoronaTestResultResponse
     )
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/CoronaTestService.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/CoronaTestService.kt
@@ -5,6 +5,7 @@ import de.rki.coronawarnapp.coronatest.server.VerificationKeyType
 import de.rki.coronawarnapp.deniability.NoiseScheduler
 import de.rki.coronawarnapp.playbook.Playbook
 import de.rki.coronawarnapp.worker.BackgroundConstants
+import org.joda.time.Instant
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -13,7 +14,7 @@ class CoronaTestService @Inject constructor(
     private val noiseScheduler: NoiseScheduler,
 ) {
 
-    suspend fun asyncRequestTestResult(registrationToken: String): CoronaTestResult {
+    suspend fun asyncRequestTestResult(registrationToken: String): Pair<CoronaTestResult, Instant?> {
         return playbook.testResult(registrationToken)
     }
 
@@ -51,6 +52,6 @@ class CoronaTestService @Inject constructor(
 
     data class RegistrationData(
         val registrationToken: String,
-        val testResult: CoronaTestResult
+        val testResult: Pair<CoronaTestResult, Instant?>
     )
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRProcessor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRProcessor.kt
@@ -50,7 +50,8 @@ class PCRProcessor @Inject constructor(
             Timber.tag(TAG).d("Request %s gave us %s", request, it)
         }
 
-        testResultDataCollector.saveTestResultAnalyticsSettings(registrationData.testResult.first) // This saves received at
+        // This saves received at
+        testResultDataCollector.saveTestResultAnalyticsSettings(registrationData.testResult.first)
 
         return createCoronaTest(request, registrationData)
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRProcessor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRProcessor.kt
@@ -51,7 +51,7 @@ class PCRProcessor @Inject constructor(
         }
 
         // This saves received at
-        testResultDataCollector.saveTestResultAnalyticsSettings(registrationData.testResult.first)
+        testResultDataCollector.saveTestResultAnalyticsSettings(registrationData.testResultResponse.coronaTestResult)
 
         return createCoronaTest(request, registrationData)
     }
@@ -75,7 +75,7 @@ class PCRProcessor @Inject constructor(
     ): PCRCoronaTest {
         analyticsKeySubmissionCollector.reset()
 
-        val testResult = response.testResult.first.let {
+        val testResult = response.testResultResponse.coronaTestResult.let {
             Timber.tag(TAG).v("Raw test result $it")
             testResultDataCollector.updatePendingTestResultReceivedTime(it)
 
@@ -119,7 +119,7 @@ class PCRProcessor @Inject constructor(
             }
 
             val newTestResult = try {
-                submissionService.asyncRequestTestResult(test.registrationToken).first.let {
+                submissionService.asyncRequestTestResult(test.registrationToken).coronaTestResult.let {
                     Timber.tag(TAG).d("Raw test result was %s", it)
                     testResultDataCollector.updatePendingTestResultReceivedTime(it)
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRProcessor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRProcessor.kt
@@ -50,7 +50,7 @@ class PCRProcessor @Inject constructor(
             Timber.tag(TAG).d("Request %s gave us %s", request, it)
         }
 
-        testResultDataCollector.saveTestResultAnalyticsSettings(registrationData.testResult) // This saves received at
+        testResultDataCollector.saveTestResultAnalyticsSettings(registrationData.testResult.first) // This saves received at
 
         return createCoronaTest(request, registrationData)
     }
@@ -74,7 +74,7 @@ class PCRProcessor @Inject constructor(
     ): PCRCoronaTest {
         analyticsKeySubmissionCollector.reset()
 
-        val testResult = response.testResult.let {
+        val testResult = response.testResult.first.let {
             Timber.tag(TAG).v("Raw test result $it")
             testResultDataCollector.updatePendingTestResultReceivedTime(it)
 
@@ -118,7 +118,7 @@ class PCRProcessor @Inject constructor(
             }
 
             val newTestResult = try {
-                submissionService.asyncRequestTestResult(test.registrationToken).let {
+                submissionService.asyncRequestTestResult(test.registrationToken).first.let {
                     Timber.tag(TAG).d("Raw test result was %s", it)
                     testResultDataCollector.updatePendingTestResultReceivedTime(it)
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RACoronaTest.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RACoronaTest.kt
@@ -61,6 +61,9 @@ data class RACoronaTest(
     @SerializedName("dateOfBirth")
     val dateOfBirth: LocalDate? = null,
 
+    @SerializedName("sampleCollectedAt")
+    val sampleCollectedAt: Instant? = null,
+
     @Transient override val isProcessing: Boolean = false,
     @Transient override val lastError: Throwable? = null,
 ) : CoronaTest {
@@ -68,8 +71,10 @@ data class RACoronaTest(
     override val type: CoronaTest.Type
         get() = CoronaTest.Type.RAPID_ANTIGEN
 
-    private fun isOutdated(nowUTC: Instant, testConfig: CoronaTestConfig) =
-        testedAt.plus(testConfig.coronaRapidAntigenTestParameters.hoursToDeemTestOutdated).isBefore(nowUTC)
+    private fun isOutdated(nowUTC: Instant, testConfig: CoronaTestConfig): Boolean {
+        val timeoutTime = sampleCollectedAt ?: testedAt
+        return timeoutTime.plus(testConfig.coronaRapidAntigenTestParameters.hoursToDeemTestOutdated).isBefore(nowUTC)
+    }
 
     fun getState(nowUTC: Instant, testConfig: CoronaTestConfig) =
         if (testResult == RAT_NEGATIVE && isOutdated(nowUTC, testConfig)) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RapidAntigenProcessor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RapidAntigenProcessor.kt
@@ -13,6 +13,7 @@ import de.rki.coronawarnapp.coronatest.server.CoronaTestResult.RAT_NEGATIVE
 import de.rki.coronawarnapp.coronatest.server.CoronaTestResult.RAT_PENDING
 import de.rki.coronawarnapp.coronatest.server.CoronaTestResult.RAT_POSITIVE
 import de.rki.coronawarnapp.coronatest.server.CoronaTestResult.RAT_REDEEMED
+import de.rki.coronawarnapp.coronatest.server.CoronaTestResultResponse
 import de.rki.coronawarnapp.coronatest.server.VerificationServer
 import de.rki.coronawarnapp.coronatest.tan.CoronaTestTAN
 import de.rki.coronawarnapp.coronatest.type.CoronaTest
@@ -45,12 +46,12 @@ class RapidAntigenProcessor @Inject constructor(
             Timber.tag(TAG).d("Request %s gave us %s", request, it)
         }
 
-        val testResult = registrationData.testResult.let {
+        val testResult = registrationData.testResultResponse.coronaTestResult.let {
             Timber.tag(TAG).v("Raw test result was %s", it)
-            it.first.toValidatedResult()
+            it.toValidatedResult()
         }
 
-        val sampleCollectedAt = registrationData.testResult.second
+        val sampleCollectedAt = registrationData.testResultResponse.sampleCollectedAt
 
         val now = timeStamper.nowUTC
 
@@ -102,12 +103,18 @@ class RapidAntigenProcessor @Inject constructor(
             val newTestResult = try {
                 submissionService.asyncRequestTestResult(test.registrationToken).let {
                     Timber.tag(TAG).v("Raw test result was %s", it)
-                    it.first.toValidatedResult() to it.second
+                    CoronaTestResultResponse(
+                        coronaTestResult = it.coronaTestResult.toValidatedResult(),
+                        sampleCollectedAt = it.sampleCollectedAt
+                    )
                 }
             } catch (e: BadRequestException) {
                 if (isOlderThan21Days) {
                     Timber.tag(TAG).w("HTTP 400 error after 21 days, remapping to RAT_REDEEMED.")
-                    RAT_REDEEMED to null
+                    CoronaTestResultResponse(
+                        coronaTestResult = RAT_REDEEMED,
+                        sampleCollectedAt = null
+                    )
                 } else {
                     Timber.tag(TAG).v("Unexpected HTTP 400 error, rethrowing...")
                     throw e
@@ -115,11 +122,11 @@ class RapidAntigenProcessor @Inject constructor(
             }
 
             test.copy(
-                testResult = check60Days(test, newTestResult.first),
-                testResultReceivedAt = determineReceivedDate(test, newTestResult.first),
+                testResult = check60Days(test, newTestResult.coronaTestResult),
+                testResultReceivedAt = determineReceivedDate(test, newTestResult.coronaTestResult),
                 lastUpdatedAt = nowUTC,
                 lastError = null,
-                sampleCollectedAt = newTestResult.second
+                sampleCollectedAt = newTestResult.sampleCollectedAt
             )
         } catch (e: Exception) {
             Timber.tag(TAG).e(e, "Failed to poll server for  %s", test)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RapidAntigenProcessor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RapidAntigenProcessor.kt
@@ -103,9 +103,8 @@ class RapidAntigenProcessor @Inject constructor(
             val newTestResult = try {
                 submissionService.asyncRequestTestResult(test.registrationToken).let {
                     Timber.tag(TAG).v("Raw test result was %s", it)
-                    CoronaTestResultResponse(
-                        coronaTestResult = it.coronaTestResult.toValidatedResult(),
-                        sampleCollectedAt = it.sampleCollectedAt
+                    it.copy(
+                        coronaTestResult = it.coronaTestResult.toValidatedResult()
                     )
                 }
             } catch (e: BadRequestException) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/playbook/DefaultPlaybook.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/playbook/DefaultPlaybook.kt
@@ -1,6 +1,6 @@
 package de.rki.coronawarnapp.playbook
 
-import de.rki.coronawarnapp.coronatest.server.CoronaTestResult
+import de.rki.coronawarnapp.coronatest.server.CoronaTestResultResponse
 import de.rki.coronawarnapp.coronatest.server.VerificationKeyType
 import de.rki.coronawarnapp.coronatest.server.VerificationServer
 import de.rki.coronawarnapp.exception.TanPairingException
@@ -10,7 +10,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import org.joda.time.Instant
 import timber.log.Timber
 import java.util.UUID
 import java.util.concurrent.TimeUnit
@@ -29,7 +28,7 @@ class DefaultPlaybook @Inject constructor(
     override suspend fun initialRegistration(
         key: String,
         keyType: VerificationKeyType
-    ): Pair<String, Pair<CoronaTestResult, Instant?>> {
+    ): Pair<String, CoronaTestResultResponse> {
         Timber.i("[$uid] New Initial Registration Playbook")
 
         // real registration
@@ -63,7 +62,7 @@ class DefaultPlaybook @Inject constructor(
         propagateException(registrationException, testResultException)
     }
 
-    override suspend fun testResult(registrationToken: String): Pair<CoronaTestResult, Instant?> {
+    override suspend fun testResult(registrationToken: String): CoronaTestResultResponse {
         Timber.i("[$uid] New Test Result Playbook")
 
         // real test result

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/playbook/DefaultPlaybook.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/playbook/DefaultPlaybook.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import org.joda.time.Instant
 import timber.log.Timber
 import java.util.UUID
 import java.util.concurrent.TimeUnit
@@ -28,7 +29,7 @@ class DefaultPlaybook @Inject constructor(
     override suspend fun initialRegistration(
         key: String,
         keyType: VerificationKeyType
-    ): Pair<String, CoronaTestResult> {
+    ): Pair<String, Pair<CoronaTestResult, Instant?>> {
         Timber.i("[$uid] New Initial Registration Playbook")
 
         // real registration
@@ -62,7 +63,7 @@ class DefaultPlaybook @Inject constructor(
         propagateException(registrationException, testResultException)
     }
 
-    override suspend fun testResult(registrationToken: String): CoronaTestResult {
+    override suspend fun testResult(registrationToken: String): Pair<CoronaTestResult, Instant?> {
         Timber.i("[$uid] New Test Result Playbook")
 
         // real test result

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/playbook/Playbook.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/playbook/Playbook.kt
@@ -5,6 +5,7 @@ import de.rki.coronawarnapp.coronatest.server.VerificationKeyType
 import de.rki.coronawarnapp.server.protocols.external.exposurenotification.TemporaryExposureKeyExportOuterClass
 import de.rki.coronawarnapp.server.protocols.internal.SubmissionPayloadOuterClass.SubmissionPayload
 import de.rki.coronawarnapp.server.protocols.internal.pt.CheckInOuterClass
+import org.joda.time.Instant
 
 /**
  * The concept of Plausible Deniability aims to hide the existence of a positive test result by always using a defined
@@ -26,9 +27,9 @@ interface Playbook {
     suspend fun initialRegistration(
         key: String,
         keyType: VerificationKeyType
-    ): Pair<String, CoronaTestResult>
+    ): Pair<String, Pair<CoronaTestResult, Instant?>>
 
-    suspend fun testResult(registrationToken: String): CoronaTestResult
+    suspend fun testResult(registrationToken: String): Pair<CoronaTestResult, Instant?>
 
     suspend fun submit(data: SubmissionData)
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/playbook/Playbook.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/playbook/Playbook.kt
@@ -1,11 +1,11 @@
 package de.rki.coronawarnapp.playbook
 
 import de.rki.coronawarnapp.coronatest.server.CoronaTestResult
+import de.rki.coronawarnapp.coronatest.server.CoronaTestResultResponse
 import de.rki.coronawarnapp.coronatest.server.VerificationKeyType
 import de.rki.coronawarnapp.server.protocols.external.exposurenotification.TemporaryExposureKeyExportOuterClass
 import de.rki.coronawarnapp.server.protocols.internal.SubmissionPayloadOuterClass.SubmissionPayload
 import de.rki.coronawarnapp.server.protocols.internal.pt.CheckInOuterClass
-import org.joda.time.Instant
 
 /**
  * The concept of Plausible Deniability aims to hide the existence of a positive test result by always using a defined
@@ -27,9 +27,9 @@ interface Playbook {
     suspend fun initialRegistration(
         key: String,
         keyType: VerificationKeyType
-    ): Pair<String, Pair<CoronaTestResult, Instant?>>
+    ): Pair<String, CoronaTestResultResponse>
 
-    suspend fun testResult(registrationToken: String): Pair<CoronaTestResult, Instant?>
+    suspend fun testResult(registrationToken: String): CoronaTestResultResponse
 
     suspend fun submit(data: SubmissionData)
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/server/VerificationApiV1Test.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/server/VerificationApiV1Test.kt
@@ -124,7 +124,8 @@ class VerificationApiV1Test : BaseIOTest() {
             headerPadding = "testPadding",
             requestBody
         ) shouldBe VerificationApiV1.TestResultResponse(
-            testResult = 1
+            testResult = 1,
+            sampleCollectedAt = null
         )
 
         webServer.takeRequest(5, TimeUnit.SECONDS)!!.apply {

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/server/VerificationServerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/server/VerificationServerTest.kt
@@ -112,10 +112,10 @@ class VerificationServerTest : BaseIOTest() {
                 registrationToken shouldBe "testRegistrationToken"
                 requestPadding!!.length shouldBe 170
             }
-            VerificationApiV1.TestResultResponse(testResult = 2)
+            VerificationApiV1.TestResultResponse(testResult = 2, sampleCollectedAt = null)
         }
 
-        server.pollTestResult("testRegistrationToken") shouldBe CoronaTestResult.PCR_POSITIVE
+        server.pollTestResult("testRegistrationToken") shouldBe (CoronaTestResult.PCR_POSITIVE to null)
 
         coVerify { verificationApi.getTestResult(any(), any(), any()) }
     }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/server/VerificationServerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/server/VerificationServerTest.kt
@@ -115,7 +115,10 @@ class VerificationServerTest : BaseIOTest() {
             VerificationApiV1.TestResultResponse(testResult = 2, sampleCollectedAt = null)
         }
 
-        server.pollTestResult("testRegistrationToken") shouldBe (CoronaTestResult.PCR_POSITIVE to null)
+        server.pollTestResult("testRegistrationToken") shouldBe CoronaTestResultResponse(
+            coronaTestResult = CoronaTestResult.PCR_POSITIVE,
+            sampleCollectedAt = null
+        )
 
         coVerify { verificationApi.getTestResult(any(), any(), any()) }
     }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRProcessorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRProcessorTest.kt
@@ -13,6 +13,7 @@ import de.rki.coronawarnapp.coronatest.server.CoronaTestResult.RAT_PENDING
 import de.rki.coronawarnapp.coronatest.server.CoronaTestResult.RAT_POSITIVE
 import de.rki.coronawarnapp.coronatest.server.CoronaTestResult.RAT_REDEEMED
 import de.rki.coronawarnapp.coronatest.server.CoronaTestResult.values
+import de.rki.coronawarnapp.coronatest.server.CoronaTestResultResponse
 import de.rki.coronawarnapp.coronatest.tan.CoronaTestTAN
 import de.rki.coronawarnapp.coronatest.type.CoronaTestService
 import de.rki.coronawarnapp.datadonation.analytics.modules.keysubmission.AnalyticsKeySubmissionCollector
@@ -49,14 +50,23 @@ class PCRProcessorTest : BaseTest() {
         every { timeStamper.nowUTC } returns nowUTC
 
         submissionService.apply {
-            coEvery { asyncRequestTestResult(any()) } returns (PCR_OR_RAT_PENDING to null)
+            coEvery { asyncRequestTestResult(any()) } returns CoronaTestResultResponse(
+                coronaTestResult = PCR_OR_RAT_PENDING,
+                sampleCollectedAt = null,
+            )
             coEvery { asyncRegisterDeviceViaGUID(any()) } returns CoronaTestService.RegistrationData(
                 registrationToken = "regtoken-qr",
-                testResult = PCR_OR_RAT_PENDING to null,
+                testResultResponse = CoronaTestResultResponse(
+                    coronaTestResult = PCR_OR_RAT_PENDING,
+                    sampleCollectedAt = null,
+                ),
             )
             coEvery { asyncRegisterDeviceViaTAN(any()) } returns CoronaTestService.RegistrationData(
                 registrationToken = "regtoken-tan",
-                testResult = PCR_OR_RAT_PENDING to null,
+                testResultResponse = CoronaTestResultResponse(
+                    coronaTestResult = PCR_OR_RAT_PENDING,
+                    sampleCollectedAt = null,
+                ),
             )
         }
 
@@ -104,7 +114,10 @@ class PCRProcessorTest : BaseTest() {
     fun `registering a new test maps invalid results to INVALID state`() = runBlockingTest {
         var registrationData = CoronaTestService.RegistrationData(
             registrationToken = "regtoken",
-            testResult = PCR_OR_RAT_PENDING to null,
+            testResultResponse = CoronaTestResultResponse(
+                coronaTestResult = PCR_OR_RAT_PENDING,
+                sampleCollectedAt = null,
+            )
         )
         coEvery { submissionService.asyncRegisterDeviceViaGUID(any()) } answers { registrationData }
 
@@ -113,7 +126,12 @@ class PCRProcessorTest : BaseTest() {
         val request = CoronaTestQRCode.PCR(qrCodeGUID = "guid")
 
         values().forEach {
-            registrationData = registrationData.copy(testResult = it to null)
+            registrationData = registrationData.copy(
+                testResultResponse = CoronaTestResultResponse(
+                    coronaTestResult = it,
+                    sampleCollectedAt = null,
+                )
+            )
             when (it) {
                 PCR_OR_RAT_PENDING,
                 PCR_NEGATIVE,
@@ -134,7 +152,12 @@ class PCRProcessorTest : BaseTest() {
     @Test
     fun `polling maps invalid results to INVALID state`() = runBlockingTest {
         var pollResult: CoronaTestResult = PCR_OR_RAT_PENDING
-        coEvery { submissionService.asyncRequestTestResult(any()) } answers { pollResult to null }
+        coEvery { submissionService.asyncRequestTestResult(any()) } answers {
+            CoronaTestResultResponse(
+                coronaTestResult = pollResult,
+                sampleCollectedAt = null,
+            )
+        }
 
         val instance = createInstance()
 
@@ -185,7 +208,12 @@ class PCRProcessorTest : BaseTest() {
 
     @Test
     fun `polling is skipped if test is older than 21 days and state was already REDEEMED`() = runBlockingTest {
-        coEvery { submissionService.asyncRequestTestResult(any()) } answers { PCR_POSITIVE to null }
+        coEvery { submissionService.asyncRequestTestResult(any()) } answers {
+            CoronaTestResultResponse(
+                coronaTestResult = PCR_OR_RAT_PENDING,
+                sampleCollectedAt = null,
+            )
+        }
 
         val instance = createInstance()
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRProcessorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRProcessorTest.kt
@@ -49,14 +49,14 @@ class PCRProcessorTest : BaseTest() {
         every { timeStamper.nowUTC } returns nowUTC
 
         submissionService.apply {
-            coEvery { asyncRequestTestResult(any()) } returns PCR_OR_RAT_PENDING
+            coEvery { asyncRequestTestResult(any()) } returns (PCR_OR_RAT_PENDING to null)
             coEvery { asyncRegisterDeviceViaGUID(any()) } returns CoronaTestService.RegistrationData(
                 registrationToken = "regtoken-qr",
-                testResult = PCR_OR_RAT_PENDING,
+                testResult = PCR_OR_RAT_PENDING to null,
             )
             coEvery { asyncRegisterDeviceViaTAN(any()) } returns CoronaTestService.RegistrationData(
                 registrationToken = "regtoken-tan",
-                testResult = PCR_OR_RAT_PENDING,
+                testResult = PCR_OR_RAT_PENDING to null,
             )
         }
 
@@ -104,7 +104,7 @@ class PCRProcessorTest : BaseTest() {
     fun `registering a new test maps invalid results to INVALID state`() = runBlockingTest {
         var registrationData = CoronaTestService.RegistrationData(
             registrationToken = "regtoken",
-            testResult = PCR_OR_RAT_PENDING,
+            testResult = PCR_OR_RAT_PENDING to null,
         )
         coEvery { submissionService.asyncRegisterDeviceViaGUID(any()) } answers { registrationData }
 
@@ -113,7 +113,7 @@ class PCRProcessorTest : BaseTest() {
         val request = CoronaTestQRCode.PCR(qrCodeGUID = "guid")
 
         values().forEach {
-            registrationData = registrationData.copy(testResult = it)
+            registrationData = registrationData.copy(testResult = it to null)
             when (it) {
                 PCR_OR_RAT_PENDING,
                 PCR_NEGATIVE,
@@ -134,7 +134,7 @@ class PCRProcessorTest : BaseTest() {
     @Test
     fun `polling maps invalid results to INVALID state`() = runBlockingTest {
         var pollResult: CoronaTestResult = PCR_OR_RAT_PENDING
-        coEvery { submissionService.asyncRequestTestResult(any()) } answers { pollResult }
+        coEvery { submissionService.asyncRequestTestResult(any()) } answers { pollResult to null }
 
         val instance = createInstance()
 
@@ -185,7 +185,7 @@ class PCRProcessorTest : BaseTest() {
 
     @Test
     fun `polling is skipped if test is older than 21 days and state was already REDEEMED`() = runBlockingTest {
-        coEvery { submissionService.asyncRequestTestResult(any()) } answers { PCR_POSITIVE }
+        coEvery { submissionService.asyncRequestTestResult(any()) } answers { PCR_POSITIVE to null }
 
         val instance = createInstance()
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRProcessorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRProcessorTest.kt
@@ -210,7 +210,7 @@ class PCRProcessorTest : BaseTest() {
     fun `polling is skipped if test is older than 21 days and state was already REDEEMED`() = runBlockingTest {
         coEvery { submissionService.asyncRequestTestResult(any()) } answers {
             CoronaTestResultResponse(
-                coronaTestResult = PCR_OR_RAT_PENDING,
+                coronaTestResult = PCR_POSITIVE,
                 sampleCollectedAt = null,
             )
         }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/http/playbook/DefaultPlaybookTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/http/playbook/DefaultPlaybookTest.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.http.playbook
 
 import de.rki.coronawarnapp.coronatest.server.CoronaTestResult
+import de.rki.coronawarnapp.coronatest.server.CoronaTestResultResponse
 import de.rki.coronawarnapp.coronatest.server.VerificationKeyType
 import de.rki.coronawarnapp.coronatest.server.VerificationServer
 import de.rki.coronawarnapp.exception.TanPairingException
@@ -33,7 +34,10 @@ class DefaultPlaybookTest : BaseTest() {
         MockKAnnotations.init(this)
 
         coEvery { verificationServer.retrieveRegistrationToken(any(), any()) } returns "token"
-        coEvery { verificationServer.pollTestResult(any()) } returns (CoronaTestResult.PCR_OR_RAT_PENDING to null)
+        coEvery { verificationServer.pollTestResult(any()) } returns CoronaTestResultResponse(
+            coronaTestResult = CoronaTestResult.PCR_OR_RAT_PENDING,
+            sampleCollectedAt = null
+        )
         coEvery { verificationServer.retrieveTanFake() } returns mockk()
         coEvery { verificationServer.retrieveTan(any()) } returns "tan"
 
@@ -198,14 +202,20 @@ class DefaultPlaybookTest : BaseTest() {
         val expectedToken = "token"
         coEvery { verificationServer.retrieveRegistrationToken(any(), any()) } returns expectedToken
         val expectedResult = CoronaTestResult.PCR_OR_RAT_PENDING
-        coEvery { verificationServer.pollTestResult(expectedToken) } returns (expectedResult to null)
+        coEvery { verificationServer.pollTestResult(expectedToken) } returns CoronaTestResultResponse(
+            coronaTestResult = expectedResult,
+            sampleCollectedAt = null
+        )
         coEvery { submissionServer.submitFakePayload() } throws TestException()
 
         val (registrationToken, testResult) = createPlaybook()
             .initialRegistration("key", VerificationKeyType.GUID)
 
         registrationToken shouldBe expectedToken
-        testResult shouldBe (expectedResult to null)
+        testResult shouldBe CoronaTestResultResponse(
+            coronaTestResult = expectedResult,
+            sampleCollectedAt = null
+        )
     }
 
     @Test

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/http/playbook/DefaultPlaybookTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/http/playbook/DefaultPlaybookTest.kt
@@ -33,7 +33,7 @@ class DefaultPlaybookTest : BaseTest() {
         MockKAnnotations.init(this)
 
         coEvery { verificationServer.retrieveRegistrationToken(any(), any()) } returns "token"
-        coEvery { verificationServer.pollTestResult(any()) } returns CoronaTestResult.PCR_OR_RAT_PENDING
+        coEvery { verificationServer.pollTestResult(any()) } returns (CoronaTestResult.PCR_OR_RAT_PENDING to null)
         coEvery { verificationServer.retrieveTanFake() } returns mockk()
         coEvery { verificationServer.retrieveTan(any()) } returns "tan"
 
@@ -198,14 +198,14 @@ class DefaultPlaybookTest : BaseTest() {
         val expectedToken = "token"
         coEvery { verificationServer.retrieveRegistrationToken(any(), any()) } returns expectedToken
         val expectedResult = CoronaTestResult.PCR_OR_RAT_PENDING
-        coEvery { verificationServer.pollTestResult(expectedToken) } returns expectedResult
+        coEvery { verificationServer.pollTestResult(expectedToken) } returns (expectedResult to null)
         coEvery { submissionServer.submitFakePayload() } throws TestException()
 
         val (registrationToken, testResult) = createPlaybook()
             .initialRegistration("key", VerificationKeyType.GUID)
 
         registrationToken shouldBe expectedToken
-        testResult shouldBe expectedResult
+        testResult shouldBe (expectedResult to null)
     }
 
     @Test

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/service/submission/SubmissionServiceTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/service/submission/SubmissionServiceTest.kt
@@ -48,7 +48,7 @@ class SubmissionServiceTest : BaseTest() {
     fun registrationWithGUIDSucceeds() {
         coEvery {
             mockPlaybook.initialRegistration(guid, VerificationKeyType.GUID)
-        } returns (registrationToken to CoronaTestResult.PCR_OR_RAT_PENDING)
+        } returns (registrationToken to (CoronaTestResult.PCR_OR_RAT_PENDING to null))
 
         runBlocking {
             submissionService.asyncRegisterDeviceViaGUID(guid)
@@ -63,7 +63,7 @@ class SubmissionServiceTest : BaseTest() {
     fun registrationWithTeleTANSucceeds() {
         coEvery {
             mockPlaybook.initialRegistration(any(), VerificationKeyType.TELETAN)
-        } returns (registrationToken to CoronaTestResult.PCR_OR_RAT_PENDING)
+        } returns (registrationToken to (CoronaTestResult.PCR_OR_RAT_PENDING to null))
 
         runBlocking {
             submissionService.asyncRegisterDeviceViaTAN(tan)
@@ -76,10 +76,10 @@ class SubmissionServiceTest : BaseTest() {
 
     @Test
     fun requestTestResultSucceeds() {
-        coEvery { mockPlaybook.testResult(registrationToken) } returns CoronaTestResult.PCR_NEGATIVE
+        coEvery { mockPlaybook.testResult(registrationToken) } returns (CoronaTestResult.PCR_NEGATIVE to null)
 
         runBlocking {
-            submissionService.asyncRequestTestResult(registrationToken) shouldBe CoronaTestResult.PCR_NEGATIVE
+            submissionService.asyncRequestTestResult(registrationToken) shouldBe (CoronaTestResult.PCR_NEGATIVE to null)
         }
         coVerify(exactly = 1) {
             mockPlaybook.testResult(registrationToken)

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/service/submission/SubmissionServiceTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/service/submission/SubmissionServiceTest.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.service.submission
 
 import de.rki.coronawarnapp.coronatest.server.CoronaTestResult
+import de.rki.coronawarnapp.coronatest.server.CoronaTestResultResponse
 import de.rki.coronawarnapp.coronatest.server.VerificationKeyType
 import de.rki.coronawarnapp.coronatest.type.CoronaTestService
 import de.rki.coronawarnapp.deniability.NoiseScheduler
@@ -48,7 +49,10 @@ class SubmissionServiceTest : BaseTest() {
     fun registrationWithGUIDSucceeds() {
         coEvery {
             mockPlaybook.initialRegistration(guid, VerificationKeyType.GUID)
-        } returns (registrationToken to (CoronaTestResult.PCR_OR_RAT_PENDING to null))
+        } returns (registrationToken to CoronaTestResultResponse(
+            coronaTestResult = CoronaTestResult.PCR_OR_RAT_PENDING,
+            sampleCollectedAt = null
+        ))
 
         runBlocking {
             submissionService.asyncRegisterDeviceViaGUID(guid)
@@ -63,7 +67,10 @@ class SubmissionServiceTest : BaseTest() {
     fun registrationWithTeleTANSucceeds() {
         coEvery {
             mockPlaybook.initialRegistration(any(), VerificationKeyType.TELETAN)
-        } returns (registrationToken to (CoronaTestResult.PCR_OR_RAT_PENDING to null))
+        } returns (registrationToken to CoronaTestResultResponse(
+            coronaTestResult = CoronaTestResult.PCR_OR_RAT_PENDING,
+            sampleCollectedAt = null
+        ))
 
         runBlocking {
             submissionService.asyncRegisterDeviceViaTAN(tan)
@@ -76,10 +83,16 @@ class SubmissionServiceTest : BaseTest() {
 
     @Test
     fun requestTestResultSucceeds() {
-        coEvery { mockPlaybook.testResult(registrationToken) } returns (CoronaTestResult.PCR_NEGATIVE to null)
+        coEvery { mockPlaybook.testResult(registrationToken) } returns CoronaTestResultResponse(
+            coronaTestResult = CoronaTestResult.PCR_NEGATIVE,
+            sampleCollectedAt = null
+        )
 
         runBlocking {
-            submissionService.asyncRequestTestResult(registrationToken) shouldBe (CoronaTestResult.PCR_NEGATIVE to null)
+            submissionService.asyncRequestTestResult(registrationToken) shouldBe CoronaTestResultResponse(
+                coronaTestResult = CoronaTestResult.PCR_NEGATIVE,
+                sampleCollectedAt = null,
+            )
         }
         coVerify(exactly = 1) {
             mockPlaybook.testResult(registrationToken)

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/service/submission/SubmissionServiceTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/service/submission/SubmissionServiceTest.kt
@@ -49,10 +49,12 @@ class SubmissionServiceTest : BaseTest() {
     fun registrationWithGUIDSucceeds() {
         coEvery {
             mockPlaybook.initialRegistration(guid, VerificationKeyType.GUID)
-        } returns (registrationToken to CoronaTestResultResponse(
-            coronaTestResult = CoronaTestResult.PCR_OR_RAT_PENDING,
-            sampleCollectedAt = null
-        ))
+        } returns (
+            registrationToken to CoronaTestResultResponse(
+                coronaTestResult = CoronaTestResult.PCR_OR_RAT_PENDING,
+                sampleCollectedAt = null
+            )
+            )
 
         runBlocking {
             submissionService.asyncRegisterDeviceViaGUID(guid)
@@ -67,10 +69,12 @@ class SubmissionServiceTest : BaseTest() {
     fun registrationWithTeleTANSucceeds() {
         coEvery {
             mockPlaybook.initialRegistration(any(), VerificationKeyType.TELETAN)
-        } returns (registrationToken to CoronaTestResultResponse(
-            coronaTestResult = CoronaTestResult.PCR_OR_RAT_PENDING,
-            sampleCollectedAt = null
-        ))
+        } returns (
+            registrationToken to CoronaTestResultResponse(
+                coronaTestResult = CoronaTestResult.PCR_OR_RAT_PENDING,
+                sampleCollectedAt = null
+            )
+            )
 
         runBlocking {
             submissionService.asyncRegisterDeviceViaTAN(tan)


### PR DESCRIPTION
### Description
This pr adds fetching of the sampleCollectedAt parameter to the ra test backend and (if present) bases outdated check on this value

### Steps to reproduce
1. Scan a Ra test
2. Check if it provided a sampleCollectedAt value
3. check if outdated state is based on the right value
