### PR TITLE
Fix dcc attributes (EXPOSUREAPP-8522)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/listitem/AffectedFieldsMapper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/listitem/AffectedFieldsMapper.kt
@@ -26,8 +26,8 @@ fun mapAffectedFields(affectedFields: List<String>, certificate: CwaCovidCertifi
 private val String.stringResource: Int
     get() = when (this) {
         // Vaccination certificate
-        "v.0.vp" -> R.string.rule_vaccine
-        "v.0.mp" -> R.string.rule_vaccine_type
+        "v.0.vp" -> R.string.rule_vaccine_type
+        "v.0.mp" -> R.string.rule_vaccine
         "v.0.ma" -> R.string.rule_vaccine_manufacturer
         "v.0.dn" -> R.string.rule_vaccination_number
         "v.0.sd" -> R.string.rule_vaccination_total_number


### PR DESCRIPTION
This PR addresses Exposureapp-8522.
MetaData mix up.

See:
https://github.com/corona-warn-app/cwa-app-tech-spec/pull/70/commits/83ec5fd36f606244e1a05670a44389429dd0166e
