### PR TITLE
Generate test certificate rsa key-pair only once (EXPOSUREAPP-8162)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/exception/InvalidTestCertificateException.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/exception/InvalidTestCertificateException.kt
@@ -5,7 +5,10 @@ import de.rki.coronawarnapp.util.HumanReadableError
 import de.rki.coronawarnapp.util.ui.CachedString
 import de.rki.coronawarnapp.util.ui.LazyString
 
-class InvalidTestCertificateException(errorCode: ErrorCode) : InvalidHealthCertificateException(errorCode) {
+class InvalidTestCertificateException(
+    errorCode: ErrorCode,
+    cause: Throwable? = null
+) : InvalidHealthCertificateException(errorCode, cause) {
     override fun toHumanReadableError(context: Context): HumanReadableError {
         return HumanReadableError(
             description = errorMessage.get(context) + " ($PREFIX$errorCode)"

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/exception/TestCertificateServerException.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/exception/TestCertificateServerException.kt
@@ -8,8 +8,9 @@ import de.rki.coronawarnapp.util.ui.CachedString
 import de.rki.coronawarnapp.util.ui.LazyString
 
 class TestCertificateServerException(
-    val errorCode: ErrorCode
-) : HasHumanReadableError, Exception(errorCode.message) {
+    val errorCode: ErrorCode,
+    cause: Throwable? = null
+) : HasHumanReadableError, Exception(errorCode.message, cause) {
 
     override fun toHumanReadableError(context: Context): HumanReadableError {
         return HumanReadableError(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateProcessor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateProcessor.kt
@@ -140,7 +140,7 @@ class TestCertificateProcessor @Inject constructor(
             )
         } catch (e: Throwable) {
             Timber.tag(TAG).e(e, "RSA_DECRYPTION_FAILED")
-            throw InvalidTestCertificateException(InvalidHealthCertificateException.ErrorCode.RSA_DECRYPTION_FAILED)
+            throw InvalidTestCertificateException(InvalidHealthCertificateException.ErrorCode.RSA_DECRYPTION_FAILED, e)
         }
 
         val extractedData = qrCodeExtractor.extractEncrypted(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateProcessor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateProcessor.kt
@@ -14,7 +14,6 @@ import de.rki.coronawarnapp.covidcertificate.test.core.storage.types.RACertifica
 import de.rki.coronawarnapp.covidcertificate.test.core.storage.types.RetrievedTestCertificate
 import de.rki.coronawarnapp.util.TimeStamper
 import de.rki.coronawarnapp.util.encryption.rsa.RSACryptography
-import de.rki.coronawarnapp.util.encryption.rsa.RSAKeyPairGenerator
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import okio.ByteString.Companion.decodeBase64
@@ -26,7 +25,6 @@ import javax.inject.Inject
 class TestCertificateProcessor @Inject constructor(
     private val timeStamper: TimeStamper,
     private val certificateServer: TestCertificateServer,
-    private val rsaKeyPairGenerator: RSAKeyPairGenerator,
     private val rsaCryptography: RSACryptography,
     private val appConfigProvider: AppConfigProvider,
     private val qrCodeExtractor: DccQrCodeExtractor,
@@ -51,30 +49,31 @@ class TestCertificateProcessor @Inject constructor(
             return data
         }
 
-        val rsaKeyPair = try {
-            rsaKeyPairGenerator.generate()
-        } catch (e: Throwable) {
-            throw InvalidTestCertificateException(InvalidHealthCertificateException.ErrorCode.RSA_KP_GENERATION_FAILED)
-        }
+        val publicKey = data.rsaPublicKey ?: throw IllegalArgumentException("rsaPublicKey was null")
+        requireNotNull(data.rsaPrivateKey) { "We have a public key without private key?" }
 
-        certificateServer.registerPublicKeyForTest(
-            testRegistrationToken = data.registrationToken,
-            publicKey = rsaKeyPair.publicKey,
-        )
-        Timber.tag(TAG).i("Public key successfully registered for %s", data)
+        try {
+            certificateServer.registerPublicKeyForTest(
+                testRegistrationToken = data.registrationToken,
+                publicKey = publicKey,
+            )
+            Timber.tag(TAG).i("Public key successfully registered for %s", data)
+        } catch (e: TestCertificateServerException) {
+            if (e.errorCode == ErrorCode.PKR_409) {
+                Timber.tag(TAG).w("PublicKey already registered, assuming we can go ahead.")
+            } else {
+                throw e
+            }
+        }
 
         val nowUTC = timeStamper.nowUTC
 
         return when (data) {
             is PCRCertificateData -> data.copy(
                 publicKeyRegisteredAt = nowUTC,
-                rsaPublicKey = rsaKeyPair.publicKey,
-                rsaPrivateKey = rsaKeyPair.privateKey,
             )
             is RACertificateData -> data.copy(
                 publicKeyRegisteredAt = nowUTC,
-                rsaPublicKey = rsaKeyPair.publicKey,
-                rsaPrivateKey = rsaKeyPair.privateKey,
             )
         }
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepository.kt
@@ -90,7 +90,7 @@ class TestCertificateRepository @Inject constructor(
                 it.reportProblem(TAG, "Failed to snapshot TestCertificateContainer data to storage.")
                 throw it
             }
-            .launchIn(appScope + dispatcherProvider.Default)
+            .launchIn(appScope + dispatcherProvider.IO)
     }
 
     /**

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepository.kt
@@ -17,6 +17,7 @@ import de.rki.coronawarnapp.covidcertificate.valueset.ValueSetsRepository
 import de.rki.coronawarnapp.util.TimeStamper
 import de.rki.coronawarnapp.util.coroutine.AppScope
 import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
+import de.rki.coronawarnapp.util.encryption.rsa.RSAKeyPairGenerator
 import de.rki.coronawarnapp.util.flow.HotDataFlow
 import de.rki.coronawarnapp.util.flow.combine
 import de.rki.coronawarnapp.util.mutate
@@ -44,6 +45,7 @@ class TestCertificateRepository @Inject constructor(
     private val processor: TestCertificateProcessor,
     private val timeStamper: TimeStamper,
     valueSetsRepository: ValueSetsRepository,
+    private val rsaKeyPairGenerator: RSAKeyPairGenerator,
 ) {
 
     private val internalData: HotDataFlow<Map<TestCertificateContainerId, TestCertificateContainer>> = HotDataFlow(
@@ -121,18 +123,28 @@ class TestCertificateRepository @Inject constructor(
 
             val identifier = UUID.randomUUID().toString()
 
+            val rsaKeyPair = try {
+                rsaKeyPairGenerator.generate()
+            } catch (e: Throwable) {
+                throw InvalidTestCertificateException(InvalidHealthCertificateException.ErrorCode.RSA_KP_GENERATION_FAILED)
+            }
+
             val data = when (test.type) {
                 CoronaTest.Type.PCR -> PCRCertificateData(
                     identifier = identifier,
                     registeredAt = test.registeredAt,
                     registrationToken = test.registrationToken,
-                    labId = test.labId
+                    labId = test.labId,
+                    rsaPublicKey = rsaKeyPair.publicKey,
+                    rsaPrivateKey = rsaKeyPair.privateKey,
                 )
                 CoronaTest.Type.RAPID_ANTIGEN -> RACertificateData(
                     identifier = identifier,
                     registeredAt = test.registeredAt,
                     registrationToken = test.registrationToken,
-                    labId = test.labId
+                    labId = test.labId,
+                    rsaPublicKey = rsaKeyPair.publicKey,
+                    rsaPrivateKey = rsaKeyPair.privateKey,
                 )
             }
             val container = TestCertificateContainer(
@@ -165,7 +177,7 @@ class TestCertificateRepository @Inject constructor(
             val data = GenericTestCertificateData(
                 identifier = UUID.randomUUID().toString(),
                 registeredAt = nowUtc,
-                certificateReceivedAt = nowUtc,
+                certificateReceivedAt = nowUtc, // Set this as we don't need to retrieve one
                 testCertificateQrCode = qrCode.qrCode
             )
             val container = TestCertificateContainer(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepository.kt
@@ -126,7 +126,10 @@ class TestCertificateRepository @Inject constructor(
             val rsaKeyPair = try {
                 rsaKeyPairGenerator.generate()
             } catch (e: Throwable) {
-                throw InvalidTestCertificateException(InvalidHealthCertificateException.ErrorCode.RSA_KP_GENERATION_FAILED)
+                throw InvalidTestCertificateException(
+                    errorCode = InvalidHealthCertificateException.ErrorCode.RSA_KP_GENERATION_FAILED,
+                    cause = e
+                )
             }
 
             val data = when (test.type) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/server/TestCertificateServer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/server/TestCertificateServer.kt
@@ -70,7 +70,7 @@ class TestCertificateServer @Inject constructor(
             Timber.tag(TAG).w(e, "registerPublicKeyForTest failed")
             throw when (e) {
                 is TestCertificateServerException -> e
-                else -> TestCertificateServerException(PKR_FAILED)
+                else -> TestCertificateServerException(PKR_FAILED, e)
             }
         }
     }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepositoryTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepositoryTest.kt
@@ -13,8 +13,10 @@ import de.rki.coronawarnapp.covidcertificate.test.core.storage.types.GenericTest
 import de.rki.coronawarnapp.covidcertificate.test.core.storage.types.PCRCertificateData
 import de.rki.coronawarnapp.covidcertificate.valueset.ValueSetsRepository
 import de.rki.coronawarnapp.util.TimeStamper
+import de.rki.coronawarnapp.util.encryption.rsa.RSAKeyPairGenerator
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.every
@@ -93,6 +95,7 @@ class TestCertificateRepositoryTest : BaseTest() {
         valueSetsRepository = valueSetsRepository,
         timeStamper = timeStamper,
         processor = testCertificateProcessor,
+        rsaKeyPairGenerator = RSAKeyPairGenerator(),
     )
 
     @Test
@@ -129,6 +132,10 @@ class TestCertificateRepositoryTest : BaseTest() {
             registeredAt shouldBe Instant.ofEpochSecond(4555)
             certificateReceivedAt shouldBe null
             registrationToken shouldBe "token"
+
+            publicKeyRegisteredAt shouldBe null
+            rsaPublicKey shouldNotBe null
+            rsaPrivateKey shouldNotBe null
         }
     }
 


### PR DESCRIPTION
Generate RSA key-pair once on registration, instead "everytime until we have successfully registered a pair".

This prevents a stale-mate between client and server where the client tries to register a publickey but server returns HTTP409.
But if the client tried to register a new key pair, then the app doesn't have the already registered key that the server is referring to. See #3638

This PR changes the RSA key-pair generation to happen once when the test is registered, so we can't loose a registered key if a client/server errors during registration and we can just continue if the server responds with HTTP409.
