### PR TITLE
Fix ripple effect of (i) button on Validity of Certificate screen (COMMUNITY)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/validation_start_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/validation_start_fragment.xml
@@ -130,7 +130,7 @@
                 android:layout_height="20dp"
                 android:layout_marginTop="8dp"
                 android:layout_marginEnd="32dp"
-                android:background="@drawable/circle_ripple"
+                android:background="?android:attr/selectableItemBackgroundBorderless"
                 android:contentDescription="@string/statistics_info_button"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/date_layout"


### PR DESCRIPTION
The ripple effect for the (i) button on the Validity of Certificate screen is too small.

The reason is that a custom ripple drawable (`@drawable/circle_ripple`) is used. This drawable was introduced in https://github.com/corona-warn-app/cwa-app-android/pull/2138 for the reason that there, the bounds of the view are also the outer bounds of the ripple effect, i.e. the ripple should have a circular shape and be completely within the rectangle.

Here, the case is different: the rectangular (i) view (which has no padding) must be completely within the circular ripple. The `?android:attr/selectableItemBackgroundBorderless` resource provides that.

Note: in my view, unless I am missing a key point, the `?android:attr/selectableItemBackgroundBorderless` resource is to be preferred over the `@drawable/circle_ripple` resource because the former has a fade-out effect after releasing the button whereas the latter does not.

Previous | After
---|---
![Screenshot_1627548743](https://user-images.githubusercontent.com/16943720/127462500-7779af6d-86e3-4d65-a13e-97173309d685.png) | ![Screenshot_1627548699](https://user-images.githubusercontent.com/16943720/127462502-5701552b-7cba-4cf2-aecf-595cb23d5efd.png)
