### PR TITLE
Fix certficate status last day expiration (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/signature/core/DccStateChecker.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/signature/core/DccStateChecker.kt
@@ -45,7 +45,7 @@ internal fun DccData<*>.getExpirationState(
     val daysUntilExpiration = now.daysUntil(expiresAt, timeZone)
     val diff = daysUntilExpiration - expirationThresholdInDays
     return when {
-        daysUntilExpiration <= 0 -> CwaCovidCertificate.State.Expired(expiresAt)
+        daysUntilExpiration < 0 -> CwaCovidCertificate.State.Expired(expiresAt)
         diff > 0 -> CwaCovidCertificate.State.Valid(expiresAt)
         diff <= 0 -> CwaCovidCertificate.State.ExpiringSoon(expiresAt)
         else -> throw IllegalArgumentException() // impossible!

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/signature/core/DccStateCheckerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/signature/core/DccStateCheckerTest.kt
@@ -30,7 +30,7 @@ class DccStateCheckerTest : BaseTest() {
             expirationThresholdInDays = 10,
             now = Instant.parse("2021-06-03T10:12:48.000+02:00"),
             timeZone = DateTimeZone.forOffsetHours(2)
-        ) shouldBe CwaCovidCertificate.State.Expired(exp)
+        ) shouldBe CwaCovidCertificate.State.ExpiringSoon(exp)
 
         dccData.getExpirationState(
             expirationThresholdInDays = 10,


### PR DESCRIPTION
In an edge case where the current date would be the same as the expiration date of the certificate, the status would be set to "Expired" even though the certificate should still be valid on that day as well. This small change sets the status to "ExpiringSoon". 