### PR TITLE
Generate empty byte array without GMS dependency

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/cryptography/AesCryptography.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/cryptography/AesCryptography.kt
@@ -1,6 +1,5 @@
 package de.rki.coronawarnapp.covidcertificate.common.cryptography
 
-import com.google.android.gms.common.util.Hex
 import javax.crypto.Cipher
 import javax.crypto.spec.IvParameterSpec
 import javax.crypto.spec.SecretKeySpec
@@ -18,7 +17,9 @@ class AesCryptography @Inject constructor() {
     }
 
     private val ivParameterSpec
-        get() = IvParameterSpec(Hex.stringToBytes("00000000000000000000000000000000"))
+        get() = IvParameterSpec(
+            ByteArray(16) { 0 }
+        )
 }
 
 private const val ALGORITHM = "AES"


### PR DESCRIPTION
The `AesCryptography` class is currently generating an empty byte array using:

    Hex.stringToBytes("00000000000000000000000000000000")

The problem with this code is that `Hex` is contained in the package `com.google.android.gms.common.util`, which appears to be a Google Play services library that CCTG doesn't contain. For this reason, I propose generating the empty array as follows:

    ByteArray(16) { 0 }