### PR TITLE
Improve "time till immunity" calculation & display (EXPOSUREAPP-8121, EXPOSUREAPP-8158)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/list/VaccinationListFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/list/VaccinationListFragmentTest.kt
@@ -24,7 +24,6 @@ import de.rki.coronawarnapp.util.TimeAndDateExtensions.toDayFormat
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import org.joda.time.Duration
 import org.joda.time.Instant
 import org.joda.time.LocalDate
 import org.joda.time.format.DateTimeFormat
@@ -104,7 +103,7 @@ internal class VaccinationListFragmentTest : BaseUITest() {
                 expiresAt = Instant.parse("2022-04-24T00:00:00.000Z")
             ),
             createNameCardItem(),
-            VaccinationListImmunityInformationCardItem(Duration.standardDays(14)),
+            VaccinationListImmunityInformationCardItem(14),
             createVaccinationCardItem(
                 doseNumber = 1,
                 totalSeriesOfDoses = 2,

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/main/home/HomeData.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/main/home/HomeData.kt
@@ -36,7 +36,6 @@ import de.rki.coronawarnapp.tracing.ui.homecards.TracingProgressCard
 import de.rki.coronawarnapp.util.TimeAndDateExtensions.toLocalDateUtc
 import io.mockk.every
 import io.mockk.mockk
-import org.joda.time.Duration
 import org.joda.time.Instant
 
 object HomeData {
@@ -192,7 +191,7 @@ object HomeData {
                 every { fullName } returns "Andrea Schneider"
                 every { identifier } returns mockk()
                 every { getVaccinationStatus(any()) } returns VaccinatedPerson.Status.INCOMPLETE
-                every { getTimeUntilImmunity(any()) } returns Duration.standardDays(14)
+                every { getDaysUntilImmunity(any()) } returns 14
             },
             onClickAction = {}
         )
@@ -201,7 +200,7 @@ object HomeData {
                 every { fullName } returns "Andrea Schneider"
                 every { identifier } returns mockk()
                 every { getVaccinationStatus(any()) } returns VaccinatedPerson.Status.COMPLETE
-                every { getTimeUntilImmunity(any()) } returns Duration.standardDays(14)
+                every { getDaysUntilImmunity(any()) } returns 14
             },
             onClickAction = {}
         )
@@ -210,7 +209,7 @@ object HomeData {
                 every { fullName } returns "Andrea Schneider"
                 every { identifier } returns mockk()
                 every { getVaccinationStatus(any()) } returns VaccinatedPerson.Status.IMMUNITY
-                every { getTimeUntilImmunity(any()) } returns Duration.standardDays(14)
+                every { getDaysUntilImmunity(any()) } returns 14
             },
             onClickAction = {}
         )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
@@ -3,8 +3,8 @@ package de.rki.coronawarnapp.covidcertificate.vaccination.core
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CertificatePersonIdentifier
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.repository.storage.VaccinatedPersonData
 import de.rki.coronawarnapp.covidcertificate.valueset.valuesets.VaccinationValueSets
-import de.rki.coronawarnapp.util.TimeAndDateExtensions.toUserTimeZone
-import org.joda.time.Duration
+import de.rki.coronawarnapp.util.TimeAndDateExtensions.toLocalDateUserTz
+import org.joda.time.Days
 import org.joda.time.Instant
 import org.joda.time.LocalDate
 
@@ -36,28 +36,24 @@ data class VaccinatedPerson(
         )
 
     fun getVaccinationStatus(nowUTC: Instant = Instant.now()): Status {
-        val timeToImmunity = getTimeUntilImmunity(nowUTC) ?: return Status.INCOMPLETE
+        val timeToImmunity = getDaysUntilImmunity(nowUTC) ?: return Status.INCOMPLETE
 
         return when {
-            timeToImmunity <= Duration.ZERO -> Status.IMMUNITY
+            timeToImmunity <= 0 -> Status.IMMUNITY
             else -> Status.COMPLETE
         }
     }
 
-    fun getTimeUntilImmunity(nowUTC: Instant = Instant.now()): Duration? {
+    fun getDaysUntilImmunity(nowUTC: Instant = Instant.now()): Int? {
         val newestFullDose = vaccinationCertificates
             .filter { it.doseNumber == it.totalSeriesOfDoses }
             .maxByOrNull { it.vaccinatedAt }
             ?: return null
 
-        val immunityAt = newestFullDose.vaccinatedAt
-            .toDateTimeAtStartOfDay()
-            .plus(IMMUNITY_WAITING_PERIOD)
+        val today = nowUTC
+            .toLocalDateUserTz()
 
-        val now = nowUTC
-            .toUserTimeZone()
-
-        return Duration(now, immunityAt)
+        return IMMUNITY_WAITING_DAYS - Days.daysBetween(newestFullDose.vaccinatedAt, today).days
     }
 
     enum class Status {
@@ -67,6 +63,6 @@ data class VaccinatedPerson(
     }
 
     companion object {
-        private val IMMUNITY_WAITING_PERIOD = Duration.standardDays(15)
+        private val IMMUNITY_WAITING_DAYS = 15
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
@@ -3,10 +3,12 @@ package de.rki.coronawarnapp.covidcertificate.vaccination.core
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CertificatePersonIdentifier
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.repository.storage.VaccinatedPersonData
 import de.rki.coronawarnapp.covidcertificate.valueset.valuesets.VaccinationValueSets
-import de.rki.coronawarnapp.util.TimeAndDateExtensions.toLocalDateUtc
+import de.rki.coronawarnapp.util.TimeAndDateExtensions.toUserTimeZone
+import org.joda.time.DateTimeZone
 import org.joda.time.Duration
 import org.joda.time.Instant
 import org.joda.time.LocalDate
+import java.util.TimeZone
 
 data class VaccinatedPerson(
     internal val data: VaccinatedPersonData,
@@ -50,9 +52,14 @@ data class VaccinatedPerson(
             .maxByOrNull { it.vaccinatedAt }
             ?: return null
 
-        val immunityAt = newestFullDose.vaccinatedAt.toDateTimeAtStartOfDay().plus(IMMUNITY_WAITING_PERIOD)
+        val immunityAt = newestFullDose.vaccinatedAt
+            .toDateTimeAtStartOfDay(DateTimeZone.forTimeZone(TimeZone.getDefault()))
+            .plus(IMMUNITY_WAITING_PERIOD)
 
-        return Duration(nowUTC.toLocalDateUtc().toDateTimeAtStartOfDay(), immunityAt)
+        val now = nowUTC
+            .toUserTimeZone()
+
+        return Duration(now, immunityAt)
     }
 
     enum class Status {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
@@ -63,6 +63,6 @@ data class VaccinatedPerson(
     }
 
     companion object {
-        private val IMMUNITY_WAITING_DAYS = 15
+        private const val IMMUNITY_WAITING_DAYS = 15
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
@@ -36,10 +36,10 @@ data class VaccinatedPerson(
         )
 
     fun getVaccinationStatus(nowUTC: Instant = Instant.now()): Status {
-        val timeToImmunity = getDaysUntilImmunity(nowUTC) ?: return Status.INCOMPLETE
+        val daysToImmunity = getDaysUntilImmunity(nowUTC) ?: return Status.INCOMPLETE
 
         return when {
-            timeToImmunity <= 0 -> Status.IMMUNITY
+            daysToImmunity <= 0 -> Status.IMMUNITY
             else -> Status.COMPLETE
         }
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
@@ -4,11 +4,9 @@ import de.rki.coronawarnapp.covidcertificate.common.certificate.CertificatePerso
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.repository.storage.VaccinatedPersonData
 import de.rki.coronawarnapp.covidcertificate.valueset.valuesets.VaccinationValueSets
 import de.rki.coronawarnapp.util.TimeAndDateExtensions.toUserTimeZone
-import org.joda.time.DateTimeZone
 import org.joda.time.Duration
 import org.joda.time.Instant
 import org.joda.time.LocalDate
-import java.util.TimeZone
 
 data class VaccinatedPerson(
     internal val data: VaccinatedPersonData,
@@ -38,10 +36,10 @@ data class VaccinatedPerson(
         )
 
     fun getVaccinationStatus(nowUTC: Instant = Instant.now()): Status {
-        val daysToImmunity = getTimeUntilImmunity(nowUTC)?.standardDays ?: return Status.INCOMPLETE
+        val timeToImmunity = getTimeUntilImmunity(nowUTC) ?: return Status.INCOMPLETE
 
         return when {
-            daysToImmunity < 0 -> Status.IMMUNITY
+            timeToImmunity <= Duration.ZERO -> Status.IMMUNITY
             else -> Status.COMPLETE
         }
     }
@@ -53,7 +51,7 @@ data class VaccinatedPerson(
             ?: return null
 
         val immunityAt = newestFullDose.vaccinatedAt
-            .toDateTimeAtStartOfDay(DateTimeZone.forTimeZone(TimeZone.getDefault()))
+            .toDateTimeAtStartOfDay()
             .plus(IMMUNITY_WAITING_PERIOD)
 
         val now = nowUTC
@@ -69,6 +67,6 @@ data class VaccinatedPerson(
     }
 
     companion object {
-        private val IMMUNITY_WAITING_PERIOD = Duration.standardDays(14)
+        private val IMMUNITY_WAITING_PERIOD = Duration.standardDays(15)
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/cards/VaccinationCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/cards/VaccinationCard.kt
@@ -27,7 +27,7 @@ class VaccinationCard(parent: ViewGroup) :
         when (curItem.vaccinatedPerson.getVaccinationStatus()) {
             VaccinatedPerson.Status.COMPLETE -> {
                 val immunityInDays = curItem.vaccinatedPerson.getDaysUntilImmunity()!!
-                vaccinationState.text = if (immunityInDays < 1) {
+                vaccinationState.text = if (immunityInDays == 1) {
                     resources.getString(R.string.vaccination_card_status_vaccination_complete_tomorrow)
                 } else {
                     resources.getQuantityString(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/cards/VaccinationCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/cards/VaccinationCard.kt
@@ -31,7 +31,8 @@ class VaccinationCard(parent: ViewGroup) :
                 vaccinationState.text = if (immunityIn < Duration.standardDays(1)) {
                     resources.getString(R.string.vaccination_card_status_vaccination_complete_tomorrow)
                 } else {
-                    val days = immunityIn.standardDays.toInt()
+                    // Round up, start with 15 despite 15th day already being started for better UX
+                    val days = immunityIn.standardDays.toInt() + 1
                     resources.getQuantityString(
                         R.plurals.vaccination_card_status_vaccination_complete,
                         days,

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/cards/VaccinationCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/cards/VaccinationCard.kt
@@ -6,7 +6,6 @@ import de.rki.coronawarnapp.covidcertificate.test.ui.CertificatesAdapter
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinatedPerson
 import de.rki.coronawarnapp.databinding.VaccinationHomeCardBinding
 import de.rki.coronawarnapp.util.lists.diffutil.HasPayloadDiffer
-import org.joda.time.Duration
 
 class VaccinationCard(parent: ViewGroup) :
     CertificatesAdapter.CertificatesItemVH<VaccinationCard.Item, VaccinationHomeCardBinding>(
@@ -27,16 +26,14 @@ class VaccinationCard(parent: ViewGroup) :
         personName.text = curItem.vaccinatedPerson.fullName
         when (curItem.vaccinatedPerson.getVaccinationStatus()) {
             VaccinatedPerson.Status.COMPLETE -> {
-                val immunityIn = curItem.vaccinatedPerson.getTimeUntilImmunity()!!
-                vaccinationState.text = if (immunityIn < Duration.standardDays(1)) {
+                val immunityInDays = curItem.vaccinatedPerson.getDaysUntilImmunity()!!
+                vaccinationState.text = if (immunityInDays < 1) {
                     resources.getString(R.string.vaccination_card_status_vaccination_complete_tomorrow)
                 } else {
-                    // Round up, start with 15 despite 15th day already being started for better UX
-                    val days = immunityIn.standardDays.toInt() + 1
                     resources.getQuantityString(
                         R.plurals.vaccination_card_status_vaccination_complete,
-                        days,
-                        days
+                        immunityInDays,
+                        immunityInDays
                     )
                 }
             }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/cards/VaccinationCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/cards/VaccinationCard.kt
@@ -6,6 +6,7 @@ import de.rki.coronawarnapp.covidcertificate.test.ui.CertificatesAdapter
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinatedPerson
 import de.rki.coronawarnapp.databinding.VaccinationHomeCardBinding
 import de.rki.coronawarnapp.util.lists.diffutil.HasPayloadDiffer
+import org.joda.time.Duration
 
 class VaccinationCard(parent: ViewGroup) :
     CertificatesAdapter.CertificatesItemVH<VaccinationCard.Item, VaccinationHomeCardBinding>(
@@ -26,12 +27,17 @@ class VaccinationCard(parent: ViewGroup) :
         personName.text = curItem.vaccinatedPerson.fullName
         when (curItem.vaccinatedPerson.getVaccinationStatus()) {
             VaccinatedPerson.Status.COMPLETE -> {
-                val days = curItem.vaccinatedPerson.getTimeUntilImmunity()!!.standardDays.toInt()
-                vaccinationState.text = context.resources.getQuantityString(
-                    R.plurals.vaccination_card_status_vaccination_complete,
-                    days,
-                    days
-                )
+                val immunityIn = curItem.vaccinatedPerson.getTimeUntilImmunity()!!
+                vaccinationState.text = if (immunityIn < Duration.standardDays(1)) {
+                    resources.getString(R.string.vaccination_card_status_vaccination_complete_tomorrow)
+                } else {
+                    val days = immunityIn.standardDays.toInt()
+                    resources.getQuantityString(
+                        R.plurals.vaccination_card_status_vaccination_complete,
+                        days,
+                        days
+                    )
+                }
             }
             else -> {
                 vaccinationState.setText(R.string.vaccination_card_status_vaccination_incomplete)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/list/VaccinationListViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/list/VaccinationListViewModel.kt
@@ -108,7 +108,7 @@ class VaccinationListViewModel @AssistedInject constructor(
             )
 
             if (vaccinatedPerson.getVaccinationStatus() == VaccinatedPerson.Status.COMPLETE) {
-                val timeUntilImmunity = vaccinatedPerson.getTimeUntilImmunity()
+                val timeUntilImmunity = vaccinatedPerson.getDaysUntilImmunity()
                 if (timeUntilImmunity != null) {
                     add(
                         VaccinationListImmunityInformationCardItem(timeUntilImmunity)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/list/VaccinationListViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/list/VaccinationListViewModel.kt
@@ -108,10 +108,10 @@ class VaccinationListViewModel @AssistedInject constructor(
             )
 
             if (vaccinatedPerson.getVaccinationStatus() == VaccinatedPerson.Status.COMPLETE) {
-                val timeUntilImmunity = vaccinatedPerson.getDaysUntilImmunity()
-                if (timeUntilImmunity != null) {
+                val daysUntilImmunity = vaccinatedPerson.getDaysUntilImmunity()
+                if (daysUntilImmunity != null) {
                     add(
-                        VaccinationListImmunityInformationCardItem(timeUntilImmunity)
+                        VaccinationListImmunityInformationCardItem(daysUntilImmunity)
                     )
                 }
             }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/list/adapter/viewholder/VaccinationListImmunityInformationCardItemVH.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/list/adapter/viewholder/VaccinationListImmunityInformationCardItemVH.kt
@@ -6,7 +6,6 @@ import de.rki.coronawarnapp.covidcertificate.vaccination.ui.list.adapter.Vaccina
 import de.rki.coronawarnapp.covidcertificate.vaccination.ui.list.adapter.VaccinationListItem
 import de.rki.coronawarnapp.covidcertificate.vaccination.ui.list.adapter.viewholder.VaccinationListImmunityInformationCardItemVH.VaccinationListImmunityInformationCardItem
 import de.rki.coronawarnapp.databinding.VaccinationListImmunityCardBinding
-import org.joda.time.Duration
 
 class VaccinationListImmunityInformationCardItemVH(parent: ViewGroup) :
     VaccinationListAdapter.ItemVH<VaccinationListImmunityInformationCardItem, VaccinationListImmunityCardBinding>(
@@ -20,16 +19,15 @@ class VaccinationListImmunityInformationCardItemVH(parent: ViewGroup) :
 
     override val onBindData: VaccinationListImmunityCardBinding
     .(item: VaccinationListImmunityInformationCardItem, payloads: List<Any>) -> Unit = { item, _ ->
-        val daysUntilImmunity = item.timeUntilImmunity.standardDays.toInt()
         body.text =
             context.resources.getQuantityString(
                 R.plurals.vaccination_list_immunity_card_body,
-                daysUntilImmunity,
-                daysUntilImmunity
+                item.daysUntilImmunity,
+                item.daysUntilImmunity
             )
     }
 
-    data class VaccinationListImmunityInformationCardItem(val timeUntilImmunity: Duration) : VaccinationListItem {
+    data class VaccinationListImmunityInformationCardItem(val daysUntilImmunity: Int) : VaccinationListItem {
         override val stableId = VaccinationListImmunityInformationCardItem::class.java.name.hashCode().toLong()
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/TimeAndDateExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/TimeAndDateExtensions.kt
@@ -13,7 +13,6 @@ import org.joda.time.format.DateTimeFormat
 import timber.log.Timber
 import java.math.RoundingMode
 import java.util.Date
-import java.util.TimeZone
 import java.util.concurrent.TimeUnit
 
 @Suppress("TooManyFunctions")
@@ -106,7 +105,7 @@ object TimeAndDateExtensions {
 
     val Instant.seconds get() = TimeUnit.MILLISECONDS.toSeconds(millis)
 
-    fun Instant.toUserTimeZone(): DateTime = this.toDateTime(DateTimeZone.forTimeZone(TimeZone.getDefault()))
+    fun Instant.toUserTimeZone(): DateTime = this.toDateTime(DateTimeZone.getDefault())
 
     fun Instant.toLocalDateUserTz(): LocalDate = this.toUserTimeZone().toLocalDate()
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/TimeAndDateExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/TimeAndDateExtensions.kt
@@ -102,7 +102,7 @@ object TimeAndDateExtensions {
 
     fun Instant.toLocalDateUtc(): LocalDate = this.toDateTime(DateTimeZone.UTC).toLocalDate()
 
-    fun Instant.toLocalTime(): LocalTime = this.toDateTime(DateTimeZone.UTC).toLocalTime()
+    fun Instant.toLocalTimeUtc(): LocalTime = this.toDateTime(DateTimeZone.UTC).toLocalTime()
 
     val Instant.seconds get() = TimeUnit.MILLISECONDS.toSeconds(millis)
 

--- a/Corona-Warn-App/src/main/res/values-de/vaccination_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/vaccination_strings.xml
@@ -87,7 +87,7 @@
         <item quantity="few">Vollständiger Impfschutz in %1$d Tagen</item>
         <item quantity="many">Vollständiger Impfschutz in %1$d Tagen</item>
     </plurals>
-    <string name="vaccination_card_status_vaccination_complete_tomorrow">Sie haben nun alle derzeit geplanten Impfungen erhalten. Allerdings ist der Impfschutz erst morgen vollständig.</string>
+    <string name="vaccination_card_status_vaccination_complete_tomorrow">Vollständiger Impfschutz ab morgen</string>
     <!-- XTXT: Homescreen card complete vaccination status label -->
     <string name="vaccination_card_status_vaccination_complete">"Gültig bis einschließlich %s"</string>
 

--- a/Corona-Warn-App/src/main/res/values-de/vaccination_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/vaccination_strings.xml
@@ -87,7 +87,7 @@
         <item quantity="few">Vollständiger Impfschutz in %1$d Tagen</item>
         <item quantity="many">Vollständiger Impfschutz in %1$d Tagen</item>
     </plurals>
-    <string name="vaccination_card_status_vaccination_complete_tomorrow">Vollständiger Impfschutz ab morgen</string>
+    <string name="vaccination_card_status_vaccination_complete_tomorrow">Sie haben nun alle derzeit geplanten Impfungen erhalten. Allerdings ist der Impfschutz erst morgen vollständig.</string>
     <!-- XTXT: Homescreen card complete vaccination status label -->
     <string name="vaccination_card_status_vaccination_complete">"Gültig bis einschließlich %s"</string>
 

--- a/Corona-Warn-App/src/main/res/values-de/vaccination_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/vaccination_strings.xml
@@ -87,6 +87,7 @@
         <item quantity="few">Vollständiger Impfschutz in %1$d Tagen</item>
         <item quantity="many">Vollständiger Impfschutz in %1$d Tagen</item>
     </plurals>
+    <string name="vaccination_card_status_vaccination_complete_tomorrow">Vollständiger Impfschutz ab morgen</string>
     <!-- XTXT: Homescreen card complete vaccination status label -->
     <string name="vaccination_card_status_vaccination_complete">"Gültig bis einschließlich %s"</string>
 

--- a/Corona-Warn-App/src/main/res/values/vaccination_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/vaccination_strings.xml
@@ -87,7 +87,7 @@
         <item quantity="few">"Full vaccination protection in %1$d days"</item>
         <item quantity="many">"Full vaccination protection in %1$d days"</item>
     </plurals>
-    <string name="vaccination_card_status_vaccination_complete_tomorrow">Sie haben nun alle derzeit geplanten Impfungen erhalten. Allerdings ist der Impfschutz erst morgen vollständig.</string>
+    <string name="vaccination_card_status_vaccination_complete_tomorrow">Full vaccination protection tomorrow</string>
     <!-- XTXT: Homescreen card complete vaccination status label -->
     <string name="vaccination_card_status_vaccination_complete">"Valid through %s"</string>
 

--- a/Corona-Warn-App/src/main/res/values/vaccination_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/vaccination_strings.xml
@@ -87,7 +87,7 @@
         <item quantity="few">"Full vaccination protection in %1$d days"</item>
         <item quantity="many">"Full vaccination protection in %1$d days"</item>
     </plurals>
-    <string name="vaccination_card_status_vaccination_complete_tomorrow">Full vaccination protection tomorrow</string>
+    <string name="vaccination_card_status_vaccination_complete_tomorrow">Sie haben nun alle derzeit geplanten Impfungen erhalten. Allerdings ist der Impfschutz erst morgen vollständig.</string>
     <!-- XTXT: Homescreen card complete vaccination status label -->
     <string name="vaccination_card_status_vaccination_complete">"Valid through %s"</string>
 

--- a/Corona-Warn-App/src/main/res/values/vaccination_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/vaccination_strings.xml
@@ -87,6 +87,7 @@
         <item quantity="few">"Full vaccination protection in %1$d days"</item>
         <item quantity="many">"Full vaccination protection in %1$d days"</item>
     </plurals>
+    <string name="vaccination_card_status_vaccination_complete_tomorrow">Full vaccination protection tomorrow</string>
     <!-- XTXT: Homescreen card complete vaccination status label -->
     <string name="vaccination_card_status_vaccination_complete">"Valid through %s"</string>
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPersonTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPersonTest.kt
@@ -6,7 +6,6 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import org.joda.time.DateTimeZone
-import org.joda.time.Duration
 import org.joda.time.Instant
 import org.joda.time.LocalDate
 import org.junit.jupiter.api.AfterEach
@@ -128,31 +127,26 @@ class VaccinatedPersonTest : BaseTest() {
         VaccinatedPerson(data = personData, valueSet = null).apply {
 
             Instant.parse("2021-04-27T12:00:00.000Z").let { now ->
-                getTimeUntilImmunity(now)!!.apply {
-                    standardDays shouldBe 14
+                getDaysUntilImmunity(now)!!.apply {
+                    this shouldBe 15
                 }
                 getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.COMPLETE
             }
             Instant.parse("2021-05-10T12:00:00.000Z").let { now ->
-                getTimeUntilImmunity(now)!!.apply {
-                    standardDays shouldBe 1
-                    standardHours shouldBe 36
+                getDaysUntilImmunity(now)!!.apply {
+                    this shouldBe 2
                 }
                 getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.COMPLETE
             }
             Instant.parse("2021-05-11T12:00:00.000Z").let { now ->
-                getTimeUntilImmunity(now)!!.apply {
-                    standardHours shouldBe 12
-                    standardDays shouldBe 0
-                    this shouldBe Duration.standardHours(12)
+                getDaysUntilImmunity(now)!!.apply {
+                    this shouldBe 1
                 }
                 getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.COMPLETE
             }
             Instant.parse("2021-05-12T0:00:00.000Z").let { now ->
-                getTimeUntilImmunity(now)!!.apply {
-                    standardHours shouldBe 0
-                    standardDays shouldBe 0
-                    this shouldBe Duration.ZERO
+                getDaysUntilImmunity(now)!!.apply {
+                    this shouldBe 0
                 }
                 getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.IMMUNITY
             }
@@ -177,21 +171,17 @@ class VaccinatedPersonTest : BaseTest() {
 
         VaccinatedPerson(data = personData, valueSet = null).apply {
             // User was in GMT+2 timezone (UTC+2) , we want their MIDNIGHT
-            // Last day before immunity, UI shows 0 days until immunity
+            // Last day before immunity, UI shows 1 day until immunity
             Instant.parse("2021-06-27T12:00:00.000Z").let { now ->
-                getTimeUntilImmunity(now)!!.apply {
-                    standardHours shouldBe 10 // In 10 hours it is 22 UTC, which is midnight in the users TZ.
-                    standardDays shouldBe 0
-                    this shouldBe Duration.standardHours(10)
+                getDaysUntilImmunity(now)!!.apply {
+                    this shouldBe 1
                 }
                 getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.COMPLETE
             }
             // Immunity should be reached at midnight in the users timezone
             Instant.parse("2021-06-27T22:00:00.000Z").let { now ->
-                getTimeUntilImmunity(now)!!.apply {
-                    standardHours shouldBe 0
-                    standardDays shouldBe 0
-                    this shouldBe Duration.ZERO
+                getDaysUntilImmunity(now)!!.apply {
+                    this shouldBe 0
                 }
                 getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.IMMUNITY
             }
@@ -216,26 +206,21 @@ class VaccinatedPersonTest : BaseTest() {
 
         VaccinatedPerson(data = personData, valueSet = null).apply {
             Instant.parse("2021-01-14T0:00:00.000Z").let { now ->
-                getTimeUntilImmunity(now)!!.standardHours shouldBe 47
-                getTimeUntilImmunity(now)!!.standardDays shouldBe 1
+                getDaysUntilImmunity(now)!! shouldBe 2
                 getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.COMPLETE
             }
             Instant.parse("2021-01-15T0:00:00.000Z").let { now ->
-                getTimeUntilImmunity(now)!!.standardHours shouldBe 23
-                getTimeUntilImmunity(now)!!.standardDays shouldBe 0
+                getDaysUntilImmunity(now)!! shouldBe 1
                 getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.COMPLETE
             }
-            // Case Luka#1 happens on 01.15.21, this mean it's winter time!
+            // Case Luka#1 happens on 15.01.21, this mean it's winter time!
             // The users timezone is GMT+1 (winter-time) (UTC+1), not GMT+2 (summer-time) (UTC+2)
             Instant.parse("2021-01-15T22:00:00.000Z").let { now ->
-                getTimeUntilImmunity(now)!!.standardMinutes shouldBe 60
-                getTimeUntilImmunity(now)!!.standardHours shouldBe 1
-                getTimeUntilImmunity(now) shouldBe Duration.standardHours(1)
+                getDaysUntilImmunity(now)!! shouldBe 1
                 getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.COMPLETE
             }
             Instant.parse("2021-01-16T0:00:00.000Z").let { now ->
-                getTimeUntilImmunity(now)!!.standardHours shouldBe -1
-                getTimeUntilImmunity(now)!!.standardDays shouldBe 0
+                getDaysUntilImmunity(now)!! shouldBe 0
                 getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.IMMUNITY
             }
         }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPersonTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPersonTest.kt
@@ -5,6 +5,8 @@ import de.rki.coronawarnapp.covidcertificate.vaccination.core.repository.storage
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import org.joda.time.DateTimeZone
+import org.joda.time.Duration
 import org.joda.time.Instant
 import org.joda.time.LocalDate
 import org.junit.jupiter.api.AfterEach
@@ -18,18 +20,18 @@ class VaccinatedPersonTest : BaseTest() {
 
     @Inject lateinit var testData: VaccinationTestData
 
-    lateinit var defaultTimezone: TimeZone
+    lateinit var defaultTimezone: DateTimeZone
 
     @BeforeEach
     fun setup() {
         DaggerVaccinationTestComponent.factory().create().inject(this)
-        defaultTimezone = TimeZone.getDefault()
-        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Berlin"))
+        defaultTimezone = DateTimeZone.getDefault()
+        DateTimeZone.setDefault(DateTimeZone.UTC)
     }
 
     @AfterEach
     fun teardown() {
-        TimeZone.setDefault(defaultTimezone)
+        DateTimeZone.setDefault(defaultTimezone)
     }
 
     @Test
@@ -123,26 +125,44 @@ class VaccinatedPersonTest : BaseTest() {
         val personData = mockk<VaccinatedPersonData>().apply {
             every { vaccinations } returns setOf(testData.personAVac1Container, immunityContainer)
         }
-        val vaccinatedPerson = VaccinatedPerson(
-            data = personData,
-            valueSet = null
-        )
-        vaccinatedPerson.apply {
-            getTimeUntilImmunity(Instant.parse("2021-04-27T12:00:00.000Z"))!!.apply {
-                standardDays shouldBe 13
+        VaccinatedPerson(data = personData, valueSet = null).apply {
+
+            Instant.parse("2021-04-27T12:00:00.000Z").let { now ->
+                getTimeUntilImmunity(now)!!.apply {
+                    standardDays shouldBe 14
+                }
+                getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.COMPLETE
             }
-            getTimeUntilImmunity(Instant.parse("2021-05-10T12:00:00.000Z"))!!.apply {
-                standardDays shouldBe 0
-                standardHours shouldBe 10
+            Instant.parse("2021-05-10T12:00:00.000Z").let { now ->
+                getTimeUntilImmunity(now)!!.apply {
+                    standardDays shouldBe 1
+                    standardHours shouldBe 36
+                }
+                getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.COMPLETE
             }
-            getTimeUntilImmunity(Instant.parse("2021-05-11T12:00:00.000Z"))!!.apply {
-                standardDays shouldBe 0
+            Instant.parse("2021-05-11T12:00:00.000Z").let { now ->
+                getTimeUntilImmunity(now)!!.apply {
+                    standardHours shouldBe 12
+                    standardDays shouldBe 0
+                    this shouldBe Duration.standardHours(12)
+                }
+                getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.COMPLETE
+            }
+            Instant.parse("2021-05-12T0:00:00.000Z").let { now ->
+                getTimeUntilImmunity(now)!!.apply {
+                    standardHours shouldBe 0
+                    standardDays shouldBe 0
+                    this shouldBe Duration.ZERO
+                }
+                getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.IMMUNITY
             }
         }
     }
 
     @Test
     fun `time until immunity - case #3562`() {
+        DateTimeZone.setDefault(DateTimeZone.forTimeZone(TimeZone.getTimeZone("Europe/Berlin")))
+
         val personData = mockk<VaccinatedPersonData>().apply {
             every { vaccinations } returns setOf(
                 mockk<VaccinationContainer>().apply {
@@ -156,17 +176,23 @@ class VaccinatedPersonTest : BaseTest() {
         }
 
         VaccinatedPerson(data = personData, valueSet = null).apply {
-            // User was in GMT+2 timezone, we want their MIDNIGHT
+            // User was in GMT+2 timezone (UTC+2) , we want their MIDNIGHT
             // Last day before immunity, UI shows 0 days until immunity
             Instant.parse("2021-06-27T12:00:00.000Z").let { now ->
-                getTimeUntilImmunity(now)!!.standardHours shouldBe -14
-                getTimeUntilImmunity(now)!!.standardDays shouldBe 0
+                getTimeUntilImmunity(now)!!.apply {
+                    standardHours shouldBe 10 // In 10 hours it is 22 UTC, which is midnight in the users TZ.
+                    standardDays shouldBe 0
+                    this shouldBe Duration.standardHours(10)
+                }
                 getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.COMPLETE
             }
             // Immunity should be reached at midnight in the users timezone
             Instant.parse("2021-06-27T22:00:00.000Z").let { now ->
-                getTimeUntilImmunity(now)!!.standardHours shouldBe -24
-                getTimeUntilImmunity(now)!!.standardDays shouldBe -1
+                getTimeUntilImmunity(now)!!.apply {
+                    standardHours shouldBe 0
+                    standardDays shouldBe 0
+                    this shouldBe Duration.ZERO
+                }
                 getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.IMMUNITY
             }
         }
@@ -174,6 +200,8 @@ class VaccinatedPersonTest : BaseTest() {
 
     @Test
     fun `time until immunity - case Luka#1`() {
+        DateTimeZone.setDefault(DateTimeZone.forTimeZone(TimeZone.getTimeZone("Europe/Berlin")))
+
         val personData = mockk<VaccinatedPersonData>().apply {
             every { vaccinations } returns setOf(
                 mockk<VaccinationContainer>().apply {
@@ -188,18 +216,26 @@ class VaccinatedPersonTest : BaseTest() {
 
         VaccinatedPerson(data = personData, valueSet = null).apply {
             Instant.parse("2021-01-14T0:00:00.000Z").let { now ->
+                getTimeUntilImmunity(now)!!.standardHours shouldBe 47
+                getTimeUntilImmunity(now)!!.standardDays shouldBe 1
+                getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.COMPLETE
+            }
+            Instant.parse("2021-01-15T0:00:00.000Z").let { now ->
                 getTimeUntilImmunity(now)!!.standardHours shouldBe 23
                 getTimeUntilImmunity(now)!!.standardDays shouldBe 0
                 getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.COMPLETE
             }
-            Instant.parse("2021-01-15T0:00:00.000Z").let { now ->
-                getTimeUntilImmunity(now)!!.standardHours shouldBe -1
-                getTimeUntilImmunity(now)!!.standardDays shouldBe 0
+            // Case Luka#1 happens on 01.15.21, this mean it's winter time!
+            // The users timezone is GMT+1 (winter-time) (UTC+1), not GMT+2 (summer-time) (UTC+2)
+            Instant.parse("2021-01-15T22:00:00.000Z").let { now ->
+                getTimeUntilImmunity(now)!!.standardMinutes shouldBe 60
+                getTimeUntilImmunity(now)!!.standardHours shouldBe 1
+                getTimeUntilImmunity(now) shouldBe Duration.standardHours(1)
                 getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.COMPLETE
             }
             Instant.parse("2021-01-16T0:00:00.000Z").let { now ->
-                getTimeUntilImmunity(now)!!.standardHours shouldBe -25
-                getTimeUntilImmunity(now)!!.standardDays shouldBe -1
+                getTimeUntilImmunity(now)!!.standardHours shouldBe -1
+                getTimeUntilImmunity(now)!!.standardDays shouldBe 0
                 getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.IMMUNITY
             }
         }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPersonTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPersonTest.kt
@@ -223,6 +223,10 @@ class VaccinatedPersonTest : BaseTest() {
                 getDaysUntilImmunity(now)!! shouldBe 0
                 getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.IMMUNITY
             }
+            Instant.parse("2021-01-15T23:00:00.000Z").let { now ->
+                getDaysUntilImmunity(now)!! shouldBe 0
+                getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.IMMUNITY
+            }
         }
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPersonTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPersonTest.kt
@@ -5,20 +5,31 @@ import de.rki.coronawarnapp.covidcertificate.vaccination.core.repository.storage
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
-import org.joda.time.Duration
 import org.joda.time.Instant
+import org.joda.time.LocalDate
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import java.util.TimeZone
 import javax.inject.Inject
 
 class VaccinatedPersonTest : BaseTest() {
 
     @Inject lateinit var testData: VaccinationTestData
 
+    lateinit var defaultTimezone: TimeZone
+
     @BeforeEach
     fun setup() {
         DaggerVaccinationTestComponent.factory().create().inject(this)
+        defaultTimezone = TimeZone.getDefault()
+        TimeZone.setDefault(TimeZone.getTimeZone("Europe/Berlin"))
+    }
+
+    @AfterEach
+    fun teardown() {
+        TimeZone.setDefault(defaultTimezone)
     }
 
     @Test
@@ -117,15 +128,80 @@ class VaccinatedPersonTest : BaseTest() {
             valueSet = null
         )
         vaccinatedPerson.apply {
-            getTimeUntilImmunity(
-                Instant.parse("2021-04-27T12:00:00.000Z")
-            )!!.standardDays shouldBe Duration.standardDays(14).standardDays
-            getTimeUntilImmunity(
-                Instant.parse("2021-05-10T12:00:00.000Z")
-            )!!.standardDays shouldBe Duration.standardDays(1).standardDays
-            getTimeUntilImmunity(
-                Instant.parse("2021-05-11T12:00:00.000Z")
-            )!!.standardDays shouldBe Duration.ZERO.standardDays
+            getTimeUntilImmunity(Instant.parse("2021-04-27T12:00:00.000Z"))!!.apply {
+                standardDays shouldBe 13
+            }
+            getTimeUntilImmunity(Instant.parse("2021-05-10T12:00:00.000Z"))!!.apply {
+                standardDays shouldBe 0
+                standardHours shouldBe 10
+            }
+            getTimeUntilImmunity(Instant.parse("2021-05-11T12:00:00.000Z"))!!.apply {
+                standardDays shouldBe 0
+            }
+        }
+    }
+
+    @Test
+    fun `time until immunity - case #3562`() {
+        val personData = mockk<VaccinatedPersonData>().apply {
+            every { vaccinations } returns setOf(
+                mockk<VaccinationContainer>().apply {
+                    every { toVaccinationCertificate(any()) } returns mockk<VaccinationCertificate>().apply {
+                        every { vaccinatedAt } returns LocalDate.parse("2021-06-13")
+                        every { doseNumber } returns 2
+                        every { totalSeriesOfDoses } returns 2
+                    }
+                }
+            )
+        }
+
+        VaccinatedPerson(data = personData, valueSet = null).apply {
+            // User was in GMT+2 timezone, we want their MIDNIGHT
+            // Last day before immunity, UI shows 0 days until immunity
+            Instant.parse("2021-06-27T12:00:00.000Z").let { now ->
+                getTimeUntilImmunity(now)!!.standardHours shouldBe -14
+                getTimeUntilImmunity(now)!!.standardDays shouldBe 0
+                getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.COMPLETE
+            }
+            // Immunity should be reached at midnight in the users timezone
+            Instant.parse("2021-06-27T22:00:00.000Z").let { now ->
+                getTimeUntilImmunity(now)!!.standardHours shouldBe -24
+                getTimeUntilImmunity(now)!!.standardDays shouldBe -1
+                getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.IMMUNITY
+            }
+        }
+    }
+
+    @Test
+    fun `time until immunity - case Luka#1`() {
+        val personData = mockk<VaccinatedPersonData>().apply {
+            every { vaccinations } returns setOf(
+                mockk<VaccinationContainer>().apply {
+                    every { toVaccinationCertificate(any()) } returns mockk<VaccinationCertificate>().apply {
+                        every { vaccinatedAt } returns LocalDate.parse("2021-01-01")
+                        every { doseNumber } returns 2
+                        every { totalSeriesOfDoses } returns 2
+                    }
+                }
+            )
+        }
+
+        VaccinatedPerson(data = personData, valueSet = null).apply {
+            Instant.parse("2021-01-14T0:00:00.000Z").let { now ->
+                getTimeUntilImmunity(now)!!.standardHours shouldBe 23
+                getTimeUntilImmunity(now)!!.standardDays shouldBe 0
+                getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.COMPLETE
+            }
+            Instant.parse("2021-01-15T0:00:00.000Z").let { now ->
+                getTimeUntilImmunity(now)!!.standardHours shouldBe -1
+                getTimeUntilImmunity(now)!!.standardDays shouldBe 0
+                getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.COMPLETE
+            }
+            Instant.parse("2021-01-16T0:00:00.000Z").let { now ->
+                getTimeUntilImmunity(now)!!.standardHours shouldBe -25
+                getTimeUntilImmunity(now)!!.standardDays shouldBe -1
+                getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.IMMUNITY
+            }
         }
     }
 }


### PR DESCRIPTION
* Use local timezone to determine "midnight" which affects when the user's state switches from COMPLETE to IMMUNITY.
* Change calculation so that `IMMUNITY` is reached when `getTimeUntilImmunity` reaches 0. Previously we just compared days and had to check for `days < 0` which makes for confusing code due to rounding.
* UI now shows specific text when time until immunity is less than a day ("tomorrow")

See #3561 and #3562.
