### PR TITLE
Remove duplicate ok button string and move FAQ link to neutral action (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/scan/DccQrCodeScanFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/scan/DccQrCodeScanFragment.kt
@@ -105,10 +105,9 @@ class DccQrCodeScanFragment :
 
                         it.isSignatureInvalid -> {
                             setTitle(R.string.dcc_signature_validation_dialog_title)
-                            setPositiveButton(R.string.dcc_signature_validation_dialog_faq_button) { _, _ ->
+                            setNeutralButton(R.string.dcc_signature_validation_dialog_faq_button) { _, _ ->
                                 openUrl(R.string.dcc_signature_validation_dialog_faq_link)
                             }
-                            setNeutralButton(R.string.dcc_signature_validation_dialog_ok_button) { _, _ -> }
                         }
                     }
                 }

--- a/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
@@ -280,6 +280,5 @@
     <string name="dcc_signature_validation_dialog_faq_button">FAQ zur Signaturprüfung</string>
     <!-- XTXT: Signature validation dialog FAQ lint-->
     <string name="dcc_signature_validation_dialog_faq_link">https://www.coronawarn.app/de/faq/#hc_signature_invalid</string>
-    <!-- XBUT: Signature validation dialog OK button-->
-    <string name="dcc_signature_validation_dialog_ok_button">OK</string>
+
 </resources>

--- a/Corona-Warn-App/src/main/res/values/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/covid_certificate_strings.xml
@@ -280,7 +280,5 @@
     <string name="dcc_signature_validation_dialog_faq_button">FAQ zur Signaturprüfung</string>
     <!-- XTXT: Signature validation dialog FAQ lint-->
     <string name="dcc_signature_validation_dialog_faq_link">https://www.coronawarn.app/en/faq/#hc_signature_invalid</string>
-    <!-- XBUT: Signature validation dialog OK button-->
-    <string name="dcc_signature_validation_dialog_ok_button">OK</string>
 
 </resources>


### PR DESCRIPTION
* The default button label is already `OK`
* In other error dialogs, the FAQ is always the neutral action, the user expects the dismissive "OK" action to be in the same place, align for consistency.