### PR TITLE
 Inserting non-breaking spaces(EXPOSUREAPP-8120)

### DIFF
--- a/Corona-Warn-App/src/main/res/values-de/green_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/green_certificate_strings.xml
@@ -7,7 +7,7 @@
     <!-- XTXT: Request green certificate body section 1 -->
     <string name="request_green_certificate_body_1">Das Testzertifikat wird nur bei einem negativen Testergebnis ausgestellt.</string>
     <!-- XTXT: Request green certificate body section 2 -->
-    <string name="request_green_certificate_body_2">Das Testzertifikat gilt innerhalb der EU als gültiger Nachweis eines negativen Testergebnisses (z.B. für Reisen).</string>
+    <string name="request_green_certificate_body_2">Das Testzertifikat gilt innerhalb der EU als gültiger Nachweis eines negativen Testergebnisses (z.\u00A0B. für Reisen).</string>
     <!-- XTXT: Request green certificate body section 3 -->
     <string name="request_green_certificate_body_3">Das Testzertifikat enthält Daten, die der Prüf-App die Validierung Ihres Zertifikats erlauben.</string>
     <!-- XBUT: Request green certificate agree button -->


### PR DESCRIPTION
This fixes EXPOSUREAPP-8120 in Green Certificate Strings
