### PR TITLE
Adjust German Translation of EU Certificate

### DIFF
--- a/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
@@ -20,18 +20,18 @@
     <!-- XTXT: Person overview no certificates image content description-->
     <string name="person_overview_no_certificates_image_description">A certificate with a QR code symbol on it.</string>
     <!-- XTXT: Person card title-->
-    <string name="person_card_title">EU Digitales</string>
+    <string name="person_card_title">Digitales</string>
     <!-- XTXT: Person card subtitle-->
-    <string name="person_card_subtitle">COVID-Zertifikat</string>
+    <string name="person_card_subtitle">COVID-Zertifikat der EU</string>
 
     <!-- XTXT: Vaccination Consent title-->
     <string name="vaccination_consent_title">Ihr Einverständnis</string>
     <!-- XTXT: Vaccination Consent subtitle-->
     <string name="vaccination_consent_headline">"Zertifikate hinzufügen"</string>
     <!-- XTXT: Vaccination Consent subtitle of qr info -->
-    <string name="vaccination_consent_info_subtitle_text">"Fügen Sie EU digitale COVID-Zertifikate in der App hinzu, um mit der App den Impfschutz, ein negatives Testergebnis oder eine überstandene Infektion nachweisen zu können."</string>
+    <string name="vaccination_consent_info_subtitle_text">"Fügen Sie digitale COVID-Zertifikate der EU in der App hinzu, um mit der App den Impfschutz, ein negatives Testergebnis oder eine überstandene Infektion nachweisen zu können."</string>
     <!-- XTXT: Vaccination Consent text of qr info -->
-    <string name="vaccination_consent_qr_info_text">"Sie können EU digitale COVID-Impfzertifikate, COVID-Testzertifikate und COVID-Genesenenzertifikate in der App hinzufügen."</string>
+    <string name="vaccination_consent_qr_info_text">"Sie können digitale COVID-Impfzertifikate, COVID-Testzertifikate und COVID-Genesenenzertifikate der EU in der App hinzufügen."</string>
     <!-- XTXT: Vaccination Consent qr code text -->
     <string name="vaccination_consent_qr_info_qr_code_text">"Die Zertifikate gelten innerhalb der EU als gültiger Nachweis (z.B. für Reisen)."</string>
     <!-- XTXT: Vaccination Consent time text  -->
@@ -47,7 +47,7 @@
     <!-- XTXT: Current priority certificate info -->
     <string name="certificate_card_bookmark_info">Aktuell verwendetes Zertifikat</string>
     <!-- XHED: Person certificate details title -->
-    <string name="person_details_certificate_title">"EU Digitales COVID-Zertifikat"</string>
+    <string name="person_details_certificate_title">"Digitales COVID-Zertifikat der EU"</string>
     <!-- XTXT: Test Certificate CWA User card description -->
     <string name="person_details_cwa_user_description">"Mein Smartphone, meine App. Zertifikate für mich erscheinen in der Liste an erster Stelle."</string>
     <!-- XTXT: Test Certificate CWA User card birthdate -->
@@ -82,7 +82,7 @@
     <!-- XTXT: Recovery certificate detail title -->
     <string name="recovery_certificate_details_title">"Genesenenzertifikat"</string>
     <!-- XTXT: Recovery certificate detail subtitle -->
-    <string name="recovery_certificate_details_subtitle">"EU Digitales COVID-Zertifikat"</string>
+    <string name="recovery_certificate_details_subtitle">"Digitales COVID-Zertifikat der EU"</string>
     <!-- XTXT: Recovery certificate card name  -->
     <string name="recovery_certificate_name">Genesenzertifikat</string>
     <!-- XTXT: Recovery certificate valid until -->


### PR DESCRIPTION
Part 1/3 - Old German translation of certificate "EU Digitales COVID-Zertifikat“ is replaced by new official name „Digitales COVID-Zertifikat der EU“. Attention: This is only valid for the German translation. Related Jira issue: https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8014 