### PR TITLE
Show different strings on negative RAT screen depending of whether the test is anonymous or not (EXPOSUREAPP-7468)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/ui/testresults/negative/RATResultNegativeFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/ui/testresults/negative/RATResultNegativeFragment.kt
@@ -71,6 +71,24 @@ class RATResultNegativeFragment : Fragment(R.layout.fragment_submission_antigen_
             localTime?.toString(DATE_FORMAT),
             localTime?.toString(shortTime)
         )
+
+        val isAnonymousTest = with(testAge.test) {
+            firstName == null && lastName == null && dateOfBirth == null
+        }
+
+        val titleString = if (isAnonymousTest) {
+            R.string.submission_test_result_antigen_negative_proof_title_anonymous
+        } else {
+            R.string.submission_test_result_antigen_negative_proof_title
+        }
+        negativeTestProofTitle.text = getString(titleString)
+
+        val proofBodyString = if (isAnonymousTest) {
+            R.string.submission_test_result_antigen_negative_proof_body_anonymous
+        } else {
+            R.string.submission_test_result_antigen_negative_proof_body
+        }
+        negativeTestProofBody.text = getString(proofBodyString)
     }
 
     companion object {

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_antigen_test_result_negative.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_antigen_test_result_negative.xml
@@ -150,7 +150,7 @@
                 android:layout_height="wrap_content"
                 android:layout_margin="@dimen/spacing_small"
                 android:accessibilityHeading="true"
-                android:text="@string/submission_test_result_antigen_negative_proof_title"
+                tools:text="@string/submission_test_result_antigen_negative_proof_title"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/rapid_test_card" />
@@ -161,10 +161,21 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/spacing_small"
-                android:text="@string/submission_test_result_antigen_negative_proof_body"
+                tools:text="@string/submission_test_result_antigen_negative_proof_body"
                 app:layout_constraintEnd_toEndOf="@id/negative_test_proof_title"
                 app:layout_constraintStart_toStartOf="@id/negative_test_proof_title"
                 app:layout_constraintTop_toBottomOf="@id/negative_test_proof_title" />
+
+            <TextView
+                android:id="@+id/negative_test_proof_additional_information"
+                style="@style/subtitle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:text="@string/submission_test_result_antigen_negative_proof_additional_information"
+                app:layout_constraintEnd_toEndOf="@id/negative_test_proof_body"
+                app:layout_constraintStart_toStartOf="@id/negative_test_proof_body"
+                app:layout_constraintTop_toBottomOf="@id/negative_test_proof_body" />
 
             <TextView
                 android:id="@+id/submission_test_result_subtitle"
@@ -176,7 +187,7 @@
                 android:text="@string/submission_test_result_subtitle"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/negative_test_proof_body" />
+                app:layout_constraintTop_toBottomOf="@id/negative_test_proof_additional_information" />
 
             <de.rki.coronawarnapp.ui.view.SimpleStepEntry
                 android:id="@+id/test_result_negative_steps_added"

--- a/Corona-Warn-App/src/main/res/values-de/antigen_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/antigen_strings.xml
@@ -120,8 +120,14 @@
     <string name="submission_test_result_negative_message">"Das Virus SARS-CoV-2 wurde bei Ihnen nicht nachgewiesen."</string>
     <!-- XHED: submission result antigen fragment negative result proof title -->
     <string name="submission_test_result_antigen_negative_proof_title">"Nachweis-Funktion"</string>
+    <!-- XHED: submission result antigen fragment negative result proof title for anonymous tests-->
+    <string name="submission_test_result_antigen_negative_proof_title_anonymous">"Keine Nachweis-Funktion"</string>
     <!-- XHED: submission result antigen fragment negative result proof body -->
-    <string name="submission_test_result_antigen_negative_proof_body">"Sie können den hier angezeigten Befund auch als Nachweis für das Vorliegen eines negativen Schnelltest-Ergebnisses verwenden.\n\nBitte beachten Sie, dass Sie nur dann einen Nachweis über Ihr Schnelltest-Ergebnis erbringen müssen, wenn dies gesetzlich festgelegt ist. Sie können den Nachweis über die App oder auch auf andere Weise erbringen. Informieren Sie sich hierzu bitte auch über die Kriterien für die Anerkennung von Test-Nachweisen in Ihrem Bundesland."</string>
+    <string name="submission_test_result_antigen_negative_proof_body">"Sie können den hier angezeigten Befund auch als Nachweis für das Vorliegen eines negativen Schnelltest-Ergebnisses verwenden."</string>
+    <!-- XHED: submission result antigen fragment negative result proof body anonymous -->
+    <string name="submission_test_result_antigen_negative_proof_body_anonymous">"Da der hier angezeigte Befund anonymisiert ist, kann er nicht als Nachweis für das Vorliegen eines negativen Schnelltest-Ergebnisses verwendet werden."</string>
+    <!-- XHED: submission result antigen fragment negative result proof additional information -->
+    <string name="submission_test_result_antigen_negative_proof_additional_information">"Bitte beachten Sie, dass Sie nur dann einen Nachweis über Ihr Schnelltest-Ergebnis erbringen müssen, wenn dies gesetzlich festgelegt ist. Sie können den Nachweis über die App oder auch auf andere Weise erbringen. Informieren Sie sich hierzu bitte auch über die Kriterien für die Anerkennung von Test-Nachweisen in Ihrem Bundesland."</string>
     <!-- XHED: submission result antigen negative result counter title -->
     <string name="submission_test_result_antigen_negative_counter_title">"Ergebnis liegt vor seit"</string>
     <!-- XHED: coronatest negative antigen result first info title -->

--- a/Corona-Warn-App/src/main/res/values/antigen_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/antigen_strings.xml
@@ -120,8 +120,14 @@
     <string name="submission_test_result_negative_message">"You have not been diagnosed with the SARS-CoV-2 virus."</string>
     <!-- XHED: submission result antigen fragment negative result proof title -->
     <string name="submission_test_result_antigen_negative_proof_title">"Verification Feature"</string>
+    <!-- XHED: submission result antigen fragment negative result proof title for anonymous tests-->
+    <string name="submission_test_result_antigen_negative_proof_title_anonymous">"Keine Nachweis-Funktion"</string>
     <!-- XHED: submission result antigen fragment negative result proof body -->
     <string name="submission_test_result_antigen_negative_proof_body">"Your test result is private, although some laws may require you to share it. When required, you may show it via any of the ways provided."</string>
+    <!-- XHED: submission result antigen fragment negative result proof body anonymous -->
+    <string name="submission_test_result_antigen_negative_proof_body_anonymous">"Da der hier angezeigte Befund anonymisiert ist, kann er nicht als Nachweis für das Vorliegen eines negativen Schnelltest-Ergebnisses verwendet werden."</string>
+    <!-- XHED: submission result antigen fragment negative result proof additional information -->
+    <string name="submission_test_result_antigen_negative_proof_additional_information">"Bitte beachten Sie, dass Sie nur dann einen Nachweis über Ihr Schnelltest-Ergebnis erbringen müssen, wenn dies gesetzlich festgelegt ist. Sie können den Nachweis über die App oder auch auf andere Weise erbringen. Informieren Sie sich hierzu bitte auch über die Kriterien für die Anerkennung von Test-Nachweisen in Ihrem Bundesland."</string>
     <!-- XHED: submission result antigen negative result counter title -->
     <string name="submission_test_result_antigen_negative_counter_title">"Result available since"</string>
     <!-- XHED: coronatest negative antigen result first info title -->

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,5 +19,5 @@ org.gradle.dependency.verification.console=verbose
 # Versioning, this is used by the app & pipelines to calculate the current versionCode & versionName
 VERSION_MAJOR=2
 VERSION_MINOR=3
-VERSION_PATCH=1
+VERSION_PATCH=2
 VERSION_BUILD=0


### PR DESCRIPTION
### How to test: 
- Scan non-anonymous RAT test and see the following texts: 
[rat negative non-anonymous](https://user-images.githubusercontent.com/10398034/120176217-4ef26480-c207-11eb-97bb-ae2e6cb76518.png)
 - Scan anonymous RAT test and see the following texts: 
[rat negative anonymous](https://user-images.githubusercontent.com/10398034/120176307-6893ac00-c207-11eb-85ae-88e7fd095e31.png)
