### PR TITLE
Anonymous Rapid Test - No proof as negative test - hide if anonymous (EXPOSUREAPP-7468)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/ui/testresults/negative/RATResultNegativeFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/ui/testresults/negative/RATResultNegativeFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.core.text.bold
 import androidx.core.text.buildSpannedString
+import androidx.core.view.isGone
 import androidx.fragment.app.Fragment
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.FragmentSubmissionAntigenTestResultNegativeBinding
@@ -89,6 +90,8 @@ class RATResultNegativeFragment : Fragment(R.layout.fragment_submission_antigen_
             R.string.submission_test_result_antigen_negative_proof_body
         }
         negativeTestProofBody.text = getString(proofBodyString)
+
+        negativeTestProofAdditionalInformation.isGone = isAnonymousTest
     }
 
     companion object {


### PR DESCRIPTION
### Description
The negative RAT Fragment displays text informing the user about the "Nachweisfunktion" of the test,
if the test is anonymous the "Nachweisfunktion" is unavailable and the additional text should be hidden as well.

### Steps to reproduce
1. Scan a anonymous negative RAT
2. Check if RAT Fragment hides the additional text
3. Scan a non anonymous negative RAT
4. Check if RAT Fragment sows the additional text