### PR TITLE
Fix: pending DCC label (EXPOSUREAPP-7848)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/testresult/pending/SubmissionTestResultPendingViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/testresult/pending/SubmissionTestResultPendingViewModel.kt
@@ -106,7 +106,7 @@ class SubmissionTestResultPendingViewModel @AssistedInject constructor(
                     R.string.submission_test_result_pending_steps_test_certificate_not_supported_body
                 }
                 else -> {
-                    if (it.coronaTest.isAdvancedConsentGiven) {
+                    if (it.coronaTest.isDccConsentGiven) {
                         R.string.submission_test_result_pending_steps_test_certificate_not_available_yet_body
                     } else {
                         R.string.submission_test_result_pending_steps_test_certificate_not_desired_by_user_body


### PR DESCRIPTION
Fix incorrect label for DCC on pending page.

Aligned with QA: switched from overall consent (isAdvancedConsentGiven) to precise DCC consent flag (isDccConsentGiven).
This consent is given in RequestCovidCertificateFragment:
```
agreeButton.setOnClickListener { viewModel.onAgreeGC() }
disagreeButton.setOnClickListener { viewModel.onDisagreeGC() }
```

How to test:
1) Install the app
2) Complete onboarding
3) Scan pending PCR test
4) On COVID-Testsecrtificate press "Testzertifikat Anfordern" button
5) Check that on next page bottom icon item (with QR-code icon) is in this state:
<img width="227" alt="Screenshot 2021-06-16 at 14 27 57" src="https://user-images.githubusercontent.com/64849422/122211179-1e6d2480-ceaf-11eb-81ee-174bc9b59902.png">

6) Delete test
7) Scan pending PCR test
8) On COVID-Testsecrtificate press "Nein Danke" button
9) Check that on next page bottom icon item (with QR-code icon) is in this state:
<img width="190" alt="Screenshot 2021-06-16 at 14 30 57" src="https://user-images.githubusercontent.com/64849422/122211996-01852100-ceb0-11eb-81eb-3fb1f4131c3a.png">

