### PR TITLE
First vaccination dose shows up as complete for recovered people (EXPOSUREAPP-8896)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsViewModel.kt
@@ -102,17 +102,12 @@ class PersonDetailsViewModel @AssistedInject constructor(
             // Find any vaccination certificate to determine the vaccination information
             personCertificates.certificates.find { it is VaccinationCertificate }?.let { certificate ->
                 val vaccinatedPerson = vaccinatedPerson(certificate)
-                if (vaccinatedPerson != null && vaccinatedPerson.getVaccinationStatus(timeStamper.nowUTC) != IMMUNITY) {
-                    vaccinatedPerson.isFirstVaccinationDoseAfterRecovery()
-
-                    /**Don't show the vaccination hint section
-                     * if the person had their first dose of vaccine after recovering from covid.
-                     * Applies to ASTRA, BIONTECH and MODERNA vaccines only
-                     */
-                    if (!vaccinatedPerson.isFirstVaccinationDoseAfterRecovery()) {
-                        val timeUntilImmunity = vaccinatedPerson.getDaysUntilImmunity()
-                        add(VaccinationInfoCard.Item(timeUntilImmunity))
-                    }
+                if (vaccinatedPerson != null &&
+                    vaccinatedPerson.getVaccinationStatus(timeStamper.nowUTC) != IMMUNITY &&
+                    !vaccinatedPerson.isFirstVaccinationDoseAfterRecovery()
+                ) {
+                    val timeUntilImmunity = vaccinatedPerson.getDaysUntilImmunity()
+                    add(VaccinationInfoCard.Item(timeUntilImmunity))
                 }
             }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsViewModel.kt
@@ -102,10 +102,7 @@ class PersonDetailsViewModel @AssistedInject constructor(
             // Find any vaccination certificate to determine the vaccination information
             personCertificates.certificates.find { it is VaccinationCertificate }?.let { certificate ->
                 val vaccinatedPerson = vaccinatedPerson(certificate)
-                if (vaccinatedPerson != null &&
-                    vaccinatedPerson.getVaccinationStatus(timeStamper.nowUTC) != IMMUNITY &&
-                    !vaccinatedPerson.isFirstVaccinationDoseAfterRecovery()
-                ) {
+                if (vaccinatedPerson != null && vaccinatedPerson.getVaccinationStatus(timeStamper.nowUTC) != IMMUNITY) {
                     val timeUntilImmunity = vaccinatedPerson.getDaysUntilImmunity()
                     add(VaccinationInfoCard.Item(timeUntilImmunity))
                 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsViewModel.kt
@@ -103,8 +103,16 @@ class PersonDetailsViewModel @AssistedInject constructor(
             personCertificates.certificates.find { it is VaccinationCertificate }?.let { certificate ->
                 val vaccinatedPerson = vaccinatedPerson(certificate)
                 if (vaccinatedPerson != null && vaccinatedPerson.getVaccinationStatus(timeStamper.nowUTC) != IMMUNITY) {
-                    val timeUntilImmunity = vaccinatedPerson.getDaysUntilImmunity()
-                    add(VaccinationInfoCard.Item(timeUntilImmunity))
+                    vaccinatedPerson.isFirstVaccinationDoseAfterRecovery()
+
+                    /**Don't show the vaccination hint section
+                     * if the person had their first dose of vaccine after recovering from covid.
+                     * Applies to ASTRA, BIONTECH and MODERNA vaccines only
+                     */
+                    if (!vaccinatedPerson.isFirstVaccinationDoseAfterRecovery()) {
+                        val timeUntilImmunity = vaccinatedPerson.getDaysUntilImmunity()
+                        add(VaccinationInfoCard.Item(timeUntilImmunity))
+                    }
                 }
             }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
@@ -2,6 +2,7 @@ package de.rki.coronawarnapp.covidcertificate.vaccination.core
 
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CertificatePersonIdentifier
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate
+import de.rki.coronawarnapp.covidcertificate.common.certificate.DccV1
 import de.rki.coronawarnapp.covidcertificate.common.repository.VaccinationCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.repository.storage.VaccinatedPersonData
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.repository.storage.VaccinationContainer
@@ -71,6 +72,16 @@ data class VaccinatedPerson(
         return IMMUNITY_WAITING_DAYS - Days.daysBetween(newestFullDose.vaccinatedOn, today).days
     }
 
+    private fun getNewestFullDose() = vaccinationCertificates.filter { it.doseNumber == it.totalSeriesOfDoses }
+
+    fun isFirstVaccinationDoseAfterRecovery(): Boolean {
+        val vaccinationDetails = getNewestFullDose()[0].rawCertificate.vaccination
+        return when (vaccinationDetails.medicalProductId) {
+            BIONTECH, ASTRA, MODERNA -> vaccinationDetails.doseNumber == 1
+            else -> false
+        }
+    }
+
     enum class Status {
         INCOMPLETE,
         COMPLETE,
@@ -79,5 +90,8 @@ data class VaccinatedPerson(
 
     companion object {
         private const val IMMUNITY_WAITING_DAYS = 15
+        private const val BIONTECH = "EU/1/20/1528"
+        private const val ASTRA = "EU/1/21/1529"
+        private const val MODERNA = "EU/1/20/1507"
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
@@ -2,7 +2,6 @@ package de.rki.coronawarnapp.covidcertificate.vaccination.core
 
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CertificatePersonIdentifier
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate
-import de.rki.coronawarnapp.covidcertificate.common.certificate.DccV1
 import de.rki.coronawarnapp.covidcertificate.common.repository.VaccinationCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.repository.storage.VaccinatedPersonData
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.repository.storage.VaccinationContainer

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPersonTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPersonTest.kt
@@ -270,7 +270,7 @@ class VaccinatedPersonTest : BaseTest() {
     }
 
     @Test
-    fun `vaccination after recovery returns immunity`() {
+    fun `vaccination with 1 of 1 dose after recovery returns immunity - case BIONTECH`() {
         DateTimeZone.setDefault(DateTimeZone.forTimeZone(TimeZone.getTimeZone("Europe/Berlin")))
 
         val personData = mockk<VaccinatedPersonData>().apply {
@@ -299,6 +299,107 @@ class VaccinatedPersonTest : BaseTest() {
             Instant.parse("2021-01-14T0:00:00.000Z").let { now ->
                 getDaysUntilImmunity(now)!! shouldBe 2
                 getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.IMMUNITY
+            }
+        }
+    }
+
+    @Test
+    fun `vaccination with 1 of 1 dose after recovery returns immunity - case MODERNA`() {
+        DateTimeZone.setDefault(DateTimeZone.forTimeZone(TimeZone.getTimeZone("Europe/Berlin")))
+
+        val personData = mockk<VaccinatedPersonData>().apply {
+            every { vaccinations } returns setOf(
+                mockk<VaccinationContainer>().apply {
+                    every { toVaccinationCertificate(any(), any()) } returns mockk<VaccinationCertificate>().apply {
+                        every { vaccinatedOn } returns LocalDate.parse("2021-01-01")
+                        every { doseNumber } returns 1
+                        every { totalSeriesOfDoses } returns 1
+                        every { rawCertificate.vaccination.doseNumber } returns doseNumber
+                        every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1507" // MODERNA
+                    }
+
+                    every { containerId } returns VaccinationCertificateContainerId("VaccinationCertificateContainerId")
+                }
+            )
+        }
+
+        VaccinatedPerson(
+            data = personData,
+            valueSet = null,
+            certificateStates = personData.vaccinations
+                .map { it.containerId to CwaCovidCertificate.State.Invalid() }
+                .toMap()
+        ).apply {
+            Instant.parse("2021-01-14T0:00:00.000Z").let { now ->
+                getDaysUntilImmunity(now)!! shouldBe 2
+                getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.IMMUNITY
+            }
+        }
+    }
+
+    @Test
+    fun `vaccination with 1 of 1 dose after recovery returns immunity - case ASTRA`() {
+        DateTimeZone.setDefault(DateTimeZone.forTimeZone(TimeZone.getTimeZone("Europe/Berlin")))
+
+        val personData = mockk<VaccinatedPersonData>().apply {
+            every { vaccinations } returns setOf(
+                mockk<VaccinationContainer>().apply {
+                    every { toVaccinationCertificate(any(), any()) } returns mockk<VaccinationCertificate>().apply {
+                        every { vaccinatedOn } returns LocalDate.parse("2021-01-01")
+                        every { doseNumber } returns 1
+                        every { totalSeriesOfDoses } returns 1
+                        every { rawCertificate.vaccination.doseNumber } returns doseNumber
+                        every { rawCertificate.vaccination.medicalProductId } returns "EU/1/21/1529" // ASTRA
+                    }
+
+                    every { containerId } returns VaccinationCertificateContainerId("VaccinationCertificateContainerId")
+                }
+            )
+        }
+
+        VaccinatedPerson(
+            data = personData,
+            valueSet = null,
+            certificateStates = personData.vaccinations
+                .map { it.containerId to CwaCovidCertificate.State.Invalid() }
+                .toMap()
+        ).apply {
+            Instant.parse("2021-01-14T0:00:00.000Z").let { now ->
+                getDaysUntilImmunity(now)!! shouldBe 2
+                getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.IMMUNITY
+            }
+        }
+    }
+
+    @Test
+    fun `vaccination with 1 of 2 dose returns incomplete`() {
+        DateTimeZone.setDefault(DateTimeZone.forTimeZone(TimeZone.getTimeZone("Europe/Berlin")))
+
+        val personData = mockk<VaccinatedPersonData>().apply {
+            every { vaccinations } returns setOf(
+                mockk<VaccinationContainer>().apply {
+                    every { toVaccinationCertificate(any(), any()) } returns mockk<VaccinationCertificate>().apply {
+                        every { vaccinatedOn } returns LocalDate.parse("2021-01-01")
+                        every { doseNumber } returns 1
+                        every { totalSeriesOfDoses } returns 2
+                        every { rawCertificate.vaccination.doseNumber } returns doseNumber
+                        every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528" // BIONTECH
+                    }
+
+                    every { containerId } returns VaccinationCertificateContainerId("VaccinationCertificateContainerId")
+                }
+            )
+        }
+
+        VaccinatedPerson(
+            data = personData,
+            valueSet = null,
+            certificateStates = personData.vaccinations
+                .map { it.containerId to CwaCovidCertificate.State.Invalid() }
+                .toMap()
+        ).apply {
+            Instant.parse("2021-01-14T0:00:00.000Z").let { now ->
+                getVaccinationStatus(now) shouldBe VaccinatedPerson.Status.INCOMPLETE
             }
         }
     }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPersonTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPersonTest.kt
@@ -184,6 +184,8 @@ class VaccinatedPersonTest : BaseTest() {
                         every { vaccinatedOn } returns LocalDate.parse("2021-06-13")
                         every { doseNumber } returns 2
                         every { totalSeriesOfDoses } returns 2
+                        every { rawCertificate.vaccination.doseNumber } returns doseNumber
+                        every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
                     }
                     every { containerId } returns VaccinationCertificateContainerId("VaccinationCertificateContainerId")
                 }
@@ -226,6 +228,8 @@ class VaccinatedPersonTest : BaseTest() {
                         every { vaccinatedOn } returns LocalDate.parse("2021-01-01")
                         every { doseNumber } returns 2
                         every { totalSeriesOfDoses } returns 2
+                        every { rawCertificate.vaccination.doseNumber } returns doseNumber
+                        every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
                     }
 
                     every { containerId } returns VaccinationCertificateContainerId("VaccinationCertificateContainerId")


### PR DESCRIPTION
We already had the logic to show the vaccination as complete if the  `doseNumber == totalSeriesOfDoses`, what was left was to hide the Vaccination Info box that shows up if the vaccination is incomplete or it's complete but the number of days until immunity hasn't been reached. 

To test, scan one of the presets from [this PR](https://github.com/corona-warn-app/cwa-app-tech-spec/pull/91). The vaccination card should have the complete icon (the one with the chekmark) and it should say "Vaccination 1 of 1". Also the vaccination hint is not shown.