### PR TITLE
Add text for clarity

### DIFF
--- a/Corona-Warn-App/src/main/res/values/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/covid_certificate_strings.xml
@@ -123,7 +123,7 @@
     <!-- XTXT: Validation Rule Result Valid - note point 3 -->
     <string name="validation_rules_result_valid_result_note_3">Um die Echtheit eines Zertifikats sicherzustellen, wird jedes Zertifikat mit einer digitalen Signatur ausgestellt. Diese Signatur wird in einer Prüf-Anwendung validiert.</string>
     <!-- XTXT: Validation Rule Result Valid - note point 4 -->
-    <string name="validation_rules_result_valid_result_note_4">Ob die im Zertifikat eingetragenen Daten richtig sind, wird nicht geprüft.</string>
+    <string name="validation_rules_result_valid_result_note_4">Ob die im Zertifikat eingetragenen Daten richtig sind, wird in der Corona-Warn-App nicht geprüft.</string>
     <!-- XTXT: Validation Rule Result Valid - Infos about country, date and check date -->
     <string name="validation_rules_result_valid_result_country_and_time">Einreise nach %1$s am %2$s, geprüft am %3$s</string>
     <!-- XTXT: Validation Rule Result Valid - faq & infos -->


### PR DESCRIPTION
Adding "in der Corona-Warn-App" to the sentence for more clarity after we received feedback from the community here.
