### PR TITLE
Don't show infobox for incomplete vaccination if Booster vaccination certificate is available (EXPOSUREAPP-9176)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
@@ -68,7 +68,7 @@ data class VaccinatedPerson(
     }
 
     private fun getNewestFullDose(): VaccinationCertificate? = vaccinationCertificates
-        .filter { it.doseNumber == it.totalSeriesOfDoses }
+        .filter { it.doseNumber >= it.totalSeriesOfDoses }
         .maxByOrNull { it.vaccinatedOn }
 
     private fun isFirstVaccinationDoseAfterRecovery(): Boolean {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
@@ -53,8 +53,10 @@ data class VaccinatedPerson(
     fun getVaccinationStatus(nowUTC: Instant = Instant.now()): Status {
         val daysToImmunity = getDaysUntilImmunity(nowUTC) ?: return Status.INCOMPLETE
 
+        val isImmune = daysToImmunity <= 0 || isFirstVaccinationDoseAfterRecovery() ||
+            getNewestFullDose()?.isBooster == true
         return when {
-            daysToImmunity <= 0 || isFirstVaccinationDoseAfterRecovery() -> Status.IMMUNITY
+            isImmune -> Status.IMMUNITY
             else -> Status.COMPLETE
         }
     }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPersonTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPersonTest.kt
@@ -186,6 +186,7 @@ class VaccinatedPersonTest : BaseTest() {
                         every { totalSeriesOfDoses } returns 2
                         every { rawCertificate.vaccination.doseNumber } returns doseNumber
                         every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
+                        every { isBooster } returns false
                     }
                     every { containerId } returns VaccinationCertificateContainerId("VaccinationCertificateContainerId")
                 }
@@ -230,6 +231,7 @@ class VaccinatedPersonTest : BaseTest() {
                         every { totalSeriesOfDoses } returns 2
                         every { rawCertificate.vaccination.doseNumber } returns doseNumber
                         every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
+                        every { isBooster } returns false
                     }
 
                     every { containerId } returns VaccinationCertificateContainerId("VaccinationCertificateContainerId")


### PR DESCRIPTION
Addresses user story [EXPOSUREAPP-9176](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9176).

How to test:
- `cwa vc gen -s v.0.dn=1 v.0.sd=2 -e wru --seed mm`
- `cwa vc gen -s v.0.dn=2 v.0.sd=2 -e wru --seed mm`
- `cwa vc gen -s v.0.dn=3 v.0.sd=2 -e wru --seed mm` (Booster)

*Note: Untested, but it should work*