### PR TITLE
 For RAT the test date is not set correct (EXPOSUREAPP-7555)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RACoronaTest.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RACoronaTest.kt
@@ -71,10 +71,8 @@ data class RACoronaTest(
     override val type: CoronaTest.Type
         get() = CoronaTest.Type.RAPID_ANTIGEN
 
-    private fun isOutdated(nowUTC: Instant, testConfig: CoronaTestConfig): Boolean {
-        val timeoutTime = sampleCollectedAt ?: testedAt
-        return timeoutTime.plus(testConfig.coronaRapidAntigenTestParameters.hoursToDeemTestOutdated).isBefore(nowUTC)
-    }
+    private fun isOutdated(nowUTC: Instant, testConfig: CoronaTestConfig): Boolean =
+        testTakenAt.plus(testConfig.coronaRapidAntigenTestParameters.hoursToDeemTestOutdated).isBefore(nowUTC)
 
     fun getState(nowUTC: Instant, testConfig: CoronaTestConfig) =
         if (testResult == RAT_NEGATIVE && isOutdated(nowUTC, testConfig)) {
@@ -90,6 +88,9 @@ data class RACoronaTest(
                 else -> throw IllegalArgumentException("Invalid RAT test state $testResult")
             }
         }
+
+    val testTakenAt: Instant
+        get() = sampleCollectedAt ?: testedAt
 
     override val isFinal: Boolean
         get() = testResult == RAT_REDEEMED

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RapidAntigenCoronaTestExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RapidAntigenCoronaTestExtensions.kt
@@ -28,10 +28,10 @@ fun RACoronaTest?.toSubmissionState(nowUTC: Instant = Instant.now(), coronaTestC
     else -> when (getState(nowUTC, coronaTestConfig)) {
         INVALID -> TestError
         POSITIVE -> {
-            if (isViewed) TestPositive(testRegisteredAt = testedAt)
+            if (isViewed) TestPositive(testRegisteredAt = testTakenAt)
             else TestResultReady
         }
-        NEGATIVE -> TestNegative(testRegisteredAt = testedAt)
+        NEGATIVE -> TestNegative(testRegisteredAt = testTakenAt)
         REDEEMED -> TestInvalid
         PENDING -> TestPending
         OUTDATED -> TestOutdated

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/ui/testresults/negative/RATResultNegativeFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/ui/testresults/negative/RATResultNegativeFragment.kt
@@ -65,7 +65,7 @@ class RATResultNegativeFragment : Fragment(R.layout.fragment_submission_antigen_
             }
         }
 
-        val localTime = testAge.test.testedAt.toUserTimeZone()
+        val localTime = testAge.test.testTakenAt.toUserTimeZone()
         resultReceivedTimeAndDate.text = getString(
             R.string.coronatest_negative_antigen_result_time_date_placeholder,
             localTime?.toString(DATE_FORMAT),

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/ui/testresults/negative/RATResultNegativeViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/ui/testresults/negative/RATResultNegativeViewModel.kt
@@ -47,7 +47,7 @@ class RATResultNegativeViewModel @AssistedInject constructor(
         }
 
         val nowUTC = timeStamper.nowUTC
-        val age = nowUTC.millis - testedAt.millis
+        val age = nowUTC.millis - testTakenAt.millis
         val ageText = formatter.print(Duration(age).toPeriod())
 
         return TestAge(test = this, ageText)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/view/TestResultSectionView.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/view/TestResultSectionView.kt
@@ -81,7 +81,7 @@ constructor(
         return if (coronaTest is RACoronaTest) {
             context.getString(
                 R.string.ag_homescreen_card_rapid_body_result_date,
-                coronaTest.testedAt.toDate()?.toUIFormat(context)
+                coronaTest.testTakenAt.toDate()?.toUIFormat(context)
             )
         } else {
             context.getString(


### PR DESCRIPTION
### Description
This PR should contain the missing changes that allow rat test times to not only base outdated calculations on the new timestamp from the server,  but also display the timestamp to the user.

### Steps to reproduce
1. Scan a RAT qr code
2. Set its result and sampleCollectedAt time
3. Check if sampleCollectedAt time is displayed everywhere in the ui
