### PR TITLE
Automatically refresh certificates after DSC list update (EXPOSUREAPP-8886)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/signature/core/DscRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/signature/core/DscRepository.kt
@@ -45,7 +45,7 @@ class DscRepository @Inject constructor(
     val dscData = internalData.data
 
     suspend fun refresh() {
-        Timber.tag(TAG).d("refresh()")
+        Timber.tag(TAG).d("refresh() - START")
         internalData.updateBlocking {
             dscServer.getDscList().let { rawData ->
                 mapDscList(rawData).apply {
@@ -53,6 +53,7 @@ class DscRepository @Inject constructor(
                 }
             }
         }
+        Timber.tag(TAG).d("refresh() - DONE")
     }
 
     suspend fun clear() {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/VaccinationRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/VaccinationRepository.kt
@@ -8,6 +8,7 @@ import de.rki.coronawarnapp.covidcertificate.common.exception.InvalidHealthCerti
 import de.rki.coronawarnapp.covidcertificate.common.exception.InvalidVaccinationCertificateException
 import de.rki.coronawarnapp.covidcertificate.common.repository.VaccinationCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.common.statecheck.DccStateChecker
+import de.rki.coronawarnapp.covidcertificate.signature.core.DscRepository
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinatedPerson
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinationCertificate
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.qrcode.VaccinationCertificateQRCode
@@ -46,6 +47,7 @@ class VaccinationRepository @Inject constructor(
     valueSetsRepository: ValueSetsRepository,
     private val qrCodeExtractor: DccQrCodeExtractor,
     private val dccStateChecker: DccStateChecker,
+    dscRepository: DscRepository
 ) {
 
     private val internalData: HotDataFlow<Set<VaccinatedPerson>> = HotDataFlow(
@@ -84,8 +86,9 @@ class VaccinationRepository @Inject constructor(
 
     val vaccinationInfos: Flow<Set<VaccinatedPerson>> = combine(
         internalData.data,
-        valueSetsRepository.latestVaccinationValueSets
-    ) { personDatas, currentValueSet ->
+        valueSetsRepository.latestVaccinationValueSets,
+        dscRepository.dscData
+    ) { personDatas, currentValueSet, _ ->
         personDatas.map { person ->
             val stateMap = person.data.getStates()
             person.copy(valueSet = currentValueSet, certificateStates = stateMap)

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/recovery/core/RecoveryCertificateRepositoryTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/recovery/core/RecoveryCertificateRepositoryTest.kt
@@ -8,6 +8,8 @@ import de.rki.coronawarnapp.covidcertificate.recovery.RecoveryQrCodeTestData
 import de.rki.coronawarnapp.covidcertificate.recovery.core.qrcode.RecoveryCertificateQRCode
 import de.rki.coronawarnapp.covidcertificate.recovery.core.storage.RecoveryCertificateStorage
 import de.rki.coronawarnapp.covidcertificate.recovery.core.storage.StoredRecoveryCertificateData
+import de.rki.coronawarnapp.covidcertificate.signature.core.DscData
+import de.rki.coronawarnapp.covidcertificate.signature.core.DscRepository
 import de.rki.coronawarnapp.covidcertificate.valueset.ValueSetsRepository
 import de.rki.coronawarnapp.covidcertificate.valueset.valuesets.emptyTestCertificateValueSets
 import de.rki.coronawarnapp.covidcertificate.valueset.valuesets.emptyVaccinationValueSets
@@ -35,6 +37,7 @@ class RecoveryCertificateRepositoryTest : BaseTest() {
     @MockK lateinit var storage: RecoveryCertificateStorage
     @MockK lateinit var valueSetsRepository: ValueSetsRepository
     @MockK lateinit var dccStateChecker: DccStateChecker
+    @MockK lateinit var dscRepository: DscRepository
 
     @Inject lateinit var qrCodeExtractor: DccQrCodeExtractor
 
@@ -48,6 +51,7 @@ class RecoveryCertificateRepositoryTest : BaseTest() {
         DaggerCovidCertificateTestComponent.factory().create().inject(this)
 
         every { timeStamper.nowUTC } returns nowUTC
+        every { dscRepository.dscData } returns flowOf(DscData(listOf(), nowUTC))
 
         valueSetsRepository.apply {
             every { latestTestCertificateValueSets } returns flowOf(emptyTestCertificateValueSets)
@@ -68,6 +72,7 @@ class RecoveryCertificateRepositoryTest : BaseTest() {
         qrCodeExtractor = qrCodeExtractor,
         dccStateChecker = dccStateChecker,
         timeStamper = timeStamper,
+        dscRepository = dscRepository,
     )
 
     @Test

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepositoryTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepositoryTest.kt
@@ -8,6 +8,8 @@ import de.rki.coronawarnapp.covidcertificate.common.certificate.DccQrCodeExtract
 import de.rki.coronawarnapp.covidcertificate.common.exception.InvalidHealthCertificateException.ErrorCode
 import de.rki.coronawarnapp.covidcertificate.common.exception.InvalidTestCertificateException
 import de.rki.coronawarnapp.covidcertificate.common.statecheck.DccStateChecker
+import de.rki.coronawarnapp.covidcertificate.signature.core.DscData
+import de.rki.coronawarnapp.covidcertificate.signature.core.DscRepository
 import de.rki.coronawarnapp.covidcertificate.test.TestCertificateTestData
 import de.rki.coronawarnapp.covidcertificate.test.core.storage.TestCertificateStorage
 import de.rki.coronawarnapp.covidcertificate.test.core.storage.types.BaseTestCertificateData
@@ -29,6 +31,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import org.joda.time.Duration
 import org.joda.time.Instant
 import org.junit.jupiter.api.BeforeEach
@@ -47,6 +50,7 @@ class TestCertificateRepositoryTest : BaseTest() {
     @MockK lateinit var testCertificateProcessor: TestCertificateProcessor
     @MockK lateinit var timeStamper: TimeStamper
     @MockK lateinit var dccStateChecker: DccStateChecker
+    @MockK lateinit var dscRepository: DscRepository
 
     @Inject lateinit var testData: TestCertificateTestData
 
@@ -93,6 +97,8 @@ class TestCertificateRepositoryTest : BaseTest() {
         every { valueSetsRepository.latestTestCertificateValueSets } returns emptyFlow()
 
         every { timeStamper.nowUTC } returns Instant.ofEpochSecond(12345678)
+
+        every { dscRepository.dscData } returns flowOf(DscData(listOf(), timeStamper.nowUTC))
     }
 
     private fun createInstance(scope: CoroutineScope) = TestCertificateRepository(
@@ -105,6 +111,7 @@ class TestCertificateRepositoryTest : BaseTest() {
         processor = testCertificateProcessor,
         rsaKeyPairGenerator = RSAKeyPairGenerator(),
         dccStateChecker = dccStateChecker,
+        dscRepository = dscRepository,
     )
 
     @Test

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/VaccinationRepositoryTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/VaccinationRepositoryTest.kt
@@ -7,6 +7,8 @@ import de.rki.coronawarnapp.covidcertificate.common.exception.InvalidHealthCerti
 import de.rki.coronawarnapp.covidcertificate.common.exception.InvalidVaccinationCertificateException
 import de.rki.coronawarnapp.covidcertificate.common.repository.VaccinationCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.common.statecheck.DccStateChecker
+import de.rki.coronawarnapp.covidcertificate.signature.core.DscData
+import de.rki.coronawarnapp.covidcertificate.signature.core.DscRepository
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinationTestData
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.repository.storage.VaccinatedPersonData
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.repository.storage.VaccinationStorage
@@ -42,6 +44,7 @@ class VaccinationRepositoryTest : BaseTest() {
     @MockK lateinit var vaccinationValueSet: VaccinationValueSets
     @MockK lateinit var qrCodeExtractor: DccQrCodeExtractor
     @MockK lateinit var dccStateChecker: DccStateChecker
+    @MockK lateinit var dscRepository: DscRepository
 
     private var testStorage: Set<VaccinatedPersonData> = emptySet()
 
@@ -62,6 +65,8 @@ class VaccinationRepositoryTest : BaseTest() {
 
         every { valueSetsRepository.latestVaccinationValueSets } returns flowOf(vaccinationValueSet)
 
+        every { dscRepository.dscData } returns flowOf(DscData(listOf(), nowUTC))
+
         storage.apply {
             coEvery { load() } answers { testStorage }
             coEvery { save(any()) } answers { testStorage = arg(0) }
@@ -76,6 +81,7 @@ class VaccinationRepositoryTest : BaseTest() {
         valueSetsRepository = valueSetsRepository,
         qrCodeExtractor = qrCodeExtractor,
         dccStateChecker = dccStateChecker,
+        dscRepository = dscRepository,
     )
 
     @Test


### PR DESCRIPTION
### Testing
- install CWA 2.6
- generate and scan tc, vc, rc
- update CWA with this branch
- check if all certificates are still valid
- you can also play with the Test Menu ( DCC Signature Verification > Refresh / Clear cache )