### PR TITLE
Adjust German Translation of EU Certificate

### DIFF
--- a/Corona-Warn-App/src/main/res/values-de/vaccination_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/vaccination_strings.xml
@@ -26,7 +26,7 @@
     <string name="vaccination_qrcode_card_subtitle">Geimpft %1$s - gültig bis %2$s</string>
 
     <!-- XTXT: Vaccination List title-->
-    <string name="vaccination_list_title">EU Digitaler COVID-Impfnachweis</string>
+    <string name="vaccination_list_title">Digitaler COVID-Impfnachweis der EU</string>
     <!-- XTXT: Vaccination List complete vaccination subtitle-->
     <string name="vaccination_list_complete_vaccination_subtitle">SARS-CoV-2-Impfschutz</string>
     <!-- XTXT: Vaccination card date-->
@@ -66,17 +66,17 @@
         Homescreen cards
     ###################################### -->
     <!-- XHED: Title for Vaccination Certificate Registration Home Card -->
-    <string name="vaccination_card_registration_title_line_1">"EU Digitalen"</string>
+    <string name="vaccination_card_registration_title_line_1">"Digitalen"</string>
     <!-- XHED: Title for Vaccination Certificate Registration Home Card -->
-    <string name="vaccination_card_registration_title_line_2">"COVID-Impfnachweis hinzufügen"</string>
+    <string name="vaccination_card_registration_title_line_2">"COVID-Impfnachweis der EU hinzufügen"</string>
     <!-- YTXT: Body text for Vaccination Certificate Registration Home Card -->
     <string name="vaccination_card_registration_body">"Fügen Sie Ihre Impfzertifikate in die App hinzu, um sie immer bei sich zu haben. Scannen Sie dafür den QR-Code Ihres Dokuments."</string>
     <!-- XBUT: button for Vaccination Certificate Registration Home Card -->
     <string name="vaccination_card_register">"Hinzufügen"</string>
     <!-- XHED: Homescreen vaccination status card title -->
-    <string name="vaccination_card_status_title_line_1">"EU Digitaler"</string>
+    <string name="vaccination_card_status_title_line_1">"Digitaler"</string>
     <!-- XHED: Homescreen vaccination status card title -->
-    <string name="vaccination_card_status_title_line_2">"COVID-Impfnachweis"</string>
+    <string name="vaccination_card_status_title_line_2">"COVID-Impfnachweis der EU"</string>
     <!-- XHED: Homescreen vaccination status card vaccination name -->
     <string name="vaccination_card_status_vaccination_name">SARS-CoV-2 Impfschutz</string>
     <!-- XTXT: Homescreen card incomplete vaccination status label -->
@@ -112,6 +112,6 @@
     <!-- XTXT: Vaccination certificate Detail title -->
     <string name="vaccination_certificate_title">"Impfzertifikat"</string>
     <!-- XTXT: Vaccination certificate Detail subtitle -->
-    <string name="vaccination_certificate_subtitle">"EU Digitales COVID-Zertifikat"</string>
+    <string name="vaccination_certificate_subtitle">"Digitales COVID-Zertifikat der EU"</string>
 
 </resources>


### PR DESCRIPTION
Part 3/3 - Old German translation of certificate "EU Digitales COVID-Zertifikat“ is replaced by new official name „Digitales COVID-Zertifikat der EU“. Attention: This is only valid for the German translation. Related Jira issue: https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8014 