### PR TITLE
Incomplete error message at the input field (EXPOSUREAPP-8787)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/validation_start_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/validation_start_fragment.xml
@@ -116,7 +116,7 @@
                 android:id="@+id/date_info"
                 style="@style/TextAppearance.MaterialComponents.Caption"
                 android:layout_width="0dp"
-                android:layout_height="31dp"
+                android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
                 android:layout_marginEnd="10dp"
                 android:text="@string/validation_start_date_info"


### PR DESCRIPTION
Addresses [EXPOSUREAPP-8787](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8787).

TextView was set to a fixed height of `31dp`, so that error messages longer than 2 lines were not displayed correctly. Fixed it by setting the TextView height to `wrap_content`.