### PR TITLE
Adjust German Translation of EU Certificate

### DIFF
--- a/Corona-Warn-App/src/main/res/values-de/green_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/green_certificate_strings.xml
@@ -3,7 +3,7 @@
     <!-- XTXT: Request green certificate title -->
     <string name="request_green_certificate_title">COVID-Testzertifikat</string>
     <!-- XTXT: Request green certificate subtitle -->
-    <string name="request_green_certificate_subtitle">Sie können über die App ein offizielles EU digitales Testzertifikat anfordern, das anschließend in der App hinzugefügt wird.</string>
+    <string name="request_green_certificate_subtitle">Sie können über die App ein offizielles digitales COVID-Testzertifikat der EU anfordern, das anschließend in der App hinzugefügt wird.</string>
     <!-- XTXT: Request green certificate body section 1 -->
     <string name="request_green_certificate_body_1">Das Testzertifikat wird nur bei einem negativen Testergebnis ausgestellt.</string>
     <!-- XTXT: Request green certificate body section 2 -->
@@ -27,7 +27,7 @@
     <!-- XBUT: Request green certificate exit dialog negative button -->
     <string name="request_gc_dialog_negative_button">Registrierung fortsetzen</string>
     <!-- XTXT: Detail green certificate title -->
-    <string name="detail_green_certificate_title">EU Digitales COVID-Testzertifikat</string>
+    <string name="detail_green_certificate_title">Digitales COVID-Testzertifikat der EU</string>
     <!-- XTXT: Detail green certificate test type -->
     <string name="detail_green_certificate_test_type">SARS-CoV-2-Test</string>
     <!-- XTXT: Detail green certificate card title -->
@@ -56,9 +56,9 @@
     <!-- XTXT: Green certificate main screen header text -->
     <string name="green_certification_header_info">Hier werden Ihre digitalen Impfzertifikate und Testzertifikate angezeigt.</string>
     <!-- XTXT: Green certificate info card title 1st line -->
-    <string name="info_banner_title_1">EU Digitales</string>
+    <string name="info_banner_title_1">Digitales</string>
     <!-- XTXT: Green certificate info card title 2nd line  -->
-    <string name="info_banner_title_2">COVID-Testzertifikat</string>
+    <string name="info_banner_title_2">COVID-Testzertifikat der EU</string>
     <!-- XTXT: Green certificate info card body  -->
     <string name="info_banner_body">Registrieren Sie einen Test auf der Startseite und stimmen Sie zu, ein digitales Testzertifikat zu erhalten. Sobald das Zertifikat vorliegt, wird es hier angezeigt.</string>
 


### PR DESCRIPTION
Part 2/3 - Old German translation of certificate "EU Digitales COVID-Zertifikat“ is replaced by new official name „Digitales COVID-Zertifikat der EU“. Attention: This is only valid for the German translation. Related Jira issue: https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8014 