### PR TITLE
Fix analytics `reportAdvancedConsentGiven` not being called on every navigation path (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/covidcertificate/RequestCovidCertificateViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/covidcertificate/RequestCovidCertificateViewModel.kt
@@ -7,7 +7,6 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import de.rki.coronawarnapp.coronatest.TestRegistrationRequest
 import de.rki.coronawarnapp.coronatest.qrcode.CoronaTestQRCode
-import de.rki.coronawarnapp.datadonation.analytics.modules.keysubmission.AnalyticsKeySubmissionCollector
 import de.rki.coronawarnapp.submission.TestRegistrationStateProcessor
 import de.rki.coronawarnapp.util.ui.SingleLiveEvent
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
@@ -19,7 +18,6 @@ class RequestCovidCertificateViewModel @AssistedInject constructor(
     @Assisted("coronaTestConsent") private val coronaTestConsent: Boolean,
     @Assisted("deleteOldTest") private val deleteOldTest: Boolean,
     private val registrationStateProcessor: TestRegistrationStateProcessor,
-    private val analyticsKeySubmissionCollector: AnalyticsKeySubmissionCollector,
 ) : CWAViewModel() {
 
     val registrationState = registrationStateProcessor.state.asLiveData2()
@@ -63,8 +61,6 @@ class RequestCovidCertificateViewModel @AssistedInject constructor(
             isSubmissionConsentGiven = coronaTestConsent,
             allowReplacement = deleteOldTest
         )
-
-        if (coronaTestConsent) analyticsKeySubmissionCollector.reportAdvancedConsentGiven(consentedQrCode.type)
     }
 
     @AssistedFactory

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/scan/SubmissionQRCodeScanViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/scan/SubmissionQRCodeScanViewModel.kt
@@ -5,7 +5,6 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import de.rki.coronawarnapp.coronatest.qrcode.CoronaTestQrCodeValidator
 import de.rki.coronawarnapp.coronatest.qrcode.InvalidQRCodeException
-import de.rki.coronawarnapp.datadonation.analytics.modules.keysubmission.AnalyticsKeySubmissionCollector
 import de.rki.coronawarnapp.submission.SubmissionRepository
 import de.rki.coronawarnapp.submission.TestRegistrationStateProcessor
 import de.rki.coronawarnapp.ui.submission.viewmodel.SubmissionNavigationEvents
@@ -24,7 +23,6 @@ class SubmissionQRCodeScanViewModel @AssistedInject constructor(
     private val registrationStateProcessor: TestRegistrationStateProcessor,
     private val submissionRepository: SubmissionRepository,
     private val qrCodeValidator: CoronaTestQrCodeValidator,
-    private val analyticsKeySubmissionCollector: AnalyticsKeySubmissionCollector
 ) : CWAViewModel(dispatcherProvider = dispatcherProvider) {
 
     val events = SingleLiveEvent<SubmissionNavigationEvents>()
@@ -50,8 +48,6 @@ class SubmissionQRCodeScanViewModel @AssistedInject constructor(
                         isSubmissionConsentGiven = isConsentGiven,
                         allowReplacement = false
                     )
-
-                    if (isConsentGiven) analyticsKeySubmissionCollector.reportAdvancedConsentGiven(ctQrCode.type)
                 } else {
                     events.postValue(
                         SubmissionNavigationEvents.NavigateToRequestDccFragment(ctQrCode, isConsentGiven)

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/submission/TestRegistrationStateProcessorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/submission/TestRegistrationStateProcessorTest.kt
@@ -1,7 +1,9 @@
 package de.rki.coronawarnapp.submission
 
 import de.rki.coronawarnapp.coronatest.TestRegistrationRequest
+import de.rki.coronawarnapp.coronatest.qrcode.CoronaTestQRCode
 import de.rki.coronawarnapp.coronatest.type.CoronaTest
+import de.rki.coronawarnapp.datadonation.analytics.modules.keysubmission.AnalyticsKeySubmissionCollector
 import de.rki.coronawarnapp.exception.http.BadRequestException
 import io.kotest.matchers.shouldBe
 import io.mockk.MockKAnnotations
@@ -13,6 +15,7 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.just
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runBlockingTest
+import org.joda.time.Instant
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
@@ -20,40 +23,55 @@ import testhelpers.BaseTest
 class TestRegistrationStateProcessorTest : BaseTest() {
 
     @MockK lateinit var submissionRepository: SubmissionRepository
-    @MockK lateinit var request: TestRegistrationRequest
-    @MockK lateinit var registeredTest: CoronaTest
+    @MockK lateinit var analyticsKeySubmissionCollector: AnalyticsKeySubmissionCollector
+    @MockK lateinit var registeredTestRA: CoronaTest
+    @MockK lateinit var registeredTestPCR: CoronaTest
+
+    private val raRequest: TestRegistrationRequest = CoronaTestQRCode.RapidAntigen(
+        hash = "ra-hash",
+        createdAt = Instant.EPOCH,
+    )
+    private val pcrRequest: TestRegistrationRequest = CoronaTestQRCode.PCR(
+        qrCodeGUID = "pcr-guid"
+    )
 
     @BeforeEach
     fun setup() {
         MockKAnnotations.init(this)
 
         submissionRepository.apply {
-            coEvery { registerTest(any()) } returns registeredTest
-            coEvery { tryReplaceTest(any()) } returns registeredTest
+            coEvery { registerTest(raRequest) } returns registeredTestRA
+            coEvery { registerTest(pcrRequest) } returns registeredTestPCR
+
+            coEvery { tryReplaceTest(raRequest) } returns registeredTestRA
+            coEvery { tryReplaceTest(pcrRequest) } returns registeredTestPCR
+
             coEvery { giveConsentToSubmission(any()) } just Runs
         }
 
-        registeredTest.apply {
+        registeredTestRA.apply {
             every { type } returns CoronaTest.Type.RAPID_ANTIGEN
+        }
+        registeredTestPCR.apply {
+            every { type } returns CoronaTest.Type.PCR
         }
 
-        request.apply {
-            every { type } returns CoronaTest.Type.RAPID_ANTIGEN
-        }
+        every { analyticsKeySubmissionCollector.reportAdvancedConsentGiven(any()) } just Runs
     }
 
     private fun createInstance() = TestRegistrationStateProcessor(
-        submissionRepository = submissionRepository
+        submissionRepository = submissionRepository,
+        analyticsKeySubmissionCollector = analyticsKeySubmissionCollector,
     )
 
     @Test
-    fun `register new test - with consent`() = runBlockingTest {
+    fun `register new RA test - with consent`() = runBlockingTest {
         val instance = createInstance()
 
         instance.state.first() shouldBe TestRegistrationStateProcessor.State.Idle
 
         instance.startRegistration(
-            request = request,
+            request = raRequest,
             isSubmissionConsentGiven = true,
             allowReplacement = false
         )
@@ -61,23 +79,24 @@ class TestRegistrationStateProcessorTest : BaseTest() {
         advanceUntilIdle()
 
         instance.state.first() shouldBe TestRegistrationStateProcessor.State.TestRegistered(
-            test = registeredTest
+            test = registeredTestRA
         )
 
         coVerify {
-            submissionRepository.registerTest(request)
+            submissionRepository.registerTest(raRequest)
             submissionRepository.giveConsentToSubmission(CoronaTest.Type.RAPID_ANTIGEN)
+            analyticsKeySubmissionCollector.reportAdvancedConsentGiven(CoronaTest.Type.RAPID_ANTIGEN)
         }
     }
 
     @Test
-    fun `register new test - without consent`() = runBlockingTest {
+    fun `register new RA test - without consent`() = runBlockingTest {
         val instance = createInstance()
 
         instance.state.first() shouldBe TestRegistrationStateProcessor.State.Idle
 
         instance.startRegistration(
-            request = request,
+            request = raRequest,
             isSubmissionConsentGiven = false,
             allowReplacement = false
         )
@@ -85,25 +104,26 @@ class TestRegistrationStateProcessorTest : BaseTest() {
         advanceUntilIdle()
 
         instance.state.first() shouldBe TestRegistrationStateProcessor.State.TestRegistered(
-            test = registeredTest
+            test = registeredTestRA
         )
 
         coVerify {
-            submissionRepository.registerTest(request)
+            submissionRepository.registerTest(raRequest)
         }
         coVerify(exactly = 0) {
             submissionRepository.giveConsentToSubmission(any())
+            analyticsKeySubmissionCollector.reportAdvancedConsentGiven(any())
         }
     }
 
     @Test
-    fun `replace test - with consent`() = runBlockingTest {
+    fun `replace RA test - with consent`() = runBlockingTest {
         val instance = createInstance()
 
         instance.state.first() shouldBe TestRegistrationStateProcessor.State.Idle
 
         instance.startRegistration(
-            request = request,
+            request = raRequest,
             isSubmissionConsentGiven = true,
             allowReplacement = true
         )
@@ -111,23 +131,24 @@ class TestRegistrationStateProcessorTest : BaseTest() {
         advanceUntilIdle()
 
         instance.state.first() shouldBe TestRegistrationStateProcessor.State.TestRegistered(
-            test = registeredTest
+            test = registeredTestRA
         )
 
         coVerify {
-            submissionRepository.tryReplaceTest(request)
+            submissionRepository.tryReplaceTest(raRequest)
             submissionRepository.giveConsentToSubmission(CoronaTest.Type.RAPID_ANTIGEN)
+            analyticsKeySubmissionCollector.reportAdvancedConsentGiven(CoronaTest.Type.RAPID_ANTIGEN)
         }
     }
 
     @Test
-    fun `replace new test - without consent`() = runBlockingTest {
+    fun `replace RA new test - without consent`() = runBlockingTest {
         val instance = createInstance()
 
         instance.state.first() shouldBe TestRegistrationStateProcessor.State.Idle
 
         instance.startRegistration(
-            request = request,
+            request = raRequest,
             isSubmissionConsentGiven = false,
             allowReplacement = true
         )
@@ -135,14 +156,119 @@ class TestRegistrationStateProcessorTest : BaseTest() {
         advanceUntilIdle()
 
         instance.state.first() shouldBe TestRegistrationStateProcessor.State.TestRegistered(
-            test = registeredTest
+            test = registeredTestRA
         )
 
         coVerify {
-            submissionRepository.tryReplaceTest(request)
+            submissionRepository.tryReplaceTest(raRequest)
         }
         coVerify(exactly = 0) {
             submissionRepository.giveConsentToSubmission(any())
+            analyticsKeySubmissionCollector.reportAdvancedConsentGiven(any())
+        }
+    }
+
+    @Test
+    fun `register new PCR test - with consent`() = runBlockingTest {
+        val instance = createInstance()
+
+        instance.state.first() shouldBe TestRegistrationStateProcessor.State.Idle
+
+        instance.startRegistration(
+            request = pcrRequest,
+            isSubmissionConsentGiven = true,
+            allowReplacement = false
+        )
+
+        advanceUntilIdle()
+
+        instance.state.first() shouldBe TestRegistrationStateProcessor.State.TestRegistered(
+            test = registeredTestPCR
+        )
+
+        coVerify {
+            submissionRepository.registerTest(pcrRequest)
+            submissionRepository.giveConsentToSubmission(CoronaTest.Type.PCR)
+            analyticsKeySubmissionCollector.reportAdvancedConsentGiven(CoronaTest.Type.PCR)
+        }
+    }
+
+    @Test
+    fun `register new PCR test - without consent`() = runBlockingTest {
+        val instance = createInstance()
+
+        instance.state.first() shouldBe TestRegistrationStateProcessor.State.Idle
+
+        instance.startRegistration(
+            request = pcrRequest,
+            isSubmissionConsentGiven = false,
+            allowReplacement = false
+        )
+
+        advanceUntilIdle()
+
+        instance.state.first() shouldBe TestRegistrationStateProcessor.State.TestRegistered(
+            test = registeredTestPCR
+        )
+
+        coVerify {
+            submissionRepository.registerTest(pcrRequest)
+        }
+        coVerify(exactly = 0) {
+            submissionRepository.giveConsentToSubmission(any())
+            analyticsKeySubmissionCollector.reportAdvancedConsentGiven(any())
+        }
+    }
+
+    @Test
+    fun `replace PCR test - with consent`() = runBlockingTest {
+        val instance = createInstance()
+
+        instance.state.first() shouldBe TestRegistrationStateProcessor.State.Idle
+
+        instance.startRegistration(
+            request = pcrRequest,
+            isSubmissionConsentGiven = true,
+            allowReplacement = true
+        )
+
+        advanceUntilIdle()
+
+        instance.state.first() shouldBe TestRegistrationStateProcessor.State.TestRegistered(
+            test = registeredTestPCR
+        )
+
+        coVerify {
+            submissionRepository.tryReplaceTest(pcrRequest)
+            submissionRepository.giveConsentToSubmission(CoronaTest.Type.PCR)
+            analyticsKeySubmissionCollector.reportAdvancedConsentGiven(CoronaTest.Type.PCR)
+        }
+    }
+
+    @Test
+    fun `replace PCR new test - without consent`() = runBlockingTest {
+        val instance = createInstance()
+
+        instance.state.first() shouldBe TestRegistrationStateProcessor.State.Idle
+
+        instance.startRegistration(
+            request = pcrRequest,
+            isSubmissionConsentGiven = false,
+            allowReplacement = true
+        )
+
+        advanceUntilIdle()
+
+        instance.state.first() shouldBe TestRegistrationStateProcessor.State.TestRegistered(
+            test = registeredTestPCR
+        )
+
+        coVerify {
+            submissionRepository.tryReplaceTest(pcrRequest)
+        }
+        coVerify(exactly = 0) {
+            submissionRepository.giveConsentToSubmission(any())
+            analyticsKeySubmissionCollector.reportAdvancedConsentGiven(any())
         }
     }
 
@@ -156,7 +282,7 @@ class TestRegistrationStateProcessorTest : BaseTest() {
         instance.state.first() shouldBe TestRegistrationStateProcessor.State.Idle
 
         instance.startRegistration(
-            request = request,
+            request = raRequest,
             isSubmissionConsentGiven = true,
             allowReplacement = false
         )
@@ -168,7 +294,7 @@ class TestRegistrationStateProcessorTest : BaseTest() {
         )
 
         coVerify {
-            submissionRepository.registerTest(request)
+            submissionRepository.registerTest(raRequest)
         }
         coVerify(exactly = 0) {
             submissionRepository.giveConsentToSubmission(any())

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/covidcertificate/RequestCovidCertificateViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/covidcertificate/RequestCovidCertificateViewModelTest.kt
@@ -2,16 +2,13 @@ package de.rki.coronawarnapp.ui.submission.covidcertificate
 
 import de.rki.coronawarnapp.coronatest.qrcode.CoronaTestQRCode
 import de.rki.coronawarnapp.coronatest.type.CoronaTest
-import de.rki.coronawarnapp.datadonation.analytics.modules.keysubmission.AnalyticsKeySubmissionCollector
 import de.rki.coronawarnapp.submission.TestRegistrationStateProcessor
 import io.kotest.matchers.shouldBe
 import io.mockk.MockKAnnotations
-import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import io.mockk.just
 import io.mockk.mockk
 import kotlinx.coroutines.flow.flowOf
 import org.joda.time.Instant
@@ -28,7 +25,6 @@ import testhelpers.extensions.getOrAwaitValue
 internal class RequestCovidCertificateViewModelTest : BaseTest() {
 
     @MockK lateinit var testRegistrationStateProcessor: TestRegistrationStateProcessor
-    @MockK lateinit var analyticsKeySubmissionCollector: AnalyticsKeySubmissionCollector
     @MockK lateinit var coronaTest: CoronaTest
 
     private val date = LocalDate.parse(
@@ -49,7 +45,6 @@ internal class RequestCovidCertificateViewModelTest : BaseTest() {
         }
 
         every { coronaTest.identifier } returns "identifier"
-        every { analyticsKeySubmissionCollector.reportAdvancedConsentGiven(any()) } just Runs
     }
 
     private fun createInstance(
@@ -61,7 +56,6 @@ internal class RequestCovidCertificateViewModelTest : BaseTest() {
         coronaTestConsent = coronTestConsent,
         deleteOldTest = deleteOldTest,
         registrationStateProcessor = testRegistrationStateProcessor,
-        analyticsKeySubmissionCollector = analyticsKeySubmissionCollector
     )
 
     @Test
@@ -84,7 +78,6 @@ internal class RequestCovidCertificateViewModelTest : BaseTest() {
                     isSubmissionConsentGiven = any(),
                     allowReplacement = true
                 )
-                analyticsKeySubmissionCollector.reportAdvancedConsentGiven(any())
             }
         }
     }
@@ -101,7 +94,6 @@ internal class RequestCovidCertificateViewModelTest : BaseTest() {
                     isSubmissionConsentGiven = any(),
                     allowReplacement = false
                 )
-                analyticsKeySubmissionCollector.reportAdvancedConsentGiven(any())
             }
         }
     }
@@ -117,7 +109,6 @@ internal class RequestCovidCertificateViewModelTest : BaseTest() {
                     isSubmissionConsentGiven = any(),
                     allowReplacement = true
                 )
-                analyticsKeySubmissionCollector.reportAdvancedConsentGiven(any())
             }
         }
     }
@@ -133,7 +124,6 @@ internal class RequestCovidCertificateViewModelTest : BaseTest() {
                     isSubmissionConsentGiven = any(),
                     allowReplacement = false
                 )
-                analyticsKeySubmissionCollector.reportAdvancedConsentGiven(any())
             }
         }
     }
@@ -149,7 +139,6 @@ internal class RequestCovidCertificateViewModelTest : BaseTest() {
                     isSubmissionConsentGiven = any(),
                     allowReplacement = true
                 )
-                analyticsKeySubmissionCollector.reportAdvancedConsentGiven(any())
             }
         }
     }
@@ -165,7 +154,6 @@ internal class RequestCovidCertificateViewModelTest : BaseTest() {
                     isSubmissionConsentGiven = any(),
                     allowReplacement = false
                 )
-                analyticsKeySubmissionCollector.reportAdvancedConsentGiven(any())
             }
         }
     }
@@ -181,7 +169,6 @@ internal class RequestCovidCertificateViewModelTest : BaseTest() {
                     isSubmissionConsentGiven = any(),
                     allowReplacement = true
                 )
-                analyticsKeySubmissionCollector.reportAdvancedConsentGiven(any())
             }
         }
     }
@@ -197,7 +184,6 @@ internal class RequestCovidCertificateViewModelTest : BaseTest() {
                     isSubmissionConsentGiven = any(),
                     allowReplacement = false
                 )
-                analyticsKeySubmissionCollector.reportAdvancedConsentGiven(any())
             }
         }
     }
@@ -223,46 +209,6 @@ internal class RequestCovidCertificateViewModelTest : BaseTest() {
         createInstance().apply {
             navigateToDispatcherScreen()
             events.getOrAwaitValue() shouldBe ToDispatcherScreen
-        }
-    }
-
-    @Test
-    fun `onAgreeGC reports analytics`() {
-        createInstance(coronTestConsent = true).apply {
-            onAgreeGC()
-            coVerify {
-                analyticsKeySubmissionCollector.reportAdvancedConsentGiven(any())
-            }
-        }
-    }
-
-    @Test
-    fun `onDisagreeGC reports analytics`() {
-        createInstance(coronTestConsent = true).apply {
-            onDisagreeGC()
-            coVerify {
-                analyticsKeySubmissionCollector.reportAdvancedConsentGiven(any())
-            }
-        }
-    }
-
-    @Test
-    fun `onAgreeGC does not report analytics`() {
-        createInstance(coronTestConsent = false).apply {
-            onAgreeGC()
-            coVerify(exactly = 0) {
-                analyticsKeySubmissionCollector.reportAdvancedConsentGiven(any())
-            }
-        }
-    }
-
-    @Test
-    fun `onDisagreeGC does not report analytics`() {
-        createInstance(coronTestConsent = false).apply {
-            onDisagreeGC()
-            coVerify(exactly = 0) {
-                analyticsKeySubmissionCollector.reportAdvancedConsentGiven(any())
-            }
         }
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/qrcode/scan/SubmissionQRCodeScanViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/qrcode/scan/SubmissionQRCodeScanViewModelTest.kt
@@ -4,23 +4,18 @@ import de.rki.coronawarnapp.coronatest.qrcode.CoronaTestQRCode
 import de.rki.coronawarnapp.coronatest.qrcode.CoronaTestQrCodeValidator
 import de.rki.coronawarnapp.coronatest.qrcode.InvalidQRCodeException
 import de.rki.coronawarnapp.coronatest.type.CoronaTest
-import de.rki.coronawarnapp.datadonation.analytics.modules.keysubmission.AnalyticsKeySubmissionCollector
 import de.rki.coronawarnapp.submission.SubmissionRepository
 import de.rki.coronawarnapp.submission.TestRegistrationStateProcessor
 import de.rki.coronawarnapp.util.permission.CameraSettings
 import io.kotest.matchers.shouldBe
 import io.mockk.MockKAnnotations
-import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.runBlockingTest
-import org.joda.time.Instant
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -36,7 +31,6 @@ class SubmissionQRCodeScanViewModelTest : BaseTest() {
     @MockK lateinit var cameraSettings: CameraSettings
     @MockK lateinit var qrCodeValidator: CoronaTestQrCodeValidator
     @MockK lateinit var testRegistrationStateProcessor: TestRegistrationStateProcessor
-    @MockK lateinit var analyticsKeySubmissionCollector: AnalyticsKeySubmissionCollector
 
     @BeforeEach
     fun setUp() {
@@ -57,7 +51,6 @@ class SubmissionQRCodeScanViewModelTest : BaseTest() {
         registrationStateProcessor = testRegistrationStateProcessor,
         submissionRepository = submissionRepository,
         qrCodeValidator = qrCodeValidator,
-        analyticsKeySubmissionCollector = analyticsKeySubmissionCollector
     )
 
     @Test
@@ -97,77 +90,4 @@ class SubmissionQRCodeScanViewModelTest : BaseTest() {
 
         verify { cameraSettings.isCameraDeniedPermanently }
     }
-
-    @Test
-    fun `registerCoronaTest() should call analyticsKeySubmissionCollector for PCR tests`() =
-        runBlockingTest {
-            val coronaTestQRCode = CoronaTestQRCode.PCR(qrCodeGUID = "123456-12345678-1234-4DA7-B166-B86D85475064")
-
-            every { qrCodeValidator.validate(any()) } returns coronaTestQRCode
-            every { analyticsKeySubmissionCollector.reportAdvancedConsentGiven(any()) } just Runs
-
-            createViewModel().registerCoronaTest(rawResult = "")
-
-            verify(exactly = 0) {
-                analyticsKeySubmissionCollector.reportAdvancedConsentGiven(CoronaTest.Type.PCR)
-                analyticsKeySubmissionCollector.reportAdvancedConsentGiven(CoronaTest.Type.RAPID_ANTIGEN)
-            }
-        }
-
-    @Test
-    fun `registerCoronaTest() should NOT call analyticsKeySubmissionCollector for RAT tests`() =
-        runBlockingTest {
-            val coronaTestQRCode = CoronaTestQRCode.PCR(qrCodeGUID = "123456-12345678-1234-4DA7-B166-B86D85475064")
-
-            every { qrCodeValidator.validate(any()) } returns coronaTestQRCode
-            every { analyticsKeySubmissionCollector.reportAdvancedConsentGiven(any()) } just Runs
-
-            createViewModel().registerCoronaTest(rawResult = "")
-
-            verify(exactly = 0) {
-                analyticsKeySubmissionCollector.reportAdvancedConsentGiven(CoronaTest.Type.PCR)
-                analyticsKeySubmissionCollector.reportAdvancedConsentGiven(CoronaTest.Type.RAPID_ANTIGEN)
-            }
-        }
-
-    @Test
-    fun `registerCoronaTest() should call analyticsKeySubmissionCollector for RAT tests - no-dcc support`() =
-        runBlockingTest {
-            val coronaTestQRCode = CoronaTestQRCode.RapidAntigen(
-                hash = "123456-12345678-1234-4DA7-B166-B86D85475064",
-                createdAt = Instant.EPOCH,
-                isDccSupportedByPoc = false
-            )
-
-            every { qrCodeValidator.validate(any()) } returns coronaTestQRCode
-            every { analyticsKeySubmissionCollector.reportAdvancedConsentGiven(any()) } just Runs
-
-            createViewModel().registerCoronaTest(rawResult = "")
-
-            verify(exactly = 1) {
-                analyticsKeySubmissionCollector.reportAdvancedConsentGiven(CoronaTest.Type.RAPID_ANTIGEN)
-            }
-            verify(exactly = 0) {
-                analyticsKeySubmissionCollector.reportAdvancedConsentGiven(CoronaTest.Type.PCR)
-            }
-        }
-
-    @Test
-    fun `registerCoronaTest() should Not call analyticsKeySubmissionCollector for RAT tests - dcc support`() =
-        runBlockingTest {
-            val coronaTestQRCode = CoronaTestQRCode.RapidAntigen(
-                hash = "123456-12345678-1234-4DA7-B166-B86D85475064",
-                createdAt = Instant.EPOCH,
-                isDccSupportedByPoc = true
-            )
-
-            every { qrCodeValidator.validate(any()) } returns coronaTestQRCode
-            every { analyticsKeySubmissionCollector.reportAdvancedConsentGiven(any()) } just Runs
-
-            createViewModel().registerCoronaTest(rawResult = "")
-            verify(exactly = 0) {
-                analyticsKeySubmissionCollector.reportAdvancedConsentGiven(CoronaTest.Type.RAPID_ANTIGEN)
-                analyticsKeySubmissionCollector.reportAdvancedConsentGiven(CoronaTest.Type.PCR)
-            }
-        }
 }


### PR DESCRIPTION
Fix missing `Analytics.reportAdvancedConsentGiven` in RequestCovidCertificateViewModel, by refactoring and moving the analytics call into the common TestRegistrationStateProcessor.