### PR TITLE
Reflect language updates to app shortcut label (EXPOSUREAPP-8391)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/shortcuts/AppShortcutsHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/shortcuts/AppShortcutsHelper.kt
@@ -18,15 +18,17 @@ import javax.inject.Singleton
 class AppShortcutsHelper @Inject constructor(@AppContext private val context: Context) {
 
     suspend fun restoreAppShortcut() = withContext(Dispatchers.IO) {
-        if (ShortcutManagerCompat.getDynamicShortcuts(context).size == 0) {
-            val shortcut = ShortcutInfoCompat.Builder(context, CONTACT_DIARY_SHORTCUT_ID)
-                .setShortLabel(context.getString(R.string.app_shortcut_contact_diary_title))
-                .setLongLabel(context.getString(R.string.app_shortcut_contact_diary_title))
-                .setIcon(IconCompat.createWithResource(context, R.drawable.ic_contact_diary_shortcut_icon))
-                .setIntent(createContactDiaryIntent())
-                .build()
+        val shortcut = ShortcutInfoCompat.Builder(context, CONTACT_DIARY_SHORTCUT_ID)
+            .setShortLabel(context.getString(R.string.app_shortcut_contact_diary_title))
+            .setLongLabel(context.getString(R.string.app_shortcut_contact_diary_title))
+            .setIcon(IconCompat.createWithResource(context, R.drawable.ic_contact_diary_shortcut_icon))
+            .setIntent(createContactDiaryIntent())
+            .build()
 
+        if (ShortcutManagerCompat.getDynamicShortcuts(context).size == 0) {
             ShortcutManagerCompat.addDynamicShortcuts(context, listOf(shortcut))
+        } else {
+            ShortcutManagerCompat.updateShortcuts(context, listOf(shortcut))
         }
     }
 


### PR DESCRIPTION
Addresses [EXPOSUREAPP-8391](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8391) / #3685 

Update app shortcuts on every launch to reflect language changes.
The label of the shortcut does not change immediately after changing the device language. The app has to be started once to get the shortcut updated.

---
Internal Tracking ID: [EXPOSUREAPP-8391](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8391)