### PR TITLE
Tile "Test registrieren" headline + button text wrong (EXPOSUREAPP-8291)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/home_submission_status_card_unregistered.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_submission_status_card_unregistered.xml
@@ -18,7 +18,7 @@
             android:layout_marginEnd="@dimen/spacing_small"
             android:accessibilityHeading="true"
             android:focusable="false"
-            android:text="@string/ag_homescreen_card_test_register_title"
+            android:text="@string/submission_status_card_button_unregistered"
             app:layout_constraintEnd_toStartOf="@+id/icon"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
@@ -62,7 +62,7 @@
             android:layout_marginTop="@dimen/spacing_small"
             android:layout_marginEnd="@dimen/card_padding"
             android:layout_marginBottom="@dimen/card_padding"
-            android:text="@string/submission_status_card_button_unregistered"
+            android:text="@string/ag_homescreen_card_test_register_title"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Somehow the title and button string were swapped:

**Before** 
![image](https://user-images.githubusercontent.com/64483219/124744397-ff4a3b80-df1e-11eb-8dca-bbaf2a22b415.png)

**After**
![image](https://user-images.githubusercontent.com/64483219/124745080-b646b700-df1f-11eb-9608-c9e58ae4865a.png)

