### PR TITLE
Vaccine details are reversed (EXPOSUREAPP-7573)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/vaccination/ui/details/VaccinationDetailsFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/vaccination/ui/details/VaccinationDetailsFragmentTest.kt
@@ -100,7 +100,7 @@ class VaccinationDetailsFragmentTest : BaseUITest() {
             every { lastName } returns "Mustermann"
             every { dateOfBirth } returns LocalDate.parse("01.02.1976", formatter)
             every { vaccinatedAt } returns LocalDate.parse("18.02.2021", formatter)
-            every { vaccineName } returns "Comirnaty (mRNA)"
+            every { vaccineTypeName } returns "Comirnaty (mRNA)"
             every { vaccineManufacturer } returns "BioNTech"
             every { certificateIssuer } returns "Landratsamt Musterstadt"
             every { certificateCountry } returns "Deutschland"

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/vaccination/core/VaccinatedPerson.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/vaccination/core/VaccinatedPerson.kt
@@ -21,7 +21,7 @@ data class VaccinatedPerson(
     }
 
     val vaccineName: String
-        get() = vaccinationCertificates.first().vaccineName
+        get() = vaccinationCertificates.first().vaccineTypeName
 
     val firstName: String?
         get() = vaccinationCertificates.first().firstName

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/vaccination/core/VaccinationCertificate.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/vaccination/core/VaccinationCertificate.kt
@@ -11,7 +11,7 @@ interface VaccinationCertificate {
     val dateOfBirth: LocalDate
     val vaccinatedAt: LocalDate
 
-    val vaccineName: String
+    val vaccineTypeName: String
     val vaccineManufacturer: String
     val medicalProductName: String
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/vaccination/core/repository/storage/VaccinationContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/vaccination/core/repository/storage/VaccinationContainer.kt
@@ -74,7 +74,7 @@ data class VaccinationContainer internal constructor(
         override val totalSeriesOfDoses: Int
             get() = vaccination.totalSeriesOfDoses
 
-        override val vaccineName: String
+        override val vaccineTypeName: String
             get() = valueSet?.getDisplayText(vaccination.vaccineId) ?: vaccination.vaccineId
         override val vaccineManufacturer: String
             get() = valueSet?.getDisplayText(vaccination.marketAuthorizationHolderId)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/vaccination/ui/details/VaccinationDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/vaccination/ui/details/VaccinationDetailsFragment.kt
@@ -93,9 +93,9 @@ class VaccinationDetailsFragment : Fragment(R.layout.fragment_vaccination_detail
             certificate.dateOfBirth.toDayFormat()
         )
         vaccinatedAt.text = certificate.vaccinatedAt.toDayFormat()
-        vaccineName.text = certificate.vaccineName
+        vaccineName.text = certificate.medicalProductName
         vaccineManufacturer.text = certificate.vaccineManufacturer
-        medicalProductName.text = certificate.medicalProductName
+        vaccineTypeName.text = certificate.vaccineTypeName
         certificateIssuer.text = certificate.certificateIssuer
         certificateCountry.text = certificate.certificateCountry
         certificateId.text = certificate.certificateId

--- a/Corona-Warn-App/src/main/res/layout/fragment_vaccination_details.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_vaccination_details.xml
@@ -189,7 +189,7 @@
                     android:text="@string/vaccination_details_vaccine_medical_product_name" />
 
                 <TextView
-                    android:id="@+id/medical_product_name"
+                    android:id="@+id/vaccine_type_name"
                     style="@style/body2Medium"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/vaccination/core/repository/storage/VaccinationContainerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/vaccination/core/repository/storage/VaccinationContainerTest.kt
@@ -65,7 +65,7 @@ class VaccinationContainerTest : BaseTest() {
             lastName shouldBe "Astrá Eins"
             dateOfBirth shouldBe LocalDate.parse("1966-11-11")
             vaccinatedAt shouldBe LocalDate.parse("2021-03-01")
-            vaccineName shouldBe "1119305005"
+            vaccineTypeName shouldBe "1119305005"
             vaccineManufacturer shouldBe "ORG-100001699"
             medicalProductName shouldBe "EU/1/21/1529"
             doseNumber shouldBe 1
@@ -113,7 +113,7 @@ class VaccinationContainerTest : BaseTest() {
             lastName shouldBe "Astrá Eins"
             dateOfBirth shouldBe LocalDate.parse("1966-11-11")
             vaccinatedAt shouldBe LocalDate.parse("2021-03-01")
-            vaccineName shouldBe "Vaccine-Name"
+            vaccineTypeName shouldBe "Vaccine-Name"
             vaccineManufacturer shouldBe "Manufactorer-Name"
             medicalProductName shouldBe "MedicalProduct-Name"
             doseNumber shouldBe 1


### PR DESCRIPTION
### Description
There was a mismatch with the fields in the vaccine info fragment, this PR fixes those issues.
I made some adjustments to the field names to make sure that the error is more obvious next time.

### Steps to reproduce
1. Scan a vaccination certificate
2. Check if the certificate data is displayed correctly