### PR TITLE
Fix dev menu crash (DEV)

### DIFF
--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/dsc/ui/DscTestFragment.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/dsc/ui/DscTestFragment.kt
@@ -26,7 +26,7 @@ class DscTestFragment : Fragment(R.layout.fragment_test_dsc), AutoInject {
 
         binding.apply {
             clearCache.setOnClickListener {
-                viewModel.clear()
+                viewModel.clearDscList()
             }
             refreshCache.setOnClickListener {
                 viewModel.refresh()

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/dsc/ui/DscTestViewModel.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/dsc/ui/DscTestViewModel.kt
@@ -30,7 +30,7 @@ class DscTestViewModel @AssistedInject constructor(
         )
     }.asLiveData2()
 
-    fun clear() {
+    fun clearDscList() {
         launch {
             dscRepository.clear()
         }


### PR DESCRIPTION
Crash only in release build
```
androidx.fragment.app.Fragment$InstantiationException: Unable to instantiate fragment de.rki.coronawarnapp.test.dsc.ui.DscTestFragment: calling Fragment constructor caused an exception
	at androidx.fragment.app.Fragment.instantiate(Fragment.java:7)
	at androidx.fragment.app.FragmentManager$3.instantiate(FragmentManager.java:5)
	at androidx.navigation.fragment.FragmentNavigator.navigate(FragmentNavigator.java:10)
	at androidx.navigation.NavController.navigate(NavController.java:8)
	at androidx.navigation.NavController.navigate(NavController.java:86)
	at -$$LambdaGroup$ks$lEEPkVodahxwxQo-q4ONGyX3rZE.invoke(kotlin-style lambda group:4)
	at de.rki.coronawarnapp.util.ui.-$$Lambda$LiveDataExtensionsKt$14jvLvl2f22mjOqlxI6k3EYpecI.onChanged(lambda:2)
	at de.rki.coronawarnapp.util.ui.-$$Lambda$SingleLiveEvent$i2SKvtpAesIkvQqDEFattcwNiOo.onChanged(lambda:3)
	at androidx.lifecycle.LiveData.considerNotify(LiveData.java:6)
	at androidx.lifecycle.LiveData.dispatchingValue(LiveData.java:8)
	at androidx.lifecycle.MutableLiveData.setValue(MutableLiveData.java:4)
	at de.rki.coronawarnapp.util.ui.SingleLiveEvent.setValue(SingleLiveEvent.kt:2)
	at androidx.lifecycle.LiveData$1.run(LiveData.java:5)
	at android.os.Handler.handleCallback(Handler.java:751)
	at android.os.Handler.dispatchMessage(Handler.java:95)
	at android.os.Looper.loop(Looper.java:154)
	at android.app.ActivityThread.main(ActivityThread.java:6816)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1563)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1451)
Caused by: java.lang.reflect.InvocationTargetException
	at java.lang.reflect.Constructor.newInstance0(Native Method)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:430)
	at androidx.fragment.app.Fragment.instantiate(Fragment.java:4)
	... 19 more
Caused by: java.lang.LinkageError: Method void de.rki.coronawarnapp.test.dsc.ui.DscTestViewModel.clear() overrides final method in class Landroidx/lifecycle/ViewModel; (declaration of 'de.rki.coronawarnapp.test.dsc.ui.DscTestViewModel' appears in /data/app/de.rki.coronawarnapp.test-2/base.apk)
	at de.rki.coronawarnapp.test.dsc.ui.DscTestFragment.<init>(DscTestFragment.kt:4)
	... 22 more
```