### PR TITLE
Risk calculation with result CALCULATION_FAILED (EXPOSUREAPP-9020)

### DIFF
--- a/Corona-Warn-App/proguard-rules.pro
+++ b/Corona-Warn-App/proguard-rules.pro
@@ -39,6 +39,10 @@
     @retrofit2.http.* <methods>;
 }
 
+-keepclasseswithmembers class * {
+    @retrofit2.http.* <methods>;
+}
+
 # Ignore annotation used for build tooling.
 -dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 


### PR DESCRIPTION
How verify the fix?
Before:
1- build `deviceForTestersRelease` not `deviceForTestersDebug`
2- Scan Qrcode from ticket
3-From Test menu -> Presence Tracing -> Hit `Run Task` and `Calculate Risk` 
4- Risk Card will show failed state 

After:
Do the same, but the Risk will be LOW as it 