### PR TITLE
Fix missing DCC consent navigation for clicked RA test links (EXPOSUREAPP-7875) 

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/consent/SubmissionConsentFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/consent/SubmissionConsentFragment.kt
@@ -55,15 +55,18 @@ class SubmissionConsentFragment : Fragment(R.layout.fragment_submission_consent)
                         requireActivity(),
                         REQUEST_USER_RESOLUTION
                     )
-                is SubmissionNavigationEvents.NavigateToDeletionWarningFragmentFromQrCode -> {
-                    doNavigate(
-                        NavGraphDirections
-                            .actionToSubmissionDeletionWarningFragment(
-                                testRegistrationRequest = it.coronaTestQRCode,
-                                isConsentGiven = it.consentGiven,
-                            )
+                is SubmissionNavigationEvents.NavigateToDeletionWarningFragmentFromQrCode -> doNavigate(
+                    NavGraphDirections.actionToSubmissionDeletionWarningFragment(
+                        testRegistrationRequest = it.coronaTestQRCode,
+                        isConsentGiven = it.consentGiven,
                     )
-                }
+                )
+                is SubmissionNavigationEvents.NavigateToRequestDccFragment -> doNavigate(
+                    NavGraphDirections.actionRequestCovidCertificateFragment(
+                        testRegistrationRequest = it.coronaTestQRCode,
+                        coronaTestConsent = it.consentGiven
+                    )
+                )
             }
         }
         viewModel.countries.observe2(this) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/consent/SubmissionConsentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/consent/SubmissionConsentViewModel.kt
@@ -83,17 +83,26 @@ class SubmissionConsentViewModel @AssistedInject constructor(
 
         val coronaTest = submissionRepository.testForType(coronaTestQRCode.type).first()
 
-        if (coronaTest != null) {
-            SubmissionNavigationEvents.NavigateToDeletionWarningFragmentFromQrCode(
-                coronaTestQRCode,
-                consentGiven = true
-            ).run { routeToScreen.postValue(this) }
-        } else {
-            registrationStateProcessor.startRegistration(
-                request = coronaTestQRCode,
-                isSubmissionConsentGiven = true,
-                allowReplacement = false
-            )
+        when {
+            coronaTest != null -> {
+                SubmissionNavigationEvents.NavigateToDeletionWarningFragmentFromQrCode(
+                    coronaTestQRCode,
+                    consentGiven = true
+                ).run { routeToScreen.postValue(this) }
+            }
+            coronaTestQRCode.isDccSupportedByPoc && !coronaTestQRCode.isDccConsentGiven -> {
+                SubmissionNavigationEvents.NavigateToRequestDccFragment(
+                    coronaTestQRCode = coronaTestQRCode,
+                    consentGiven = true,
+                ).run { routeToScreen.postValue(this) }
+            }
+            else -> {
+                registrationStateProcessor.startRegistration(
+                    request = coronaTestQRCode,
+                    isSubmissionConsentGiven = true,
+                    allowReplacement = false
+                )
+            }
         }
     }
 


### PR DESCRIPTION
Fix clicked corona-test links, with DCC support, not navigating to DCC consent screen, so it behaves the same as it when it is scanned via camera.

Previously the navigation did not allow you to reach the consent screen for test certificates, when you came from a clicked link, instead of a qrcode.