### PR TITLE
Fix DCC request screen abort dialog actions (EXPOSUREAPP-7872)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/covidcertificate/RequestCovidCertificateFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/covidcertificate/RequestCovidCertificateFragment.kt
@@ -118,7 +118,7 @@ class RequestCovidCertificateFragment : Fragment(R.layout.fragment_request_covid
     private fun showCloseDialog() = MaterialAlertDialogBuilder(requireContext())
         .setTitle(R.string.request_gc_dialog_title)
         .setMessage(R.string.request_gc_dialog_message)
-        .setNegativeButton(R.string.request_gc_dialog_negative_button) { _, _ -> viewModel.navigateBack() }
+        .setNegativeButton(R.string.request_gc_dialog_negative_button) { _, _ -> }
         .setPositiveButton(R.string.request_gc_dialog_positive_button) { _, _ -> viewModel.navigateToHomeScreen() }
         .create()
         .show()

--- a/Corona-Warn-App/src/main/res/values-de/green_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/green_certificate_strings.xml
@@ -22,10 +22,10 @@
     <string name="request_gc_dialog_title">Registrierung abbrechen</string>
     <!-- XTXT: Request green certificate exit dialog message -->
     <string name="request_gc_dialog_message">Wenn Sie die Test-Registrierung abbrechen, können Sie Ihr Testergebnis nicht in der App erhalten.</string>
+    <!-- XBUT: Request green certificate exit dialog positive button -->
+    <string name="request_gc_dialog_positive_button">Registrierung abbrechen</string>
     <!-- XBUT: Request green certificate exit dialog negative button -->
-    <string name="request_gc_dialog_positive_button">OK</string>
-    <!-- XBUT: Request green certificate exit dialog negative button -->
-    <string name="request_gc_dialog_negative_button">Abbrechen</string>
+    <string name="request_gc_dialog_negative_button">Registrierung fortsetzen</string>
     <!-- XTXT: Detail green certificate title -->
     <string name="detail_green_certificate_title">EU Digitales COVID-Testzertifikat</string>
     <!-- XTXT: Detail green certificate test type -->


### PR DESCRIPTION
Canceling the dialog (negative action) stays on screen.
Confirming the dialog (positive action) aborts the registration and sends the user back to the home screen.

Strings were changed after initial implementation. Will adjust the German ones here, depending on whether there will be an additional translation delivery, other languages will be delivered with 2.5.