### PR TITLE
Fix an addtional popup in redeemed test (EXPOSUREAPP-7893)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/TestRegistrationStateProcessor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/TestRegistrationStateProcessor.kt
@@ -102,7 +102,7 @@ class TestRegistrationStateProcessor @Inject constructor(
             coronaTest
         } catch (err: Exception) {
             stateInternal.value = State.Error(exception = err)
-            if (err !is CwaWebException) {
+            if (err !is CwaWebException && err !is AlreadyRedeemedException) {
                 err.report(ExceptionCategory.INTERNAL)
             }
             null


### PR DESCRIPTION
remove generic error for `AlreadyRedeemedException` as we handle it later in `TestRegistrationStateProcessor`
## Testing
- scan redeemed PCR test QR Code
or
- use `cwa server` with updated `.server-config.yml` to get always redeemed response
```yaml
      - name: /version/v1/testresult
        responseId: 200+4
```