### PR TITLE
DGC Ausstellungslands country adjusted (EXPOSUREAPP-8460)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/ValidationResultItemCreator.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/ValidationResultItemCreator.kt
@@ -43,7 +43,7 @@ class ValidationResultItemCreator @Inject constructor() {
         }
 
         val ruleDescription = rule.getRuleDescription().toLazyString()
-        val countryInformation = rule.getCountryDescription(certificate)
+        val countryInformation = rule.getCountryDescription()
 
         val affectedFields = mapAffectedFields(rule.affectedFields, certificate)
 
@@ -135,12 +135,10 @@ class ValidationResultItemCreator @Inject constructor() {
     }
 
     // Apply rules from tech spec to decide which rule description to display
-    private fun DccValidationRule.getCountryDescription(certificate: CwaCovidCertificate): LazyString = when (typeDcc) {
+    private fun DccValidationRule.getCountryDescription(): LazyString = when (typeDcc) {
         DccValidationRule.Type.ACCEPTANCE -> R.string.validation_rules_acceptance_country.toResolvingString(
             DccCountry(country).displayName()
         )
-        DccValidationRule.Type.INVALIDATION -> R.string.validation_rules_invalidation_country.toResolvingString(
-            certificate.certificateCountry
-        )
+        DccValidationRule.Type.INVALIDATION -> R.string.validation_rules_invalidation_country.toResolvingString()
     }
 }

--- a/Corona-Warn-App/src/main/res/values-bg/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-bg/covid_certificate_strings.xml
@@ -256,6 +256,6 @@
     <!-- XHED: travel country for the validation failed card  -->
     <string name="validation_rules_acceptance_country">"Това е правило в държавата, където отивате: %s."</string>
     <!-- XHED: issuer country for the validation failed card  -->
-    <string name="validation_rules_invalidation_country">"Това е правило в държавата, където е издаден сертификатът: %s."</string>
+    <string name="validation_rules_invalidation_country">"Това е правило в държавата, където е издаден сертификатът."</string>
 
 </resources>

--- a/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
@@ -257,7 +257,7 @@
     <!-- XHED: travel country for the validation failed card  -->
     <string name="validation_rules_acceptance_country">"Dies ist eine Regel des Reiselandes %s."</string>
     <!-- XHED: issuer country for the validation failed card  -->
-    <string name="validation_rules_invalidation_country">"Dies ist eine Regel des Ausstellerlandes %s."</string>
+    <string name="validation_rules_invalidation_country">"Dies ist eine Regel des Ausstellerlandes."</string>
 
 
     <!-- XHED: Vaccination Detail expiration Date title -->

--- a/Corona-Warn-App/src/main/res/values-pl/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-pl/covid_certificate_strings.xml
@@ -256,6 +256,6 @@
     <!-- XHED: travel country for the validation failed card  -->
     <string name="validation_rules_acceptance_country">"To jest zasada obowiązująca w kraju docelowym, %s."</string>
     <!-- XHED: issuer country for the validation failed card  -->
-    <string name="validation_rules_invalidation_country">"To jest zasada obowiązująca w kraju wydającym, %s."</string>
+    <string name="validation_rules_invalidation_country">"To jest zasada obowiązująca w kraju wydającym."</string>
 
 </resources>

--- a/Corona-Warn-App/src/main/res/values-ro/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-ro/covid_certificate_strings.xml
@@ -256,6 +256,6 @@
     <!-- XHED: travel country for the validation failed card  -->
     <string name="validation_rules_acceptance_country">"Aceasta este o regulă pentru țara dvs. de destinație, %s."</string>
     <!-- XHED: issuer country for the validation failed card  -->
-    <string name="validation_rules_invalidation_country">"Aceasta este o regulă a țării emitente, %s."</string>
+    <string name="validation_rules_invalidation_country">"Aceasta este o regulă a țării emitente."</string>
 
 </resources>

--- a/Corona-Warn-App/src/main/res/values-tr/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-tr/covid_certificate_strings.xml
@@ -256,6 +256,6 @@
     <!-- XHED: travel country for the validation failed card  -->
     <string name="validation_rules_acceptance_country">"Bu, gideceğiniz ülke olan %s için geçerli bir kural."</string>
     <!-- XHED: issuer country for the validation failed card  -->
-    <string name="validation_rules_invalidation_country">"Bu, düzenleyen ülke olan %s için geçerli bir kural."</string>
+    <string name="validation_rules_invalidation_country">"Bu, düzenleyen ülke olan için geçerli bir kural."</string>
 
 </resources>

--- a/Corona-Warn-App/src/main/res/values/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/covid_certificate_strings.xml
@@ -256,7 +256,7 @@
     <!-- XHED: travel country for the validation failed card  -->
     <string name="validation_rules_acceptance_country">"This is a rule of your destination country, %s."</string>
     <!-- XHED: issuer country for the validation failed card  -->
-    <string name="validation_rules_invalidation_country">"This is a rule of the issuing country, %s."</string>
+    <string name="validation_rules_invalidation_country">"This is a rule of the issuing country."</string>
 
     <!-- XHED: Vaccination Detail expiration Date title -->
     <string name="expiration_date_title">Technisches Ablaufdatum</string>


### PR DESCRIPTION
This PR addresses Exposureapp-8460.
It simply removed the country params for Ausstellungsland (not required regarding Figma).

QR Code can be found inside the ticket