### PR TITLE
Updated priority rules (EXPOSUREAPP-9244)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensions.kt
@@ -220,12 +220,12 @@ fun Collection<CwaCovidCertificate>.findHighestPriorityCertificate(
         }
 
         certsForState.rule3findRecentRecovery(nowUtc)?.let {
-            Timber.d("Rule 4 match (Recovery Certificate <= 180 days): %s", it)
+            Timber.d("Rule 3 match (Recovery Certificate <= 180 days): %s", it)
             return@mapNotNull it
         }
 
         certsForState.rule4FindRecentLastShot(nowUtc)?.let {
-            Timber.d("Rule 3 match (Series-completing Vaccination Certificate > 14 days): %s", it)
+            Timber.d("Rule 4 match (Series-completing Vaccination Certificate > 14 days): %s", it)
             return@mapNotNull it
         }
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensionsTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensionsTest.kt
@@ -145,10 +145,10 @@ class PersonCertificatesExtensionsTest : BaseTest() {
         certificates.remove(first)
         certificates.findHighestPriorityCertificate(time) shouldBe second
         certificates.remove(second)
-        certificates.findHighestPriorityCertificate(time) shouldBe third
-        certificates.remove(third)
         certificates.findHighestPriorityCertificate(time) shouldBe fourth
         certificates.remove(fourth)
+        certificates.findHighestPriorityCertificate(time) shouldBe third
+        certificates.remove(third)
         certificates.findHighestPriorityCertificate(time) shouldBe sixth
         certificates.remove(sixth)
         certificates.findHighestPriorityCertificate(time) shouldBe fifth

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CertificatePersonIdentifier
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate.State
 import de.rki.coronawarnapp.covidcertificate.common.certificate.DccV1
+import de.rki.coronawarnapp.covidcertificate.common.certificate.RecoveryDccV1
 import de.rki.coronawarnapp.covidcertificate.common.certificate.TestDccV1
 import de.rki.coronawarnapp.covidcertificate.common.certificate.VaccinationDccV1
 import de.rki.coronawarnapp.covidcertificate.common.repository.CertificateContainerId
@@ -39,6 +40,7 @@ import io.mockk.just
 import io.mockk.mockk
 import kotlinx.coroutines.flow.flowOf
 import org.joda.time.Instant
+import org.joda.time.LocalDate
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -209,6 +211,11 @@ class PersonDetailsViewModelTest : BaseTest() {
             every { qrCodeToDisplay } returns CoilQrCode("qrCode")
             every { containerId } returns rcContainerId
             every { isValid } returns true
+            every { rawCertificate } returns mockk<RecoveryDccV1>().apply {
+                every { recovery } returns mockk<DccV1.RecoveryCertificateData>().apply {
+                    every { validFrom } returns LocalDate.now()
+                }
+            }
             every { getState() } returns State.Valid(expiresAt = Instant.parse("2022-01-01T11:35:00.000Z"))
         }
 


### PR DESCRIPTION
Small update to the priority rules that should have been part of #4002

Testing:
- scan every certificate from here: https://dgc.a-sit.at/ehn/
- in the end highest prio cert should be the recovery one.