### PR TITLE
Update logic to show / hide notification badges (EXPOSUREAPP-9192)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragmentTest.kt
@@ -48,7 +48,6 @@ class PersonOverviewFragmentTest : BaseUITest() {
         viewModel.apply {
             every { events } returns SingleLiveEvent()
             every { personCertificates } returns MutableLiveData()
-            every { markNewCertsAsSeen } returns MutableLiveData()
         }
         setupFakeImageLoader(
             createFakeImageLoaderForQrCodes()

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/test/ui/TestCertificateDetailsFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/test/ui/TestCertificateDetailsFragmentTest.kt
@@ -185,6 +185,11 @@ class TestCertificateDetailsFragmentTest : BaseUITest() {
 
         override val notifiedInvalidAt: Instant?
             get() = null
+
+        override val lastSeenStateChange: CwaCovidCertificate.State?
+            get() = null
+        override val lastSeenStateChangeAt: Instant?
+            get() = null
     }
 
     private fun getTestCertificateObject(state: CwaCovidCertificate.State): TestCertificate {

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/test/ui/TestCertificateDetailsFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/test/ui/TestCertificateDetailsFragmentTest.kt
@@ -180,7 +180,7 @@ class TestCertificateDetailsFragmentTest : BaseUITest() {
         override val dccData: DccData<*>
             get() = mockk()
 
-        override val hasNotification: Boolean
+        override val hasNotificationBadge: Boolean
             get() = false
 
         override val notifiedInvalidAt: Instant?

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/CwaCovidCertificate.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/CwaCovidCertificate.kt
@@ -91,8 +91,8 @@ interface CwaCovidCertificate {
         }
 
         companion object {
-            const val TYPE_FIELD_NAME = "typeName"
-            val typeAdapter = RuntimeTypeAdapterFactory.of(State::class.java, "type", true)
+            val typeAdapter: RuntimeTypeAdapterFactory<State> = RuntimeTypeAdapterFactory
+                .of(State::class.java, "type", true)
                 .registerSubtype(Valid::class.java, "Valid")
                 .registerSubtype(ExpiringSoon::class.java, "ExpiringSoon")
                 .registerSubtype(Expired::class.java, "Expired")

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/CwaCovidCertificate.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/CwaCovidCertificate.kt
@@ -41,14 +41,12 @@ interface CwaCovidCertificate {
 
     val notifiedExpiresSoonAt: Instant?
     val notifiedExpiredAt: Instant?
+    val notifiedInvalidAt: Instant?
 
     val lastSeenStateChange: State?
     val lastSeenStateChangeAt: Instant?
 
     val hasNotification: Boolean
-
-    val notifiedInvalidAt: Instant?
-
     /**
      * The current state of the certificate, see [State]
      */

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/CwaCovidCertificate.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/CwaCovidCertificate.kt
@@ -46,7 +46,13 @@ interface CwaCovidCertificate {
     val lastSeenStateChange: State?
     val lastSeenStateChangeAt: Instant?
 
-    val hasNotification: Boolean
+    /**
+     * Indicates that certificate has updates regarding its status
+     * for example state changed to Expiring_Soon, Expired, Invalid or
+     * retrieved Test certificate became available
+     */
+    val hasNotificationBadge: Boolean
+
     /**
      * The current state of the certificate, see [State]
      */

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/statecheck/DccStateCheckScheduler.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/statecheck/DccStateCheckScheduler.kt
@@ -45,7 +45,7 @@ class DccStateCheckScheduler @Inject constructor(
             .distinctUntilChanged()
             .filter { it } // Only when going into foreground
             .onEach {
-                dccExpirationNotificationService.showNotificationIfExpired()
+                dccExpirationNotificationService.showNotificationIfStateChanged()
             }
             .launchIn(appScope)
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/statecheck/DccStateCheckWorker.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/statecheck/DccStateCheckWorker.kt
@@ -17,7 +17,7 @@ class DccStateCheckWorker @AssistedInject constructor(
 ) : CoroutineWorker(context, workerParams) {
 
     override suspend fun doWork(): Result = try {
-        dccExpirationNotificationService.showNotificationIfExpired()
+        dccExpirationNotificationService.showNotificationIfStateChanged()
 
         Result.success()
     } catch (e: Exception) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/expiration/DccExpirationNotificationService.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/expiration/DccExpirationNotificationService.kt
@@ -38,9 +38,9 @@ class DccExpirationNotificationService @Inject constructor(
             return
         }
 
-        val allCerts = getCertificates()
+        val vacRecCerts = getCertificates()
 
-        allCerts
+        vacRecCerts
             .filter { it.getState() is CwaCovidCertificate.State.Expired }
             .firstOrNull {
                 Timber.tag(TAG).w("Certificate expired: %s", it)
@@ -52,7 +52,7 @@ class DccExpirationNotificationService @Inject constructor(
                 }
             }
 
-        allCerts
+        vacRecCerts
             .filter { it.getState() is CwaCovidCertificate.State.ExpiringSoon }
             .firstOrNull {
                 Timber.tag(TAG).w("Certificate expiring soon: %s", it)
@@ -63,6 +63,10 @@ class DccExpirationNotificationService @Inject constructor(
                     setStateNotificationShown(it)
                 }
             }
+
+        val testCerts = testCertificateRepository.certificates.first().mapNotNull { it.testCertificate }
+        Timber.tag(TAG).d("Checking %d test certificates", testCerts.size)
+        val allCerts = vacRecCerts + testCerts
 
         allCerts
             .filter { it.getState() is CwaCovidCertificate.State.Invalid }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/expiration/DccExpirationNotificationService.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/expiration/DccExpirationNotificationService.kt
@@ -28,8 +28,8 @@ class DccExpirationNotificationService @Inject constructor(
 ) {
     private val mutex = Mutex()
 
-    suspend fun showNotificationIfExpired() = mutex.withLock {
-        Timber.tag(TAG).v("checkStates()")
+    suspend fun showNotificationIfStateChanged() = mutex.withLock {
+        Timber.tag(TAG).v("showNotificationIfStateChanged()")
 
         val lastCheck = covidCertificateSettings.lastDccStateBackgroundCheck.value
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesProvider.kt
@@ -3,11 +3,8 @@ package de.rki.coronawarnapp.covidcertificate.person.core
 import dagger.Reusable
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CertificatePersonIdentifier
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate
-import de.rki.coronawarnapp.covidcertificate.recovery.core.RecoveryCertificate
 import de.rki.coronawarnapp.covidcertificate.recovery.core.RecoveryCertificateRepository
-import de.rki.coronawarnapp.covidcertificate.test.core.TestCertificate
 import de.rki.coronawarnapp.covidcertificate.test.core.TestCertificateRepository
-import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinationCertificate
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.repository.VaccinationRepository
 import de.rki.coronawarnapp.util.coroutine.AppScope
 import de.rki.coronawarnapp.util.flow.shareLatest
@@ -22,9 +19,9 @@ import javax.inject.Inject
 @Reusable
 class PersonCertificatesProvider @Inject constructor(
     private val personCertificatesSettings: PersonCertificatesSettings,
-    private val vaccinationRepository: VaccinationRepository,
-    private val testCertificateRepository: TestCertificateRepository,
-    private val recoveryCertificateRepository: RecoveryCertificateRepository,
+    vaccinationRepository: VaccinationRepository,
+    testCertificateRepository: TestCertificateRepository,
+    recoveryCertificateRepository: RecoveryCertificateRepository,
     @AppScope private val appScope: CoroutineScope,
 ) {
     init {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesProvider.kt
@@ -14,7 +14,6 @@ import de.rki.coronawarnapp.util.flow.shareLatest
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import timber.log.Timber
 import javax.inject.Inject
@@ -58,7 +57,7 @@ class PersonCertificatesProvider @Inject constructor(
             PersonCertificates(
                 certificates = certs.toCertificateSortOrder(),
                 isCwaUser = personIdentifier == cwaUser,
-                badgeCount = certs.filter { it.hasNotification }.count()
+                badgeCount = certs.filter { it.hasNotificationBadge }.count()
             )
         }.toSet()
     }.shareLatest(scope = appScope)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesProvider.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import timber.log.Timber
 import javax.inject.Inject

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesProvider.kt
@@ -95,8 +95,8 @@ class PersonCertificatesProvider @Inject constructor(
         newTestCertificates + vacStateChanges + recoveryStateChanges
     }.shareLatest(scope = appScope)
 
-    // TODO return person badge count
-    val personsBadgeCount: Flow<Int> = flowOf()
+    val personsBadgeCount: Flow<Int> = personCertificates
+        .map { persons -> persons.sumOf { it.badgeCount } }
 
     suspend fun acknowledgeStateChange(certificate: CwaCovidCertificate) {
         Timber.tag(TAG).d("acknowledgeStateChange(containerId=$certificate.containerId)")

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesProvider.kt
@@ -73,6 +73,7 @@ class PersonCertificatesProvider @Inject constructor(
         personCertificatesSettings.currentCwaUser.update { personIdentifier }
     }
 
+    // TODO remove
     val badgeCount: Flow<Int> = combine(
         testCertificateRepository.certificates.map { certs ->
             certs.filter { !it.seenByUser && !it.isCertificateRetrievalPending }.size
@@ -93,6 +94,7 @@ class PersonCertificatesProvider @Inject constructor(
     ) { newTestCertificates, vacStateChanges, recoveryStateChanges ->
         newTestCertificates + vacStateChanges + recoveryStateChanges
     }.shareLatest(scope = appScope)
+    // TODO end
 
     val personsBadgeCount: Flow<Int> = personCertificates
         .map { persons -> persons.sumOf { it.badgeCount } }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragment.kt
@@ -48,22 +48,6 @@ class PersonOverviewFragment : Fragment(R.layout.person_overview_fragment), Auto
         }
         viewModel.personCertificates.observe(viewLifecycleOwner) { binding.bindViews(it) }
         viewModel.events.observe(viewLifecycleOwner) { onNavEvent(it) }
-        viewModel.markNewCertsAsSeen.observe(viewLifecycleOwner) {
-            Timber.tag(TAG).d("markNewCertsAsSeen=%s", it)
-
-            /**
-             * This just needs to stay subscribed while the UI is open.
-             * It causes new certificates to be marked seen automatically.
-             */
-        }
-        viewModel.markStateChangesAsSeen.observe(viewLifecycleOwner) {
-            Timber.tag(TAG).d("markStateChangesAsSeen=%s", it)
-
-            /**
-             * This just needs to stay subscribed while the UI is open.
-             * It causes certificate state changes to be marked seen automatically.
-             */
-        }
     }
 
     private fun onNavEvent(event: PersonOverviewFragmentEvents) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewViewModel.kt
@@ -25,10 +25,7 @@ import de.rki.coronawarnapp.util.ui.SingleLiveEvent
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
 import de.rki.coronawarnapp.util.viewmodel.SimpleCWAViewModelFactory
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
 import timber.log.Timber
 
 class PersonOverviewViewModel @AssistedInject constructor(
@@ -61,17 +58,6 @@ class PersonOverviewViewModel @AssistedInject constructor(
             addPersonItems(persons, tcWrappers)
         }
     }.asLiveData(dispatcherProvider.Default)
-
-    val markNewCertsAsSeen = testCertificateRepository.certificates
-        .onEach { wrappers ->
-            wrappers
-                .filter { !it.seenByUser && !it.isCertificateRetrievalPending }
-                .forEach {
-                    testCertificateRepository.markCertificateAsSeenByUser(it.containerId)
-                }
-        }
-        .catch { Timber.tag(TAG).w("Failed to mark certificates as seen.") }
-        .asLiveData2()
 
     fun deleteTestCertificate(containerId: TestCertificateContainerId) = launch {
         testCertificateRepository.deleteCertificate(containerId)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewViewModel.kt
@@ -34,10 +34,10 @@ import timber.log.Timber
 class PersonOverviewViewModel @AssistedInject constructor(
     dispatcherProvider: DispatcherProvider,
     certificatesProvider: PersonCertificatesProvider,
-    private val testCertificateRepository: TestCertificateRepository,
+    cameraPermissionProvider: CameraPermissionProvider,
     valueSetsRepository: ValueSetsRepository,
+    private val testCertificateRepository: TestCertificateRepository,
     @AppContext context: Context,
-    private val cameraPermissionProvider: CameraPermissionProvider,
     @AppScope private val appScope: CoroutineScope
 ) : CWAViewModel(dispatcherProvider) {
 
@@ -69,23 +69,6 @@ class PersonOverviewViewModel @AssistedInject constructor(
                 .forEach {
                     testCertificateRepository.markCertificateAsSeenByUser(it.containerId)
                 }
-        }
-        .catch { Timber.tag(TAG).w("Failed to mark certificates as seen.") }
-        .asLiveData2()
-
-    // TODO move this logic into certificate details screen
-    val markStateChangesAsSeen = certificatesProvider.personCertificates
-        .map { persons ->
-            persons.map { it.certificates }.flatten()
-        }
-        .onEach { certs ->
-            certs.forEach {
-                if (it.getState() == it.lastSeenStateChange) {
-                    return@forEach
-                } else {
-                    certificatesProvider.acknowledgeStateChange(it)
-                }
-            }
         }
         .catch { Timber.tag(TAG).w("Failed to mark certificates as seen.") }
         .asLiveData2()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewViewModel.kt
@@ -96,8 +96,6 @@ class PersonOverviewViewModel @AssistedInject constructor(
 
     fun onScanQrCode() = events.postValue(ScanQrCode)
 
-    fun checkCameraSettings() = cameraPermissionProvider.checkSettings()
-
     private fun MutableList<PersonCertificatesItem>.addPersonItems(
         persons: Set<PersonCertificates>,
         tcWrappers: Set<TestCertificateWrapper>,

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/RecoveryCertificateRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/RecoveryCertificateRepository.kt
@@ -146,6 +146,7 @@ class RecoveryCertificateRepository @Inject constructor(
             val newData = when (state) {
                 is CwaCovidCertificate.State.Expired -> toUpdate.data.copy(notifiedExpiredAt = time)
                 is CwaCovidCertificate.State.ExpiringSoon -> toUpdate.data.copy(notifiedExpiresSoonAt = time)
+                is CwaCovidCertificate.State.Invalid -> toUpdate.data.copy(notifiedInvalidAt = time)
                 else -> throw UnsupportedOperationException("$state is not supported.")
             }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/storage/RecoveryCertificateContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/storage/RecoveryCertificateContainer.kt
@@ -62,6 +62,9 @@ data class RecoveryCertificateContainer(
             override val notifiedExpiredAt: Instant?
                 get() = data.notifiedExpiredAt
 
+            override val notifiedInvalidAt: Instant?
+                get() = data.notifiedInvalidAt
+
             override val lastSeenStateChange: State?
                 get() = data.lastSeenStateChange
 
@@ -133,11 +136,11 @@ data class RecoveryCertificateContainer(
             override val dccData: DccData<out DccV1.MetaData>
                 get() = certificateData
 
-            // TODO check notification conditions
             override val hasNotification: Boolean
-                get() = false
-            override val notifiedInvalidAt: Instant?
-                get() = null
+                get() {
+                    val state = getState()
+                    return state !is State.Valid && state != lastSeenStateChange
+                }
 
             override fun toString(): String = "RecoveryCertificate($containerId)"
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/storage/RecoveryCertificateContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/storage/RecoveryCertificateContainer.kt
@@ -136,7 +136,7 @@ data class RecoveryCertificateContainer(
             override val dccData: DccData<out DccV1.MetaData>
                 get() = certificateData
 
-            override val hasNotification: Boolean
+            override val hasNotificationBadge: Boolean
                 get() {
                     val state = getState()
                     return state !is State.Valid && state != lastSeenStateChange

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/storage/StoredRecoveryCertificateData.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/storage/StoredRecoveryCertificateData.kt
@@ -8,6 +8,7 @@ data class StoredRecoveryCertificateData(
     @SerializedName("recoveryCertificateQrCode") val recoveryCertificateQrCode: String,
     @SerializedName("notifiedExpiresSoonAt") val notifiedExpiresSoonAt: Instant? = null,
     @SerializedName("notifiedExpiredAt") val notifiedExpiredAt: Instant? = null,
+    @SerializedName("notifiedInvalidAt") val notifiedInvalidAt: Instant? = null,
     @SerializedName("lastSeenStateChange") val lastSeenStateChange: State? = null,
     @SerializedName("lastSeenStateChangeAt") val lastSeenStateChangeAt: Instant? = null,
 )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/details/RecoveryCertificateDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/details/RecoveryCertificateDetailsFragment.kt
@@ -68,8 +68,8 @@ class RecoveryCertificateDetailsFragment : Fragment(R.layout.fragment_recovery_c
         viewModel.recoveryCertificate.observe(viewLifecycleOwner) { it?.let { onCertificateReady(it) } }
     }
 
-    override fun onStart() {
-        super.onStart()
+    override fun onStop() {
+        super.onStop()
         viewModel.refreshCertState()
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificate.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificate.kt
@@ -32,15 +32,16 @@ interface TestCertificate : CwaCovidCertificate {
     val isCertificateRetrievalPending: Boolean
 
     /**
+     * Newly retrieved from backend and user has not seen it yet
+     */
+    val isNewlyRetrieved: Boolean get() = false
+
+    /**
      * Not supported by this type of certificate (at the moment)
      */
     override val notifiedExpiredAt: Instant?
         get() = null
     override val notifiedExpiresSoonAt: Instant?
-        get() = null
-    override val lastSeenStateChange: CwaCovidCertificate.State?
-        get() = null
-    override val lastSeenStateChangeAt: Instant?
         get() = null
 
     override val rawCertificate: TestDccV1

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateProcessor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateProcessor.kt
@@ -213,7 +213,7 @@ class TestCertificateProcessor @Inject constructor(
         }
     }
 
-    internal suspend fun updateSeenByUser(
+    fun updateSeenByUser(
         data: RetrievedTestCertificate,
         seenByUser: Boolean,
     ): RetrievedTestCertificate {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepository.kt
@@ -393,6 +393,7 @@ class TestCertificateRepository @Inject constructor(
     suspend fun acknowledgeState(containerId: TestCertificateContainerId) {
         Timber.tag(TAG).d("acknowledgeState(containerId=$containerId)")
         // Currently not supported
+        // TODO for invalid state
     }
 
     fun setNotifiedState(
@@ -400,7 +401,7 @@ class TestCertificateRepository @Inject constructor(
         state: CwaCovidCertificate.State,
         now: Instant
     ) {
-        TODO("Not yet implemented")
+        // TODO
     }
 
     companion object {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepository.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext
+import org.joda.time.Instant
 import timber.log.Timber
 import java.util.UUID
 import javax.inject.Inject
@@ -392,6 +393,14 @@ class TestCertificateRepository @Inject constructor(
     suspend fun acknowledgeState(containerId: TestCertificateContainerId) {
         Timber.tag(TAG).d("acknowledgeState(containerId=$containerId)")
         // Currently not supported
+    }
+
+    fun setNotifiedState(
+        containerId: TestCertificateContainerId,
+        state: CwaCovidCertificate.State,
+        now: Instant
+    ) {
+        TODO("Not yet implemented")
     }
 
     companion object {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateWrapper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateWrapper.kt
@@ -20,8 +20,6 @@ data class TestCertificateWrapper(
 
     val registeredAt: Instant get() = container.registeredAt
 
-    val seenByUser: Boolean get() = container.certificateSeenByUser
-
     val registrationToken: String? get() = container.registrationToken
 
     val testCertificate: TestCertificate? by lazy {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateContainer.kt
@@ -156,7 +156,7 @@ data class TestCertificateContainer(
             override val notifiedInvalidAt: Instant?
                 get() = null
 
-            override val hasNotification: Boolean
+            override val hasNotificationBadge: Boolean
                 get() = (!certificateSeenByUser && !isCertificateRetrievalPending) ||
                     (getState() is State.Invalid && notifiedInvalidAt == null)
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateContainer.kt
@@ -153,12 +153,12 @@ data class TestCertificateContainer(
             override val dccData: DccData<out DccV1.MetaData>
                 get() = testCertificateQRCode!!.data
 
-            // TODO check notification conditions
-            override val hasNotification: Boolean
-                get() = false
-
             override val notifiedInvalidAt: Instant?
                 get() = null
+
+            override val hasNotification: Boolean
+                get() = (!certificateSeenByUser && !isCertificateRetrievalPending) ||
+                    (getState() is State.Invalid && notifiedInvalidAt == null)
 
             override fun toString(): String = "TestCertificate($containerId)"
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateContainer.kt
@@ -154,11 +154,23 @@ data class TestCertificateContainer(
                 get() = testCertificateQRCode!!.data
 
             override val notifiedInvalidAt: Instant?
-                get() = null
+                get() = data.notifiedInvalidAt
+
+            override val lastSeenStateChange: State?
+                get() = data.lastSeenStateChange
+
+            override val lastSeenStateChangeAt: Instant?
+                get() = data.lastSeenStateChangeAt
+
+            override val isNewlyRetrieved: Boolean
+                get() = !certificateSeenByUser && !isCertificateRetrievalPending
 
             override val hasNotificationBadge: Boolean
-                get() = (!certificateSeenByUser && !isCertificateRetrievalPending) ||
-                    (getState() is State.Invalid && notifiedInvalidAt == null)
+                get() {
+                    val state = getState()
+                    return isNewlyRetrieved ||
+                        (state is State.Invalid && state != lastSeenStateChange)
+                }
 
             override fun toString(): String = "TestCertificate($containerId)"
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateStorage.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateStorage.kt
@@ -6,6 +6,7 @@ import androidx.core.content.edit
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import de.rki.coronawarnapp.coronatest.server.CoronaTestResult
+import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate
 import de.rki.coronawarnapp.covidcertificate.test.core.storage.types.BaseTestCertificateData
 import de.rki.coronawarnapp.covidcertificate.test.core.storage.types.GenericTestCertificateData
 import de.rki.coronawarnapp.covidcertificate.test.core.storage.types.PCRCertificateData
@@ -31,6 +32,7 @@ class TestCertificateStorage @Inject constructor(
 
     private val gson by lazy {
         baseGson.newBuilder().apply {
+            registerTypeAdapterFactory(CwaCovidCertificate.State.typeAdapter)
             registerTypeAdapter(CoronaTestResult::class.java, CoronaTestResult.GsonAdapter())
         }.create()
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/types/BaseTestCertificateData.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/types/BaseTestCertificateData.kt
@@ -1,5 +1,6 @@
 package de.rki.coronawarnapp.covidcertificate.test.core.storage.types
 
+import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate
 import org.joda.time.Instant
 
 /**
@@ -10,5 +11,7 @@ sealed class BaseTestCertificateData {
     abstract val registeredAt: Instant
     abstract val certificateReceivedAt: Instant?
     abstract val notifiedInvalidAt: Instant?
+    abstract val lastSeenStateChange: CwaCovidCertificate.State?
+    abstract val lastSeenStateChangeAt: Instant?
     abstract val testCertificateQrCode: String?
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/types/BaseTestCertificateData.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/types/BaseTestCertificateData.kt
@@ -9,5 +9,6 @@ sealed class BaseTestCertificateData {
     abstract val identifier: String
     abstract val registeredAt: Instant
     abstract val certificateReceivedAt: Instant?
+    abstract val notifiedInvalidAt: Instant?
     abstract val testCertificateQrCode: String?
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/types/GenericTestCertificateData.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/types/GenericTestCertificateData.kt
@@ -17,6 +17,9 @@ data class GenericTestCertificateData(
     @SerializedName("certificateReceivedAt")
     override val certificateReceivedAt: Instant? = null,
 
+    @SerializedName("notifiedInvalidAt")
+    override val notifiedInvalidAt: Instant? = null,
+
     @SerializedName("testCertificateQrCode")
     override val testCertificateQrCode: String? = null,
 ) : ScannedTestCertificate() {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/types/GenericTestCertificateData.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/types/GenericTestCertificateData.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.covidcertificate.test.core.storage.types
 
 import com.google.gson.annotations.SerializedName
+import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate
 import org.joda.time.Instant
 
 /**
@@ -19,6 +20,12 @@ data class GenericTestCertificateData(
 
     @SerializedName("notifiedInvalidAt")
     override val notifiedInvalidAt: Instant? = null,
+
+    @SerializedName("lastSeenStateChange")
+    override val lastSeenStateChange: CwaCovidCertificate.State? = null,
+
+    @SerializedName("lastSeenStateChangeAt")
+    override val lastSeenStateChangeAt: Instant? = null,
 
     @SerializedName("testCertificateQrCode")
     override val testCertificateQrCode: String? = null,

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/types/PCRCertificateData.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/types/PCRCertificateData.kt
@@ -16,6 +16,9 @@ data class PCRCertificateData internal constructor(
     @SerializedName("registeredAt")
     override val registeredAt: Instant,
 
+    @SerializedName("notifiedInvalidAt")
+    override val notifiedInvalidAt: Instant? = null,
+
     @SerializedName("publicKeyRegisteredAt")
     override val publicKeyRegisteredAt: Instant? = null,
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/types/PCRCertificateData.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/types/PCRCertificateData.kt
@@ -2,6 +2,7 @@ package de.rki.coronawarnapp.covidcertificate.test.core.storage.types
 
 import com.google.gson.annotations.SerializedName
 import de.rki.coronawarnapp.coronatest.type.RegistrationToken
+import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate
 import de.rki.coronawarnapp.util.encryption.rsa.RSAKey
 import okio.ByteString
 import org.joda.time.Instant
@@ -18,6 +19,12 @@ data class PCRCertificateData internal constructor(
 
     @SerializedName("notifiedInvalidAt")
     override val notifiedInvalidAt: Instant? = null,
+
+    @SerializedName("lastSeenStateChange")
+    override val lastSeenStateChange: CwaCovidCertificate.State? = null,
+
+    @SerializedName("lastSeenStateChangeAt")
+    override val lastSeenStateChangeAt: Instant? = null,
 
     @SerializedName("publicKeyRegisteredAt")
     override val publicKeyRegisteredAt: Instant? = null,

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/types/RACertificateData.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/types/RACertificateData.kt
@@ -16,6 +16,9 @@ data class RACertificateData(
     @SerializedName("registeredAt")
     override val registeredAt: Instant,
 
+    @SerializedName("notifiedInvalidAt")
+    override val notifiedInvalidAt: Instant? = null,
+
     @SerializedName("publicKeyRegisteredAt")
     override val publicKeyRegisteredAt: Instant? = null,
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/types/RACertificateData.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/types/RACertificateData.kt
@@ -2,6 +2,7 @@ package de.rki.coronawarnapp.covidcertificate.test.core.storage.types
 
 import com.google.gson.annotations.SerializedName
 import de.rki.coronawarnapp.coronatest.type.RegistrationToken
+import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate
 import de.rki.coronawarnapp.util.encryption.rsa.RSAKey
 import okio.ByteString
 import org.joda.time.Instant
@@ -18,6 +19,12 @@ data class RACertificateData(
 
     @SerializedName("notifiedInvalidAt")
     override val notifiedInvalidAt: Instant? = null,
+
+    @SerializedName("lastSeenStateChange")
+    override val lastSeenStateChange: CwaCovidCertificate.State? = null,
+
+    @SerializedName("lastSeenStateChangeAt")
+    override val lastSeenStateChangeAt: Instant? = null,
 
     @SerializedName("publicKeyRegisteredAt")
     override val publicKeyRegisteredAt: Instant? = null,

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/TestCertificateDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/TestCertificateDetailsFragment.kt
@@ -137,8 +137,8 @@ class TestCertificateDetailsFragment : Fragment(R.layout.fragment_test_certifica
         }
     }
 
-    override fun onStart() {
-        super.onStart()
+    override fun onStop() {
+        super.onStop()
         viewModel.refreshCertState()
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/TestCertificateDetailsViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/TestCertificateDetailsViewModel.kt
@@ -56,7 +56,11 @@ class TestCertificateDetailsViewModel @AssistedInject constructor(
 
     fun refreshCertState() = launch(scope = appScope) {
         Timber.v("refreshCertState()")
-        testCertificateRepository.acknowledgeState(containerId)
+        if (covidCertificate.value?.isNewlyRetrieved == true) {
+            testCertificateRepository.markCertificateAsSeenByUser(containerId)
+        } else {
+            testCertificateRepository.acknowledgeState(containerId)
+        }
     }
 
     @AssistedFactory

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/VaccinationRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/VaccinationRepository.kt
@@ -229,6 +229,7 @@ class VaccinationRepository @Inject constructor(
             val newVaccination = when (state) {
                 is CwaCovidCertificate.State.Expired -> toUpdateVaccination.copy(notifiedExpiredAt = time)
                 is CwaCovidCertificate.State.ExpiringSoon -> toUpdateVaccination.copy(notifiedExpiresSoonAt = time)
+                is CwaCovidCertificate.State.Invalid -> toUpdateVaccination.copy(notifiedInvalidAt = time)
                 else -> throw UnsupportedOperationException("$state is not supported.")
             }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/storage/VaccinationContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/storage/VaccinationContainer.kt
@@ -3,6 +3,7 @@ package de.rki.coronawarnapp.covidcertificate.vaccination.core.repository.storag
 import androidx.annotation.Keep
 import com.google.gson.annotations.SerializedName
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CertificatePersonIdentifier
+import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate.State
 import de.rki.coronawarnapp.covidcertificate.common.certificate.DccData
 import de.rki.coronawarnapp.covidcertificate.common.certificate.DccHeader
@@ -27,6 +28,7 @@ data class VaccinationContainer internal constructor(
     @SerializedName("scannedAt") val scannedAt: Instant,
     @SerializedName("notifiedExpiresSoonAt") val notifiedExpiresSoonAt: Instant? = null,
     @SerializedName("notifiedExpiredAt") val notifiedExpiredAt: Instant? = null,
+    @SerializedName("notifiedInvalidAt") val notifiedInvalidAt: Instant? = null,
     @SerializedName("lastSeenStateChange") val lastSeenStateChange: State? = null,
     @SerializedName("lastSeenStateChangeAt") val lastSeenStateChangeAt: Instant? = null,
 ) : CertificateRepoContainer {
@@ -80,6 +82,9 @@ data class VaccinationContainer internal constructor(
 
         override val notifiedExpiredAt: Instant?
             get() = this@VaccinationContainer.notifiedExpiredAt
+
+        override val notifiedInvalidAt: Instant?
+            get() = this@VaccinationContainer.notifiedInvalidAt
 
         override val lastSeenStateChange: State?
             get() = this@VaccinationContainer.lastSeenStateChange
@@ -163,11 +168,11 @@ data class VaccinationContainer internal constructor(
         override val dccData: DccData<out DccV1.MetaData>
             get() = certificateData
 
-        // TODO check notification conditions
         override val hasNotification: Boolean
-            get() = false
-        override val notifiedInvalidAt: Instant?
-            get() = null
+            get() {
+                val state = getState()
+                return state !is State.Valid && state != lastSeenStateChange
+            }
 
         override fun toString(): String = "VaccinationCertificate($containerId)"
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/storage/VaccinationContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/storage/VaccinationContainer.kt
@@ -167,7 +167,7 @@ data class VaccinationContainer internal constructor(
         override val dccData: DccData<out DccV1.MetaData>
             get() = certificateData
 
-        override val hasNotification: Boolean
+        override val hasNotificationBadge: Boolean
             get() {
                 val state = getState()
                 return state !is State.Valid && state != lastSeenStateChange

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/storage/VaccinationContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/storage/VaccinationContainer.kt
@@ -3,7 +3,6 @@ package de.rki.coronawarnapp.covidcertificate.vaccination.core.repository.storag
 import androidx.annotation.Keep
 import com.google.gson.annotations.SerializedName
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CertificatePersonIdentifier
-import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate.State
 import de.rki.coronawarnapp.covidcertificate.common.certificate.DccData
 import de.rki.coronawarnapp.covidcertificate.common.certificate.DccHeader

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragment.kt
@@ -117,8 +117,8 @@ class VaccinationDetailsFragment : Fragment(R.layout.fragment_vaccination_detail
             }
         }
 
-    override fun onStart() {
-        super.onStart()
+    override fun onStop() {
+        super.onStop()
         viewModel.refreshCertState()
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainActivity.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainActivity.kt
@@ -111,6 +111,11 @@ class MainActivity : AppCompatActivity(), HasAndroidInjector {
             binding.mainBottomNavigation.updateCountBadge(R.id.covid_certificates_graph, count)
         }
 
+        vm.personsBadgeCount.observe(this) { count ->
+            Timber.d("personsBadgeCount=$count")
+            binding.mainBottomNavigation.updateCountBadge(R.id.covid_certificates_graph, count)
+        }
+
         if (savedInstanceState == null) {
             processExtraParameters()
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainActivity.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainActivity.kt
@@ -106,11 +106,6 @@ class MainActivity : AppCompatActivity(), HasAndroidInjector {
             binding.mainBottomNavigation.updateCountBadge(R.id.trace_location_attendee_nav_graph, count)
         }
 
-        vm.certificateBadgeCount.observe(this) { count ->
-            Timber.d("certificateBadgeCount=$count")
-            binding.mainBottomNavigation.updateCountBadge(R.id.covid_certificates_graph, count)
-        }
-
         vm.personsBadgeCount.observe(this) { count ->
             Timber.d("personsBadgeCount=$count")
             binding.mainBottomNavigation.updateCountBadge(R.id.covid_certificates_graph, count)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainActivityViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainActivityViewModel.kt
@@ -53,6 +53,7 @@ class MainActivityViewModel @AssistedInject constructor(
         .asLiveData2()
 
     val certificateBadgeCount: LiveData<Int> = personCertificatesProvider.badgeCount.asLiveData2()
+    val personsBadgeCount: LiveData<Int> = personCertificatesProvider.personsBadgeCount.asLiveData2()
 
     init {
         if (CWADebug.isDeviceForTestersBuild) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainActivityViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainActivityViewModel.kt
@@ -52,7 +52,6 @@ class MainActivityViewModel @AssistedInject constructor(
         .map { checkins -> checkins.filter { !it.completed }.size }
         .asLiveData2()
 
-    val certificateBadgeCount: LiveData<Int> = personCertificatesProvider.badgeCount.asLiveData2()
     val personsBadgeCount: LiveData<Int> = personCertificatesProvider.personsBadgeCount.asLiveData2()
 
     init {

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/common/statecheck/DccStateCheckSchedulerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/common/statecheck/DccStateCheckSchedulerTest.kt
@@ -49,7 +49,7 @@ class DccStateCheckSchedulerTest : BaseTest() {
 
         every { mockDscData.updatedAt } returns Instant.EPOCH
         every { timeStamper.nowUTC } returns Instant.ofEpochSecond(1234567)
-        coEvery { dccExpirationNotificationService.showNotificationIfExpired() } just Runs
+        coEvery { dccExpirationNotificationService.showNotificationIfStateChanged() } just Runs
     }
 
     fun createInstance(scope: CoroutineScope) = DccStateCheckScheduler(
@@ -96,7 +96,7 @@ class DccStateCheckSchedulerTest : BaseTest() {
             isForeground.value = false
             advanceUntilIdle()
 
-            coVerify(exactly = 1) { dccExpirationNotificationService.showNotificationIfExpired() }
+            coVerify(exactly = 1) { dccExpirationNotificationService.showNotificationIfStateChanged() }
         }
     }
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/common/statecheck/DccStateCheckWorkerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/common/statecheck/DccStateCheckWorkerTest.kt
@@ -30,7 +30,7 @@ class DccStateCheckWorkerTest : BaseTest() {
         MockKAnnotations.init(this)
 
         dccExpirationNotificationService.apply {
-            coEvery { showNotificationIfExpired() } just Runs
+            coEvery { showNotificationIfStateChanged() } just Runs
         }
     }
 
@@ -50,18 +50,18 @@ class DccStateCheckWorkerTest : BaseTest() {
         createWorker().doWork() shouldBe ListenableWorker.Result.success()
 
         coVerifySequence {
-            dccExpirationNotificationService.showNotificationIfExpired()
+            dccExpirationNotificationService.showNotificationIfStateChanged()
         }
     }
 
     @Test
     fun `retry on errors`() = runBlockingTest {
-        coEvery { dccExpirationNotificationService.showNotificationIfExpired() } throws RuntimeException()
+        coEvery { dccExpirationNotificationService.showNotificationIfStateChanged() } throws RuntimeException()
 
         createWorker().doWork() shouldBe ListenableWorker.Result.retry()
 
         coVerifySequence {
-            dccExpirationNotificationService.showNotificationIfExpired()
+            dccExpirationNotificationService.showNotificationIfStateChanged()
         }
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/expiration/DccExpirationNotificationServiceTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/expiration/DccExpirationNotificationServiceTest.kt
@@ -6,6 +6,7 @@ import de.rki.coronawarnapp.covidcertificate.common.repository.VaccinationCertif
 import de.rki.coronawarnapp.covidcertificate.recovery.core.RecoveryCertificate
 import de.rki.coronawarnapp.covidcertificate.recovery.core.RecoveryCertificateRepository
 import de.rki.coronawarnapp.covidcertificate.recovery.core.RecoveryCertificateWrapper
+import de.rki.coronawarnapp.covidcertificate.test.core.TestCertificateRepository
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.CovidCertificateSettings
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinatedPerson
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinationCertificate
@@ -33,6 +34,7 @@ class DccExpirationNotificationServiceTest : BaseTest() {
     @MockK lateinit var expirationNotification: DccExpirationNotification
     @MockK lateinit var vaccinationRepository: VaccinationRepository
     @MockK lateinit var recoveryRepository: RecoveryCertificateRepository
+    @MockK lateinit var testCertificateRepository: TestCertificateRepository
     @MockK lateinit var covidCertificateSettings: CovidCertificateSettings
     @MockK lateinit var timeStamper: TimeStamper
 
@@ -82,6 +84,10 @@ class DccExpirationNotificationServiceTest : BaseTest() {
             every { notifiedExpiresSoonAt } returns null
             every { notifiedExpiredAt } returns null
         }
+
+        testCertificateRepository.apply {
+            every { setNotifiedState(any(), any(), any()) } just Runs
+        }
     }
 
     fun createInstance() = DccExpirationNotificationService(
@@ -89,6 +95,7 @@ class DccExpirationNotificationServiceTest : BaseTest() {
         vaccinationRepository = vaccinationRepository,
         recoveryRepository = recoveryRepository,
         covidCertificateSettings = covidCertificateSettings,
+        testCertificateRepository = testCertificateRepository,
         timeStamper = timeStamper,
     )
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/expiration/DccExpirationNotificationServiceTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/expiration/DccExpirationNotificationServiceTest.kt
@@ -86,7 +86,7 @@ class DccExpirationNotificationServiceTest : BaseTest() {
         }
 
         testCertificateRepository.apply {
-            every { setNotifiedState(any(), any(), any()) } just Runs
+            coEvery { setNotifiedState(any(), any(), any()) } just Runs
         }
     }
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/expiration/DccExpirationNotificationServiceTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/expiration/DccExpirationNotificationServiceTest.kt
@@ -2,11 +2,14 @@ package de.rki.coronawarnapp.covidcertificate.expiration
 
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate.State
 import de.rki.coronawarnapp.covidcertificate.common.repository.RecoveryCertificateContainerId
+import de.rki.coronawarnapp.covidcertificate.common.repository.TestCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.common.repository.VaccinationCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.recovery.core.RecoveryCertificate
 import de.rki.coronawarnapp.covidcertificate.recovery.core.RecoveryCertificateRepository
 import de.rki.coronawarnapp.covidcertificate.recovery.core.RecoveryCertificateWrapper
+import de.rki.coronawarnapp.covidcertificate.test.core.TestCertificate
 import de.rki.coronawarnapp.covidcertificate.test.core.TestCertificateRepository
+import de.rki.coronawarnapp.covidcertificate.test.core.TestCertificateWrapper
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.CovidCertificateSettings
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinatedPerson
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinationCertificate
@@ -46,6 +49,10 @@ class DccExpirationNotificationServiceTest : BaseTest() {
     @MockK lateinit var recoveryCertificate: RecoveryCertificate
     private val recoverContainerId = RecoveryCertificateContainerId("rec")
 
+    @MockK lateinit var testCertificateWrapper: TestCertificateWrapper
+    @MockK lateinit var testCertificate: TestCertificate
+    private val testContainerId = TestCertificateContainerId("test")
+
     private val lastDccStateBackgroundCheck = mockFlowPreference(Instant.EPOCH)
     private val nowUtc = Instant.EPOCH.plus(Duration.standardDays(7))
 
@@ -71,6 +78,7 @@ class DccExpirationNotificationServiceTest : BaseTest() {
             every { containerId } returns vaccinationContainerId
             every { notifiedExpiresSoonAt } returns null
             every { notifiedExpiredAt } returns null
+            every { notifiedInvalidAt } returns null
         }
 
         recoveryRepository.apply {
@@ -83,10 +91,21 @@ class DccExpirationNotificationServiceTest : BaseTest() {
             every { containerId } returns recoverContainerId
             every { notifiedExpiresSoonAt } returns null
             every { notifiedExpiredAt } returns null
+            every { notifiedInvalidAt } returns null
+        }
+
+        every { testCertificateWrapper.testCertificate } returns testCertificate
+        testCertificate.apply {
+            every { getState() } returns State.Valid(expiresAt = Instant.EPOCH)
+            every { containerId } returns testContainerId
+            every { notifiedExpiresSoonAt } returns null
+            every { notifiedExpiredAt } returns null
+            every { notifiedInvalidAt } returns null
         }
 
         testCertificateRepository.apply {
             coEvery { setNotifiedState(any(), any(), any()) } just Runs
+            every { certificates } returns flowOf(setOf(testCertificateWrapper))
         }
     }
 
@@ -116,7 +135,7 @@ class DccExpirationNotificationServiceTest : BaseTest() {
         every { vaccinationRepository.vaccinationInfos } returns flowOf(emptySet())
         every { recoveryRepository.certificates } returns flowOf(emptySet())
 
-        createInstance().showNotificationIfExpired()
+        createInstance().showNotificationIfStateChanged()
 
         verify {
             vaccinationRepository.vaccinationInfos
@@ -127,7 +146,7 @@ class DccExpirationNotificationServiceTest : BaseTest() {
 
     @Test
     fun `certificates that are all valid`() = runBlockingTest {
-        createInstance().showNotificationIfExpired()
+        createInstance().showNotificationIfStateChanged()
 
         verify { expirationNotification wasNot Called }
 
@@ -142,7 +161,7 @@ class DccExpirationNotificationServiceTest : BaseTest() {
         every { vaccinationCertificate.getState() } returns State.Expired(expiredAt = Instant.EPOCH)
         every { recoveryCertificate.getState() } returns State.Expired(expiredAt = Instant.EPOCH)
 
-        createInstance().showNotificationIfExpired()
+        createInstance().showNotificationIfStateChanged()
 
         coVerify { expirationNotification.showNotification(any()) }
     }
@@ -152,7 +171,7 @@ class DccExpirationNotificationServiceTest : BaseTest() {
         every { vaccinationCertificate.getState() } returns State.ExpiringSoon(expiresAt = Instant.EPOCH)
         every { recoveryCertificate.getState() } returns State.ExpiringSoon(expiresAt = Instant.EPOCH)
 
-        createInstance().showNotificationIfExpired()
+        createInstance().showNotificationIfStateChanged()
 
         coVerify { expirationNotification.showNotification(any()) }
     }
@@ -162,7 +181,7 @@ class DccExpirationNotificationServiceTest : BaseTest() {
         every { vaccinationCertificate.getState() } returns State.ExpiringSoon(expiresAt = Instant.EPOCH)
         every { recoveryCertificate.getState() } returns State.Expired(expiredAt = Instant.EPOCH)
 
-        createInstance().showNotificationIfExpired()
+        createInstance().showNotificationIfStateChanged()
 
         coVerify(exactly = 2) { expirationNotification.showNotification(any()) }
 
@@ -182,6 +201,86 @@ class DccExpirationNotificationServiceTest : BaseTest() {
     }
 
     @Test
+    fun `one invalid each - one notification`() = runBlockingTest {
+        every { vaccinationCertificate.getState() } returns State.Invalid()
+        every { recoveryCertificate.getState() } returns State.Invalid()
+        every { testCertificate.getState() } returns State.Invalid()
+
+        createInstance().showNotificationIfStateChanged()
+
+        coVerify(exactly = 1) {
+            expirationNotification.showNotification(any())
+            vaccinationRepository.setNotifiedState(
+                containerId = vaccinationContainerId,
+                state = State.Invalid(),
+                time = nowUtc,
+            )
+        }
+
+        coVerify(exactly = 0) {
+            recoveryRepository.setNotifiedState(
+                containerId = recoverContainerId,
+                state = State.Invalid(),
+                time = nowUtc,
+            )
+
+            testCertificateRepository.setNotifiedState(
+                containerId = testContainerId,
+                state = State.Invalid(),
+                time = nowUtc,
+            )
+        }
+    }
+
+    @Test
+    fun `one invalid test certificate`() = runBlockingTest {
+        every { testCertificate.getState() } returns State.Invalid()
+
+        createInstance().showNotificationIfStateChanged()
+
+        coVerify(exactly = 1) {
+            expirationNotification.showNotification(any())
+            testCertificateRepository.setNotifiedState(
+                containerId = testContainerId,
+                state = State.Invalid(),
+                time = nowUtc,
+            )
+        }
+    }
+
+    @Test
+    fun `one invalid vaccination certificate`() = runBlockingTest {
+        every { vaccinationCertificate.getState() } returns State.Invalid()
+
+        createInstance().showNotificationIfStateChanged()
+
+        coVerify(exactly = 1) {
+            expirationNotification.showNotification(any())
+            vaccinationRepository.setNotifiedState(
+                containerId = vaccinationContainerId,
+                state = State.Invalid(),
+                time = nowUtc,
+            )
+        }
+    }
+
+    @Test
+    fun `one invalid recovery certificate`() = runBlockingTest {
+        every { recoveryCertificate.getState() } returns State.Invalid()
+
+        createInstance().showNotificationIfStateChanged()
+
+        coVerify(exactly = 1) {
+            expirationNotification.showNotification(any())
+            recoveryRepository.setNotifiedState(
+                containerId = recoverContainerId,
+                state = State.Invalid(),
+                time = nowUtc,
+            )
+        }
+    }
+
+    @Test
     fun `one of each but already notified the user`() = runBlockingTest {
         vaccinationCertificate.apply {
             every { getState() } returns State.ExpiringSoon(expiresAt = Instant.EPOCH)
@@ -192,7 +291,7 @@ class DccExpirationNotificationServiceTest : BaseTest() {
             every { notifiedExpiredAt } returns Instant.EPOCH
         }
 
-        createInstance().showNotificationIfExpired()
+        createInstance().showNotificationIfStateChanged()
 
         coVerify(exactly = 0) {
             expirationNotification.showNotification(any())

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesProviderTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesProviderTest.kt
@@ -20,10 +20,14 @@ import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.runBlockingTest
 import org.joda.time.Instant
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import testhelpers.TestDispatcherProvider
 import testhelpers.coroutines.runBlockingTest2
 import testhelpers.preferences.mockFlowPreference
 
@@ -34,10 +38,12 @@ class PersonCertificatesProviderTest : BaseTest() {
     @MockK lateinit var personCertificatesSettings: PersonCertificatesSettings
 
     private val identifierA = mockk<CertificatePersonIdentifier>()
+    private val identifierB = mockk<CertificatePersonIdentifier>()
 
     private val vaccinatedPersonACertificate1 = mockk<VaccinationCertificate>().apply {
         every { personIdentifier } returns identifierA
         every { vaccinatedOn } returns Instant.EPOCH.toLocalDateUtc()
+        every { hasNotification } returns false
     }
     private val vaccinatedPersonA = mockk<VaccinatedPerson>().apply {
         every { vaccinationCertificates } returns setOf(vaccinatedPersonACertificate1)
@@ -45,6 +51,8 @@ class PersonCertificatesProviderTest : BaseTest() {
     private val testWrapperACertificate = mockk<TestCertificate>().apply {
         every { personIdentifier } returns identifierA
         every { sampleCollectedAt } returns Instant.EPOCH
+        every { hasNotification } returns true
+
     }
     private val testWrapperA = mockk<TestCertificateWrapper>().apply {
         every { testCertificate } returns testWrapperACertificate
@@ -52,14 +60,37 @@ class PersonCertificatesProviderTest : BaseTest() {
     private val recoveryWrapperACertificate = mockk<RecoveryCertificate>().apply {
         every { personIdentifier } returns identifierA
         every { validFrom } returns Instant.EPOCH.toLocalDateUtc()
+        every { hasNotification } returns true
     }
     private val recoveryWrapperA = mockk<RecoveryCertificateWrapper>().apply {
         every { recoveryCertificate } returns recoveryWrapperACertificate
     }
 
+    // Person B
+    private val testCertificateB = mockk<TestCertificate>().apply {
+        every { personIdentifier } returns identifierB
+        every { sampleCollectedAt } returns Instant.EPOCH
+        every { hasNotification } returns true
+
+    }
+
+    private val recoveryCertificateB = mockk<RecoveryCertificate>().apply {
+        every { personIdentifier } returns identifierB
+        every { validFrom } returns Instant.EPOCH.toLocalDateUtc()
+        every { hasNotification } returns true
+    }
+
+    private val recoveryWrapperB = mockk<RecoveryCertificateWrapper>().apply {
+        every { recoveryCertificate } returns recoveryCertificateB
+    }
+
+    private val testWrapperB = mockk<TestCertificateWrapper>().apply {
+        every { testCertificate } returns testCertificateB
+    }
+
     private val vaccinationPersons = MutableStateFlow(setOf(vaccinatedPersonA))
-    private val testWrappers = MutableStateFlow(setOf(testWrapperA))
-    private val recoveryWrappers = MutableStateFlow(setOf(recoveryWrapperA))
+    private val testWrappers = MutableStateFlow(setOf(testWrapperA, testWrapperB))
+    private val recoveryWrappers = MutableStateFlow(setOf(recoveryWrapperA, recoveryWrapperB))
 
     @BeforeEach
     fun setup() {
@@ -111,8 +142,19 @@ class PersonCertificatesProviderTest : BaseTest() {
                     recoveryWrapperACertificate
                 ),
                 isCwaUser = true,
+                badgeCount = 2
+            ),
+            PersonCertificates(
+                certificates = listOf(
+                    testCertificateB,
+                    recoveryCertificateB
+                ),
+                isCwaUser = false,
+                badgeCount = 2
             )
         )
+
+        instance.personsBadgeCount.first() shouldBe 4
 
         verify {
             recoveryRepo.certificates

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesProviderTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesProviderTest.kt
@@ -20,14 +20,10 @@ import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.runBlockingTest
 import org.joda.time.Instant
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
-import testhelpers.TestDispatcherProvider
 import testhelpers.coroutines.runBlockingTest2
 import testhelpers.preferences.mockFlowPreference
 
@@ -52,7 +48,6 @@ class PersonCertificatesProviderTest : BaseTest() {
         every { personIdentifier } returns identifierA
         every { sampleCollectedAt } returns Instant.EPOCH
         every { hasNotification } returns true
-
     }
     private val testWrapperA = mockk<TestCertificateWrapper>().apply {
         every { testCertificate } returns testWrapperACertificate
@@ -71,7 +66,6 @@ class PersonCertificatesProviderTest : BaseTest() {
         every { personIdentifier } returns identifierB
         every { sampleCollectedAt } returns Instant.EPOCH
         every { hasNotification } returns true
-
     }
 
     private val recoveryCertificateB = mockk<RecoveryCertificate>().apply {

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesProviderTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesProviderTest.kt
@@ -39,7 +39,7 @@ class PersonCertificatesProviderTest : BaseTest() {
     private val vaccinatedPersonACertificate1 = mockk<VaccinationCertificate>().apply {
         every { personIdentifier } returns identifierA
         every { vaccinatedOn } returns Instant.EPOCH.toLocalDateUtc()
-        every { hasNotification } returns false
+        every { hasNotificationBadge } returns false
     }
     private val vaccinatedPersonA = mockk<VaccinatedPerson>().apply {
         every { vaccinationCertificates } returns setOf(vaccinatedPersonACertificate1)
@@ -47,7 +47,7 @@ class PersonCertificatesProviderTest : BaseTest() {
     private val testWrapperACertificate = mockk<TestCertificate>().apply {
         every { personIdentifier } returns identifierA
         every { sampleCollectedAt } returns Instant.EPOCH
-        every { hasNotification } returns true
+        every { hasNotificationBadge } returns true
     }
     private val testWrapperA = mockk<TestCertificateWrapper>().apply {
         every { testCertificate } returns testWrapperACertificate
@@ -55,7 +55,7 @@ class PersonCertificatesProviderTest : BaseTest() {
     private val recoveryWrapperACertificate = mockk<RecoveryCertificate>().apply {
         every { personIdentifier } returns identifierA
         every { validFrom } returns Instant.EPOCH.toLocalDateUtc()
-        every { hasNotification } returns true
+        every { hasNotificationBadge } returns true
     }
     private val recoveryWrapperA = mockk<RecoveryCertificateWrapper>().apply {
         every { recoveryCertificate } returns recoveryWrapperACertificate
@@ -65,13 +65,13 @@ class PersonCertificatesProviderTest : BaseTest() {
     private val testCertificateB = mockk<TestCertificate>().apply {
         every { personIdentifier } returns identifierB
         every { sampleCollectedAt } returns Instant.EPOCH
-        every { hasNotification } returns true
+        every { hasNotificationBadge } returns true
     }
 
     private val recoveryCertificateB = mockk<RecoveryCertificate>().apply {
         every { personIdentifier } returns identifierB
         every { validFrom } returns Instant.EPOCH.toLocalDateUtc()
-        every { hasNotification } returns true
+        every { hasNotificationBadge } returns true
     }
 
     private val recoveryWrapperB = mockk<RecoveryCertificateWrapper>().apply {

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonCertificatesData.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonCertificatesData.kt
@@ -83,7 +83,7 @@ fun testCertificate(
     override val certificateIssuer: String = "certificateIssuer"
     override val certificateCountry: String = "certificateCountry"
     override val certificateId: String = "certificateId"
-    override val hasNotification: Boolean
+    override val hasNotificationBadge: Boolean
         get() = false
     override val notifiedInvalidAt: Instant?
         get() = null

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonCertificatesData.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonCertificatesData.kt
@@ -87,6 +87,10 @@ fun testCertificate(
         get() = false
     override val notifiedInvalidAt: Instant?
         get() = null
+    override val lastSeenStateChange: CwaCovidCertificate.State?
+        get() = null
+    override val lastSeenStateChangeAt: Instant?
+        get() = null
 
     override val rawCertificate: TestDccV1
         get() = mockk()

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/main/MainActivityViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/main/MainActivityViewModelTest.kt
@@ -56,7 +56,7 @@ class MainActivityViewModelTest : BaseTest() {
         every { checkInRepository.checkInsWithinRetention } returns MutableStateFlow(listOf())
         personCertificatesProvider.apply {
             every { personCertificates } returns emptyFlow()
-            every { badgeCount } returns flowOf(0)
+            every { personsBadgeCount } returns flowOf(0)
         }
     }
 


### PR DESCRIPTION
- Adjust certificates badges logic per type and badge should disappear when user open the respective details screen
  - VC -> `Expired, Expiring_Soon, Invalid` 
  - RC -> `Expired, Expiring_Soon, Invalid`
  - TC -> `Invalid, Retrieved_Newly`
- Every person has its own count of badges 
- Test certificate that is newly retrieved and user did not see it has now a flag to indicate that `isNewlyRetrieved`
- `isNewlyRetrieved` to indicate that the certificate is `new` as below
     <img width="312" alt="Screenshot 2021-08-27 at 18 53 46" src="https://user-images.githubusercontent.com/25054729/131162396-d116e711-806c-4ee6-b309-1d504da97678.png">
- `hasNotificationBadge`  should be used whenever badge indicator is needed in `certificate level`
- `PersonCertificates.badgeCount` gives that total count of badges per `Person` 

### Testing 
- Scan VC/RC/TC (or retrieve it for PCR - RAT)
- Badge count should be reflected in BottomNav and should be reduced once screen details of the respective Certificate `was` opened

    