### PR TITLE
Create screenshot for different certificate types (EXPOSUREAPP-8943)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/RecoveryCertificateDetailFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/RecoveryCertificateDetailFragmentTest.kt
@@ -67,37 +67,65 @@ class RecoveryCertificateDetailFragmentTest : BaseUITest() {
     @Screenshot
     @Test
     fun capture_screenshot_recovered() {
-        every { recoveryDetailsViewModel.recoveryCertificate } returns mockCertificate()
+        every { recoveryDetailsViewModel.recoveryCertificate } returns validMockCertificate()
         launchFragmentInContainer2<RecoveryCertificateDetailsFragment>(fragmentArgs = args)
         takeScreenshot<RecoveryCertificateDetailsFragment>("recovered")
         onView(withId(R.id.coordinator_layout)).perform(swipeUp())
         takeScreenshot<RecoveryCertificateDetailsFragment>("recovered_2")
     }
 
-    private fun mockCertificate(): MutableLiveData<RecoveryCertificate> {
-        val mockCertificate = mockk<RecoveryCertificate>().apply {
-            every { fullName } returns "Max Mustermann"
-            every { fullNameStandardizedFormatted } returns "MUSTERMANN, MAX"
-            every { dateOfBirthFormatted } returns "1969-01-08"
-            every { targetDisease } returns "COVID-19"
-            every { testedPositiveOnFormatted } returns "2021-05-24"
-            every { certificateCountry } returns "Deutschland"
-            every { certificateIssuer } returns "Robert-Koch-Institut"
-            every { validFromFormatted } returns "2021-06-07"
-            every { validUntilFormatted } returns "2021-11-10"
-            every { certificateId } returns "05930482748454836478695764787841"
-            every { qrCodeToDisplay } returns CoilQrCode(ScreenshotCertificateTestData.recoveryCertificate)
-            every { isValid } returns true
-            every { validUntil } returns
-                LocalDate.parse("2021-11-10", DateTimeFormat.forPattern("yyyy-MM-dd"))
+    @Screenshot
+    @Test
+    fun capture_screenshot_recovered_expired() {
+        every { recoveryDetailsViewModel.recoveryCertificate } returns expiredMockCertificate()
+        launchFragmentInContainer2<RecoveryCertificateDetailsFragment>(fragmentArgs = args)
+        takeScreenshot<RecoveryCertificateDetailsFragment>("recovered_expired")
+        onView(withId(R.id.coordinator_layout)).perform(swipeUp())
+        takeScreenshot<RecoveryCertificateDetailsFragment>("recovered_expired_2")
+    }
 
-            every { getState() } returns CwaCovidCertificate.State.Valid(Instant.now().plus(21))
+    @Screenshot
+    @Test
+    fun capture_screenshot_recovered_invalid() {
+        every { recoveryDetailsViewModel.recoveryCertificate } returns invalidMockCertificate()
+        launchFragmentInContainer2<RecoveryCertificateDetailsFragment>(fragmentArgs = args)
+        takeScreenshot<RecoveryCertificateDetailsFragment>("recovered_invalid")
+        onView(withId(R.id.coordinator_layout)).perform(swipeUp())
+        takeScreenshot<RecoveryCertificateDetailsFragment>("recovered_invalid_2")
+    }
 
-            every { fullNameFormatted } returns "Max, Mustermann"
-            every { headerExpiresAt } returns Instant.now().plus(21)
-        }
+    private fun validMockCertificate() = MutableLiveData(mockCertificate().apply {
+        every { isValid } returns true
+        every { getState() } returns CwaCovidCertificate.State.Valid(Instant.now().plus(21))
+    })
 
-        return MutableLiveData(mockCertificate)
+    private fun invalidMockCertificate() = MutableLiveData(mockCertificate().apply {
+        every { isValid } returns false
+        every { getState() } returns CwaCovidCertificate.State.Invalid()
+    })
+
+    private fun expiredMockCertificate() = MutableLiveData(mockCertificate().apply {
+        every { isValid } returns false
+        every { getState() } returns CwaCovidCertificate.State.Expired(Instant.now())
+    })
+
+    private fun mockCertificate() = mockk<RecoveryCertificate>().apply {
+        every { fullName } returns "Max Mustermann"
+        every { fullNameStandardizedFormatted } returns "MUSTERMANN, MAX"
+        every { dateOfBirthFormatted } returns "1969-01-08"
+        every { targetDisease } returns "COVID-19"
+        every { testedPositiveOnFormatted } returns "2021-05-24"
+        every { certificateCountry } returns "Deutschland"
+        every { certificateIssuer } returns "Robert-Koch-Institut"
+        every { validFromFormatted } returns "2021-06-07"
+        every { validUntilFormatted } returns "2021-11-10"
+        every { certificateId } returns "05930482748454836478695764787841"
+        every { qrCodeToDisplay } returns CoilQrCode(ScreenshotCertificateTestData.recoveryCertificate)
+        every { validUntil } returns
+            LocalDate.parse("2021-11-10", DateTimeFormat.forPattern("yyyy-MM-dd"))
+
+        every { fullNameFormatted } returns "Max, Mustermann"
+        every { headerExpiresAt } returns Instant.now().plus(21)
     }
 
     @After

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/RecoveryCertificateDetailFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/RecoveryCertificateDetailFragmentTest.kt
@@ -94,20 +94,26 @@ class RecoveryCertificateDetailFragmentTest : BaseUITest() {
         takeScreenshot<RecoveryCertificateDetailsFragment>("recovered_invalid_2")
     }
 
-    private fun validMockCertificate() = MutableLiveData(mockCertificate().apply {
-        every { isValid } returns true
-        every { getState() } returns CwaCovidCertificate.State.Valid(Instant.now().plus(21))
-    })
+    private fun validMockCertificate() = MutableLiveData(
+        mockCertificate().apply {
+            every { isValid } returns true
+            every { getState() } returns CwaCovidCertificate.State.Valid(Instant.now().plus(21))
+        }
+    )
 
-    private fun invalidMockCertificate() = MutableLiveData(mockCertificate().apply {
-        every { isValid } returns false
-        every { getState() } returns CwaCovidCertificate.State.Invalid()
-    })
+    private fun invalidMockCertificate() = MutableLiveData(
+        mockCertificate().apply {
+            every { isValid } returns false
+            every { getState() } returns CwaCovidCertificate.State.Invalid()
+        }
+    )
 
-    private fun expiredMockCertificate() = MutableLiveData(mockCertificate().apply {
-        every { isValid } returns false
-        every { getState() } returns CwaCovidCertificate.State.Expired(Instant.now())
-    })
+    private fun expiredMockCertificate() = MutableLiveData(
+        mockCertificate().apply {
+            every { isValid } returns false
+            every { getState() } returns CwaCovidCertificate.State.Expired(Instant.now())
+        }
+    )
 
     private fun mockCertificate() = mockk<RecoveryCertificate>().apply {
         every { fullName } returns "Max Mustermann"

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/test/ui/TestCertificateDetailsFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/test/ui/TestCertificateDetailsFragmentTest.kt
@@ -77,75 +77,117 @@ class TestCertificateDetailsFragmentTest : BaseUITest() {
         takeScreenshot<TestCertificateDetailsFragment>("_2")
     }
 
-    private fun vaccinationDetailsData(): MutableLiveData<TestCertificate> {
+    @Screenshot
+    @Test
+    fun capture_screenshot_invalid() {
+        every { vaccinationDetailsViewModel.covidCertificate } returns invalidVaccinationDetailsData()
+        launchFragmentInContainer2<TestCertificateDetailsFragment>(fragmentArgs = args)
+        takeScreenshot<TestCertificateDetailsFragment>("invalid")
+        onView(withId(R.id.coordinator_layout)).perform(swipeUp())
+        takeScreenshot<TestCertificateDetailsFragment>("invalid_2")
+    }
+
+    @Screenshot
+    @Test
+    fun capture_screenshot_expired() {
+        every { vaccinationDetailsViewModel.covidCertificate } returns expiredVaccinationDetailsData()
+        launchFragmentInContainer2<TestCertificateDetailsFragment>(fragmentArgs = args)
+        takeScreenshot<TestCertificateDetailsFragment>("expired")
+        onView(withId(R.id.coordinator_layout)).perform(swipeUp())
+        takeScreenshot<TestCertificateDetailsFragment>("expired_2")
+    }
+
+    private fun invalidVaccinationDetailsData() = MutableLiveData(
+        getTestCertificateObject(
+            CwaCovidCertificate.State.Invalid()
+        )
+    )
+
+    private fun expiredVaccinationDetailsData() = MutableLiveData(
+        getTestCertificateObject(
+            CwaCovidCertificate.State.Expired(Instant.now())
+        )
+    )
+
+    private fun vaccinationDetailsData() = MutableLiveData(
+        getTestCertificateObject(
+            CwaCovidCertificate.State.Valid(Instant.now())
+        )
+    )
+
+    abstract class AbstractTestCertificate(
+        private val testDate: Instant,
+        private val certificatePersonIdentifier: CertificatePersonIdentifier
+    ) : TestCertificate {
+        override val rawCertificate: TestDccV1
+            get() = mockk()
+        override val notifiedExpiredAt: Instant?
+            get() = null
+        override val notifiedExpiresSoonAt: Instant?
+            get() = null
+        override val containerId: TestCertificateContainerId
+            get() = TestCertificateContainerId("identifier")
+        override val targetName: String
+            get() = "Schneider, Andrea"
+        override val testType: String
+            get() = "SARS-CoV-2-Test"
+        override val testResult: String
+            get() = "negative"
+        override val testName: String
+            get() = "Xep"
+        override val testNameAndManufacturer: String
+            get() = "Xup"
+        override val sampleCollectedAt: Instant
+            get() = testDate
+        override val sampleCollectedAtFormatted: String
+            get() = "12.05.2021 19:00"
+        override val testCenter: String
+            get() = "AB123"
+        override val registeredAt: Instant
+            get() = testDate
+        override val isUpdatingData: Boolean
+            get() = false
+        override val isCertificateRetrievalPending: Boolean
+            get() = false
+        override val headerIssuer: String
+            get() = "G0593048274845483647869576478784"
+        override val headerIssuedAt: Instant
+            get() = testDate
+        override val headerExpiresAt: Instant
+            get() = testDate
+        override val qrCodeToDisplay: CoilQrCode
+            get() = CoilQrCode(ScreenshotCertificateTestData.testCertificate)
+        override val firstName: String
+            get() = "Andrea"
+        override val lastName: String
+            get() = "Schneider"
+        override val fullName: String
+            get() = "Andrea Schneider"
+        override val fullNameFormatted: String
+            get() = "Schneider, Andrea"
+        override val fullNameStandardizedFormatted: String
+            get() = "SCHNEIDER, ANDREA"
+        override val dateOfBirthFormatted: String
+            get() = "1943-04-18"
+        override val personIdentifier: CertificatePersonIdentifier
+            get() = certificatePersonIdentifier
+        override val certificateIssuer: String
+            get() = "G0593048274845483647869576478784"
+        override val certificateCountry: String
+            get() = "Germany"
+        override val certificateId: String
+            get() = "05930482748454836478695764787840"
+        override val dccData: DccData<*>
+            get() = mockk()
+    }
+
+    private fun getTestCertificateObject(state: CwaCovidCertificate.State): TestCertificate {
         val formatter = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm")
         val testDate = DateTime.parse("12.05.2021 19:00", formatter).toInstant()
-        return MutableLiveData(
-            object : TestCertificate {
-                override val rawCertificate: TestDccV1
-                    get() = mockk()
-                override val notifiedExpiredAt: Instant?
-                    get() = null
-                override val notifiedExpiresSoonAt: Instant?
-                    get() = null
-                override val containerId: TestCertificateContainerId
-                    get() = TestCertificateContainerId("identifier")
-                override val targetName: String
-                    get() = "Schneider, Andrea"
-                override val testType: String
-                    get() = "SARS-CoV-2-Test"
-                override val testResult: String
-                    get() = "negative"
-                override val testName: String
-                    get() = "Xep"
-                override val testNameAndManufacturer: String
-                    get() = "Xup"
-                override val sampleCollectedAt: Instant
-                    get() = testDate
-                override val sampleCollectedAtFormatted: String
-                    get() = "12.05.2021 19:00"
-                override val testCenter: String
-                    get() = "AB123"
-                override val registeredAt: Instant
-                    get() = testDate
-                override val isUpdatingData: Boolean
-                    get() = false
-                override val isCertificateRetrievalPending: Boolean
-                    get() = false
-                override val headerIssuer: String
-                    get() = "G0593048274845483647869576478784"
-                override val headerIssuedAt: Instant
-                    get() = testDate
-                override val headerExpiresAt: Instant
-                    get() = testDate
-                override val qrCodeToDisplay: CoilQrCode
-                    get() = CoilQrCode(ScreenshotCertificateTestData.testCertificate)
-                override val firstName: String
-                    get() = "Andrea"
-                override val lastName: String
-                    get() = "Schneider"
-                override val fullName: String
-                    get() = "Andrea Schneider"
-                override val fullNameFormatted: String
-                    get() = "Schneider, Andrea"
-                override val fullNameStandardizedFormatted: String
-                    get() = "SCHNEIDER, ANDREA"
-                override val dateOfBirthFormatted: String
-                    get() = "1943-04-18"
-                override val personIdentifier: CertificatePersonIdentifier
-                    get() = certificatePersonIdentifier
-                override val certificateIssuer: String
-                    get() = "G0593048274845483647869576478784"
-                override val certificateCountry: String
-                    get() = "Germany"
-                override val certificateId: String
-                    get() = "05930482748454836478695764787840"
-                override val dccData: DccData<*>
-                    get() = mockk()
 
-                override fun getState(): CwaCovidCertificate.State = CwaCovidCertificate.State.Valid(Instant.now())
-            }
-        )
+        return object : AbstractTestCertificate(testDate, certificatePersonIdentifier) {
+            override fun getState(): CwaCovidCertificate.State = state
+        }
     }
 
     @After

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragmentTest.kt
@@ -1,5 +1,6 @@
 package de.rki.coronawarnapp.covidcertificate.vaccination.ui.details
 
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.swipeUp
@@ -64,7 +65,7 @@ class VaccinationDetailsFragmentTest : BaseUITest() {
     @Screenshot
     @Test
     fun capture_screenshot_immune() {
-        every { vaccinationDetailsViewModel.vaccinationCertificate } returns vaccinationDetailsData(true)
+        every { vaccinationDetailsViewModel.vaccinationCertificate } returns validVaccinationDetailsData(true)
         launchFragmentInContainer2<VaccinationDetailsFragment>(fragmentArgs = args)
         takeScreenshot<VaccinationDetailsFragment>("immune")
         onView(withId(R.id.coordinator_layout)).perform(swipeUp())
@@ -74,16 +75,63 @@ class VaccinationDetailsFragmentTest : BaseUITest() {
     @Screenshot
     @Test
     fun capture_screenshot_incomplete() {
-        every { vaccinationDetailsViewModel.vaccinationCertificate } returns vaccinationDetailsData(false)
+        every { vaccinationDetailsViewModel.vaccinationCertificate } returns validVaccinationDetailsData(false)
         launchFragmentInContainer2<VaccinationDetailsFragment>(fragmentArgs = args)
         takeScreenshot<VaccinationDetailsFragment>("incomplete")
         onView(withId(R.id.coordinator_layout)).perform(swipeUp())
         takeScreenshot<VaccinationDetailsFragment>("incomplete_2")
     }
 
-    private fun vaccinationDetailsData(complete: Boolean): MutableLiveData<VaccinationDetails> {
+    @Screenshot
+    @Test
+    fun capture_screenshot_invalid() {
+        every { vaccinationDetailsViewModel.vaccinationCertificate } returns invalidVaccinationDetailsData()
+        launchFragmentInContainer2<VaccinationDetailsFragment>(fragmentArgs = args)
+        takeScreenshot<VaccinationDetailsFragment>("invalid")
+        onView(withId(R.id.coordinator_layout)).perform(swipeUp())
+        takeScreenshot<VaccinationDetailsFragment>("invalid_2")
+    }
+
+    @Screenshot
+    @Test
+    fun capture_screenshot_expired() {
+        every { vaccinationDetailsViewModel.vaccinationCertificate } returns expiredVaccinationDetailsData()
+        launchFragmentInContainer2<VaccinationDetailsFragment>(fragmentArgs = args)
+        takeScreenshot<VaccinationDetailsFragment>("expired")
+        onView(withId(R.id.coordinator_layout)).perform(swipeUp())
+        takeScreenshot<VaccinationDetailsFragment>("expired_2")
+    }
+
+    private fun validVaccinationDetailsData(complete: Boolean): LiveData<VaccinationDetails> {
+        val vaccinationCertificate = vaccinationCertificate().apply {
+            if (complete) every { doseNumber } returns 2 else every { doseNumber } returns 1
+            every { isValid } returns true
+            every { getState() } returns CwaCovidCertificate.State.Valid(Instant.now().plus(21))
+        }
+        return MutableLiveData(VaccinationDetails(vaccinationCertificate, complete))
+    }
+
+    private fun invalidVaccinationDetailsData(): LiveData<VaccinationDetails> {
+        val vaccinationCertificate = vaccinationCertificate().apply {
+            every { doseNumber } returns 2
+            every { isValid } returns false
+            every { getState() } returns CwaCovidCertificate.State.Invalid()
+        }
+        return MutableLiveData(VaccinationDetails(vaccinationCertificate, false))
+    }
+
+    private fun expiredVaccinationDetailsData(): LiveData<VaccinationDetails> {
+        val vaccinationCertificate = vaccinationCertificate().apply {
+            every { doseNumber } returns 2
+            every { isValid } returns false
+            every { getState() } returns CwaCovidCertificate.State.Expired(Instant.now())
+        }
+        return MutableLiveData(VaccinationDetails(vaccinationCertificate, false))
+    }
+
+    private fun vaccinationCertificate(): VaccinationCertificate {
         val formatter = DateTimeFormat.forPattern("dd.MM.yyyy")
-        val mockCertificate = mockk<VaccinationCertificate>().apply {
+        return mockk<VaccinationCertificate>().apply {
             every { fullName } returns "Max Mustermann"
             every { fullNameStandardizedFormatted } returns "MUSTERMANN, MAX"
             every { dateOfBirthFormatted } returns "01.02.1976"
@@ -99,15 +147,8 @@ class VaccinationDetailsFragmentTest : BaseUITest() {
             every { headerExpiresAt } returns Instant.parse("2021-05-16T00:00:00.000Z")
             every { totalSeriesOfDoses } returns 2
             every { qrCodeToDisplay } returns CoilQrCode(ScreenshotCertificateTestData.vaccinationCertificate)
-            every { isValid } returns true
-            every { getState() } returns CwaCovidCertificate.State.Valid(Instant.now().plus(21))
             every { fullNameFormatted } returns "Max, Mustermann"
-            if (complete) every { doseNumber } returns 2 else every { doseNumber } returns 1
         }
-
-        return MutableLiveData(
-            VaccinationDetails(mockCertificate, complete)
-        )
     }
 
     @After


### PR DESCRIPTION
Add missing screenshots for:

- invalid/expired vaccination certificate as shown on the right screenshot
- invalid/expired recovery certificate as shown on the right screenshot
- invalid/expired test certificate as shown on the right screenshot
