### PR TITLE
fix order of the certificates  (EXPOSUREAPP-8154)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensions.kt
@@ -9,9 +9,23 @@ import org.joda.time.Days
 import org.joda.time.Duration
 import org.joda.time.Instant
 import timber.log.Timber
+import java.lang.IllegalStateException
 
+/*
+    The list items shall be sorted descending by the following date attributes depending on the type of the DGC:
+    for Vaccination Certificates (i.e. DGC with v[0]): the date of the vaccination v[0].dt
+    for Test Certificates (i.e. DGC with t[0]): the date of the sample collection t[0].sc
+    for Recovery Certificates (i.e. DGC with r[0]): the date of begin of the validity r[0].df
+ */
 fun Collection<CwaCovidCertificate>.toCertificateSortOrder(): List<CwaCovidCertificate> {
-    return this.sortedBy { it.issuedAt }
+    return this.sortedByDescending {
+        when (it) {
+            is VaccinationCertificate -> it.vaccinatedOn
+            is TestCertificate -> it.sampleCollectedAt.toLocalDateUtc()
+            is RecoveryCertificate -> it.validFrom
+            else -> throw IllegalStateException("Can't sort $it")
+        }
+    }
 }
 
 /**

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensions.kt
@@ -4,6 +4,7 @@ import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertific
 import de.rki.coronawarnapp.covidcertificate.recovery.core.RecoveryCertificate
 import de.rki.coronawarnapp.covidcertificate.test.core.TestCertificate
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinationCertificate
+import de.rki.coronawarnapp.util.TimeAndDateExtensions.toLocalDateUserTz
 import de.rki.coronawarnapp.util.TimeAndDateExtensions.toLocalDateUtc
 import org.joda.time.Days
 import org.joda.time.Duration
@@ -21,7 +22,7 @@ fun Collection<CwaCovidCertificate>.toCertificateSortOrder(): List<CwaCovidCerti
     return this.sortedByDescending {
         when (it) {
             is VaccinationCertificate -> it.vaccinatedOn
-            is TestCertificate -> it.sampleCollectedAt.toLocalDateUtc()
+            is TestCertificate -> it.sampleCollectedAt.toLocalDateUserTz()
             is RecoveryCertificate -> it.validFrom
             else -> throw IllegalStateException("Can't sort $it")
         }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensionsTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensionsTest.kt
@@ -1,6 +1,5 @@
 package de.rki.coronawarnapp.covidcertificate.person.core
 
-import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate
 import de.rki.coronawarnapp.covidcertificate.recovery.core.RecoveryCertificate
 import de.rki.coronawarnapp.covidcertificate.test.core.TestCertificate
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinationCertificate
@@ -18,20 +17,21 @@ import testhelpers.BaseTest
 class PersonCertificatesExtensionsTest : BaseTest() {
 
     private val time = Instant.parse("2021-06-24T14:00:00.000Z")
-    private val oneSecondDuration = Duration.standardSeconds(1)
+    private val oneDayDuration = Duration.standardDays(1)
 
     @Test
     fun `certificate sort order`() {
-        val certificateFirst = mockk<CwaCovidCertificate>().apply {
-            every { issuedAt } returns time.minus(oneSecondDuration)
+
+        val certificateFirst = mockk<VaccinationCertificate>().apply {
+            every { vaccinatedOn } returns time.plus(oneDayDuration).toLocalDateUtc()
         }
 
-        val certificateSecond = mockk<CwaCovidCertificate>().apply {
-            every { issuedAt } returns time
+        val certificateSecond = mockk<TestCertificate>().apply {
+            every { sampleCollectedAt } returns time
         }
 
-        val certificateThird = mockk<CwaCovidCertificate>().apply {
-            every { issuedAt } returns time.plus(oneSecondDuration)
+        val certificateThird = mockk<RecoveryCertificate>().apply {
+            every { validFrom } returns time.minus(oneDayDuration).toLocalDateUtc()
         }
 
         val expectedOrder = listOf(certificateFirst, certificateSecond, certificateThird)

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesProviderTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesProviderTest.kt
@@ -10,6 +10,7 @@ import de.rki.coronawarnapp.covidcertificate.test.core.TestCertificateWrapper
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinatedPerson
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinationCertificate
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.repository.VaccinationRepository
+import de.rki.coronawarnapp.util.TimeAndDateExtensions.toLocalDateUtc
 import io.kotest.matchers.shouldBe
 import io.mockk.MockKAnnotations
 import io.mockk.every
@@ -35,21 +36,21 @@ class PersonCertificatesProviderTest : BaseTest() {
 
     private val vaccinatedPersonACertificate1 = mockk<VaccinationCertificate>().apply {
         every { personIdentifier } returns identifierA
-        every { issuedAt } returns Instant.EPOCH
+        every { vaccinatedOn } returns Instant.EPOCH.toLocalDateUtc()
     }
     private val vaccinatedPersonA = mockk<VaccinatedPerson>().apply {
         every { vaccinationCertificates } returns setOf(vaccinatedPersonACertificate1)
     }
     private val testWrapperACertificate = mockk<TestCertificate>().apply {
         every { personIdentifier } returns identifierA
-        every { issuedAt } returns Instant.EPOCH
+        every { sampleCollectedAt } returns Instant.EPOCH
     }
     private val testWrapperA = mockk<TestCertificateWrapper>().apply {
         every { testCertificate } returns testWrapperACertificate
     }
     private val recoveryWrapperACertificate = mockk<RecoveryCertificate>().apply {
         every { personIdentifier } returns identifierA
-        every { issuedAt } returns Instant.EPOCH
+        every { validFrom } returns Instant.EPOCH.toLocalDateUtc()
     }
     private val recoveryWrapperA = mockk<RecoveryCertificateWrapper>().apply {
         every { recoveryCertificate } returns recoveryWrapperACertificate


### PR DESCRIPTION
The list items shall be sorted descending by the following date attributes depending on the type of the DGC:
 - for Vaccination Certificates (i.e. DGC with v[0]): the date of the vaccination v[0].dt
 - for Test Certificates (i.e. DGC with t[0]): the date of the sample collection t[0].sc
 - for Recovery Certificates (i.e. DGC with r[0]): the date of begin of the validity r[0].df
