### PR TITLE
Upgrade Kotlin/ AGP versions (DEV)

### DIFF
--- a/Corona-Warn-App/build.gradle
+++ b/Corona-Warn-App/build.gradle
@@ -187,9 +187,6 @@ android {
 
     lintOptions {
         checkAllWarnings = true
-        // this rule is broken on 2.3.0
-        // see the following issue: https://issuetracker.google.com/issues/169249668
-        disable 'NullSafeMutableLiveData'
     }
 
     testOptions {
@@ -313,7 +310,7 @@ repositories {
 dependencies {
     // Comes from `local-maven-repo`
     // See https://github.com/corona-warn-app/dgc-certlogic-android
-    implementation ('dgca.verifier.app:dgc-certlogic-android-light:+')
+    implementation('dgca.verifier.app:dgc-certlogic-android-light:+')
 
     // Required for rdgca.verifier.app:dgc-certlogic-android-light API 26 Time API
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'

--- a/Corona-Warn-App/build.gradle
+++ b/Corona-Warn-App/build.gradle
@@ -188,6 +188,15 @@ android {
     lintOptions {
         lintConfig file('lint.xml')
         checkAllWarnings = true
+        disable "LogNotTimber",
+                "StringFormatInTimber",
+                "ThrowableNotAtBeginning",
+                "BinaryOperationInTimber",
+                "TimberArgCount",
+                "TimberArgTypes",
+                "TimberTagLength",
+                "TimberExceptionLogging"
+
     }
 
     testOptions {

--- a/Corona-Warn-App/build.gradle
+++ b/Corona-Warn-App/build.gradle
@@ -186,6 +186,7 @@ android {
     }
 
     lintOptions {
+        lintConfig file('lint.xml')
         checkAllWarnings = true
     }
 

--- a/Corona-Warn-App/build.gradle
+++ b/Corona-Warn-App/build.gradle
@@ -186,7 +186,6 @@ android {
     }
 
     lintOptions {
-        lintConfig file('lint.xml')
         checkAllWarnings = true
     }
 

--- a/Corona-Warn-App/build.gradle
+++ b/Corona-Warn-App/build.gradle
@@ -167,13 +167,13 @@ android {
     compileOptions {
         // Required for rdgca.verifier.app:dgc-certlogic-android-light API 26 Time API
         coreLibraryDesugaringEnabled true
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
         kotlinOptions {
-            jvmTarget = "1.8"
+            jvmTarget = "11"
 
             freeCompilerArgs += [
                     "-Xno-kotlin-nothing-value-exception",
@@ -188,7 +188,14 @@ android {
     lintOptions {
         lintConfig file('lint.xml')
         checkAllWarnings = true
-        disable "LogNotTimber",
+
+        // This rule is broken on 2.3.0
+        // See https://issuetracker.google.com/issues/169249668
+        disable "NullSafeMutableLiveData",
+
+                // Disable Timber lint rules.
+                // See https://github.com/JakeWharton/timber/issues/408
+                "LogNotTimber",
                 "StringFormatInTimber",
                 "ThrowableNotAtBeginning",
                 "BinaryOperationInTimber",
@@ -229,9 +236,7 @@ android {
         useBuildCache true
         includeCompileClasspath = false
     }
-    dexOptions {
-        preDexLibraries true
-    }
+
     packagingOptions {
         exclude "**/module-info.class"
         exclude 'NOTICE'

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.5.20'
+    ext.kotlin_version = '1.5.21'
     ext.protobufVersion = '0.8.12'
     ext.nav_version = "2.3.5"
 
@@ -13,7 +13,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.google.protobuf:protobuf-gradle-plugin:$protobufVersion"
         classpath "androidx.navigation:navigation-safe-args-gradle-plugin:$nav_version"

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ task clean(type: Delete) {
 }
 
 wrapper {
-    gradleVersion = "6.7.1"
+    gradleVersion = "7.0.2"
     distributionType = "all"
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip

--- a/lint.xml
+++ b/lint.xml
@@ -1,22 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lint>
-    <!-- this rule is broken on 2.3.0
-    see the following issue: https://issuetracker.google.com/issues/169249668 -->
-    <issue id="NullSafeMutableLiveData" severity="warning" />
-
-    <!-- Reduce severity level for Timber lint rules until the following issue is fixed
-     https://github.com/JakeWharton/timber/issues/408 -->
-    <issue id="LogNotTimber" severity="ignore" />
-    <issue id="StringFormatInTimber" severity="ignore" />
-    <issue id="ThrowableNotAtBeginning" severity="ignore" />
-    <issue id="BinaryOperationInTimber" severity="ignore" />
-    <issue id="TimberArgCount" severity="ignore" />
-    <issue id="TimberArgTypes" severity="ignore" />
-    <issue id="TimberTagLength" severity="ignore" />
-    <issue id="TimberExceptionLogging" severity="ignore" />
-
-    <!-- Ignore [InvalidPackage] lint error referenced
-    from org.bouncycastle.cert.dane.fetcher.JndiDANEFetcherFactory -->
+    <!-- Ignore [InvalidPackage] lint error referenced from org.bouncycastle -->
     <issue id="InvalidPackage" severity="ignore">
         <ignore path="**/org.bouncycastle/bcprov-jdk15on/*" />
     </issue>

--- a/lint.xml
+++ b/lint.xml
@@ -6,18 +6,18 @@
 
     <!-- Reduce severity level for Timber lint rules until the following issue is fixed
      https://github.com/JakeWharton/timber/issues/408 -->
-    <issue id="LogNotTimber" severity="warning" />
-    <issue id="StringFormatInTimber" severity="warning" />
-    <issue id="ThrowableNotAtBeginning" severity="warning" />
-    <issue id="BinaryOperationInTimber" severity="warning" />
-    <issue id="TimberArgCount" severity="warning" />
-    <issue id="TimberArgTypes" severity="warning" />
-    <issue id="TimberTagLength" severity="warning" />
-    <issue id="TimberExceptionLogging" severity="warning" />
+    <issue id="LogNotTimber" severity="ignore" />
+    <issue id="StringFormatInTimber" severity="ignore" />
+    <issue id="ThrowableNotAtBeginning" severity="ignore" />
+    <issue id="BinaryOperationInTimber" severity="ignore" />
+    <issue id="TimberArgCount" severity="ignore" />
+    <issue id="TimberArgTypes" severity="ignore" />
+    <issue id="TimberTagLength" severity="ignore" />
+    <issue id="TimberExceptionLogging" severity="ignore" />
 
     <!-- Ignore [InvalidPackage] lint error referenced
     from org.bouncycastle.cert.dane.fetcher.JndiDANEFetcherFactory -->
-    <issue id="InvalidPackage" severity="warning">
+    <issue id="InvalidPackage" severity="ignore">
         <ignore path="**/org.bouncycastle/bcprov-jdk15on/*" />
     </issue>
 </lint>

--- a/lint.xml
+++ b/lint.xml
@@ -6,18 +6,18 @@
 
     <!-- Reduce severity level for Timber lint rules until the following issue is fixed
      https://github.com/JakeWharton/timber/issues/408 -->
-    <issue id="LogNotTimber" severity="ignore" />
-    <issue id="StringFormatInTimber" severity="ignore" />
-    <issue id="ThrowableNotAtBeginning" severity="ignore" />
-    <issue id="BinaryOperationInTimber" severity="ignore" />
-    <issue id="TimberArgCount" severity="ignore" />
-    <issue id="TimberArgTypes" severity="ignore" />
-    <issue id="TimberTagLength" severity="ignore" />
-    <issue id="TimberExceptionLogging" severity="ignore" />
+    <issue id="LogNotTimber" severity="warning" />
+    <issue id="StringFormatInTimber" severity="warning" />
+    <issue id="ThrowableNotAtBeginning" severity="warning" />
+    <issue id="BinaryOperationInTimber" severity="warning" />
+    <issue id="TimberArgCount" severity="warning" />
+    <issue id="TimberArgTypes" severity="warning" />
+    <issue id="TimberTagLength" severity="warning" />
+    <issue id="TimberExceptionLogging" severity="warning" />
 
     <!-- Ignore [InvalidPackage] lint error referenced
     from org.bouncycastle.cert.dane.fetcher.JndiDANEFetcherFactory -->
-    <issue id="InvalidPackage" severity="ignore">
+    <issue id="InvalidPackage" severity="warning">
         <ignore path="**/org.bouncycastle/bcprov-jdk15on/*" />
     </issue>
 </lint>

--- a/lint.xml
+++ b/lint.xml
@@ -13,6 +13,7 @@
     <issue id="TimberArgCount" severity="ignore" />
     <issue id="TimberArgTypes" severity="ignore" />
     <issue id="TimberTagLength" severity="ignore" />
+    <issue id="TimberExceptionLogging" severity="ignore" />
 
     <!-- Ignore [InvalidPackage] lint error referenced
     from org.bouncycastle.cert.dane.fetcher.JndiDANEFetcherFactory -->

--- a/lint.xml
+++ b/lint.xml
@@ -6,13 +6,13 @@
 
     <!-- Reduce severity level for Timber lint rules until the following issue is fixed
      https://github.com/JakeWharton/timber/issues/408 -->
-    <issue id="LogNotTimber" severity="warning" />
-    <issue id="StringFormatInTimber" severity="warning" />
-    <issue id="ThrowableNotAtBeginning" severity="warning" />
-    <issue id="BinaryOperationInTimber" severity="warning" />
-    <issue id="TimberArgCount" severity="warning" />
-    <issue id="TimberArgTypes" severity="warning" />
-    <issue id="TimberTagLength" severity="warning" />
+    <issue id="LogNotTimber" severity="ignore" />
+    <issue id="StringFormatInTimber" severity="ignore" />
+    <issue id="ThrowableNotAtBeginning" severity="ignore" />
+    <issue id="BinaryOperationInTimber" severity="ignore" />
+    <issue id="TimberArgCount" severity="ignore" />
+    <issue id="TimberArgTypes" severity="ignore" />
+    <issue id="TimberTagLength" severity="ignore" />
 
     <!-- Ignore [InvalidPackage] lint error referenced
     from org.bouncycastle.cert.dane.fetcher.JndiDANEFetcherFactory -->

--- a/lint.xml
+++ b/lint.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <!-- this rule is broken on 2.3.0
+    see the following issue: https://issuetracker.google.com/issues/169249668 -->
+    <issue id="NullSafeMutableLiveData" severity="warning" />
+
+    <!-- Reduce severity level for Timber lint rules until the following issue is fixed
+     https://github.com/JakeWharton/timber/issues/408 -->
+    <issue id="LogNotTimber" severity="warning" />
+    <issue id="StringFormatInTimber" severity="warning" />
+    <issue id="ThrowableNotAtBeginning" severity="warning" />
+    <issue id="BinaryOperationInTimber" severity="warning" />
+    <issue id="TimberArgCount" severity="warning" />
+    <issue id="TimberArgTypes" severity="warning" />
+    <issue id="TimberTagLength" severity="warning" />
+
+    <!-- Ignore [InvalidPackage] lint error referenced
+    from org.bouncycastle.cert.dane.fetcher.JndiDANEFetcherFactory -->
+    <issue id="InvalidPackage" severity="ignore">
+        <ignore path="**/org.bouncycastle/bcprov-jdk15on/*" />
+    </issue>
+</lint>


### PR DESCRIPTION
- Kotlin v`1.5.21`
- AGP v`7.0.0`
- Remove `dexOptions` because it is deprecated and has no influence 
- Disable Timber lint rules because it is causing a lint error due to AGP 7.0.0
### Checks
- [x] build release 
