### PR TITLE
Keep CertLogic explicitly. (EXPOSUREAPP-8531)

### DIFF
--- a/Corona-Warn-App/proguard-rules.pro
+++ b/Corona-Warn-App/proguard-rules.pro
@@ -96,3 +96,7 @@
 ## json-schema-validator
 # Caused this error: https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8402
 -keep class com.networknt.schema.** { *; }
+
+# https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8531
+-keep class dgca.verifier.** { *; }
+-keep class eu.ehn.dcc.certlogic.** { *; }


### PR DESCRIPTION
Workaround for now, future work: Move this to upstream `consumer-rules.pro`
