### PR TITLE
Fix Wrong affected failed rules (EXPOSUREAPP-8522)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinationCertificate.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinationCertificate.kt
@@ -11,11 +11,15 @@ interface VaccinationCertificate : CwaCovidCertificate {
     val vaccinatedOn: LocalDate
     val vaccinatedOnFormatted: String
     val targetDisease: String
-    val vaccineTypeName: String
     val vaccineManufacturer: String
-    val medicalProductName: String
     val doseNumber: Int
     val totalSeriesOfDoses: Int
+
+    // To avoid further confusion:
+    // vp
+    val vaccineTypeName: String
+    // mp
+    val medicalProductName: String
 
     override val rawCertificate: VaccinationDccV1
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/storage/VaccinationContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/storage/VaccinationContainer.kt
@@ -100,11 +100,15 @@ data class VaccinationContainer internal constructor(
         override val totalSeriesOfDoses: Int
             get() = vaccination.totalSeriesOfDoses
 
+        // vp
         override val vaccineTypeName: String
             get() = valueSet?.getDisplayText(vaccination.vaccineId) ?: vaccination.vaccineId
+
         override val vaccineManufacturer: String
             get() = valueSet?.getDisplayText(vaccination.marketAuthorizationHolderId)
                 ?: vaccination.marketAuthorizationHolderId
+
+        // mp
         override val medicalProductName: String
             get() = valueSet?.getDisplayText(vaccination.medicalProductId) ?: vaccination.medicalProductId
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragment.kt
@@ -132,8 +132,8 @@ class VaccinationDetailsFragment : Fragment(R.layout.fragment_vaccination_detail
     ) {
         fullname.text = certificate.fullName
         dateOfBirth.text = certificate.dateOfBirthFormatted
-        medialProductName.text = certificate.medicalProductName
-        vaccineTypeName.text = certificate.vaccineTypeName
+        vaccineName.text = certificate.vaccineTypeName
+        medicalProductName.text = certificate.medicalProductName
         targetDisease.text = certificate.targetDisease
         vaccineManufacturer.text = certificate.vaccineManufacturer
         vaccinationNumber.text = getString(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/listitem/AffectedFieldsMapper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/listitem/AffectedFieldsMapper.kt
@@ -73,8 +73,8 @@ private fun certificateValue(field: String, certificate: CwaCovidCertificate): S
     return when (certificate) {
         is VaccinationCertificate -> when (field) {
             "v.0.tg" -> certificate.targetDisease
-            "v.0.vp" -> certificate.medicalProductName
-            "v.0.mp" -> certificate.vaccineTypeName
+            "v.0.vp" -> certificate.vaccineTypeName
+            "v.0.mp" -> certificate.medicalProductName
             "v.0.ma" -> certificate.vaccineManufacturer
             "v.0.dn" -> certificate.doseNumber.toString()
             "v.0.sd" -> certificate.totalSeriesOfDoses.toString()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/listitem/AffectedFieldsMapper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/listitem/AffectedFieldsMapper.kt
@@ -36,8 +36,8 @@ private val String.stringResource: Int
 
         // Test certificate
         "t.0.tt" -> R.string.rule_test_type
-        "t.0.nm",
-        "t.0.ma" -> R.string.rule_test_name
+        "t.0.nm" -> R.string.rule_test_name
+        "t.0.ma" -> R.string.rule_test_manufacturer
         "t.0.sc" -> R.string.rule_sample_collected_at
         "t.0.tr" -> R.string.rule_test_result
         "t.0.tc" -> R.string.rule_test_center
@@ -88,8 +88,8 @@ private fun certificateValue(field: String, certificate: CwaCovidCertificate): S
         is TestCertificate -> when (field) {
             "t.0.tg" -> certificate.targetName
             "t.0.tt" -> certificate.testType
-            "t.0.nm",
-            "t.0.ma" -> certificate.testName
+            "t.0.nm" -> certificate.testName
+            "t.0.ma" -> certificate.testNameAndManufacturer
             "t.0.sc" -> certificate.sampleCollectedAtFormatted
             "t.0.tr" -> certificate.testResult
             "t.0.tc" -> certificate.testCenter

--- a/Corona-Warn-App/src/main/res/layout/fragment_vaccination_details.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_vaccination_details.xml
@@ -186,7 +186,7 @@
                         android:text="@string/vaccination_certificate_attribute_vaccine_name" />
 
                     <TextView
-                        android:id="@+id/medial_product_name"
+                        android:id="@+id/vaccine_name"
                         style="@style/body1"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
@@ -201,7 +201,7 @@
                         android:text="@string/vaccination_certificate_attribute_vaccine_type" />
 
                     <TextView
-                        android:id="@+id/vaccine_type_name"
+                        android:id="@+id/medical_product_name"
                         style="@style/body1"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"

--- a/Corona-Warn-App/src/main/res/values/covid_certificate_attribute_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/covid_certificate_attribute_strings.xml
@@ -103,6 +103,8 @@
     <string name="rule_test_type" translatable="false">"Art des Tests / Type of Test"</string>
     <!-- XTXT: Rule / Test Name -->
     <string name="rule_test_name" translatable="false">"Produktname / Test Name"</string>
+    <!-- XTXT: Rule / Test Name -->
+    <string name="rule_test_manufacturer" translatable="false">"Testhersteller / Test Manufacturer"</string>
     <!-- XTXT: Rule / Date and Time of Sample Collection (YYYY-MM-DD hh:mm Z) -->
     <string name="rule_sample_collected_at" translatable="false">"Datum und Uhrzeit der Probenahme / Date and Time of Sample Collection (YYYY-MM-DD hh:mm Z)"</string>
     <!-- XTXT: Rule / Test Result -->


### PR DESCRIPTION
This PR addresses Exposureapp-8522.
It cleans up some vp, mp confusion within failed DCC business rules.

For Testing:
- Check validity for travel to Germany
- Rule fails as expected
(QR codes can be found within the ticket)

Screenshots(now):
![image](https://user-images.githubusercontent.com/46747780/126628494-9e1cf3ec-fe0c-4169-b6ce-81957d2c3639.png)
