### PR TITLE
Shortening the Text for Statistics Card (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -1614,7 +1614,7 @@
     <!-- XTXT: Nationwide text -->
     <string name="statistics_vaccinated_nationwide_text">"Bundesweit"</string>
     <!-- XTXT: Vaccination primary value footnote text -->
-    <string name="statistics_vaccination_primary_value_footnote">"der Gesamtbevölkerung"</string>
+    <string name="statistics_vaccination_primary_value_footnote">"der Bevölkerung"</string>
 
     <!-- Persons Vaccinated Completely Statistics Card -->
     <!-- XHED: Title for vaccinated completely statistics card -->


### PR DESCRIPTION
We have to shorten the text due to some space problems.

iOS:  https://github.com/corona-warn-app/cwa-app-ios/pull/3094