### PR TITLE
Fix check-in time label (EXPOSUREAPP-6440)

### DIFF
--- a/Corona-Warn-App/src/main/res/values-de/event_registration_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/event_registration_strings.xml
@@ -201,7 +201,7 @@
     <!-- XTXT: Event organizer detail qr-code: duration with multiple date -->
     <string name="trace_location_organizer_detail_item_duration_multiple_days">"%1$s, %2$s - %3$s, %4$s Uhr"</string>
     <!-- XTXT: Past Event Info duration -->
-    <string name="trace_location_attendee_past_event_duration">"%1$s"</string>
+    <string name="trace_location_attendee_past_event_duration">"%1$s Uhr"</string>
 
     <!-- XBUT: Event organiser list item: menu: information button  -->
     <string name="trace_location_organizer_list_item_menu_duplicate_btn">"Duplizieren"</string>


### PR DESCRIPTION
Addresses [EXPOSUREAPP-6440](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-6440).

This change was already applied by [this pr](https://github.com/corona-warn-app/cwa-app-android/pull/3243), but reverted (presumably unintentionally) by [this pr](https://github.com/corona-warn-app/cwa-app-android/pull/3364).