### PR TITLE
Fix installation date plural strings (EXPOSUREAPP-7278)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/details/items/periodlogged/PeriodLoggedBox.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/details/items/periodlogged/PeriodLoggedBox.kt
@@ -37,14 +37,21 @@ class PeriodLoggedBox(
         val tracingStatus: GeneralTracingStatus.Status
     ) : DetailsItem {
 
-        fun getInstallTimePeriodLogged(context: Context): String =
-            if (daysSinceInstallation < 14) {
-                context.getString(
-                    R.string.risk_details_information_body_period_logged_assessment_under_14_days
-                ).format(daysSinceInstallation)
-            } else context.getString(
-                R.string.risk_details_information_body_period_logged_assessment_over_14_days
+        fun getInstallTimePeriodLogged(context: Context): String = when (daysSinceInstallation) {
+            0 -> context.getString(
+                R.string.risk_details_information_body_period_logged_assessment_under_14_days,
+                context.getString(R.string.risk_details_information_body_period_logged_today)
             )
+            1 -> context.getString(
+                R.string.risk_details_information_body_period_logged_assessment_under_14_days,
+                context.getString(R.string.risk_details_information_body_period_logged_yesterday)
+            )
+            in 2..13 -> context.getString(
+                R.string.risk_details_information_body_period_logged_assessment_under_14_days,
+                context.getString(R.string.risk_details_information_body_period_logged_other, daysSinceInstallation)
+            )
+            else -> context.getString(R.string.risk_details_information_body_period_logged_assessment_over_14_days)
+        }
 
         override val stableId: Long
             get() = Item::class.java.name.hashCode().toLong()

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -292,7 +292,13 @@
     <!--    Dialog part 1-->
     <string name="risk_details_information_body_period_logged">"Die Berechnung des Infektionsrisikos kann nur für die Zeiträume erfolgen, an denen die Risiko-Ermittlung aktiv war. Die Risiko- Ermittlung sollte daher dauerhaft aktiv sein. Für Ihre Risiko-Ermittlung wird der Zeitraum der letzten 14 Tage betrachtet."</string>
     <!-- XTXT: risk details - infection period logged information body, under 14 days -->
-    <string name="risk_details_information_body_period_logged_assessment_under_14_days">"Die Corona-Warn-App ist seit %s Tagen installiert. Das Infektionsrisiko wird für Zeiträume berechnet, in denen die Risiko-Ermittlung aktiv ist. Wenn Sie andere Personen getroffen haben und die Risiko-Ermittlung aktiv war, wird Ihr Infektions-Risiko berechnet."</string>
+    <string name="risk_details_information_body_period_logged_assessment_under_14_days">"Die Corona-Warn-App ist seit %s installiert. Das Infektionsrisiko wird für Zeiträume berechnet, in denen die Risiko-Ermittlung aktiv ist. Wenn Sie andere Personen getroffen haben und die Risiko-Ermittlung aktiv war, wird Ihr Infektions-Risiko berechnet."</string>
+    <!-- XTXT: risk details - infection period logged 0 days -->
+    <string name="risk_details_information_body_period_logged_today">"heute"</string>
+    <!-- XTXT: risk details - infection period logged 1 day -->
+    <string name="risk_details_information_body_period_logged_yesterday">"gestern"</string>
+    <!-- XTXT: risk details - infection period logged >=2 days -->
+    <string name="risk_details_information_body_period_logged_other">"%d Tagen"</string>
     <!-- XTXT: risk details - infection period logged information body, over 14 days -->
     <string name="risk_details_information_body_period_logged_assessment_over_14_days">"Wenn die Risiko-Ermittlung zu Zeiten, in denen Sie andere Personen getroffen haben, aktiv war, kann die Berechnung des Infektionsrisikos für diesen Zeitraum erfolgen."</string>
     <!-- XHED: risk details - infection period logged information body, below behaviors -->        <!-- XTXT: risk details - infection period logged information body, under 14 days -->

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -291,7 +291,13 @@
     <!--    Dialog part 1-->
     <string name="risk_details_information_body_period_logged">"Your risk of infection can be calculated only for periods during which exposure logging was active. The logging feature should therefore remain active permanently. Exposure logging covers the last 14 days."</string>
     <!-- XTXT: risk details - infection period logged information body, under 14 days -->
-    <string name="risk_details_information_body_period_logged_assessment_under_14_days">"The Corona-Warn-App was installed %s days ago. Your risk of infection is calculated for the periods during which exposure logging was active. If you have encountered other people and exposure logging was active, your risk of infection is calculated."</string>
+    <string name="risk_details_information_body_period_logged_assessment_under_14_days">"The Corona-Warn-App was installed %s. Your risk of infection is calculated for the periods during which exposure logging was active. If you have encountered other people and exposure logging was active, your risk of infection is calculated."</string>
+    <!-- XTXT: risk details - infection period logged 0 days -->
+    <string name="risk_details_information_body_period_logged_today">"today"</string>
+    <!-- XTXT: risk details - infection period logged 1 day -->
+    <string name="risk_details_information_body_period_logged_yesterday">"yesterday"</string>
+    <!-- XTXT: risk details - infection period logged >=2 days -->
+    <string name="risk_details_information_body_period_logged_other">"%d days ago"</string>
     <!-- XTXT: risk details - infection period logged information body, over 14 days -->
     <string name="risk_details_information_body_period_logged_assessment_over_14_days">"If exposure logging was active at times during which you encountered other people, your risk of infection can be calculated for this period."</string>
     <!-- XHED: risk details - infection period logged information body, below behaviors -->        <!-- XTXT: risk details - infection period logged information body, under 14 days -->


### PR DESCRIPTION
Addresses [EXPOSUREAPP-7278](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-7278).

German: Replaces `"seit 0 Tagen"` / `"seit 1 Tagen"` with `"seit heute"` / `"seit gestern"`.
English: Replaces `"0 days ago"` / `"1 days ago"` with `"today"` / `"yesterday"`.