### PR TITLE
Change date of birth entry from calendar to input view (EXPOSUREAPP-9128) (COMMUNITY)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/coronatest/rat/profile/create/RATProfileCreateFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/coronatest/rat/profile/create/RATProfileCreateFragment.kt
@@ -130,6 +130,8 @@ class RATProfileCreateFragment : Fragment(R.layout.rat_profile_create_fragment),
         MaterialDatePicker.Builder
             .datePicker()
             .setCalendarConstraints(constraintsBuilder.build())
+            .setInputMode(MaterialDatePicker.INPUT_MODE_TEXT)
+            .setTitleText(getResources().getString(R.string.rat_profile_create_birth_date_hint))
             .build()
             .apply {
                 addOnPositiveButtonClickListener {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/coronatest/rat/profile/create/RATProfileCreateFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/coronatest/rat/profile/create/RATProfileCreateFragment.kt
@@ -131,7 +131,7 @@ class RATProfileCreateFragment : Fragment(R.layout.rat_profile_create_fragment),
             .datePicker()
             .setCalendarConstraints(constraintsBuilder.build())
             .setInputMode(MaterialDatePicker.INPUT_MODE_TEXT)
-            .setTitleText(getResources().getString(R.string.rat_profile_create_birth_date_hint))
+            .setTitleText(getString(R.string.rat_profile_create_birth_date_hint))
             .build()
             .apply {
                 addOnPositiveButtonClickListener {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/covidcertificate/RequestCovidCertificateFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/covidcertificate/RequestCovidCertificateFragment.kt
@@ -133,6 +133,8 @@ class RequestCovidCertificateFragment : Fragment(R.layout.fragment_request_covid
         MaterialDatePicker.Builder
             .datePicker()
             .setCalendarConstraints(constraintsBuilder.build())
+            .setInputMode(MaterialDatePicker.INPUT_MODE_TEXT)
+            .setTitleText(getResources().getString(R.string.request_green_certificate_birthdate_hint))
             .build()
             .apply {
                 addOnPositiveButtonClickListener { timestamp ->

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/covidcertificate/RequestCovidCertificateFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/covidcertificate/RequestCovidCertificateFragment.kt
@@ -134,7 +134,7 @@ class RequestCovidCertificateFragment : Fragment(R.layout.fragment_request_covid
             .datePicker()
             .setCalendarConstraints(constraintsBuilder.build())
             .setInputMode(MaterialDatePicker.INPUT_MODE_TEXT)
-            .setTitleText(getResources().getString(R.string.request_green_certificate_birthdate_hint))
+            .setTitleText(getString(R.string.request_green_certificate_birthdate_hint))
             .build()
             .apply {
                 addOnPositiveButtonClickListener { timestamp ->


### PR DESCRIPTION
This PR implements the suggestion from https://github.com/corona-warn-app/cwa-app-android/issues/3968 "Date of birth input should use input view not calendar view". (Note that the change simply selects the input view as the default mode, the calendar view is still available by clicking on the calendar icon to the right of "Selected date".)

- Follow the advice from https://material.io/components/date-pickers#mobile-pickers and use the mobile date input picker, not the calendar view to enter a date of birth.

- Add the title "Date of Birth" to the date picker, so the user is reminded what data they are being asked to enter.

It affects `RATProfileCreateFragment.kt`and `RequestCovidCertificateFragment.kt`.

## Verification RAT Profile

1. Set locale to English (United States)
2. Tap "Manage Your Tests" in Start Screen
3. Tap "Create Rapid Test Profile" (tap "CONTINUE" if prompted)
4. Tap "Date of Birth"
5. Enter 12/20/1980, tap OK
6. Check that date of birth is shown (20.12.1980)
Format possibly depends on PR https://github.com/corona-warn-app/cwa-app-android/pull/3987 "Inconsistent formatting of dates (EXPOSUREAPP-9127)"

Changes outlined in green boxes in screenshot below:

![RTP DOB input](https://user-images.githubusercontent.com/66998419/131139628-b2d7cd5b-7003-40ad-b99e-73eacab2fbf5.png)

## Verification Request Covid Certificate

1. Set locale to English (United States)
2. Tap "Manage Your Tests" in Start Screen
3. Tap "Scan QR Code", tap "ACCEPT"
4. Scan QR Code e.g. PCR Test QR Code
5. Tap "Date of Birth"
6. Enter 12/20/1980, tap OK
7. Check that date of birth is shown (20.12.1980)
Format possibly depends on PR https://github.com/corona-warn-app/cwa-app-android/pull/3987 "Inconsistent formatting of dates (EXPOSUREAPP-9127)"


---
Internal Tracking ID: [EXPOSUREAPP-9128](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9128)
