### PR TITLE
Remove top-level `action` elements from nav graph (COMMUNITY)

### DIFF
--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/greencertificate/GreenCertificateTestFragment.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/greencertificate/GreenCertificateTestFragment.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
-import de.rki.coronawarnapp.NavGraphDirections
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.coronatest.type.CoronaTest.Type.PCR
 import de.rki.coronawarnapp.coronatest.type.CoronaTest.Type.RAPID_ANTIGEN
@@ -29,10 +28,14 @@ class GreenCertificateTestFragment : Fragment(R.layout.fragment_test_green_certi
 
         binding.apply {
             pcrScreen.setOnClickListener {
-                doNavigate(NavGraphDirections.actionSubmissionTestResultGreenCertificateFragment(PCR))
+                doNavigate(GreenCertificateTestFragmentDirections
+                    .actionGreenCertificateTestFragmentToRequestGreenCertificateFragment(PCR)
+                )
             }
             ratScreen.setOnClickListener {
-                doNavigate(NavGraphDirections.actionSubmissionTestResultGreenCertificateFragment(RAPID_ANTIGEN))
+                doNavigate(GreenCertificateTestFragmentDirections
+                    .actionGreenCertificateTestFragmentToRequestGreenCertificateFragment(RAPID_ANTIGEN)
+                )
             }
         }
     }

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/greencertificate/GreenCertificateTestFragment.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/greencertificate/GreenCertificateTestFragment.kt
@@ -28,13 +28,15 @@ class GreenCertificateTestFragment : Fragment(R.layout.fragment_test_green_certi
 
         binding.apply {
             pcrScreen.setOnClickListener {
-                doNavigate(GreenCertificateTestFragmentDirections
-                    .actionGreenCertificateTestFragmentToRequestGreenCertificateFragment(PCR)
+                doNavigate(
+                    GreenCertificateTestFragmentDirections
+                        .actionGreenCertificateTestFragmentToRequestGreenCertificateFragment(PCR)
                 )
             }
             ratScreen.setOnClickListener {
-                doNavigate(GreenCertificateTestFragmentDirections
-                    .actionGreenCertificateTestFragmentToRequestGreenCertificateFragment(RAPID_ANTIGEN)
+                doNavigate(
+                    GreenCertificateTestFragmentDirections
+                        .actionGreenCertificateTestFragmentToRequestGreenCertificateFragment(RAPID_ANTIGEN)
                 )
             }
         }

--- a/Corona-Warn-App/src/deviceForTesters/res/navigation/test_nav_graph.xml
+++ b/Corona-Warn-App/src/deviceForTesters/res/navigation/test_nav_graph.xml
@@ -188,9 +188,23 @@
             android:name="vaccinationCertificateId"
             app:argType="string" />
     </fragment>
+
     <fragment
         android:id="@+id/greenCertificateTestFragment"
         android:name="de.rki.coronawarnapp.test.greencertificate.GreenCertificateTestFragment"
         android:label="GreenCertificateTestFragment"
-        tools:layout="@layout/fragment_test_green_certificate" />
+        tools:layout="@layout/fragment_test_green_certificate">
+        <action
+            android:id="@+id/action_greenCertificateTestFragment_to_requestGreenCertificateFragment"
+            app:destination="@id/requestGreenCertificateFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/requestGreenCertificateFragment"
+        android:name="de.rki.coronawarnapp.ui.submission.greencertificate.RequestGreenCertificateFragment"
+        android:label="fragment_request_green_certificate"
+        tools:layout="@layout/fragment_request_green_certificate">
+        <argument
+            android:name="testType"
+            app:argType="de.rki.coronawarnapp.coronatest.type.CoronaTest$Type" />
+    </fragment>
 </navigation>

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/coronatest/rat/profile/qrcode/RATProfileQrCodeFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/coronatest/rat/profile/qrcode/RATProfileQrCodeFragment.kt
@@ -66,7 +66,7 @@ class RATProfileQrCodeFragment : Fragment(R.layout.rat_profile_qr_code_fragment)
                 ProfileQrCodeNavigation.SubmissionConsent ->
                     findNavController().navigate(R.id.submissionConsentFragment)
                 is ProfileQrCodeNavigation.FullQrCode -> findNavController().navigate(
-                    R.id.action_global_qrCodeFullScreenFragment,
+                    R.id.action_ratProfileQrCodeFragment_to_qrCodeFullScreenFragment,
                     QrCodeFullScreenFragmentArgs(it.qrcodeText).toBundle(),
                     null,
                     FragmentNavigatorExtras(binding.qrCodeImage to binding.qrCodeImage.transitionName)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainActivity.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainActivity.kt
@@ -16,12 +16,12 @@ import com.google.android.material.bottomnavigation.BottomNavigationView
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector
-import de.rki.coronawarnapp.NavGraphDirections
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.contactdiary.ui.overview.ContactDiaryOverviewFragmentDirections
 import de.rki.coronawarnapp.databinding.ActivityMainBinding
 import de.rki.coronawarnapp.datadonation.analytics.worker.DataDonationAnalyticsScheduler
 import de.rki.coronawarnapp.ui.base.startActivitySafely
+import de.rki.coronawarnapp.ui.main.home.HomeFragmentDirections
 import de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.CheckInsFragment
 import de.rki.coronawarnapp.ui.setupWithNavController2
 import de.rki.coronawarnapp.ui.submission.qrcode.consent.SubmissionConsentFragment
@@ -174,7 +174,7 @@ class MainActivity : AppCompatActivity(), HasAndroidInjector {
             CheckInsFragment.canHandle(uriString) ->
                 navController.navigate(CheckInsFragment.createDeepLink(uriString))
             SubmissionConsentFragment.canHandle(uriString) ->
-                navController.navigate(NavGraphDirections.actionSubmissionConsentFragment(uriString))
+                navController.navigate(HomeFragmentDirections.actionSubmissionConsentFragment(uriString))
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainActivity.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainActivity.kt
@@ -174,7 +174,7 @@ class MainActivity : AppCompatActivity(), HasAndroidInjector {
             CheckInsFragment.canHandle(uriString) ->
                 navController.navigate(CheckInsFragment.createDeepLink(uriString))
             SubmissionConsentFragment.canHandle(uriString) ->
-                navController.navigate(HomeFragmentDirections.actionSubmissionConsentFragment(uriString))
+                navController.navigate(HomeFragmentDirections.actionMainFragmentToSubmissionConsentFragment(uriString))
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/organizer/details/QrCodeDetailFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/organizer/details/QrCodeDetailFragment.kt
@@ -103,7 +103,7 @@ class QrCodeDetailFragment : Fragment(R.layout.trace_location_organizer_qr_code_
                     QrCodeDetailFragmentDirections.actionQrCodeDetailFragmentToQrCodePosterFragment(it.locationId)
                 )
                 is QrCodeDetailNavigationEvents.NavigateToFullScreenQrCode -> findNavController().navigate(
-                    R.id.action_global_qrCodeFullScreenFragment,
+                    R.id.action_qrCodeDetailFragment_to_qrCodeFullScreenFragment,
                     QrCodeFullScreenFragmentArgs(it.qrcodeText, it.correctionLevel).toBundle(),
                     null,
                     FragmentNavigatorExtras(binding.qrCodeImage to binding.qrCodeImage.transitionName)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/consent/SubmissionConsentFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/consent/SubmissionConsentFragment.kt
@@ -8,7 +8,6 @@ import android.view.accessibility.AccessibilityEvent
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
-import de.rki.coronawarnapp.NavGraphDirections
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.coronatest.type.CoronaTest
 import de.rki.coronawarnapp.databinding.FragmentSubmissionConsentBinding
@@ -63,7 +62,7 @@ class SubmissionConsentFragment : Fragment(R.layout.fragment_submission_consent)
                     )
                 is SubmissionNavigationEvents.NavigateToDeletionWarningFragmentFromQrCode -> {
                     doNavigate(
-                        NavGraphDirections
+                        SubmissionConsentFragmentDirections
                             .actionToSubmissionDeletionWarningFragment(
                                 it.consentGiven,
                                 it.coronaTestQRCode
@@ -108,12 +107,12 @@ class SubmissionConsentFragment : Fragment(R.layout.fragment_submission_consent)
                         when {
                             state.test.isPositive ->
                                 doNavigate(
-                                    NavGraphDirections.actionToSubmissionTestResultAvailableFragment(
+                                    SubmissionConsentFragmentDirections.actionToSubmissionTestResultAvailableFragment(
                                         CoronaTest.Type.RAPID_ANTIGEN
                                     )
                                 )
                             else -> doNavigate(
-                                NavGraphDirections.actionSubmissionTestResultPendingFragment(
+                                SubmissionConsentFragmentDirections.actionSubmissionTestResultPendingFragment(
                                     testType = CoronaTest.Type.RAPID_ANTIGEN
                                 )
                             )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/consent/SubmissionConsentFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/consent/SubmissionConsentFragment.kt
@@ -63,7 +63,7 @@ class SubmissionConsentFragment : Fragment(R.layout.fragment_submission_consent)
                 is SubmissionNavigationEvents.NavigateToDeletionWarningFragmentFromQrCode -> {
                     doNavigate(
                         SubmissionConsentFragmentDirections
-                            .actionToSubmissionDeletionWarningFragment(
+                            .actionSubmissionConsentFragmentToSubmissionDeletionWarningFragment(
                                 it.consentGiven,
                                 it.coronaTestQRCode
                             )
@@ -107,14 +107,16 @@ class SubmissionConsentFragment : Fragment(R.layout.fragment_submission_consent)
                         when {
                             state.test.isPositive ->
                                 doNavigate(
-                                    SubmissionConsentFragmentDirections.actionToSubmissionTestResultAvailableFragment(
-                                        CoronaTest.Type.RAPID_ANTIGEN
-                                    )
+                                    SubmissionConsentFragmentDirections
+                                        .actionSubmissioConsentFragmentToSubmissionTestResultPendingFragment(
+                                            CoronaTest.Type.RAPID_ANTIGEN
+                                        )
                                 )
                             else -> doNavigate(
-                                SubmissionConsentFragmentDirections.actionSubmissionTestResultPendingFragment(
-                                    testType = CoronaTest.Type.RAPID_ANTIGEN
-                                )
+                                SubmissionConsentFragmentDirections
+                                    .actionSubmissioConsentFragmentToSubmissionTestResultPendingFragment(
+                                        testType = CoronaTest.Type.RAPID_ANTIGEN
+                                    )
                             )
                         }
                     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/scan/SubmissionQRCodeScanFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/scan/SubmissionQRCodeScanFragment.kt
@@ -9,7 +9,6 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import com.google.zxing.BarcodeFormat
 import com.journeyapps.barcodescanner.DefaultDecoderFactory
-import de.rki.coronawarnapp.NavGraphDirections
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.coronatest.server.CoronaTestResult
 import de.rki.coronawarnapp.coronatest.type.CoronaTest.Type
@@ -71,7 +70,7 @@ class SubmissionQRCodeScanFragment : Fragment(R.layout.fragment_submission_qr_co
         viewModel.routeToScreen.observe2(this) {
             when (it) {
                 is SubmissionNavigationEvents.NavigateToDeletionWarningFragmentFromQrCode -> {
-                    NavGraphDirections
+                    SubmissionQRCodeScanFragmentDirections
                         .actionToSubmissionDeletionWarningFragment(it.consentGiven, it.coronaTestQRCode)
                         .run { doNavigate(this) }
                 }
@@ -108,24 +107,29 @@ class SubmissionQRCodeScanFragment : Fragment(R.layout.fragment_submission_qr_co
             }
             when (state.test?.testResult) {
                 CoronaTestResult.PCR_POSITIVE ->
-                    NavGraphDirections.actionToSubmissionTestResultAvailableFragment(testType = Type.PCR)
+                    SubmissionQRCodeScanFragmentDirections
+                        .actionToSubmissionTestResultAvailableFragment(testType = Type.PCR)
 
                 CoronaTestResult.PCR_OR_RAT_PENDING ->
-                    NavGraphDirections.actionSubmissionTestResultPendingFragment(testType = state.test.type)
+                    SubmissionQRCodeScanFragmentDirections
+                        .actionSubmissionTestResultPendingFragment(testType = state.test.type)
 
                 CoronaTestResult.PCR_NEGATIVE,
                 CoronaTestResult.PCR_INVALID,
                 CoronaTestResult.PCR_REDEEMED ->
-                    NavGraphDirections.actionSubmissionTestResultPendingFragment(testType = Type.PCR)
+                    SubmissionQRCodeScanFragmentDirections
+                        .actionSubmissionTestResultPendingFragment(testType = Type.PCR)
 
                 CoronaTestResult.RAT_POSITIVE ->
-                    NavGraphDirections.actionToSubmissionTestResultAvailableFragment(testType = Type.RAPID_ANTIGEN)
+                    SubmissionQRCodeScanFragmentDirections
+                        .actionToSubmissionTestResultAvailableFragment(testType = Type.RAPID_ANTIGEN)
 
                 CoronaTestResult.RAT_NEGATIVE,
                 CoronaTestResult.RAT_INVALID,
                 CoronaTestResult.RAT_PENDING,
                 CoronaTestResult.RAT_REDEEMED ->
-                    NavGraphDirections.actionSubmissionTestResultPendingFragment(testType = Type.RAPID_ANTIGEN)
+                    SubmissionQRCodeScanFragmentDirections
+                        .actionSubmissionTestResultPendingFragment(testType = Type.RAPID_ANTIGEN)
                 null -> {
                     Timber.w("Successful API request, but test was null?")
                     return@observe2

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/scan/SubmissionQRCodeScanFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/scan/SubmissionQRCodeScanFragment.kt
@@ -71,7 +71,9 @@ class SubmissionQRCodeScanFragment : Fragment(R.layout.fragment_submission_qr_co
             when (it) {
                 is SubmissionNavigationEvents.NavigateToDeletionWarningFragmentFromQrCode -> {
                     SubmissionQRCodeScanFragmentDirections
-                        .actionToSubmissionDeletionWarningFragment(it.consentGiven, it.coronaTestQRCode)
+                        .actionSubmissionQRCodeScanFragmentToSubmissionDeletionWarningFragment(
+                            it.consentGiven, it.coronaTestQRCode
+                        )
                         .run { doNavigate(this) }
                 }
                 is SubmissionNavigationEvents.NavigateToDispatcher -> navigateToDispatchScreen()
@@ -108,28 +110,38 @@ class SubmissionQRCodeScanFragment : Fragment(R.layout.fragment_submission_qr_co
             when (state.test?.testResult) {
                 CoronaTestResult.PCR_POSITIVE ->
                     SubmissionQRCodeScanFragmentDirections
-                        .actionToSubmissionTestResultAvailableFragment(testType = Type.PCR)
+                        .actionSubmissionQRCodeScanFragmentToSubmissionTestResultAvailableFragment(
+                            testType = Type.PCR
+                        )
 
                 CoronaTestResult.PCR_OR_RAT_PENDING ->
                     SubmissionQRCodeScanFragmentDirections
-                        .actionSubmissionTestResultPendingFragment(testType = state.test.type)
+                        .actionSubmissionQRCodeScanFragmentToSubmissionTestResultPendingFragment(
+                            testType = state.test.type
+                        )
 
                 CoronaTestResult.PCR_NEGATIVE,
                 CoronaTestResult.PCR_INVALID,
                 CoronaTestResult.PCR_REDEEMED ->
                     SubmissionQRCodeScanFragmentDirections
-                        .actionSubmissionTestResultPendingFragment(testType = Type.PCR)
+                        .actionSubmissionQRCodeScanFragmentToSubmissionTestResultPendingFragment(
+                            testType = Type.PCR
+                        )
 
                 CoronaTestResult.RAT_POSITIVE ->
                     SubmissionQRCodeScanFragmentDirections
-                        .actionToSubmissionTestResultAvailableFragment(testType = Type.RAPID_ANTIGEN)
+                        .actionSubmissionQRCodeScanFragmentToSubmissionTestResultAvailableFragment(
+                            testType = Type.RAPID_ANTIGEN
+                        )
 
                 CoronaTestResult.RAT_NEGATIVE,
                 CoronaTestResult.RAT_INVALID,
                 CoronaTestResult.RAT_PENDING,
                 CoronaTestResult.RAT_REDEEMED ->
                     SubmissionQRCodeScanFragmentDirections
-                        .actionSubmissionTestResultPendingFragment(testType = Type.RAPID_ANTIGEN)
+                        .actionSubmissionQRCodeScanFragmentToSubmissionTestResultPendingFragment(
+                            testType = Type.RAPID_ANTIGEN
+                        )
                 null -> {
                     Timber.w("Successful API request, but test was null?")
                     return@observe2

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/vaccination/ui/details/VaccinationDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/vaccination/ui/details/VaccinationDetailsFragment.kt
@@ -75,7 +75,7 @@ class VaccinationDetailsFragment : Fragment(R.layout.fragment_vaccination_detail
                 when (event) {
                     VaccinationDetailsNavigation.Back -> popBackStack()
                     is VaccinationDetailsNavigation.FullQrCode -> findNavController().navigate(
-                        R.id.action_global_qrCodeFullScreenFragment,
+                        R.id.action_vaccinationDetailsFragment_to_qrCodeFullScreenFragment,
                         QrCodeFullScreenFragmentArgs(event.qrCodeText).toBundle(),
                         null,
                         FragmentNavigatorExtras(qrCodeCard.image to qrCodeCard.image.transitionName)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/vaccination/ui/list/VaccinationListFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/vaccination/ui/list/VaccinationListFragment.kt
@@ -85,7 +85,7 @@ class VaccinationListFragment : Fragment(R.layout.fragment_vaccination_list), Au
                                     FragmentNavigatorExtras(image to image.transitionName)
                                 }
                         findNavController().navigate(
-                            R.id.action_global_qrCodeFullScreenFragment,
+                            R.id.action_vaccinationListFragment_to_qrCodeFullScreenFragment,
                             QrCodeFullScreenFragmentArgs(event.qrCode).toBundle(),
                             null,
                             navigatorExtras

--- a/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
+++ b/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
@@ -404,10 +404,6 @@
             app:popUpToInclusive="false" />
     </fragment>
 
-    <action
-        android:id="@+id/action_submissionTestResultGreenCertificateFragment"
-        app:destination="@id/requestGreenCertificateFragment" />
-
     <fragment
         android:id="@+id/submissionResultReadyFragment"
         android:name="de.rki.coronawarnapp.ui.submission.resultready.SubmissionResultReadyFragment"

--- a/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
+++ b/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
@@ -824,9 +824,7 @@
             android:defaultValue="Q"
             app:argType="com.google.zxing.qrcode.decoder.ErrorCorrectionLevel" />
     </fragment>
-    <action
-        android:id="@+id/action_global_qrCodeFullScreenFragment"
-        app:destination="@id/qrCodeFullScreenFragment" />
+
     <fragment
         android:id="@+id/requestGreenCertificateFragment"
         android:name="de.rki.coronawarnapp.ui.submission.greencertificate.RequestGreenCertificateFragment"

--- a/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
+++ b/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
@@ -80,6 +80,9 @@
             android:id="@+id/action_mainFragment_to_submissionTestResultKeysSharedFragment"
             app:destination="@id/submissionTestResultKeysSharedFragment" />
         <action
+            android:id="@+id/action_submissionConsentFragment"
+            app:destination="@id/submissionConsentFragment" />
+        <action
             android:id="@+id/action_mainFragment_to_vaccinationNavGraph"
             app:destination="@id/vaccination_nav_graph" />
     </fragment>
@@ -386,27 +389,24 @@
             android:id="@+id/action_submissionQRCodeScanFragment_to_submissionDispatcherFragment"
             app:popUpTo="@id/submissionQRCodeScanFragment"
             app:popUpToInclusive="true" />
+        <action
+            android:id="@+id/action_to_submissionDeletionWarningFragment"
+            app:destination="@id/submissionDeletionWarningFragment" />
+        <action
+            android:id="@+id/action_submissionTestResultPendingFragment"
+            app:destination="@id/submissionTestResultPendingFragment"
+            app:popUpTo="@id/mainFragment"
+            app:popUpToInclusive="false" />
+        <action
+            android:id="@+id/action_to_submissionTestResultAvailableFragment"
+            app:destination="@id/submissionTestResultAvailableFragment"
+            app:popUpTo="@id/mainFragment"
+            app:popUpToInclusive="false" />
     </fragment>
-
-    <action
-        android:id="@+id/action_submissionTestResultPendingFragment"
-        app:destination="@id/submissionTestResultPendingFragment"
-        app:popUpTo="@id/mainFragment"
-        app:popUpToInclusive="false" />
 
     <action
         android:id="@+id/action_submissionTestResultGreenCertificateFragment"
         app:destination="@id/requestGreenCertificateFragment" />
-
-    <action
-        android:id="@+id/action_to_submissionTestResultAvailableFragment"
-        app:destination="@id/submissionTestResultAvailableFragment"
-        app:popUpTo="@id/mainFragment"
-        app:popUpToInclusive="false" />
-
-    <action
-        android:id="@+id/action_to_submissionDeletionWarningFragment"
-        app:destination="@id/submissionDeletionWarningFragment" />
 
     <fragment
         android:id="@+id/submissionResultReadyFragment"
@@ -492,16 +492,25 @@
         <action
             android:id="@+id/action_submissionConsentFragment_to_informationPrivacyFragment"
             app:destination="@id/informationPrivacyFragment" />
+        <action
+            android:id="@+id/action_to_submissionDeletionWarningFragment"
+            app:destination="@id/submissionDeletionWarningFragment" />
+        <action
+            android:id="@+id/action_submissionTestResultPendingFragment"
+            app:destination="@id/submissionTestResultPendingFragment"
+            app:popUpTo="@id/mainFragment"
+            app:popUpToInclusive="false" />
+        <action
+            android:id="@+id/action_to_submissionTestResultAvailableFragment"
+            app:destination="@id/submissionTestResultAvailableFragment"
+            app:popUpTo="@id/mainFragment"
+            app:popUpToInclusive="false" />
         <argument
             android:name="qrCode"
             android:defaultValue="@null"
             app:argType="string"
             app:nullable="true" />
     </fragment>
-
-    <action
-        android:id="@+id/action_submissionConsentFragment"
-        app:destination="@id/submissionConsentFragment" />
 
     <fragment
         android:id="@+id/submissionTestResultConsentGivenFragment"

--- a/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
+++ b/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
@@ -80,7 +80,7 @@
             android:id="@+id/action_mainFragment_to_submissionTestResultKeysSharedFragment"
             app:destination="@id/submissionTestResultKeysSharedFragment" />
         <action
-            android:id="@+id/action_submissionConsentFragment"
+            android:id="@+id/action_mainFragment_to_submissionConsentFragment"
             app:destination="@id/submissionConsentFragment" />
         <action
             android:id="@+id/action_mainFragment_to_vaccinationNavGraph"
@@ -390,15 +390,15 @@
             app:popUpTo="@id/submissionQRCodeScanFragment"
             app:popUpToInclusive="true" />
         <action
-            android:id="@+id/action_to_submissionDeletionWarningFragment"
+            android:id="@+id/action_submissionQRCodeScanFragment_to_submissionDeletionWarningFragment"
             app:destination="@id/submissionDeletionWarningFragment" />
         <action
-            android:id="@+id/action_submissionTestResultPendingFragment"
+            android:id="@+id/action_submissionQRCodeScanFragment_to_submissionTestResultPendingFragment"
             app:destination="@id/submissionTestResultPendingFragment"
             app:popUpTo="@id/mainFragment"
             app:popUpToInclusive="false" />
         <action
-            android:id="@+id/action_to_submissionTestResultAvailableFragment"
+            android:id="@+id/action_submissionQRCodeScanFragment_to_submissionTestResultAvailableFragment"
             app:destination="@id/submissionTestResultAvailableFragment"
             app:popUpTo="@id/mainFragment"
             app:popUpToInclusive="false" />
@@ -493,15 +493,15 @@
             android:id="@+id/action_submissionConsentFragment_to_informationPrivacyFragment"
             app:destination="@id/informationPrivacyFragment" />
         <action
-            android:id="@+id/action_to_submissionDeletionWarningFragment"
+            android:id="@+id/action_submissionConsentFragment_to_submissionDeletionWarningFragment"
             app:destination="@id/submissionDeletionWarningFragment" />
         <action
-            android:id="@+id/action_submissionTestResultPendingFragment"
+            android:id="@+id/action_submissioConsentFragment_to_submissionTestResultPendingFragment"
             app:destination="@id/submissionTestResultPendingFragment"
             app:popUpTo="@id/mainFragment"
             app:popUpToInclusive="false" />
         <action
-            android:id="@+id/action_to_submissionTestResultAvailableFragment"
+            android:id="@+id/action_submissionConsentFragment_to_submissionTestResultAvailableFragment"
             app:destination="@id/submissionTestResultAvailableFragment"
             app:popUpTo="@id/mainFragment"
             app:popUpToInclusive="false" />

--- a/Corona-Warn-App/src/main/res/navigation/rapid_antigen_test_profile_nav_graph.xml
+++ b/Corona-Warn-App/src/main/res/navigation/rapid_antigen_test_profile_nav_graph.xml
@@ -34,7 +34,11 @@
         android:id="@+id/ratProfileQrCodeFragment"
         android:name="de.rki.coronawarnapp.ui.coronatest.rat.profile.qrcode.RATProfileQrCodeFragment"
         android:label="rat_profile_qr_code_fragment"
-        tools:layout="@layout/rat_profile_qr_code_fragment" />
+        tools:layout="@layout/rat_profile_qr_code_fragment">
+        <action
+            android:id="@+id/action_ratProfileQrCodeFragment_to_qrCodeFullScreenFragment"
+            app:destination="@id/qrCodeFullScreenFragment" />
+    </fragment>
 
     <fragment
         android:id="@+id/privacyFragment"

--- a/Corona-Warn-App/src/main/res/navigation/trace_location_organizer_nav_graph.xml
+++ b/Corona-Warn-App/src/main/res/navigation/trace_location_organizer_nav_graph.xml
@@ -85,6 +85,9 @@
         <action
             android:id="@+id/action_qrCodeDetailFragment_to_traceLocationCreateFragment"
             app:destination="@id/traceLocationCreateFragment" />
+        <action
+            android:id="@+id/action_qrCodeDetailFragment_to_qrCodeFullScreenFragment"
+            app:destination="@id/qrCodeFullScreenFragment" />
     </fragment>
 
     <fragment

--- a/Corona-Warn-App/src/main/res/navigation/vaccination_nav_graph.xml
+++ b/Corona-Warn-App/src/main/res/navigation/vaccination_nav_graph.xml
@@ -48,6 +48,9 @@
         <action
             android:id="@+id/action_vaccinationListFragment_to_vaccinationQrCodeScanFragment"
             app:destination="@id/vaccinationQrCodeScanFragment" />
+        <action
+            android:id="@+id/action_vaccinationListFragment_to_qrCodeFullScreenFragment"
+            app:destination="@id/qrCodeFullScreenFragment" />
     </fragment>
 
     <fragment
@@ -58,6 +61,9 @@
         <argument
             android:name="vaccinationCertificateId"
             app:argType="string" />
+        <action
+            android:id="@+id/action_vaccinationDetailsFragment_to_qrCodeFullScreenFragment"
+            app:destination="@id/qrCodeFullScreenFragment" />
     </fragment>
 
     <fragment


### PR DESCRIPTION
We have discovered an issue that prevents the app from building reproducibly if there are top-level `action` elements present in the nav graph.

We noticed that the `navigation.safeargs.kotlin` library *sometimes* generates `action*` functions in classes where they are not needed, but *sometimes* not, for `action`s that are independent of a `fragment`. This made builds of our app non-reproducible.

We have reported the reproducibility bug to Google (https://issuetracker.google.com/issues/189498001). In the meantime, as a workaround, it appears to be necessary not to use top-level `action` elements.

You can find our issue with more details here: https://codeberg.org/corona-contact-tracing-germany/cwa-android/issues/135

Reproducible builds are also desired by CWA users (#1483, https://github.com/corona-warn-app/cwa-wishlist/issues/275). With this change, it should theoretically be possible again to build CWA in a reproducible way.

(However, for users to be able to actually reproduce CWA builds, further documentation would be required – e.g. we are building the app in a standardized docker container which uses `fdroidserver` tools in an attempt to avoid system-specific oddities in the build, and are explaining how to do that in https://codeberg.org/corona-contact-tracing-germany/cwa-android/src/branch/main/docs/rebuilding.md.)