### PR TITLE
Don't ship debug binaries (EXPOSUREAPP-8027)

### DIFF
--- a/Corona-Warn-App/build.gradle
+++ b/Corona-Warn-App/build.gradle
@@ -232,6 +232,8 @@ android {
         exclude 'CODE_OF_CONDUCT.md'
         exclude 'META-INF/AL2.0'
         exclude 'META-INF/LGPL2.1'
+        // https://github.com/Kotlin/kotlinx.coroutines/issues/2274
+        exclude 'DebugProbesKt.bin'
     }
 
     sourceSets {


### PR DESCRIPTION
Coroutines dependency includes "DebugProbesKt.bin" by default.
See https://github.com/Kotlin/kotlinx.coroutines/issues/2274

Testing:
Build a release APK, extract it and check that it doesn't contain the mentioned file.