### PR TITLE
Better `HotData` queue handling on fast operations (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/flow/HotDataFlow.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/flow/HotDataFlow.kt
@@ -52,15 +52,15 @@ class HotDataFlow<T : Any>(
 
     private val internalProducer: Flow<State<T>> = channelFlow {
         var currentValue = valueGuard.withLock {
+            Timber.tag(tag).v("Providing startValue...")
             startValueProvider().also {
-                Timber.tag(tag).v("startValue=%s", it)
-
+                Timber.tag(tag).v("...startValue provide, emitting...")
                 val initializer = Update<T>(onError = null, onModify = { it })
 
                 send(State(value = it, updatedBy = initializer))
             }
         }
-        Timber.tag(tag).v("startValue=%s", currentValue)
+        Timber.tag(tag).v("...startValue provided and emitted.")
 
         updateActions
             .onCompletion {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/flow/HotDataFlow.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/flow/HotDataFlow.kt
@@ -54,7 +54,7 @@ class HotDataFlow<T : Any>(
         var currentValue = valueGuard.withLock {
             Timber.tag(tag).v("Providing startValue...")
             startValueProvider().also {
-                Timber.tag(tag).v("...startValue provide, emitting...")
+                Timber.tag(tag).v("...startValue provided, emitting...")
                 val initializer = Update<T>(onError = null, onModify = { it })
 
                 send(State(value = it, updatedBy = initializer))


### PR DESCRIPTION
Not an issue we had, afaict, but the code is treacherous and should be adjusted (noticed while hunting #3549).

Prevent silent NOOPs, by throwing the action away without notice.
We are not checking return values in the app anywhere, and the updateAction queue size is `Int.MAX_VALUE`.
If we really run into `emit(...)` blocking as the queue is full, then just block.

