### PR TITLE
Fix: 'Reset App' does not reset custom incidence locations (EXPOSUREAPP-8439)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/local/source/LocalStatisticsProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/local/source/LocalStatisticsProvider.kt
@@ -110,7 +110,7 @@ class LocalStatisticsProvider @Inject constructor(
     fun clear() {
         Timber.d("clear()")
 
-        localStatisticsConfigStorage.activeDistricts.update { emptySet() }
+        localStatisticsConfigStorage.clear()
         server.clear()
         localStatisticsCache.clearAll()
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/local/source/LocalStatisticsProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/local/source/LocalStatisticsProvider.kt
@@ -110,6 +110,7 @@ class LocalStatisticsProvider @Inject constructor(
     fun clear() {
         Timber.d("clear()")
 
+        localStatisticsConfigStorage.activeDistricts.update { emptySet() }
         server.clear()
         localStatisticsCache.clearAll()
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/local/storage/LocalStatisticsConfigStorage.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/local/storage/LocalStatisticsConfigStorage.kt
@@ -40,6 +40,10 @@ class LocalStatisticsConfigStorage @Inject constructor(
                 .distinct()
         }
 
+    fun clear() {
+        activeDistricts.update { emptySet() }
+    }
+
     companion object {
         private const val PKEY_ACTIVE_DISTRICTS = "statistics.local.districts"
     }


### PR DESCRIPTION
### Testing
- add one or more local statics cards
- perform app reset
- check if cards disappear 