### PR TITLE
Introduce `CertificateContainerId` to reference certificates (DEV)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/test/ui/CovidCertificateDetailsFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/test/ui/CovidCertificateDetailsFragmentTest.kt
@@ -15,8 +15,8 @@ import dagger.android.ContributesAndroidInjector
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CertificatePersonIdentifier
 import de.rki.coronawarnapp.covidcertificate.common.qrcode.QrCodeString
+import de.rki.coronawarnapp.covidcertificate.common.repository.TestCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.test.core.TestCertificate
-import de.rki.coronawarnapp.covidcertificate.test.core.storage.TestCertificateIdentifier
 import de.rki.coronawarnapp.covidcertificate.test.ui.details.CovidCertificateDetailsViewModel
 import de.rki.coronawarnapp.covidcertificate.test.ui.details.TestCertificateDetailsFragment
 import de.rki.coronawarnapp.covidcertificate.test.ui.details.TestCertificateDetailsFragmentArgs
@@ -43,7 +43,9 @@ class VaccinationDetailsFragmentTest : BaseUITest() {
     @MockK lateinit var vaccinationDetailsViewModel: CovidCertificateDetailsViewModel
     @MockK lateinit var certificatePersonIdentifier: CertificatePersonIdentifier
 
-    private val args = TestCertificateDetailsFragmentArgs("testCertificateIdentifier").toBundle()
+    private val args = TestCertificateDetailsFragmentArgs(
+        containerId = TestCertificateContainerId("testCertificateIdentifier")
+    ).toBundle()
 
     @Before
     fun setUp() {
@@ -53,7 +55,7 @@ class VaccinationDetailsFragmentTest : BaseUITest() {
 
         setupMockViewModel(
             object : CovidCertificateDetailsViewModel.Factory {
-                override fun create(testCertificateIdentifier: TestCertificateIdentifier):
+                override fun create(containerId: TestCertificateContainerId):
                     CovidCertificateDetailsViewModel = vaccinationDetailsViewModel
             }
         )
@@ -86,6 +88,8 @@ class VaccinationDetailsFragmentTest : BaseUITest() {
         val testDate = DateTime.parse("12.05.2021 19:00", formatter).toInstant()
         return MutableLiveData(
             object : TestCertificate {
+                override val containerId: TestCertificateContainerId
+                    get() = TestCertificateContainerId("identifier")
                 override val targetName: String
                     get() = "Schneider, Andrea"
                 override val testType: String

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragmentTest.kt
@@ -13,6 +13,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import dagger.Module
 import dagger.android.ContributesAndroidInjector
 import de.rki.coronawarnapp.R
+import de.rki.coronawarnapp.covidcertificate.common.repository.VaccinationCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinationCertificate
 import io.mockk.MockKAnnotations
 import io.mockk.every
@@ -36,7 +37,9 @@ class VaccinationDetailsFragmentTest : BaseUITest() {
 
     @MockK lateinit var vaccinationDetailsViewModel: VaccinationDetailsViewModel
 
-    private val args = VaccinationDetailsFragmentArgs("vaccinationCertificateId").toBundle()
+    private val args = VaccinationDetailsFragmentArgs(
+        containerId = VaccinationCertificateContainerId("vaccinationCertificateId")
+    ).toBundle()
 
     @Before
     fun setUp() {
@@ -46,7 +49,9 @@ class VaccinationDetailsFragmentTest : BaseUITest() {
 
         setupMockViewModel(
             object : VaccinationDetailsViewModel.Factory {
-                override fun create(certificateId: String): VaccinationDetailsViewModel = vaccinationDetailsViewModel
+                override fun create(
+                    containerId: VaccinationCertificateContainerId
+                ): VaccinationDetailsViewModel = vaccinationDetailsViewModel
             }
         )
     }

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/list/VaccinationListFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/list/VaccinationListFragmentTest.kt
@@ -11,6 +11,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import dagger.Module
 import dagger.android.ContributesAndroidInjector
 import de.rki.coronawarnapp.R
+import de.rki.coronawarnapp.covidcertificate.common.repository.VaccinationCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinatedPerson
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinatedPerson.Status.COMPLETE
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinatedPerson.Status.IMMUNITY
@@ -176,7 +177,7 @@ internal class VaccinationListFragmentTest : BaseUITest() {
         vaccinationStatus: VaccinatedPerson.Status,
         vaccinatedAt: LocalDate = LocalDate.parse("12.04.2021", formatter)
     ) = VaccinationListVaccinationCardItem(
-        vaccinationCertificateId = "vaccinationCertificateId",
+        containerId = VaccinationCertificateContainerId("vaccinationCertificateId"),
         doseNumber = doseNumber,
         totalSeriesOfDoses = totalSeriesOfDoses,
         vaccinatedAt = vaccinatedAt.toDayFormat(),

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/CwaCovidCertificate.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/CwaCovidCertificate.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.covidcertificate.common.certificate
 
 import de.rki.coronawarnapp.covidcertificate.common.qrcode.QrCodeString
+import de.rki.coronawarnapp.covidcertificate.common.repository.CertificateContainerId
 import org.joda.time.Instant
 import org.joda.time.LocalDate
 
@@ -26,4 +27,9 @@ interface CwaCovidCertificate {
     val certificateIssuer: String
     val certificateCountry: String
     val certificateId: String
+
+    /**
+     * The ID of the container holding this certificate in the CWA.
+     */
+    val containerId: CertificateContainerId
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/repository/CertificateContainerId.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/repository/CertificateContainerId.kt
@@ -1,0 +1,13 @@
+package de.rki.coronawarnapp.covidcertificate.common.repository
+
+import android.os.Parcelable
+
+/**
+ * A unique identifier for a container holding a certificate in the CWA.
+ * As there is a 1:1 match between container and certificates, it's also a unique ID for the certificate.
+ * It's the ID you used pass around in the UI to find it/modify/delete it via a repository.
+ * We can't use uniqueCertificateId because we also handle `TestCertificate`'s that have not been retrieved yet.
+ */
+sealed class CertificateContainerId : Parcelable {
+    abstract val identifier: String
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/repository/CertificateRepoContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/repository/CertificateRepoContainer.kt
@@ -1,0 +1,5 @@
+package de.rki.coronawarnapp.covidcertificate.common.repository
+
+interface CertificateRepoContainer {
+    val containerId: CertificateContainerId
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/repository/RecoveryCertificateContainerId.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/repository/RecoveryCertificateContainerId.kt
@@ -1,0 +1,6 @@
+package de.rki.coronawarnapp.covidcertificate.common.repository
+
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class RecoveryCertificateContainerId(override val identifier: String) : CertificateContainerId()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/repository/TestCertificateContainerId.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/repository/TestCertificateContainerId.kt
@@ -1,0 +1,6 @@
+package de.rki.coronawarnapp.covidcertificate.common.repository
+
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class TestCertificateContainerId(override val identifier: String) : CertificateContainerId()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/repository/VaccinationCertificateContainerId.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/repository/VaccinationCertificateContainerId.kt
@@ -1,0 +1,6 @@
+package de.rki.coronawarnapp.covidcertificate.common.repository
+
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class VaccinationCertificateContainerId(override val identifier: String) : CertificateContainerId()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/scan/DccQrCodeScanFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/scan/DccQrCodeScanFragment.kt
@@ -71,7 +71,7 @@ class DccQrCodeScanFragment :
                     doNavigate(
                         DccQrCodeScanFragmentDirections
                             .actionDccQrCodeScanFragmentToVaccinationDetailsFragment(
-                                event.certificateId
+                                event.containerId
                             )
                     )
                 }
@@ -82,7 +82,7 @@ class DccQrCodeScanFragment :
                     doNavigate(
                         DccQrCodeScanFragmentDirections
                             .actionDccQrCodeScanFragmentToTestCertificateDetailsFragment(
-                                event.certificateId
+                                event.containerId
                             )
                     )
                 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/scan/DccQrCodeScanViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/scan/DccQrCodeScanViewModel.kt
@@ -3,6 +3,9 @@ package de.rki.coronawarnapp.covidcertificate.common.scan
 import com.journeyapps.barcodescanner.BarcodeResult
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import de.rki.coronawarnapp.covidcertificate.common.repository.RecoveryCertificateContainerId
+import de.rki.coronawarnapp.covidcertificate.common.repository.TestCertificateContainerId
+import de.rki.coronawarnapp.covidcertificate.common.repository.VaccinationCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.recovery.core.RecoveryCertificateRepository
 import de.rki.coronawarnapp.covidcertificate.recovery.core.qrcode.RecoveryCertificateQRCode
 import de.rki.coronawarnapp.covidcertificate.test.core.TestCertificateRepository
@@ -42,8 +45,8 @@ class DccQrCodeScanViewModel @AssistedInject constructor(
     }
 
     private suspend fun registerVaccinationCertificate(qrCode: VaccinationCertificateQRCode) {
-        val certificate = vaccinationRepository.registerVaccination(qrCode)
-        event.postValue(Event.VaccinationQrCodeScanSucceeded(certificate.certificateId))
+        val certificate = vaccinationRepository.registerCertificate(qrCode)
+        event.postValue(Event.VaccinationQrCodeScanSucceeded(certificate.containerId))
     }
 
     private suspend fun registerTestCertificate(qrCode: TestCertificateQRCode) {
@@ -67,9 +70,9 @@ class DccQrCodeScanViewModel @AssistedInject constructor(
 
     sealed class Event {
         object QrCodeScanInProgress : Event()
-        data class VaccinationQrCodeScanSucceeded(val certificateId: String) : Event()
-        data class TestQrCodeScanSucceeded(val certificateId: String) : Event()
-        data class RecoveryQrCodeScanSucceeded(val certificateId: String) : Event()
+        data class VaccinationQrCodeScanSucceeded(val containerId: VaccinationCertificateContainerId) : Event()
+        data class TestQrCodeScanSucceeded(val containerId: TestCertificateContainerId) : Event()
+        data class RecoveryQrCodeScanSucceeded(val containerId: RecoveryCertificateContainerId) : Event()
     }
 
     @AssistedFactory

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesProvider.kt
@@ -4,6 +4,7 @@ import dagger.Reusable
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CertificatePersonIdentifier
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate
 import de.rki.coronawarnapp.covidcertificate.common.qrcode.QrCodeString
+import de.rki.coronawarnapp.covidcertificate.common.repository.TestCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.recovery.core.RecoveryCertificateRepository
 import de.rki.coronawarnapp.covidcertificate.test.core.TestCertificate
 import de.rki.coronawarnapp.covidcertificate.test.core.TestCertificateRepository
@@ -14,6 +15,7 @@ import kotlinx.coroutines.flow.map
 import org.joda.time.Instant
 import org.joda.time.LocalDate
 import timber.log.Timber
+import java.util.UUID
 import javax.inject.Inject
 
 // Aggregate the certificates and sort them
@@ -78,6 +80,8 @@ class PersonCertificatesProvider @Inject constructor(
         isUpdating: Boolean = false
     ) =
         object : TestCertificate {
+            override val containerId: TestCertificateContainerId
+                get() = TestCertificateContainerId(UUID.randomUUID().toString())
             override val targetName: String
                 get() = "targetName"
             override val testType: String

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragment.kt
@@ -61,7 +61,7 @@ class PersonOverviewFragment : Fragment(R.layout.person_overview_fragment), Auto
                 .setNegativeButton(R.string.test_certificate_delete_dialog_cancel_button) { _, _ -> }
                 .setCancelable(false)
                 .setPositiveButton(R.string.test_certificate_delete_dialog_confirm_button) { _, _ ->
-                    viewModel.deleteTestCertificate(event.certificateId)
+                    viewModel.deleteTestCertificate(event.containerId)
                 }
                 .show()
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragmentEvents.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragmentEvents.kt
@@ -1,9 +1,11 @@
 package de.rki.coronawarnapp.covidcertificate.person.ui.overview
 
+import de.rki.coronawarnapp.covidcertificate.common.repository.TestCertificateContainerId
+
 sealed class PersonOverviewFragmentEvents
 
 data class ShowRefreshErrorDialog(val error: Throwable) : PersonOverviewFragmentEvents()
-data class ShowDeleteDialog(val certificateId: String) : PersonOverviewFragmentEvents()
+data class ShowDeleteDialog(val containerId: TestCertificateContainerId) : PersonOverviewFragmentEvents()
 data class OpenPersonDetailsFragment(val personIdentifier: String) : PersonOverviewFragmentEvents()
 object ScanQrCode : PersonOverviewFragmentEvents()
 object OpenAppDeviceSettings : PersonOverviewFragmentEvents()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewViewModel.kt
@@ -8,15 +8,15 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import de.rki.coronawarnapp.contactdiary.util.getLocale
 import de.rki.coronawarnapp.covidcertificate.common.qrcode.QrCodeString
+import de.rki.coronawarnapp.covidcertificate.common.repository.TestCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.person.core.PersonCertificates
 import de.rki.coronawarnapp.covidcertificate.person.core.PersonCertificatesProvider
+import de.rki.coronawarnapp.covidcertificate.person.ui.overview.items.CameraPermissionCard
 import de.rki.coronawarnapp.covidcertificate.person.ui.overview.items.CertificatesItem
 import de.rki.coronawarnapp.covidcertificate.person.ui.overview.items.CovidTestCertificatePendingCard
-import de.rki.coronawarnapp.covidcertificate.person.ui.overview.items.CameraPermissionCard
 import de.rki.coronawarnapp.covidcertificate.person.ui.overview.items.PersonCertificateCard
 import de.rki.coronawarnapp.covidcertificate.test.core.TestCertificate
 import de.rki.coronawarnapp.covidcertificate.test.core.TestCertificateRepository
-import de.rki.coronawarnapp.covidcertificate.test.core.storage.TestCertificateIdentifier
 import de.rki.coronawarnapp.covidcertificate.valueset.ValueSetsRepository
 import de.rki.coronawarnapp.presencetracing.checkins.qrcode.QrCodeGenerator
 import de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.permission.CameraPermissionProvider
@@ -64,15 +64,15 @@ class PersonOverviewViewModel @AssistedInject constructor(
             wrappers
                 .filter { !it.seenByUser && !it.isCertificateRetrievalPending }
                 .forEach {
-                    testCertificateRepository.markCertificateAsSeenByUser(it.identifier)
+                    testCertificateRepository.markCertificateAsSeenByUser(it.containerId)
                 }
         }
         .map { }
         .catch { Timber.w("Failed to mark certificates as seen.") }
         .asLiveData2()
 
-    fun deleteTestCertificate(identifier: TestCertificateIdentifier) = launch {
-        testCertificateRepository.deleteCertificate(identifier)
+    fun deleteTestCertificate(containerId: TestCertificateContainerId) = launch {
+        testCertificateRepository.deleteCertificate(containerId)
     }
 
     fun onScanQrCode() = events.postValue(ScanQrCode)
@@ -113,8 +113,8 @@ class PersonOverviewViewModel @AssistedInject constructor(
                 add(
                     CovidTestCertificatePendingCard.Item(
                         certificate = certificate,
-                        onRetryAction = { refreshCertificate(certificate.certificateId) },
-                        onDeleteAction = { events.postValue(ShowDeleteDialog(certificate.certificateId)) }
+                        onRetryAction = { refreshCertificate(certificate.containerId) },
+                        onDeleteAction = { events.postValue(ShowDeleteDialog(certificate.containerId)) }
                     )
                 )
             }
@@ -149,9 +149,9 @@ class PersonOverviewViewModel @AssistedInject constructor(
         null
     }
 
-    fun refreshCertificate(identifier: TestCertificateIdentifier) =
+    fun refreshCertificate(containerId: TestCertificateContainerId) =
         launch {
-            val error = testCertificateRepository.refresh(identifier).mapNotNull { it.error }.singleOrNull()
+            val error = testCertificateRepository.refresh(containerId).mapNotNull { it.error }.singleOrNull()
             error?.let { events.postValue(ShowRefreshErrorDialog(error)) }
         }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/RecoveryCertificate.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/RecoveryCertificate.kt
@@ -1,9 +1,11 @@
 package de.rki.coronawarnapp.covidcertificate.recovery.core
 
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate
+import de.rki.coronawarnapp.covidcertificate.common.repository.RecoveryCertificateContainerId
 import org.joda.time.LocalDate
 
 interface RecoveryCertificate : CwaCovidCertificate {
+    override val containerId: RecoveryCertificateContainerId
     val testedPositiveOn: LocalDate
     val validFrom: LocalDate
     val validUntil: LocalDate

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/RecoveryCertificateRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/RecoveryCertificateRepository.kt
@@ -1,9 +1,9 @@
 package de.rki.coronawarnapp.covidcertificate.recovery.core
 
 import de.rki.coronawarnapp.covidcertificate.common.certificate.DccQrCodeExtractor
+import de.rki.coronawarnapp.covidcertificate.common.repository.RecoveryCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.recovery.core.qrcode.RecoveryCertificateQRCode
 import de.rki.coronawarnapp.covidcertificate.recovery.core.storage.RecoveryCertificateContainer
-import de.rki.coronawarnapp.covidcertificate.recovery.core.storage.RecoveryCertificateIdentifier
 import de.rki.coronawarnapp.covidcertificate.valueset.ValueSetsRepository
 import de.rki.coronawarnapp.util.coroutine.AppScope
 import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
@@ -24,13 +24,13 @@ class RecoveryCertificateRepository @Inject constructor(
 
     val certificates: Flow<Set<RecoveryCertificateWrapper>> = flowOf(emptySet())
 
-    suspend fun requestCertificate(qrCode: RecoveryCertificateQRCode): RecoveryCertificateContainer {
-        Timber.tag(TAG).d("requestCertificate(qrCode=%s)", qrCode)
+    suspend fun registerCertificate(qrCode: RecoveryCertificateQRCode): RecoveryCertificateContainer {
+        Timber.tag(TAG).d("registerCertificate(qrCode=%s)", qrCode)
         throw NotImplementedError()
     }
 
-    suspend fun deleteCertificate(identifier: RecoveryCertificateIdentifier) {
-        Timber.tag(TAG).d("deleteTestCertificate(identifier=%s)", identifier)
+    suspend fun deleteCertificate(containerId: RecoveryCertificateContainerId): RecoveryCertificateContainer? {
+        Timber.tag(TAG).d("deleteCertificate(containerId=%s)", containerId)
         throw NotImplementedError()
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/RecoveryCertificateWrapper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/RecoveryCertificateWrapper.kt
@@ -1,7 +1,7 @@
 package de.rki.coronawarnapp.covidcertificate.recovery.core
 
+import de.rki.coronawarnapp.covidcertificate.common.repository.RecoveryCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.recovery.core.storage.RecoveryCertificateContainer
-import de.rki.coronawarnapp.covidcertificate.recovery.core.storage.RecoveryCertificateIdentifier
 import de.rki.coronawarnapp.covidcertificate.valueset.valuesets.ValueSets
 
 data class RecoveryCertificateWrapper(
@@ -9,7 +9,7 @@ data class RecoveryCertificateWrapper(
     private val container: RecoveryCertificateContainer
 ) {
 
-    val identifier: RecoveryCertificateIdentifier = container.identifier
+    val containerId: RecoveryCertificateContainerId get() = container.containerId
 
     val isUpdatingData = container.isUpdatingData
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/storage/RecoveryCertificateContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/storage/RecoveryCertificateContainer.kt
@@ -6,6 +6,8 @@ import de.rki.coronawarnapp.covidcertificate.common.certificate.DccQrCodeExtract
 import de.rki.coronawarnapp.covidcertificate.common.certificate.DccV1Parser.Mode
 import de.rki.coronawarnapp.covidcertificate.common.certificate.RecoveryDccV1
 import de.rki.coronawarnapp.covidcertificate.common.qrcode.QrCodeString
+import de.rki.coronawarnapp.covidcertificate.common.repository.CertificateRepoContainer
+import de.rki.coronawarnapp.covidcertificate.common.repository.RecoveryCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.recovery.core.RecoveryCertificate
 import de.rki.coronawarnapp.covidcertificate.recovery.core.qrcode.RecoveryCertificateQRCode
 import de.rki.coronawarnapp.covidcertificate.valueset.valuesets.TestCertificateValueSets
@@ -17,7 +19,7 @@ data class RecoveryCertificateContainer(
     internal val data: StoredRecoveryCertificateData,
     private val qrCodeExtractor: DccQrCodeExtractor,
     val isUpdatingData: Boolean = false,
-) : StoredRecoveryCertificate by data {
+) : StoredRecoveryCertificate by data, CertificateRepoContainer {
 
     @delegate:Transient
     private val certificateData: DccData<RecoveryDccV1> by lazy {
@@ -31,6 +33,9 @@ data class RecoveryCertificateContainer(
         }
     }
 
+    override val containerId: RecoveryCertificateContainerId
+        get() = RecoveryCertificateContainerId(data.identifier)
+
     val certificateId: String
         get() = certificateData.certificate.recovery.uniqueCertificateIdentifier
 
@@ -43,6 +48,9 @@ data class RecoveryCertificateContainer(
         val recoveryCertificate = certificate.recovery
 
         return object : RecoveryCertificate {
+            override val containerId: RecoveryCertificateContainerId
+                get() = this@RecoveryCertificateContainer.containerId
+
             override val personIdentifier: CertificatePersonIdentifier
                 get() = certificate.personIdentifier
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/storage/RecoveryCertificateIdentifier.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/storage/RecoveryCertificateIdentifier.kt
@@ -1,3 +1,0 @@
-package de.rki.coronawarnapp.covidcertificate.recovery.core.storage
-
-typealias RecoveryCertificateIdentifier = String

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/storage/StoredRecoveryCertificateData.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/storage/StoredRecoveryCertificateData.kt
@@ -4,13 +4,13 @@ import com.google.gson.annotations.SerializedName
 import org.joda.time.Instant
 
 data class StoredRecoveryCertificateData(
-    @SerializedName("identifier") override val identifier: RecoveryCertificateIdentifier,
+    @SerializedName("identifier") override val identifier: String,
     @SerializedName("registeredAt") override val registeredAt: Instant,
     @SerializedName("recoveryCertificateQrCode") override val recoveryCertificateQrCode: String?,
 ) : StoredRecoveryCertificate
 
 interface StoredRecoveryCertificate {
-    val identifier: RecoveryCertificateIdentifier
+    val identifier: String
     val registeredAt: Instant
     val recoveryCertificateQrCode: String?
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificate.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificate.kt
@@ -1,9 +1,11 @@
 package de.rki.coronawarnapp.covidcertificate.test.core
 
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate
+import de.rki.coronawarnapp.covidcertificate.common.repository.TestCertificateContainerId
 import org.joda.time.Instant
 
 interface TestCertificate : CwaCovidCertificate {
+    override val containerId: TestCertificateContainerId
 
     /**
      * Disease or agent targeted (required)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepository.kt
@@ -5,9 +5,9 @@ import de.rki.coronawarnapp.coronatest.type.CoronaTest
 import de.rki.coronawarnapp.covidcertificate.common.certificate.DccQrCodeExtractor
 import de.rki.coronawarnapp.covidcertificate.common.exception.InvalidHealthCertificateException
 import de.rki.coronawarnapp.covidcertificate.common.exception.InvalidTestCertificateException
+import de.rki.coronawarnapp.covidcertificate.common.repository.TestCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.test.core.qrcode.TestCertificateQRCode
 import de.rki.coronawarnapp.covidcertificate.test.core.storage.TestCertificateContainer
-import de.rki.coronawarnapp.covidcertificate.test.core.storage.TestCertificateIdentifier
 import de.rki.coronawarnapp.covidcertificate.test.core.storage.TestCertificateStorage
 import de.rki.coronawarnapp.covidcertificate.test.core.storage.types.GenericTestCertificateData
 import de.rki.coronawarnapp.covidcertificate.test.core.storage.types.PCRCertificateData
@@ -46,7 +46,7 @@ class TestCertificateRepository @Inject constructor(
     valueSetsRepository: ValueSetsRepository,
 ) {
 
-    private val internalData: HotDataFlow<Map<TestCertificateIdentifier, TestCertificateContainer>> = HotDataFlow(
+    private val internalData: HotDataFlow<Map<TestCertificateContainerId, TestCertificateContainer>> = HotDataFlow(
         loggingTag = TAG,
         scope = appScope + dispatcherProvider.Default,
         sharingBehavior = SharingStarted.Eagerly,
@@ -58,7 +58,7 @@ class TestCertificateRepository @Inject constructor(
                     qrCodeExtractor = qrCodeExtractor
                 )
             }
-            .map { it.identifier to it }
+            .map { it.containerId to it }
             .toMap().also {
                 Timber.tag(TAG).v("Restored TestCertificate data: %s", it)
             }
@@ -140,7 +140,7 @@ class TestCertificateRepository @Inject constructor(
                 qrCodeExtractor = qrCodeExtractor,
             )
             Timber.tag(TAG).d("Adding test certificate entry: %s", container)
-            mutate { this[container.identifier] = container }
+            mutate { this[container.containerId] = container }
         }
 
         return newData.values.single {
@@ -148,7 +148,7 @@ class TestCertificateRepository @Inject constructor(
         }
     }
 
-    suspend fun registerTestCertificate(
+    suspend fun registerCertificate(
         qrCode: TestCertificateQRCode
     ): TestCertificateContainer {
         Timber.tag(TAG).v("registerTestCertificate(qrCode=%s)", qrCode)
@@ -173,7 +173,7 @@ class TestCertificateRepository @Inject constructor(
                 qrCodeExtractor = qrCodeExtractor,
             )
             Timber.tag(TAG).d("Adding test certificate entry: %s", container)
-            mutate { this[container.identifier] = container }
+            mutate { this[container.containerId] = container }
         }
 
         // We just registered it, it MUST be available.
@@ -202,23 +202,23 @@ class TestCertificateRepository @Inject constructor(
      * [refresh] itself will NOT throw an exception.
      */
     @Suppress("ComplexMethod")
-    suspend fun refresh(identifier: TestCertificateIdentifier? = null): Set<RefreshResult> {
-        Timber.tag(TAG).d("refresh(identifier=%s)", identifier)
+    suspend fun refresh(containerId: TestCertificateContainerId? = null): Set<RefreshResult> {
+        Timber.tag(TAG).d("refresh(containerId=%s)", containerId)
 
-        val refreshCallResults = mutableMapOf<TestCertificateIdentifier, RefreshResult>()
+        val refreshCallResults = mutableMapOf<TestCertificateContainerId, RefreshResult>()
 
-        val workedOnIds = mutableSetOf<TestCertificateIdentifier>()
+        val workedOnIds = mutableSetOf<TestCertificateContainerId>()
 
         internalData.updateBlocking {
             val toRefresh = values
-                .filter { it.identifier == identifier || identifier == null } // Targets of our refresh
+                .filter { it.containerId == containerId || containerId == null } // Targets of our refresh
                 .filter { it.data is RetrievedTestCertificate } // Can only update retrieved certificates
                 .filter { !it.isUpdatingData && it.isCertificateRetrievalPending } // Those that need refreshing
 
             mutate {
                 toRefresh.forEach {
-                    workedOnIds.add(it.identifier)
-                    this[it.identifier] = it.copy(isUpdatingData = true)
+                    workedOnIds.add(it.containerId)
+                    this[it.containerId] = it.copy(isUpdatingData = true)
                 }
             }
         }
@@ -227,7 +227,7 @@ class TestCertificateRepository @Inject constructor(
             Timber.tag(TAG).d("Checking for unregistered public keys.")
 
             val refreshedCerts = values
-                .filter { workedOnIds.contains(it.identifier) } // Refresh targets
+                .filter { workedOnIds.contains(it.containerId) } // Refresh targets
                 .mapNotNull { cert ->
                     if (cert.data !is RetrievedTestCertificate) return@mapNotNull null
                     if (cert.data.isPublicKeyRegistered) return@mapNotNull null
@@ -244,14 +244,14 @@ class TestCertificateRepository @Inject constructor(
                 }
 
             refreshedCerts.forEach {
-                refreshCallResults[it.certificateContainer.identifier] = it
+                refreshCallResults[it.certificateContainer.containerId] = it
             }
 
             mutate {
                 refreshedCerts
                     .filter { it.error == null }
                     .map { it.certificateContainer }
-                    .forEach { this[it.identifier] = it }
+                    .forEach { this[it.containerId] = it }
             }
         }
 
@@ -259,7 +259,7 @@ class TestCertificateRepository @Inject constructor(
             Timber.tag(TAG).d("Checking for pending certificates.")
 
             val refreshedCerts = values
-                .filter { workedOnIds.contains(it.identifier) } // Refresh targets
+                .filter { workedOnIds.contains(it.containerId) } // Refresh targets
                 .mapNotNull { cert ->
                     if (cert.data !is RetrievedTestCertificate) return@mapNotNull null
 
@@ -278,22 +278,22 @@ class TestCertificateRepository @Inject constructor(
                 }
 
             refreshedCerts.forEach {
-                refreshCallResults[it.certificateContainer.identifier] = it
+                refreshCallResults[it.certificateContainer.containerId] = it
             }
 
             mutate {
                 refreshedCerts
                     .filter { it.error == null }
                     .map { it.certificateContainer }
-                    .forEach { this[it.identifier] = it }
+                    .forEach { this[it.containerId] = it }
             }
         }
 
         internalData.updateBlocking {
             mutate {
                 values
-                    .filter { workedOnIds.contains(it.identifier) }
-                    .forEach { this[it.identifier] = it.copy(isUpdatingData = false) }
+                    .filter { workedOnIds.contains(it.containerId) }
+                    .forEach { this[it.containerId] = it.copy(isUpdatingData = false) }
             }
         }
 
@@ -303,12 +303,19 @@ class TestCertificateRepository @Inject constructor(
     /**
      * [deleteCertificate] does not throw an exception, if the deletion target already does not exist.
      */
-    suspend fun deleteCertificate(identifier: TestCertificateIdentifier) {
-        Timber.tag(TAG).d("deleteTestCertificate(identifier=%s)", identifier)
+    suspend fun deleteCertificate(containerId: TestCertificateContainerId): TestCertificateContainer? {
+        Timber.tag(TAG).d("deleteCertificate(containerId=%s)", containerId)
+
+        var deletedCertificate: TestCertificateContainer? = null
+
         internalData.updateBlocking {
             mutate {
-                remove(identifier)
+                deletedCertificate = remove(containerId)
             }
+        }
+
+        return deletedCertificate?.also {
+            Timber.tag(TAG).i("Deleted: %s", containerId)
         }
     }
 
@@ -317,23 +324,23 @@ class TestCertificateRepository @Inject constructor(
         internalData.updateBlocking { emptyMap() }
     }
 
-    suspend fun markCertificateAsSeenByUser(identifier: TestCertificateIdentifier) {
-        Timber.tag(TAG).d("markCertificateSeenByUser(identifier=%s)", identifier)
+    suspend fun markCertificateAsSeenByUser(containerId: TestCertificateContainerId) {
+        Timber.tag(TAG).d("markCertificateSeenByUser(containerId=%s)", containerId)
 
         internalData.updateBlocking {
-            val current = this[identifier]
+            val current = this[containerId]
             if (current == null) {
-                Timber.tag(TAG).w("Can't mark %s as seen, it doesn't exist, racecondition?", identifier)
+                Timber.tag(TAG).w("Can't mark %s as seen, it doesn't exist, racecondition?", containerId)
                 return@updateBlocking this
             }
 
             if (current.isCertificateRetrievalPending) {
-                Timber.tag(TAG).w("Can't mark %s as seen, certificate has not been retrieved yet.", identifier)
+                Timber.tag(TAG).w("Can't mark %s as seen, certificate has not been retrieved yet.", containerId)
                 return@updateBlocking this
             }
 
             if (current.data !is RetrievedTestCertificate) {
-                Timber.tag(TAG).w("%s is not a retrieved certificate, so it was immediately available.", identifier)
+                Timber.tag(TAG).w("%s is not a retrieved certificate, so it was immediately available.", containerId)
                 return@updateBlocking this
             }
 
@@ -341,7 +348,7 @@ class TestCertificateRepository @Inject constructor(
                 data = processor.updateSeenByUser(current.data, true)
             )
 
-            mutate { this[identifier] = updated }
+            mutate { this[containerId] = updated }
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateWrapper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateWrapper.kt
@@ -1,7 +1,7 @@
 package de.rki.coronawarnapp.covidcertificate.test.core
 
+import de.rki.coronawarnapp.covidcertificate.common.repository.TestCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.test.core.storage.TestCertificateContainer
-import de.rki.coronawarnapp.covidcertificate.test.core.storage.TestCertificateIdentifier
 import de.rki.coronawarnapp.covidcertificate.valueset.valuesets.TestCertificateValueSets
 import org.joda.time.Instant
 
@@ -10,7 +10,7 @@ data class TestCertificateWrapper(
     private val container: TestCertificateContainer
 ) {
 
-    val identifier: TestCertificateIdentifier get() = container.identifier
+    val containerId: TestCertificateContainerId get() = container.containerId
 
     val isCertificateRetrievalPending: Boolean get() = container.isCertificateRetrievalPending
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/execution/TestCertificateRetrievalScheduler.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/execution/TestCertificateRetrievalScheduler.kt
@@ -8,6 +8,7 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import de.rki.coronawarnapp.coronatest.CoronaTestRepository
 import de.rki.coronawarnapp.coronatest.type.common.ResultScheduler
+import de.rki.coronawarnapp.covidcertificate.common.repository.TestCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.test.core.TestCertificateRepository
 import de.rki.coronawarnapp.util.coroutine.AppScope
 import de.rki.coronawarnapp.util.device.ForegroundState
@@ -33,7 +34,7 @@ class TestCertificateRetrievalScheduler @Inject constructor(
 ) : ResultScheduler(
     workManager = workManager
 ) {
-    private val processedNewCerts = mutableSetOf<String>()
+    private val processedNewCerts = mutableSetOf<TestCertificateContainerId>()
 
     private val creationTrigger = testRepo.coronaTests
         .map { tests ->
@@ -50,8 +51,8 @@ class TestCertificateRetrievalScheduler @Inject constructor(
     ) { certificates, isForeground ->
 
         val hasNewCert = certificates.any {
-            val isNew = !processedNewCerts.contains(it.identifier)
-            if (isNew) processedNewCerts.add(it.identifier)
+            val isNew = !processedNewCerts.contains(it.containerId)
+            if (isNew) processedNewCerts.add(it.containerId)
             isNew
         }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateContainer.kt
@@ -4,6 +4,8 @@ import de.rki.coronawarnapp.covidcertificate.common.certificate.CertificatePerso
 import de.rki.coronawarnapp.covidcertificate.common.certificate.DccQrCodeExtractor
 import de.rki.coronawarnapp.covidcertificate.common.certificate.DccV1Parser
 import de.rki.coronawarnapp.covidcertificate.common.qrcode.QrCodeString
+import de.rki.coronawarnapp.covidcertificate.common.repository.CertificateRepoContainer
+import de.rki.coronawarnapp.covidcertificate.common.repository.TestCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.test.core.TestCertificate
 import de.rki.coronawarnapp.covidcertificate.test.core.qrcode.TestCertificateQRCode
 import de.rki.coronawarnapp.covidcertificate.test.core.storage.types.BaseTestCertificateData
@@ -18,7 +20,7 @@ data class TestCertificateContainer(
     internal val data: BaseTestCertificateData,
     internal val qrCodeExtractor: DccQrCodeExtractor,
     val isUpdatingData: Boolean = false,
-) {
+) : CertificateRepoContainer {
 
     @delegate:Transient
     private val testCertificateQRCode: TestCertificateQRCode by lazy {
@@ -29,6 +31,9 @@ data class TestCertificateContainer(
             ) as TestCertificateQRCode
         }
     }
+
+    override val containerId: TestCertificateContainerId
+        get() = TestCertificateContainerId(data.identifier)
 
     val registrationToken: String?
         get() = when (data) {
@@ -41,9 +46,6 @@ data class TestCertificateContainer(
             is RetrievedTestCertificate -> data.certificateSeenByUser
             is GenericTestCertificateData -> true // Immediately available
         }
-
-    val identifier: TestCertificateIdentifier
-        get() = data.identifier
 
     val registeredAt: Instant
         get() = data.registeredAt
@@ -68,6 +70,9 @@ data class TestCertificateContainer(
         val testCertificate = certificate.test
 
         return object : TestCertificate {
+            override val containerId: TestCertificateContainerId
+                get() = this@TestCertificateContainer.containerId
+
             override val personIdentifier: CertificatePersonIdentifier
                 get() = certificate.personIdentifier
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateIdentifier.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateIdentifier.kt
@@ -1,3 +1,0 @@
-package de.rki.coronawarnapp.covidcertificate.test.core.storage
-
-typealias TestCertificateIdentifier = String

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/types/BaseTestCertificateData.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/types/BaseTestCertificateData.kt
@@ -1,13 +1,12 @@
 package de.rki.coronawarnapp.covidcertificate.test.core.storage.types
 
-import de.rki.coronawarnapp.covidcertificate.test.core.storage.TestCertificateIdentifier
 import org.joda.time.Instant
 
 /**
  * Common data for test certificates, idepdent of whether they were retrieved or scanned.
  */
 sealed class BaseTestCertificateData {
-    abstract val identifier: TestCertificateIdentifier
+    abstract val identifier: String
     abstract val registeredAt: Instant
     abstract val certificateReceivedAt: Instant?
     abstract val testCertificateQrCode: String?

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/CertificatesFragmentEvents.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/CertificatesFragmentEvents.kt
@@ -1,6 +1,6 @@
 package de.rki.coronawarnapp.covidcertificate.test.ui
 
-import de.rki.coronawarnapp.covidcertificate.test.core.storage.TestCertificateIdentifier
+import de.rki.coronawarnapp.covidcertificate.common.repository.TestCertificateContainerId
 
 sealed class CertificatesFragmentEvents {
 
@@ -12,6 +12,6 @@ sealed class CertificatesFragmentEvents {
 
     data class ShowRefreshErrorCertificateDialog(val error: Exception) : CertificatesFragmentEvents()
 
-    data class ShowDeleteErrorCertificateDialog(val identifier: TestCertificateIdentifier) :
+    data class ShowDeleteErrorCertificateDialog(val containerId: TestCertificateContainerId) :
         CertificatesFragmentEvents()
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/CovidCertificateDetailsViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/CovidCertificateDetailsViewModel.kt
@@ -7,9 +7,9 @@ import androidx.lifecycle.asLiveData
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import de.rki.coronawarnapp.covidcertificate.common.repository.TestCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.test.core.TestCertificate
 import de.rki.coronawarnapp.covidcertificate.test.core.TestCertificateRepository
-import de.rki.coronawarnapp.covidcertificate.test.core.storage.TestCertificateIdentifier
 import de.rki.coronawarnapp.presencetracing.checkins.qrcode.QrCodeGenerator
 import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
 import de.rki.coronawarnapp.util.ui.SingleLiveEvent
@@ -20,7 +20,7 @@ import timber.log.Timber
 
 class CovidCertificateDetailsViewModel @AssistedInject constructor(
     dispatcherProvider: DispatcherProvider,
-    @Assisted private val testCertificateIdentifier: TestCertificateIdentifier,
+    @Assisted private val containerId: TestCertificateContainerId,
     private val qrCodeGenerator: QrCodeGenerator,
     private val testCertificateRepository: TestCertificateRepository
 ) : CWAViewModel(dispatcherProvider) {
@@ -31,7 +31,7 @@ class CovidCertificateDetailsViewModel @AssistedInject constructor(
     val events = SingleLiveEvent<CovidCertificateDetailsNavigation>()
     val errors = SingleLiveEvent<Throwable>()
     val covidCertificate = testCertificateRepository.certificates.map { certificates ->
-        certificates.find { it.identifier == testCertificateIdentifier }?.testCertificate
+        certificates.find { it.containerId == containerId }?.testCertificate
             .also { generateQrCode(it) }
     }.asLiveData(dispatcherProvider.Default)
 
@@ -40,8 +40,8 @@ class CovidCertificateDetailsViewModel @AssistedInject constructor(
     fun openFullScreen() = qrCodeText?.let { events.postValue(CovidCertificateDetailsNavigation.FullQrCode(it)) }
 
     fun onDeleteTestConfirmed() = launch {
-        Timber.d("Removing Test Certificate=$testCertificateIdentifier")
-        testCertificateRepository.deleteCertificate(testCertificateIdentifier)
+        Timber.d("Removing Test Certificate=$containerId")
+        testCertificateRepository.deleteCertificate(containerId)
         events.postValue(CovidCertificateDetailsNavigation.Back)
     }
 
@@ -53,7 +53,7 @@ class CovidCertificateDetailsViewModel @AssistedInject constructor(
                 }
             )
         } catch (e: Exception) {
-            Timber.d(e, "generateQrCode failed for covidCertificate=%s", testCertificateIdentifier)
+            Timber.d(e, "generateQrCode failed for covidCertificate=%s", containerId)
             bitmapStateData.postValue(null)
             errors.postValue(e)
         }
@@ -61,6 +61,6 @@ class CovidCertificateDetailsViewModel @AssistedInject constructor(
 
     @AssistedFactory
     interface Factory : CWAViewModelFactory<CovidCertificateDetailsViewModel> {
-        fun create(testCertificateIdentifier: TestCertificateIdentifier): CovidCertificateDetailsViewModel
+        fun create(containerId: TestCertificateContainerId): CovidCertificateDetailsViewModel
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/TestCertificateDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/TestCertificateDetailsFragment.kt
@@ -38,7 +38,7 @@ class TestCertificateDetailsFragment : Fragment(R.layout.fragment_test_certifica
         constructorCall = { factory, _ ->
             factory as CovidCertificateDetailsViewModel.Factory
             factory.create(
-                testCertificateIdentifier = args.testCertificateIdentifier
+                containerId = args.containerId
             )
         }
     )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
@@ -1,7 +1,9 @@
 package de.rki.coronawarnapp.covidcertificate.vaccination.core
 
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CertificatePersonIdentifier
+import de.rki.coronawarnapp.covidcertificate.common.repository.VaccinationCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.repository.storage.VaccinatedPersonData
+import de.rki.coronawarnapp.covidcertificate.vaccination.core.repository.storage.VaccinationContainer
 import de.rki.coronawarnapp.covidcertificate.valueset.valuesets.VaccinationValueSets
 import de.rki.coronawarnapp.util.TimeAndDateExtensions.toLocalDateUtc
 import org.joda.time.Duration
@@ -17,8 +19,15 @@ data class VaccinatedPerson(
     val identifier: CertificatePersonIdentifier
         get() = data.identifier
 
+    val vaccinationContainers: Set<VaccinationContainer>
+        get() = data.vaccinations
+
     val vaccinationCertificates: Set<VaccinationCertificate> by lazy {
-        data.vaccinations.map { it.toVaccinationCertificate(valueSet) }.toSet()
+        vaccinationContainers.map { it.toVaccinationCertificate(valueSet) }.toSet()
+    }
+
+    fun findVaccination(containerId: VaccinationCertificateContainerId) = vaccinationContainers.find {
+        it.containerId == containerId
     }
 
     val vaccineName: String

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinationCertificate.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinationCertificate.kt
@@ -1,9 +1,11 @@
 package de.rki.coronawarnapp.covidcertificate.vaccination.core
 
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate
+import de.rki.coronawarnapp.covidcertificate.common.repository.VaccinationCertificateContainerId
 import org.joda.time.LocalDate
 
 interface VaccinationCertificate : CwaCovidCertificate {
+    override val containerId: VaccinationCertificateContainerId
 
     val vaccinatedAt: LocalDate
     val targetDisease: String

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/storage/VaccinationContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/storage/VaccinationContainer.kt
@@ -10,6 +10,8 @@ import de.rki.coronawarnapp.covidcertificate.common.certificate.DccV1
 import de.rki.coronawarnapp.covidcertificate.common.certificate.DccV1Parser
 import de.rki.coronawarnapp.covidcertificate.common.certificate.VaccinationDccV1
 import de.rki.coronawarnapp.covidcertificate.common.qrcode.QrCodeString
+import de.rki.coronawarnapp.covidcertificate.common.repository.CertificateRepoContainer
+import de.rki.coronawarnapp.covidcertificate.common.repository.VaccinationCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinationCertificate
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.qrcode.VaccinationCertificateQRCode
 import de.rki.coronawarnapp.covidcertificate.valueset.valuesets.VaccinationValueSets
@@ -21,7 +23,7 @@ import java.util.Locale
 data class VaccinationContainer internal constructor(
     @SerializedName("vaccinationQrCode") val vaccinationQrCode: QrCodeString,
     @SerializedName("scannedAt") val scannedAt: Instant,
-) {
+) : CertificateRepoContainer {
 
     // Either set by [ContainerPostProcessor] or via [toVaccinationContainer]
     @Transient lateinit var qrCodeExtractor: DccQrCodeExtractor
@@ -42,6 +44,9 @@ data class VaccinationContainer internal constructor(
             .data
     }
 
+    override val containerId: VaccinationCertificateContainerId
+        get() = VaccinationCertificateContainerId(certificateId)
+
     val header: DccHeader
         get() = certificateData.header
 
@@ -61,6 +66,9 @@ data class VaccinationContainer internal constructor(
         valueSet: VaccinationValueSets?,
         userLocale: Locale = Locale.getDefault(),
     ) = object : VaccinationCertificate {
+        override val containerId: VaccinationCertificateContainerId
+            get() = this@VaccinationContainer.containerId
+
         override val personIdentifier: CertificatePersonIdentifier
             get() = certificate.personIdentifier
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragment.kt
@@ -35,7 +35,7 @@ class VaccinationDetailsFragment : Fragment(R.layout.fragment_vaccination_detail
         constructorCall = { factory, _ ->
             factory as VaccinationDetailsViewModel.Factory
             factory.create(
-                certificateId = args.vaccinationCertificateId,
+                containerId = args.containerId,
             )
         }
     )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.asLiveData
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import de.rki.coronawarnapp.covidcertificate.common.repository.VaccinationCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinatedPerson
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinationCertificate
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.repository.VaccinationRepository
@@ -20,7 +21,7 @@ import kotlinx.coroutines.flow.map
 import timber.log.Timber
 
 class VaccinationDetailsViewModel @AssistedInject constructor(
-    @Assisted private val vaccinationCertificateId: String,
+    @Assisted private val containerId: VaccinationCertificateContainerId,
     private val qrCodeGenerator: QrCodeGenerator,
     private val vaccinationRepository: VaccinationRepository,
     @AppScope private val appScope: CoroutineScope,
@@ -50,10 +51,10 @@ class VaccinationDetailsViewModel @AssistedInject constructor(
         vaccinatedPersons: Set<VaccinatedPerson>
     ): VaccinationDetails {
         val person = vaccinatedPersons.find { p ->
-            p.vaccinationCertificates.any { it.certificateId == vaccinationCertificateId }
+            p.vaccinationContainers.any { it.containerId == containerId }
         }
 
-        val certificate = person?.vaccinationCertificates?.find { it.certificateId == vaccinationCertificateId }
+        val certificate = person?.vaccinationCertificates?.find { it.containerId == containerId }
         return VaccinationDetails(
             certificate = certificate,
             isImmune = person?.getVaccinationStatus() == VaccinatedPerson.Status.IMMUNITY,
@@ -75,7 +76,7 @@ class VaccinationDetailsViewModel @AssistedInject constructor(
     fun deleteVaccination() {
         launch(scope = appScope) {
             try {
-                vaccinationRepository.deleteVaccinationCertificate(vaccinationCertificateId)
+                vaccinationRepository.deleteCertificate(containerId)
                 events.postValue(VaccinationDetailsNavigation.Back)
             } catch (exception: Exception) {
                 errors.postValue(exception)
@@ -87,7 +88,7 @@ class VaccinationDetailsViewModel @AssistedInject constructor(
     @AssistedFactory
     interface Factory : CWAViewModelFactory<VaccinationDetailsViewModel> {
         fun create(
-            certificateId: String,
+            containerId: VaccinationCertificateContainerId,
         ): VaccinationDetailsViewModel
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/list/VaccinationListFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/list/VaccinationListFragment.kt
@@ -14,6 +14,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.imageview.ShapeableImageView
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.bugreporting.ui.toErrorDialogBuilder
+import de.rki.coronawarnapp.covidcertificate.common.repository.VaccinationCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinatedPerson
 import de.rki.coronawarnapp.covidcertificate.vaccination.ui.list.VaccinationListViewModel.Event.DeleteVaccinationEvent
 import de.rki.coronawarnapp.covidcertificate.vaccination.ui.list.VaccinationListViewModel.Event.NavigateBack
@@ -72,7 +73,7 @@ class VaccinationListFragment : Fragment(R.layout.fragment_vaccination_list), Au
                 when (event) {
                     is NavigateToVaccinationCertificateDetails -> doNavigate(
                         VaccinationListFragmentDirections
-                            .actionVaccinationListFragmentToVaccinationDetailsFragment(event.vaccinationCertificateId)
+                            .actionVaccinationListFragmentToVaccinationDetailsFragment(event.containerId)
                     )
                     is NavigateToQrCodeScanScreen -> doNavigate(
                         VaccinationListFragmentDirections.actionVaccinationListFragmentToDccQrCodeScanFragment()
@@ -92,7 +93,7 @@ class VaccinationListFragment : Fragment(R.layout.fragment_vaccination_list), Au
                         )
                     }
                     is DeleteVaccinationEvent ->
-                        showDeleteVaccinationDialog(event.vaccinationCertificateId, event.position)
+                        showDeleteVaccinationDialog(event.containerId, event.position)
                     is NavigateBack -> popBackStack()
                 }
             }
@@ -147,12 +148,12 @@ class VaccinationListFragment : Fragment(R.layout.fragment_vaccination_list), Au
         behavior.overlayTop = (deviceWidth / divider) - 24
     }
 
-    private fun showDeleteVaccinationDialog(vaccinationCertificateId: String, position: Int?) {
+    private fun showDeleteVaccinationDialog(containerId: VaccinationCertificateContainerId, position: Int?) {
         MaterialAlertDialogBuilder(requireContext()).apply {
             setTitle(R.string.vaccination_list_deletion_dialog_title)
             setMessage(R.string.vaccination_list_deletion_dialog_message)
             setPositiveButton(R.string.vaccination_list_deletion_dialog_positive_button) { _, _ ->
-                viewModel.deleteVaccination(vaccinationCertificateId)
+                viewModel.deleteVaccination(containerId)
             }
             setNegativeButton(R.string.vaccination_list_deletion_dialog_negative_button) { _, _ -> }
             setOnDismissListener {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/list/adapter/viewholder/VaccinationListVaccinationCardItemVH.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/list/adapter/viewholder/VaccinationListVaccinationCardItemVH.kt
@@ -5,6 +5,7 @@ import android.view.ViewGroup
 import androidx.appcompat.widget.PopupMenu
 import androidx.recyclerview.widget.RecyclerView
 import de.rki.coronawarnapp.R
+import de.rki.coronawarnapp.covidcertificate.common.repository.VaccinationCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinatedPerson
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinatedPerson.Status.COMPLETE
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinatedPerson.Status.IMMUNITY
@@ -26,7 +27,7 @@ class VaccinationListVaccinationCardItemVH(parent: ViewGroup) :
     private var latestItem: VaccinationListVaccinationCardItem? = null
 
     override fun onSwipe(holder: RecyclerView.ViewHolder, direction: Int) {
-        latestItem?.let { it.onSwipeToDelete(it.vaccinationCertificateId, holder.adapterPosition) }
+        latestItem?.let { it.onSwipeToDelete(it.containerId, holder.adapterPosition) }
     }
 
     override val viewBinding: Lazy<VaccinationListVaccinationCardBinding> = lazy {
@@ -40,7 +41,7 @@ class VaccinationListVaccinationCardItemVH(parent: ViewGroup) :
 
         item.apply {
             root.setOnClickListener {
-                onCardClick.invoke(vaccinationCertificateId)
+                onCardClick.invoke(containerId)
             }
             vaccinationCardTitle.text = context.getString(
                 R.string.vaccination_list_vaccination_card_title,
@@ -70,7 +71,7 @@ class VaccinationListVaccinationCardItemVH(parent: ViewGroup) :
                 inflate(R.menu.menu_vaccination_item)
                 setOnMenuItemClickListener {
                     when (it.itemId) {
-                        R.id.menu_delete -> item.onDeleteClick(item.vaccinationCertificateId).let { true }
+                        R.id.menu_delete -> item.onDeleteClick(item.containerId).let { true }
                         else -> false
                     }
                 }
@@ -81,19 +82,19 @@ class VaccinationListVaccinationCardItemVH(parent: ViewGroup) :
     }
 
     data class VaccinationListVaccinationCardItem(
-        val vaccinationCertificateId: String,
+        val containerId: VaccinationCertificateContainerId,
         val doseNumber: Int,
         val totalSeriesOfDoses: Int,
         val vaccinatedAt: String,
         val vaccinationStatus: VaccinatedPerson.Status,
         val isFinalVaccination: Boolean,
-        val onCardClick: (String) -> Unit,
-        val onDeleteClick: (String) -> Unit,
-        val onSwipeToDelete: (String, Int) -> Unit
+        val onCardClick: (VaccinationCertificateContainerId) -> Unit,
+        val onDeleteClick: (VaccinationCertificateContainerId) -> Unit,
+        val onSwipeToDelete: (VaccinationCertificateContainerId, Int) -> Unit
     ) : VaccinationListItem {
 
         override val stableId: Long = Objects.hash(
-            vaccinationCertificateId,
+            containerId,
             doseNumber,
             totalSeriesOfDoses,
             vaccinatedAt,
@@ -108,7 +109,7 @@ class VaccinationListVaccinationCardItemVH(parent: ViewGroup) :
 
             other as VaccinationListVaccinationCardItem
 
-            if (vaccinationCertificateId != other.vaccinationCertificateId) return false
+            if (containerId != other.containerId) return false
             if (doseNumber != other.doseNumber) return false
             if (totalSeriesOfDoses != other.totalSeriesOfDoses) return false
             if (vaccinatedAt != other.vaccinatedAt) return false
@@ -121,7 +122,7 @@ class VaccinationListVaccinationCardItemVH(parent: ViewGroup) :
 
         // Ignore onCardClick Listener in equals() to avoid re-drawing when only the click listener is updated
         override fun hashCode(): Int {
-            var result = vaccinationCertificateId.hashCode()
+            var result = containerId.hashCode()
             result = 31 * result + doseNumber.hashCode()
             result = 31 * result + totalSeriesOfDoses.hashCode()
             result = 31 * result + vaccinatedAt.hashCode()

--- a/Corona-Warn-App/src/main/res/navigation/certificate_graph.xml
+++ b/Corona-Warn-App/src/main/res/navigation/certificate_graph.xml
@@ -52,8 +52,8 @@
         tools:layout="@layout/fragment_test_certificate_details">
 
         <argument
-            android:name="testCertificateIdentifier"
-            app:argType="string" />
+            android:name="containerId"
+            app:argType="de.rki.coronawarnapp.covidcertificate.common.repository.TestCertificateContainerId" />
     </fragment>
 
     <fragment
@@ -99,7 +99,7 @@
         android:label="fragment_vaccination_details"
         tools:layout="@layout/fragment_vaccination_details">
         <argument
-            android:name="vaccinationCertificateId"
-            app:argType="string" />
+            android:name="containerId"
+            app:argType="de.rki.coronawarnapp.covidcertificate.common.repository.VaccinationCertificateContainerId" />
     </fragment>
 </navigation>

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonCertificatesData.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonCertificatesData.kt
@@ -2,10 +2,12 @@ package de.rki.coronawarnapp.covidcertificate.person.ui.overview
 
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CertificatePersonIdentifier
 import de.rki.coronawarnapp.covidcertificate.common.qrcode.QrCodeString
+import de.rki.coronawarnapp.covidcertificate.common.repository.TestCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.person.core.PersonCertificates
 import de.rki.coronawarnapp.covidcertificate.test.core.TestCertificate
 import org.joda.time.Instant
 import org.joda.time.LocalDate
+import java.util.UUID
 
 object PersonCertificatesData {
     val certificatesWithPending = mutableSetOf<PersonCertificates>()
@@ -42,6 +44,8 @@ fun testCertificate(
     isPending: Boolean = false,
     isUpdating: Boolean = false
 ) = object : TestCertificate {
+    override val containerId: TestCertificateContainerId
+        get() = TestCertificateContainerId(UUID.randomUUID().toString())
     override val targetName: String = "targetName"
     override val testType: String = "testType"
     override val testResult: String = "testResult"

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewViewModelTest.kt
@@ -2,6 +2,7 @@ package de.rki.coronawarnapp.covidcertificate.person.ui.overview
 
 import android.content.Context
 import de.rki.coronawarnapp.contactdiary.util.getLocale
+import de.rki.coronawarnapp.covidcertificate.common.repository.TestCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.person.core.PersonCertificatesProvider
 import de.rki.coronawarnapp.covidcertificate.person.ui.overview.items.CovidTestCertificatePendingCard
 import de.rki.coronawarnapp.covidcertificate.person.ui.overview.items.PersonCertificateCard
@@ -61,22 +62,22 @@ class PersonOverviewViewModelTest : BaseTest() {
         every { refreshResult.error } returns error
 
         instance.apply {
-            refreshCertificate("Identifier")
+            refreshCertificate(TestCertificateContainerId("Identifier"))
             events.getOrAwaitValue() shouldBe ShowRefreshErrorDialog(error)
         }
     }
 
     @Test
     fun `refreshCertificate triggers refresh operation in repo`() {
-        instance.refreshCertificate("Identifier")
+        instance.refreshCertificate(TestCertificateContainerId("Identifier"))
         coVerify { testCertificateRepository.refresh(any()) }
     }
 
     @Test
     fun `deleteTestCertificate deletes certificates from repo`() {
-        coEvery { testCertificateRepository.deleteCertificate(any()) } just Runs
+        coEvery { testCertificateRepository.deleteCertificate(any()) } returns mockk()
         instance.apply {
-            deleteTestCertificate("Identifier")
+            deleteTestCertificate(TestCertificateContainerId("Identifier"))
         }
 
         coEvery { testCertificateRepository.deleteCertificate(any()) }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepositoryTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepositoryTest.kt
@@ -136,7 +136,7 @@ class TestCertificateRepositoryTest : BaseTest() {
     fun `register via qrcode`() = runBlockingTest2(ignoreActive = true) {
         val instance = createInstance(scope = this)
 
-        instance.registerTestCertificate(
+        instance.registerCertificate(
             qrCode = testData.personATest1CertQRCode
         ).apply {
             this.qrCodeExtractor shouldBe qrCodeExtractor
@@ -157,7 +157,7 @@ class TestCertificateRepositoryTest : BaseTest() {
         }
 
         shouldThrow<InvalidTestCertificateException> {
-            instance.registerTestCertificate(
+            instance.registerCertificate(
                 qrCode = testData.personATest1CertQRCode
             )
         }.errorCode shouldBe ErrorCode.ALREADY_REGISTERED

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/test/core/execution/TestCertificateRetrievalSchedulerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/test/core/execution/TestCertificateRetrievalSchedulerTest.kt
@@ -5,6 +5,7 @@ import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import de.rki.coronawarnapp.coronatest.CoronaTestRepository
 import de.rki.coronawarnapp.coronatest.type.CoronaTest
+import de.rki.coronawarnapp.covidcertificate.common.repository.TestCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.test.core.TestCertificateRepository
 import de.rki.coronawarnapp.covidcertificate.test.core.TestCertificateWrapper
 import de.rki.coronawarnapp.util.device.ForegroundState
@@ -41,7 +42,7 @@ class TestCertificateRetrievalSchedulerTest : BaseTest() {
     }
 
     private val mockCertificate = mockk<TestCertificateWrapper>().apply {
-        every { identifier } returns "UUID"
+        every { containerId } returns TestCertificateContainerId("UUID")
         every { isCertificateRetrievalPending } returns true
         every { isUpdatingData } returns false
     }
@@ -125,7 +126,7 @@ class TestCertificateRetrievalSchedulerTest : BaseTest() {
         coVerify(exactly = 1) { workManager.enqueueUniqueWork(any(), any(), any<OneTimeWorkRequest>()) }
 
         val mockCertificate2 = mockk<TestCertificateWrapper>().apply {
-            every { identifier } returns "UUID2"
+            every { containerId } returns TestCertificateContainerId("UUID2")
             every { isCertificateRetrievalPending } returns true
             every { isUpdatingData } returns false
         }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/VaccinationRepositoryTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/VaccinationRepositoryTest.kt
@@ -3,9 +3,9 @@ package de.rki.coronawarnapp.covidcertificate.vaccination.core.repository
 import de.rki.coronawarnapp.covidcertificate.common.certificate.DccQrCodeExtractor
 import de.rki.coronawarnapp.covidcertificate.common.exception.InvalidHealthCertificateException.ErrorCode.ALREADY_REGISTERED
 import de.rki.coronawarnapp.covidcertificate.common.exception.InvalidVaccinationCertificateException
+import de.rki.coronawarnapp.covidcertificate.common.repository.VaccinationCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.DaggerVaccinationTestComponent
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinationTestData
-import de.rki.coronawarnapp.covidcertificate.vaccination.core.repository.errors.VaccinationCertificateNotFoundException
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.repository.storage.VaccinatedPersonData
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.repository.storage.VaccinationStorage
 import de.rki.coronawarnapp.covidcertificate.valueset.ValueSetsRepository
@@ -74,7 +74,7 @@ class VaccinationRepositoryTest : BaseTest() {
         val instance = createInstance(this)
         advanceUntilIdle()
 
-        instance.registerVaccination(vaccinationTestData.personAVac1QRCode).apply {
+        instance.registerCertificate(vaccinationTestData.personAVac1QRCode).apply {
             Timber.i("Returned cert is %s", this)
             this.personIdentifier shouldBe vaccinationTestData.personAVac1Container.personIdentifier
         }
@@ -96,7 +96,7 @@ class VaccinationRepositoryTest : BaseTest() {
         val instance = createInstance(this)
         advanceUntilIdle()
 
-        instance.registerVaccination(vaccinationTestData.personAVac2QRCode).apply {
+        instance.registerCertificate(vaccinationTestData.personAVac2QRCode).apply {
             Timber.i("Returned cert is %s", this)
             this.personIdentifier shouldBe vaccinationTestData.personAVac2Container.personIdentifier
         }
@@ -113,7 +113,7 @@ class VaccinationRepositoryTest : BaseTest() {
 
         every { timeStamper.nowUTC } returns vaccinationTestData.personBData1Vac.vaccinations.single().scannedAt
 
-        instance.registerVaccination(vaccinationTestData.personBVac1QRCode)
+        instance.registerCertificate(vaccinationTestData.personBVac1QRCode)
 
         testStorage shouldBe setOf(
             vaccinationTestData.personAData2Vac,
@@ -133,7 +133,7 @@ class VaccinationRepositoryTest : BaseTest() {
         advanceUntilIdle()
 
         shouldThrow<InvalidVaccinationCertificateException> {
-            instance.registerVaccination(vaccinationTestData.personAVac1QRCode)
+            instance.registerCertificate(vaccinationTestData.personAVac1QRCode)
         }.errorCode shouldBe ALREADY_REGISTERED
 
         testStorage.first() shouldBe dataBefore
@@ -169,7 +169,9 @@ class VaccinationRepositoryTest : BaseTest() {
 
         instance.vaccinationInfos.first().single().data shouldBe vaccinationTestData.personAData2Vac
 
-        instance.deleteVaccinationCertificate(toRemove.certificateId)
+        instance.deleteCertificate(
+            VaccinationCertificateContainerId(toRemove.certificateId)
+        ) shouldBe vaccinationTestData.personAVac2Container
         advanceUntilIdle()
 
         testStorage shouldBe setOf(after)
@@ -185,9 +187,9 @@ class VaccinationRepositoryTest : BaseTest() {
 
         instance.vaccinationInfos.first().single().data shouldBe vaccinationTestData.personAData2Vac
 
-        shouldThrow<VaccinationCertificateNotFoundException> {
-            instance.deleteVaccinationCertificate(vaccinationTestData.personBVac1Container.certificateId)
-        }
+        instance.deleteCertificate(
+            VaccinationCertificateContainerId(vaccinationTestData.personBVac1Container.certificateId)
+        ) shouldBe null
     }
 
     @Test
@@ -199,7 +201,9 @@ class VaccinationRepositoryTest : BaseTest() {
 
         instance.vaccinationInfos.first().single().data shouldBe vaccinationTestData.personBData1Vac
 
-        instance.deleteVaccinationCertificate(vaccinationTestData.personBVac1Container.certificateId)
+        instance.deleteCertificate(
+            VaccinationCertificateContainerId(vaccinationTestData.personBVac1Container.certificateId)
+        )
         advanceUntilIdle()
 
         instance.vaccinationInfos.first() shouldBe emptySet()


### PR DESCRIPTION
Re: https://github.com/corona-warn-app/cwa-app-android/pull/3484#issuecomment-864046040
where @mtwalli noticed the difference in referencing the certificates with regards to their repositories.

This PR refactores how certificates are referenced and aligns the behavior between all 3 repositores (vaccination, test, recovery) by introducing `CertificateContainerId` as common identifier when trying to load/modify/delete certificate data via repositories.

#### Problem:

We want a unique identifier that the UI can use to reference certificates, modify and delete them.

We don't want to use the `uniqueCertificateId` that is part of the certificate itself:
* It's only unique if every country follows the spec 1:1 (which sofar has not worked out well)
* Test certificates that are retrieved via CWA are part of the UI, but we don't know their certificate ID yet

#### Solution:

As each certificate is actually a `CertificateContainer` holding the QR Code data, we introduce `CertificateContainerId` to abstract the actual ID away. 

`CertificateContainerId` is actually a sealed class (type safety :partying_face: ):
Each type implementes this as it's viable:
* `VaccinationCertificateContainerId`: Vaccination certs don't have a custom unique ID, so we have to rely use the `uniqueCertificateId` due to legacy reasons (may migrate this in another PR).
* `TestCertificateContainerId`: Test certs use a stored UUID as the certificate may not have been retrieved yet.
* `RecoveryCertificateContainerId`: Recovery certs will also use a stored UUID as it will be more robust and we have no legacy concerns yet.

`CertificateContainerId` is also parcelable and can be passed around with almost zero chance of mixing it up (no more string IDs :partying_face:). In places where we need to do something with the certificate, we can use an exhaustive `when` for nice compiler checks.
Each repository also only accepts their specific subtype of `CertificateContainerId` (e.g. `VaccinationRepository` only takes `VaccinationCertificateContainerId`), so even more type checks :grin:.

/cc @chris-cwa