### PR TITLE
Fix `labId` not being stored, when retrieved during polling (EXPOSUREAPP-7870)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/server/CoronaTestResult.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/server/CoronaTestResult.kt
@@ -8,8 +8,8 @@ import org.json.JSONObject
 
 data class CoronaTestResultResponse(
     val coronaTestResult: CoronaTestResult,
-    val sampleCollectedAt: Instant?,
-    val labId: String?
+    val sampleCollectedAt: Instant? = null, // Only used for RA tests
+    val labId: String? = null, // May initially be null while test is pending
 ) {
     companion object {
         fun fromResponse(response: VerificationApiV1.TestResultResponse) =


### PR DESCRIPTION
`labId` may be null when retrieved on initial test registration.
If we then later receive a negative test result, the response may contain a non-null lab-ID, which we then ignored.
This lead to `TestCertificateRepository` not attempting to register a publickey and request a certificate.

For testing:
Test with and without this PR by scanning a pending test and changing it later to negative.
Check the logs for `labId=`. Without this PR the stored `labId` for this case is always null.
