### PR TITLE
Ci / add camera parameter for Mobile Cloud upload (DEV)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,7 +334,7 @@ jobs:
             curl --location --request POST $tsystems_upload_url \
             --header "Authorization: Bearer $tsystems_upload_bearer" \
             --form "file=@${fileName}" \
-            --form "camera='true'"
+            --form "camera=true"
 
   instrumentation_tests_device:
     resource_class: xlarge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,6 +334,7 @@ jobs:
             curl --location --request POST $tsystems_upload_url \
             --header "Authorization: Bearer $tsystems_upload_bearer" \
             --form "file=@${fileName}" \
+            --form "camera='true'"
 
   instrumentation_tests_device:
     resource_class: xlarge


### PR DESCRIPTION
### Description
Request from TSI to add the parameter `camera=true` to the Mobile Cloud upload command which is executed during the signed build in CircleCI.

### Steps to reproduce
Already successfully tested with Circle CI (tag `vTest-CI2`) and conformed by TSI: https://app.circleci.com/pipelines/github/corona-warn-app/cwa-app-android/16913/workflows/32b93352-f0d5-48bf-890e-43d9d440928d/jobs/140162
