### PR TITLE
Increase ValueSet storage resilience (DEV,EXPOSUREAPP-8113)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/valueset/ValueSetsRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/valueset/ValueSetsRepository.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -36,17 +37,20 @@ class ValueSetsRepository @Inject constructor(
         loggingTag = TAG,
         scope = scope,
         coroutineContext = dispatcherProvider.IO,
-        sharingBehavior = SharingStarted.Lazily,
-        startValueProvider = {
-            valueSetsStorage.valueSetsContainer.also { Timber.v("Loaded initial value sets %s", it) }
-        }
-    )
+        sharingBehavior = SharingStarted.Lazily
+    ) {
+        valueSetsStorage.load().also { Timber.v("Loaded initial value sets %s", it) }
+    }
 
     init {
         internalData.data
             .onStart { Timber.d("Observing value set") }
-            .onEach { valueSetsStorage.valueSetsContainer = it }
-            .catch { Timber.e(it, "Storing new value sets failed.") }
+            .drop(1) // Initial emission that ways restored from storage anyways.
+            .onEach { valueSetsStorage.save(it) }
+            .catch {
+                Timber.e(it, "Storing new value sets failed.")
+                throw it
+            }
             .launchIn(scope + dispatcherProvider.IO)
     }
 
@@ -76,8 +80,7 @@ class ValueSetsRepository @Inject constructor(
             container = certificateValueSetServer.getVaccinationValueSets(languageCode = Locale.ENGLISH)
         }
 
-        return container
-            .also { Timber.v("New value sets %s", it) }
+        return container.also { Timber.v("New value sets %s", it) }
     }
 
     suspend fun clear() {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/valueset/ValueSetsRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/valueset/ValueSetsRepository.kt
@@ -46,7 +46,10 @@ class ValueSetsRepository @Inject constructor(
         internalData.data
             .onStart { Timber.d("Observing value set") }
             .drop(1) // Initial emission that ways restored from storage anyways.
-            .onEach { valueSetsStorage.save(it) }
+            .onEach {
+                Timber.v("Storing new valueset data.")
+                valueSetsStorage.save(it)
+            }
             .catch {
                 Timber.e(it, "Storing new value sets failed.")
                 throw it

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/valueset/valuesets/ValueSetsStorage.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/valueset/valuesets/ValueSetsStorage.kt
@@ -8,6 +8,8 @@ import dagger.Reusable
 import de.rki.coronawarnapp.util.di.AppContext
 import de.rki.coronawarnapp.util.serialization.BaseGson
 import de.rki.coronawarnapp.util.serialization.fromJson
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -16,18 +18,15 @@ class ValueSetsStorage @Inject constructor(
     @AppContext private val context: Context,
     @BaseGson private val gson: Gson
 ) {
-
+    private val mutex = Mutex()
     private val prefs: SharedPreferences by lazy {
-        context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
-            .also { removeLeftOver(it) }
+        context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE).also {
+            migration23To24(it)
+        }
     }
 
-    var valueSetsContainer: ValueSetsContainer
-        get() = getValueSet()
-        set(value) = setValueSet(value)
-
-    private fun getValueSet(): ValueSetsContainer {
-        Timber.v("Loading value sets container")
+    suspend fun load(): ValueSetsContainer = mutex.withLock {
+        Timber.tag(TAG).v("load()")
         val valueSetString = prefs.getString(PKEY_VALUE_SETS_CONTAINER_PREFIX, null)
         return when (valueSetString != null) {
             true -> gson.fromJson(valueSetString)
@@ -35,16 +34,16 @@ class ValueSetsStorage @Inject constructor(
         }.also { loaded -> Timber.v("Loaded value sets container %s", loaded) }
     }
 
-    private fun setValueSet(value: ValueSetsContainer) {
-        Timber.v("Saving value sets container %s", value)
-        prefs.edit {
+    suspend fun save(value: ValueSetsContainer) = mutex.withLock {
+        Timber.tag(TAG).v("save(value=%s)", value)
+        prefs.edit(commit = true) {
             val json = gson.toJson(value, ValueSetsContainer::class.java)
-            Timber.v("Writing %s to prefs", json)
             putString(PKEY_VALUE_SETS_CONTAINER_PREFIX, json)
         }
     }
 
-    private fun removeLeftOver(prefs: SharedPreferences) {
+    // Migration from 2.3.x to 2.4.x: Support for more value sets
+    private fun migration23To24(prefs: SharedPreferences) {
         Timber.v("Checking for leftover and removing it")
         if (prefs.contains(PKEY_VALUE_SETS_PREFIX)) {
             prefs.edit(commit = true) {
@@ -54,6 +53,7 @@ class ValueSetsStorage @Inject constructor(
     }
 
     companion object {
+        private const val TAG = "ValueSetsStorage"
         private const val PREF_NAME = "valuesets_localdata"
         private const val PKEY_VALUE_SETS_PREFIX = "valueset"
         private const val PKEY_VALUE_SETS_CONTAINER_PREFIX = "valuesets_container"

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/storage/ValueSetsStorageTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/storage/ValueSetsStorageTest.kt
@@ -11,6 +11,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.test.runBlockingTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
@@ -37,13 +38,13 @@ class ValueSetsStorageTest : BaseTest() {
     )
 
     @Test
-    fun `Updates values`() {
+    fun `Updates values`() = runBlockingTest {
         createInstance().run {
-            valueSetsContainer = valueSetsContainerDe
-            valueSetsContainer shouldBe valueSetsContainerDe
+            save(valueSetsContainerDe)
+            load() shouldBe valueSetsContainerDe
 
-            valueSetsContainer = valueSetsContainerEn
-            valueSetsContainer shouldBe valueSetsContainerEn
+            save(valueSetsContainerEn)
+            load() shouldBe valueSetsContainerEn
         }
     }
 
@@ -54,8 +55,8 @@ class ValueSetsStorageTest : BaseTest() {
     }
 
     @Test
-    fun `storage format`() {
-        createInstance().valueSetsContainer = valueSetsContainerDe
+    fun `storage format`() = runBlockingTest {
+        createInstance().save(valueSetsContainerDe)
         (prefs.dataMapPeek["valuesets_container"] as String).toComparableJsonPretty() shouldBe """
             {
               "vaccinationValueSets": {
@@ -132,8 +133,8 @@ class ValueSetsStorageTest : BaseTest() {
         """.toComparableJsonPretty()
 
         createInstance().apply {
-            valueSetsContainer shouldBe valueSetsContainerDe
-            valueSetsContainer = emptyValueSetsContainer
+            load() shouldBe valueSetsContainerDe
+            save(emptyValueSetsContainer)
         }
         (prefs.dataMapPeek["valuesets_container"] as String).toComparableJsonPretty() shouldBe """
             {
@@ -170,11 +171,11 @@ class ValueSetsStorageTest : BaseTest() {
             }
         """.toComparableJsonPretty()
 
-        createInstance().valueSetsContainer shouldBe emptyValueSetsContainer
+        createInstance().load() shouldBe emptyValueSetsContainer
     }
 
     @Test
-    fun `removes leftover`() {
+    fun `removes leftover`() = runBlockingTest {
         val leftover = "I'm a malicious leftover"
         val valueSet = "valueset"
         prefs.edit(commit = true) {
@@ -182,7 +183,7 @@ class ValueSetsStorageTest : BaseTest() {
         }
 
         prefs.dataMapPeek[valueSet] shouldBe leftover
-        createInstance().valueSetsContainer shouldBe emptyValueSetsContainer
+        createInstance().load() shouldBe emptyValueSetsContainer
         prefs.dataMapPeek.isEmpty() shouldBe true
     }
 }


### PR DESCRIPTION
Same treatment as #3742
* Mutex locking on storage
* Don't retwrite the initial dataset
* If we really fail to store the ValueSets (which uses the same storage mechanism as the certificates), then be loud and rethrow the exception.