### PR TITLE
Adapt naming inconsistencies - part 2

### DIFF
--- a/Corona-Warn-App/src/main/res/values-de/vaccination_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/vaccination_strings.xml
@@ -26,7 +26,7 @@
     <string name="vaccination_qrcode_card_subtitle">Geimpft %1$s - gültig bis %2$s</string>
 
     <!-- XTXT: Vaccination List title-->
-    <string name="vaccination_list_title">Digitaler Impfnachweis</string>
+    <string name="vaccination_list_title">EU Digitaler COVID-Impfnachweis</string>
     <!-- XTXT: Vaccination List complete vaccination subtitle-->
     <string name="vaccination_list_complete_vaccination_subtitle">SARS-CoV-2-Impfschutz</string>
     <!-- XTXT: Vaccination List top card subtitle-->
@@ -63,17 +63,17 @@
         Homescreen cards
     ###################################### -->
     <!-- XHED: Title for Vaccination Certificate Registration Home Card -->
-    <string name="vaccination_card_registration_title_line_1">"Digitalen"</string>
+    <string name="vaccination_card_registration_title_line_1">"EU Digitalen"</string>
     <!-- XHED: Title for Vaccination Certificate Registration Home Card -->
-    <string name="vaccination_card_registration_title_line_2">"Impfnachweis hinzufügen"</string>
+    <string name="vaccination_card_registration_title_line_2">"COVID-Impfnachweis hinzufügen"</string>
     <!-- YTXT: Body text for Vaccination Certificate Registration Home Card -->
     <string name="vaccination_card_registration_body">"Fügen Sie Ihre Impfzertifikate in die App hinzu, um sie immer bei sich zu haben. Scannen Sie dafür den QR-Code Ihres Dokuments."</string>
     <!-- XBUT: button for Vaccination Certificate Registration Home Card -->
     <string name="vaccination_card_register">"Hinzufügen"</string>
     <!-- XHED: Homescreen vaccination status card title -->
-    <string name="vaccination_card_status_title_line_1">"Digitaler"</string>
+    <string name="vaccination_card_status_title_line_1">"EU Digitaler"</string>
     <!-- XHED: Homescreen vaccination status card title -->
-    <string name="vaccination_card_status_title_line_2">"Impfnachweis"</string>
+    <string name="vaccination_card_status_title_line_2">"COVID-Impfnachweis"</string>
     <!-- XHED: Homescreen vaccination status card vaccination name -->
     <string name="vaccination_card_status_vaccination_name">SARS-CoV-2 Impfschutz</string>
     <!-- XTXT: Homescreen card incomplete vaccination status label -->
@@ -106,9 +106,9 @@
     <!-- XTXT: Vaccination Consent subtitle-->
     <string name="vaccination_consent_headline">"Zertifikate hinzufügen"</string>
     <!-- XTXT: Vaccination Consent subtitle of qr info -->
-    <string name="vaccination_consent_info_subtitle_text">"Fügen Sie Ihre digitalen COVID-Zertifikate in der App hinzu, um mit der App Ihren Impfschutz oder ein negatives Testergebnis nachweisen zu können."</string>
+    <string name="vaccination_consent_info_subtitle_text">"Fügen Sie Ihre EU digitalen COVID-Zertifikate in der App hinzu, um mit der App Ihren Impfschutz oder ein negatives Testergebnis nachweisen zu können."</string>
     <!-- XTXT: Vaccination Consent text of qr info -->
-    <string name="vaccination_consent_qr_info_text">"Sie können digitale COVID-Impfzertifikate oder COVID-Testzertifikate in der App hinzufügen."</string>
+    <string name="vaccination_consent_qr_info_text">"Sie können EU digitale COVID-Impfzertifikate oder COVID-Testzertifikate in der App hinzufügen."</string>
     <!-- XTXT: Vaccination Consent qr code text -->
     <string name="vaccination_consent_qr_info_qr_code_text">"Die Zertifikate gelten innerhalb der EU als gültiger Nachweis (z.B. für Reisen)."</string>
     <!-- XTXT: Vaccination Consent time text  -->


### PR DESCRIPTION
I adapted the texts to have a consistent naming throughout the app. Please be aware that further text adjustments for 2.5 will follow, according to Figma mockups.
Related Bug: https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-7835