### PR TITLE
Follow-up: Installation date "today" not correct (EXPOSUREAPP-7482)

### DIFF
--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -62,9 +62,9 @@
     <!-- XTXT: risk card - Days since installation if < 14 days -->
     <string name="risk_card_body_days_since_installation">"Seit %s Tagen installiert"</string>
     <!-- XTXT: risk card - Days since installation if today -->
-    <string name="risk_card_body_installation_today">Seit heute installiert</string>
+    <string name="risk_card_body_installation_today">Heute installiert</string>
     <!-- XTXT: risk card - Days since installation if yesterday -->
-    <string name="risk_card_body_installation_yesterday">Seit gestern installiert</string>
+    <string name="risk_card_body_installation_yesterday">Gestern installiert</string>
     <!-- XTXT; risk card - no update done yet -->
     <string name="risk_card_body_not_yet_fetched">"Begegnungen wurden noch nicht überprüft."</string>
     <!-- XTXT: risk card - last successful update -->


### PR DESCRIPTION
Addresses [EXPOSUREAPP-7482](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-7482)

Change text `seit heute installiert` to `heute installiert`. Same for `gestern`.

This change was reverted by [this merge commit](https://github.com/corona-warn-app/cwa-app-android/pull/3911/commits/1322b39ceb23102587ec00e511543318f1f1e868) by @mtwalli.