### PR TITLE
Fix heading switched - local statistics(EXPOSUREAPP-8410)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/stateselection/FederalStateSelectionFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/stateselection/FederalStateSelectionFragment.kt
@@ -69,8 +69,8 @@ class FederalStateSelectionFragment : Fragment(R.layout.federal_state_selection_
     }
 
     private fun getToolbarLabel() = if (navArgs.selectedFederalStateShortName != null) {
-        R.string.analytics_userinput_federalstate_title
-    } else {
         R.string.analytics_userinput_district_title
+    } else {
+        R.string.analytics_userinput_federalstate_title
     }
 }


### PR DESCRIPTION
This huge PR addresses Exposureapp-8410.

How to test:
- Try to add a new "local statistics card".
- Check if the header is right in the follow up screens (Ihr bundesland/ Ihr Kreis)