### PR TITLE
Fix Test Certificate times and strings (EXPOSUREAPP-7822, EXPOSUREAPP-7889)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/CertificatesViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/CertificatesViewModel.kt
@@ -124,11 +124,11 @@ class CertificatesViewModel @AssistedInject constructor(
 
     private fun Collection<TestCertificateWrapper>.toCertificateItems(): List<CertificatesItem> = this
         .map { certificate ->
-            val localRegistrationTime = certificate.registeredAt.toUserTimeZone()
+            val registrationTime = certificate.registeredAt.toUserTimeZone()
 
             if (certificate.isCertificateRetrievalPending) {
                 CovidTestCertificateErrorCard.Item(
-                    testDate = localRegistrationTime,
+                    testDate = registrationTime,
                     isUpdatingData = certificate.isUpdatingData,
                     onRetryAction = {
                         refreshTestCertificate(certificate.identifier)
@@ -143,7 +143,7 @@ class CertificatesViewModel @AssistedInject constructor(
                 )
             } else {
                 CovidTestCertificateCard.Item(
-                    testDate = localRegistrationTime,
+                    testDate = certificate.testCertificate?.sampleCollectedAt?.toUserTimeZone() ?: registrationTime,
                     testPerson =
                     certificate.testCertificate?.firstName + " " +
                         certificate.testCertificate?.lastName,

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/cards/CovidTestCertificateErrorCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/cards/CovidTestCertificateErrorCard.kt
@@ -26,7 +26,7 @@ class CovidTestCertificateErrorCard(parent: ViewGroup) :
     ) -> Unit = { item, _ ->
 
         testTime.text = context.getString(
-            R.string.test_certificate_time,
+            R.string.test_certificate_registration_time,
             item.testDate.toDayFormat(),
             item.testDate.toShortTimeFormat()
         )

--- a/Corona-Warn-App/src/main/res/values-de/green_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/green_certificate_strings.xml
@@ -64,6 +64,8 @@
 
     <!-- XTXT: Test certificate time -->
     <string name="test_certificate_time">Test durchgeführt am %1$s, %2$s Uhr</string>
+    <!-- XTXT: Test certificate registration time -->
+    <string name="test_certificate_registration_time">"Registriert am %1$s, %2$s"</string>
     <!-- XTXT: Test error label -->
     <string name="test_certificate_error_label">Fehler bei der Zertifikatsabfrage</string>
     <!-- XBUT: Test error retry button -->

--- a/Corona-Warn-App/src/main/res/values/green_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/green_certificate_strings.xml
@@ -64,6 +64,8 @@
 
     <!-- XTXT: Test certificate time -->
     <string name="test_certificate_time">"Test performed on %1$s, %2$s"</string>
+    <!-- XTXT: Test certificate registration time -->
+    <string name="test_certificate_registration_time">"Registriert am %1$s, %2$s"</string>
     <!-- XTXT: Test error label -->
     <string name="test_certificate_error_label">"Error during certificate retrieval"</string>
     <!-- XBUT: Test error retry button -->


### PR DESCRIPTION
- use registration timestamp for error card
- use `t[0].sc` timestamp for certificate card
- use correct string on error carde

- [X] ~~#3490 should be merged at first~~