### PR TITLE
Correct to "Mustermann, Max" in certificate screenshots (EXPOSUREAPP-9233) (COMMUNITY)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/RecoveryCertificateDetailFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/RecoveryCertificateDetailFragmentTest.kt
@@ -130,7 +130,7 @@ class RecoveryCertificateDetailFragmentTest : BaseUITest() {
         every { validUntil } returns
             LocalDate.parse("2021-11-10", DateTimeFormat.forPattern("yyyy-MM-dd"))
 
-        every { fullNameFormatted } returns "Max, Mustermann"
+        every { fullNameFormatted } returns "Mustermann, Max"
         every { headerExpiresAt } returns Instant.now().plus(21)
     }
 

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragmentTest.kt
@@ -147,7 +147,7 @@ class VaccinationDetailsFragmentTest : BaseUITest() {
             every { headerExpiresAt } returns Instant.parse("2021-05-16T00:00:00.000Z")
             every { totalSeriesOfDoses } returns 2
             every { qrCodeToDisplay } returns CoilQrCode(ScreenshotCertificateTestData.vaccinationCertificate)
-            every { fullNameFormatted } returns "Max, Mustermann"
+            every { fullNameFormatted } returns "Mustermann, Max"
         }
     }
 


### PR DESCRIPTION
### Description

This PR addresses issue https://github.com/corona-warn-app/cwa-app-android/issues/3994 "Transposed "Max, Mustermann" in screenshots.

Screenshots generated by
`RecoveryCertificateDetailFragmentTest.kt` and
`VaccinationDetailsFragmentTest.kt`
now render the example name correctly as "Mustermann, Max". Previously the Name and First Name were transposed.

### Steps to reproduce

In Android Studio:

1. Run RecoveryCertificateDetailFragmentTest.kt
2. Run VaccinationDetailsFragmentTest.kt
3. View > Tools Windows > Device File Explorer
4. Go to /data/data/de.rki.coronawarnapp.test/screenshots
5. Check that example name is correctly rendered as "Mustermann, Max"

See attached screenshot files corrected by this PR
[9233-screenshots.zip](https://github.com/corona-warn-app/cwa-app-android/files/7077601/9233-screenshots.zip)
