### PR TITLE
Wrong FAQ link for duplicate vaccination certificate (EXPOSUREAPP-8929)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/scan/DccQrCodeScanFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/scan/DccQrCodeScanFragment.kt
@@ -111,7 +111,7 @@ class DccQrCodeScanFragment :
                         }
                         it.errorCode == InvalidHealthCertificateException.ErrorCode.ALREADY_REGISTERED -> {
                             setNeutralButton(R.string.error_button_dcc_faq) { _, _ ->
-                                openUrl(R.string.error_button_dcc_faq_link)
+                                openUrl(R.string.error_dcc_already_registered_faq_link)
                             }
                         }
                     }

--- a/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
@@ -130,6 +130,8 @@
     <string name="error_dcc_scan_again">Das Zertifikat konnte nicht auf Ihrem Smartphone gespeichert werden. Bitte versuchen Sie es später noch einmal oder wenden Sie sich an die technische Hotline unter „App-Informationen“.</string>
     <!-- XTXT: DCC QR code scan error message-->
     <string name="error_dcc_already_registered">Das Zertifikat ist bereits in Ihrer App registriert.</string>
+    <!-- XTXT: Explains user about vaccination certificate: URL, has to be "translated" into english (relevant for all languages except german) - https://www.coronawarn.app/en/faq/#eu_dcc -->
+    <string name="error_dcc_already_registered_faq_link">https://www.coronawarn.app/de/faq/#eu_dcc</string>
 
 
     <!-- #####################################################

--- a/Corona-Warn-App/src/main/res/values/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/covid_certificate_strings.xml
@@ -129,6 +129,8 @@
     <string name="error_dcc_scan_again">"The certificate could not be saved on your smartphone. Please try again later or contact the technical hotline under “App Information”."</string>
     <!-- XTXT: DCC QR code scan error message-->
     <string name="error_dcc_already_registered">"The certificate is already registered in your app."</string>
+    <!-- XTXT: Explains user about vaccination certificate: URL, has to be "translated" into english (relevant for all languages except german) - https://www.coronawarn.app/en/faq/#eu_dcc -->
+    <string name="error_dcc_already_registered_faq_link">"https://www.coronawarn.app/en/faq/#eu_dcc"</string>
 
 
     <!-- #####################################################


### PR DESCRIPTION
Addresses [EXPOSUREAPP-8929](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8929) / #3894 

Change the faq link of duplicate certificates to a better destination.