### PR TITLE
Remember Scroll Position (EXPOSUREAPP-8799)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/validation_start_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/validation_start_fragment.xml
@@ -20,7 +20,6 @@
         app:title="@string/validation_start_header" />
 
     <ScrollView
-        android:id="@+id/scrollview"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         app:layout_constraintBottom_toTopOf="@id/start_validation_check"


### PR DESCRIPTION
When checking the validity for a certificate and then pressing the "Für weiteres Land prüfen" button, the scroll state is not remembered anymore and therefore the country and date are visible directly.