### PR TITLE
Align label and icon of 'add certificate' button to spec (EXPOSUREAPP-8530)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/person_overview_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/person_overview_fragment.xml
@@ -78,7 +78,7 @@
         android:layout_margin="@dimen/spacing_normal"
         android:text="@string/person_overview_scan_button"
         android:transitionName="shared_element_container"
-        app:icon="@drawable/ic_add"
+        app:icon="@drawable/ic_qr_code"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 

--- a/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
@@ -18,7 +18,7 @@
     <!-- XTXT: Person overview no certificates subtitle 2-->
     <string name="person_overview_no_certificates_subtitle_2">Um ein Zertifikat hinzuzufügen, scannen Sie bitte den dazugehörigen QR-Code.</string>
     <!-- XBUT: Person overview certificates scan button-->
-    <string name="person_overview_scan_button">Zertifikat</string>
+    <string name="person_overview_scan_button">Zertifikat hinzufügen</string>
     <!-- XTXT: Person overview no certificates image content description-->
     <string name="person_overview_no_certificates_image_description">A certificate with a QR code symbol on it.</string>
     <!-- XTXT: Person card title-->

--- a/Corona-Warn-App/src/main/res/values/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/covid_certificate_strings.xml
@@ -17,7 +17,7 @@
     <!-- XTXT: Person overview no certificates subtitle 2-->
     <string name="person_overview_no_certificates_subtitle_2">"To add a certificate, please scan the corresponding QR code."</string>
     <!-- XBUT: Person overview certificates scan button-->
-    <string name="person_overview_scan_button">"Certificate"</string>
+    <string name="person_overview_scan_button">"Add Certificate"</string>
     <!-- XTXT: Person overview no certificates image content description-->
     <string name="person_overview_no_certificates_image_description">"A certificate with a QR code symbol on it."</string>
     <!-- XTXT: Person card title-->


### PR DESCRIPTION
Addresses [EXPOSUREAPP-8530](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8530).

Not sure if the old behaviour was intended due to small device sizes ... If so, feel free to close the pr and please set the Jira issue to obsolute.