### PR TITLE
Follow up: Local Statistics Unittests (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/local/storage/SelectedStatisticsLocation.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/local/storage/SelectedStatisticsLocation.kt
@@ -11,12 +11,16 @@ sealed class SelectedStatisticsLocation {
     data class SelectedDistrict(
         val district: Districts.District,
         override val addedAt: Instant,
-        override val uniqueID: Long = 1000000L + district.districtId,
-    ) : SelectedStatisticsLocation()
+    ) : SelectedStatisticsLocation() {
+        override val uniqueID: Long
+            get() = 1000000L + district.districtId
+    }
 
     data class SelectedFederalState(
         val federalState: PpaData.PPAFederalState,
         override val addedAt: Instant,
-        override val uniqueID: Long = 2000000L + federalState.number
-    ) : SelectedStatisticsLocation()
+    ) : SelectedStatisticsLocation() {
+        override val uniqueID: Long
+            get() = 2000000L + federalState.number
+    }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/statistics/local/storage/LocalStatisticsConfigStorageTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/statistics/local/storage/LocalStatisticsConfigStorageTest.kt
@@ -82,6 +82,10 @@ class LocalStatisticsConfigStorageTest : BaseTest() {
 
     companion object {
         const val EXPECTED_JSON =
-            "{\"locations\":[{\"type\":\"SelectedDistrict\",\"district\":{\"districtName\":\"Hogwarts\",\"districtShortName\":\"HG\",\"districtId\":1,\"federalStateName\":\"Scotland\",\"federalStateShortName\":\"SL\",\"federalStateId\":1},\"addedAt\":{\"iMillis\":6969420000}},{\"type\":\"SelectedFederalState\",\"federalState\":\"FEDERAL_STATE_BB\",\"addedAt\":{\"iMillis\":4206969000}}]}"
+            "{\"locations\":[{\"type\":\"SelectedDistrict\",\"district\":{\"districtName\":\"Hogwarts\"," +
+                "\"districtShortName\":\"HG\",\"districtId\":1,\"federalStateName\":\"Scotland\"," +
+                "\"federalStateShortName\":\"SL\",\"federalStateId\":1},\"addedAt\":{\"iMillis\":6969420000}}," +
+                "{\"type\":\"SelectedFederalState\",\"federalState\":\"FEDERAL_STATE_BB\"," +
+                "\"addedAt\":{\"iMillis\":4206969000}}]}"
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/statistics/local/storage/LocalStatisticsConfigStorageTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/statistics/local/storage/LocalStatisticsConfigStorageTest.kt
@@ -1,0 +1,87 @@
+package de.rki.coronawarnapp.statistics.local.storage
+
+import com.google.gson.GsonBuilder
+import de.rki.coronawarnapp.datadonation.analytics.common.Districts
+import de.rki.coronawarnapp.server.protocols.internal.ppdd.PpaData
+import de.rki.coronawarnapp.util.serialization.adapter.RuntimeTypeAdapterFactory
+import de.rki.coronawarnapp.util.serialization.fromJson
+import io.kotest.matchers.shouldBe
+import org.joda.time.Instant
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class LocalStatisticsConfigStorageTest : BaseTest() {
+
+    private val gson by lazy {
+        GsonBuilder()
+            .registerTypeAdapterFactory(
+                RuntimeTypeAdapterFactory.of(SelectedStatisticsLocation::class.java)
+                    .registerSubtype(SelectedStatisticsLocation.SelectedDistrict::class.java)
+                    .registerSubtype(SelectedStatisticsLocation.SelectedFederalState::class.java)
+            )
+            .create()
+    }
+
+    @Test
+    fun `SelectedStatisticsLocation serialization works`() {
+        val locations = SelectedLocations()
+            .withLocation(
+                SelectedStatisticsLocation.SelectedDistrict(
+                    Districts.District(
+                        "Hogwarts",
+                        "HG",
+                        1,
+                        "Scotland",
+                        "SL",
+                        1
+                    ),
+                    Instant.ofEpochSecond(6969420)
+                )
+            )
+            .withLocation(
+                SelectedStatisticsLocation.SelectedFederalState(
+                    PpaData.PPAFederalState.FEDERAL_STATE_BB,
+                    Instant.ofEpochSecond(4206969)
+                )
+            )
+
+        val json = gson.toJson(locations)
+
+        json shouldBe EXPECTED_JSON
+    }
+
+    @Test
+    fun `SelectedStatisticsLocation can be serialized and deserialized`() {
+        val initialLocations = SelectedLocations()
+            .withLocation(
+                SelectedStatisticsLocation.SelectedDistrict(
+                    Districts.District(
+                        "Hogwarts",
+                        "HG",
+                        1,
+                        "Scotland",
+                        "SL",
+                        1
+                    ),
+                    Instant.ofEpochSecond(6969420)
+                )
+            )
+            .withLocation(
+                SelectedStatisticsLocation.SelectedFederalState(
+                    PpaData.PPAFederalState.FEDERAL_STATE_BB,
+                    Instant.ofEpochSecond(4206969)
+                )
+            )
+
+        val json = gson.toJson(initialLocations)
+
+        val resultLocations = gson.fromJson<SelectedLocations>(json)
+
+        initialLocations shouldBe resultLocations
+    }
+
+    companion object {
+        const val EXPECTED_JSON =
+            "{\"locations\":[{\"type\":\"SelectedDistrict\",\"district\":{\"districtName\":\"Hogwarts\",\"districtShortName\":\"HG\",\"districtId\":1,\"federalStateName\":\"Scotland\",\"federalStateShortName\":\"SL\",\"federalStateId\":1},\"addedAt\":{\"iMillis\":6969420000}},{\"type\":\"SelectedFederalState\",\"federalState\":\"FEDERAL_STATE_BB\",\"addedAt\":{\"iMillis\":4206969000}}]}"
+    }
+}

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/statistics/local/storage/LocalStatisticsConfigStorageTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/statistics/local/storage/LocalStatisticsConfigStorageTest.kt
@@ -1,91 +1,136 @@
 package de.rki.coronawarnapp.statistics.local.storage
 
-import com.google.gson.GsonBuilder
+import android.content.Context
+import androidx.core.content.edit
 import de.rki.coronawarnapp.datadonation.analytics.common.Districts
 import de.rki.coronawarnapp.server.protocols.internal.ppdd.PpaData
-import de.rki.coronawarnapp.util.serialization.adapter.RuntimeTypeAdapterFactory
-import de.rki.coronawarnapp.util.serialization.fromJson
+import de.rki.coronawarnapp.util.serialization.SerializationModule
 import io.kotest.matchers.shouldBe
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
 import org.joda.time.Instant
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import testhelpers.extensions.toComparableJsonPretty
+import testhelpers.preferences.MockSharedPreferences
 
 class LocalStatisticsConfigStorageTest : BaseTest() {
+    @MockK lateinit var context: Context
+    private lateinit var mockPreferences: MockSharedPreferences
 
-    private val gson by lazy {
-        GsonBuilder()
-            .registerTypeAdapterFactory(
-                RuntimeTypeAdapterFactory.of(SelectedStatisticsLocation::class.java)
-                    .registerSubtype(SelectedStatisticsLocation.SelectedDistrict::class.java)
-                    .registerSubtype(SelectedStatisticsLocation.SelectedFederalState::class.java)
+    private val locations = SelectedLocations()
+        .withLocation(
+            SelectedStatisticsLocation.SelectedDistrict(
+                Districts.District(
+                    "Hogwarts",
+                    "HG",
+                    1,
+                    "Scotland",
+                    "SL",
+                    1
+                ),
+                Instant.ofEpochSecond(6969420)
             )
-            .create()
+        )
+        .withLocation(
+            SelectedStatisticsLocation.SelectedFederalState(
+                PpaData.PPAFederalState.FEDERAL_STATE_BB,
+                Instant.ofEpochSecond(4206969)
+            )
+        )
+
+    private val outdatedJSON = """
+            {
+              "locations": [
+                {
+                  "type": "SelectedDistrict",
+                  "district": {
+                    "districtName": "Hogwarts",
+                    "districtShortName": "HG",
+                    "districtId": 1,
+                    "federalStateName": "Scotland",
+                    "federalStateShortName": "SL",
+                    "federalStateId": 1
+                  },
+                  "uniqueID": 1000001,
+                  "addedAt": 6969420000
+                },
+                {
+                  "type": "SelectedFederalState",
+                  "federalState": "FEDERAL_STATE_BB",
+                  "uniqueID": 2000004,
+                  "addedAt": 4206969000
+                }
+              ]
+            }
+        """.toComparableJsonPretty()
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this)
+
+        mockPreferences = MockSharedPreferences()
+
+        every {
+            context.getSharedPreferences(
+                "statistics_local_config",
+                Context.MODE_PRIVATE
+            )
+        } returns mockPreferences
+    }
+
+    private fun createInstance() = LocalStatisticsConfigStorage(
+        context = context,
+        baseGson = SerializationModule().baseGson()
+    )
+
+    @Test
+    fun `storing two selections works`() {
+        val instance = createInstance()
+
+        instance.activeSelections.update {
+            locations
+        }
+
+        val json = (mockPreferences.dataMapPeek["statistics.local.selections"] as String)
+
+        json.toComparableJsonPretty() shouldBe """
+            {
+              "locations": [
+                {
+                  "type": "SelectedDistrict",
+                  "district": {
+                    "districtName": "Hogwarts",
+                    "districtShortName": "HG",
+                    "districtId": 1,
+                    "federalStateName": "Scotland",
+                    "federalStateShortName": "SL",
+                    "federalStateId": 1
+                  },
+                  "addedAt": 6969420000
+                },
+                {
+                  "type": "SelectedFederalState",
+                  "federalState": "FEDERAL_STATE_BB",
+                  "addedAt": 4206969000
+                }
+              ]
+            }
+        """.toComparableJsonPretty()
+
+        instance.activeSelections.value shouldBe locations
     }
 
     @Test
-    fun `SelectedStatisticsLocation serialization works`() {
-        val locations = SelectedLocations()
-            .withLocation(
-                SelectedStatisticsLocation.SelectedDistrict(
-                    Districts.District(
-                        "Hogwarts",
-                        "HG",
-                        1,
-                        "Scotland",
-                        "SL",
-                        1
-                    ),
-                    Instant.ofEpochSecond(6969420)
-                )
-            )
-            .withLocation(
-                SelectedStatisticsLocation.SelectedFederalState(
-                    PpaData.PPAFederalState.FEDERAL_STATE_BB,
-                    Instant.ofEpochSecond(4206969)
-                )
-            )
+    fun `old location format is also parsable`() {
+        val instance = createInstance()
 
-        val json = gson.toJson(locations)
+        mockPreferences.edit {
+            putString("statistics.local.selections", outdatedJSON)
+        }
 
-        json shouldBe EXPECTED_JSON
-    }
-
-    @Test
-    fun `SelectedStatisticsLocation can be serialized and deserialized`() {
-        val initialLocations = SelectedLocations()
-            .withLocation(
-                SelectedStatisticsLocation.SelectedDistrict(
-                    Districts.District(
-                        "Hogwarts",
-                        "HG",
-                        1,
-                        "Scotland",
-                        "SL",
-                        1
-                    ),
-                    Instant.ofEpochSecond(6969420)
-                )
-            )
-            .withLocation(
-                SelectedStatisticsLocation.SelectedFederalState(
-                    PpaData.PPAFederalState.FEDERAL_STATE_BB,
-                    Instant.ofEpochSecond(4206969)
-                )
-            )
-
-        val json = gson.toJson(initialLocations)
-
-        val resultLocations = gson.fromJson<SelectedLocations>(json)
-
-        initialLocations shouldBe resultLocations
-    }
-
-    companion object {
-        const val EXPECTED_JSON =
-            "{\"locations\":[{\"type\":\"SelectedDistrict\",\"district\":{\"districtName\":\"Hogwarts\"," +
-                "\"districtShortName\":\"HG\",\"districtId\":1,\"federalStateName\":\"Scotland\"," +
-                "\"federalStateShortName\":\"SL\",\"federalStateId\":1},\"addedAt\":{\"iMillis\":6969420000}}," +
-                "{\"type\":\"SelectedFederalState\",\"federalState\":\"FEDERAL_STATE_BB\"," +
-                "\"addedAt\":{\"iMillis\":4206969000}}]}"
+        instance.activeSelections.value shouldBe locations
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/statistics/local/storage/SelectedLocationsTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/statistics/local/storage/SelectedLocationsTest.kt
@@ -1,0 +1,109 @@
+package de.rki.coronawarnapp.statistics.local.storage
+
+import de.rki.coronawarnapp.datadonation.analytics.common.Districts
+import de.rki.coronawarnapp.server.protocols.internal.ppdd.PpaData
+import de.rki.coronawarnapp.util.serialization.SerializationModule
+import de.rki.coronawarnapp.util.serialization.adapter.RuntimeTypeAdapterFactory
+import de.rki.coronawarnapp.util.serialization.fromJson
+import io.kotest.matchers.shouldBe
+import org.joda.time.Instant
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.extensions.toComparableJsonPretty
+
+class SelectedLocationsTest : BaseTest() {
+    private val baseGson = SerializationModule().baseGson()
+
+    private val gson by lazy {
+        baseGson
+            .newBuilder()
+            .registerTypeAdapterFactory(
+                RuntimeTypeAdapterFactory.of(SelectedStatisticsLocation::class.java)
+                    .registerSubtype(SelectedStatisticsLocation.SelectedDistrict::class.java)
+                    .registerSubtype(SelectedStatisticsLocation.SelectedFederalState::class.java)
+            )
+            .create()
+    }
+
+    private val expectedJson = """
+            {
+              "locations": [
+                {
+                  "type": "SelectedDistrict",
+                  "district": {
+                    "districtName": "Hogwarts",
+                    "districtShortName": "HG",
+                    "districtId": 1,
+                    "federalStateName": "Scotland",
+                    "federalStateShortName": "SL",
+                    "federalStateId": 1
+                  },
+                  "addedAt": 6969420000
+                },
+                {
+                  "type": "SelectedFederalState",
+                  "federalState": "FEDERAL_STATE_BB",
+                  "addedAt": 4206969000
+                }
+              ]
+            }
+        """.toComparableJsonPretty()
+
+    @Test
+    fun `SelectedStatisticsLocation serialization works`() {
+        val locations = SelectedLocations()
+            .withLocation(
+                SelectedStatisticsLocation.SelectedDistrict(
+                    Districts.District(
+                        "Hogwarts",
+                        "HG",
+                        1,
+                        "Scotland",
+                        "SL",
+                        1
+                    ),
+                    Instant.ofEpochSecond(6969420)
+                )
+            )
+            .withLocation(
+                SelectedStatisticsLocation.SelectedFederalState(
+                    PpaData.PPAFederalState.FEDERAL_STATE_BB,
+                    Instant.ofEpochSecond(4206969)
+                )
+            )
+
+        val json = gson.toJson(locations).toComparableJsonPretty()
+
+        json shouldBe expectedJson
+    }
+
+    @Test
+    fun `SelectedStatisticsLocation can be serialized and deserialized`() {
+        val initialLocations = SelectedLocations()
+            .withLocation(
+                SelectedStatisticsLocation.SelectedDistrict(
+                    Districts.District(
+                        "Hogwarts",
+                        "HG",
+                        1,
+                        "Scotland",
+                        "SL",
+                        1
+                    ),
+                    Instant.ofEpochSecond(6969420)
+                )
+            )
+            .withLocation(
+                SelectedStatisticsLocation.SelectedFederalState(
+                    PpaData.PPAFederalState.FEDERAL_STATE_BB,
+                    Instant.ofEpochSecond(4206969)
+                )
+            )
+
+        val json = gson.toJson(initialLocations)
+
+        val resultLocations = gson.fromJson<SelectedLocations>(json)
+
+        initialLocations shouldBe resultLocations
+    }
+}


### PR DESCRIPTION
### Description
This PR adds a few unittests to the local statistics serialization code and also reduces the size of the serialized json data by removing the uniqueID from the serialized package