### PR TITLE
Don't start ESL on app start in test build (EXPOSUREAPP-7946)

### DIFF
--- a/Corona-Warn-App/src/deviceForTesters/AndroidManifest.xml
+++ b/Corona-Warn-App/src/deviceForTesters/AndroidManifest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <queries>
+        <!-- See DebugLogger.isAutoLoggingEnabled -->
+        <package android:name="de.rki.coronawarnapp.els.autologger" />
+    </queries>
+
+</manifest>


### PR DESCRIPTION
Previously:
In tester builders, the app is automatically recording a debuglog, it does not have to be explicitly started.

Now:
Enable ELS autologging in tester builds only if a specific package is installed (`de.rki.coronawarnapp.els.autologger`).
This allows us to both disable it by default, and still have a way to log the initial app launch if necessary, or have it automatically enabled by just having the package installed.

[CWA-ELS-AutoLogger-de.rki.coronawarnapp.els.autologger.zip](https://github.com/corona-warn-app/cwa-app-android/files/6663025/CWA-ELS-AutoLogger-de.rki.coronawarnapp.els.autologger.zip)


