### PR TITLE
Fix "App Information" scrolling for smaller devices (EXPOSUREAPP-7765) (COMMUNITY)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/fragment_information.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_information.xml
@@ -122,7 +122,14 @@
                     android:paddingBottom="@dimen/spacing_tiny"
                     tools:text="16000000"
                     tools:visibility="visible" />
+
+                <!-- Workaround for scrolling issue where view is
+                approximately as high as available space-->
+                <Space
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/spacing_huge" />
             </LinearLayout>
+
         </ScrollView>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
### Description

This PR provides a workaround for a scrolling issue of App Information on smaller devices where the App Information almost, but not quite, fits the available display area. In this case part of the top of the version information is displayed at the bottom of the screen and the App Information cannot be scrolled to read the version information properly.

![image](https://user-images.githubusercontent.com/66998419/121576596-d1a9c980-ca28-11eb-9f5a-ea4854043c31.png)

Issue https://github.com/corona-warn-app/cwa-app-android/issues/3369 and https://github.com/corona-warn-app/cwa-app-android/issues/3059 describe the issues. 

PR https://github.com/corona-warn-app/cwa-app-android/pull/3098 previously tried to address this issue, however there are still screen and font size combination which do not scroll properly.

The PR adds a `Space` view with height `dimen/spacing_huge` at the bottom of the `fragment_information.xml` layout. In situations where the platform appears to have difficulty deciding whether it has to offer scrolling or not, this extra space takes it out of the grey zone into the situation where it clearly needs to offer scrolling.

Perhaps at some stage we may understand the root cause better and have a better cure, however this workaround seems safe without undesired side-effects and it will help users, who have encountered this issue, in a timely manner.

### Steps to reproduce

- Use Google Pixel emulator (5.0" 1080x1920 420dpi)
- With Android version: 10 (API 29) 

#### Setup
1. (Android) Settings > Display > Advanced
2. Set Font size to Large and Display size to Default

#### In CWA
1. Start Screen, tap three-dot symbol
2. Tap "App Information"
3. Try to scroll to bottom of view

![image](https://user-images.githubusercontent.com/66998419/121576938-3d8c3200-ca29-11eb-80c2-5ba5bb0923d9.png)

Compare outcome with test performed with Build Variant deviceForTestersDebug 2.4.0-RC7. In this build it is only possible to scroll App Information by grabbing the truncated version information and pulling it up. Scrolling by tapping and holding elsewhere in the view does not work.

The API 29 emulator has no Bluetooth, so no ENF version is displayed. Test outcomes will be different on API 30 with a release build, which will show an ENF version and thereby lengthen the App Information view.

Using the Android Studio debugger, I simulated the display with an ENF version, which then looks as follows with the view fully scrolled up:

![image](https://user-images.githubusercontent.com/66998419/121577344-b68b8980-ca29-11eb-97ae-444753124542.png)


---
Internal Tracking ID: [EXPOSUREAPP-7765](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-7765)
