### PR TITLE
Certificate poster fragment (EXPOSUREAPP-9188, EXPOSUREAPP-9189, EXPOSUREAPP-9190)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/DigitalCovidCertificateUIModule.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/DigitalCovidCertificateUIModule.kt
@@ -4,6 +4,8 @@ import dagger.Module
 import dagger.android.ContributesAndroidInjector
 import de.rki.coronawarnapp.covidcertificate.common.scan.DccQrCodeScanFragment
 import de.rki.coronawarnapp.covidcertificate.common.scan.DccQrCodeScanModule
+import de.rki.coronawarnapp.covidcertificate.pdf.ui.poster.CertificatePosterFragment
+import de.rki.coronawarnapp.covidcertificate.pdf.ui.poster.CertificatePosterModule
 import de.rki.coronawarnapp.covidcertificate.person.ui.details.PersonDetailsFragment
 import de.rki.coronawarnapp.covidcertificate.person.ui.details.PersonDetailsFragmentModule
 import de.rki.coronawarnapp.covidcertificate.person.ui.overview.PersonOverviewFragment
@@ -52,4 +54,7 @@ abstract class DigitalCovidCertificateUIModule {
 
     @ContributesAndroidInjector(modules = [ValidationStartModule::class])
     abstract fun validationStartFragment(): ValidationStartFragment
+
+    @ContributesAndroidInjector(modules = [CertificatePosterModule::class])
+    abstract fun certificatePosterFragment(): CertificatePosterFragment
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/ui/CertificateExportException.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/ui/CertificateExportException.kt
@@ -1,0 +1,17 @@
+package de.rki.coronawarnapp.covidcertificate.pdf.ui
+
+import android.content.Context
+import de.rki.coronawarnapp.R
+import de.rki.coronawarnapp.util.HasHumanReadableError
+import de.rki.coronawarnapp.util.HumanReadableError
+
+open class CertificateExportException(
+    cause: Throwable?,
+    message: String?
+) : Exception(message, cause), HasHumanReadableError {
+
+    override fun toHumanReadableError(context: Context): HumanReadableError = HumanReadableError(
+        description = context.getString(R.string.pdf_export_error_message),
+        title = context.getString(R.string.pdf_export_error_title)
+    )
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/ui/CertificatePdfExportInfoFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/ui/CertificatePdfExportInfoFragment.kt
@@ -3,16 +3,19 @@ package de.rki.coronawarnapp.covidcertificate.pdf.ui
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.navArgs
 import com.google.android.material.transition.MaterialSharedAxis
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.CertificatePdfExportInfoFragmentBinding
 import de.rki.coronawarnapp.ui.view.onOffsetChange
+import de.rki.coronawarnapp.util.ui.doNavigate
 import de.rki.coronawarnapp.util.ui.popBackStack
 import de.rki.coronawarnapp.util.ui.viewBinding
 
 class CertificatePdfExportInfoFragment : Fragment(R.layout.certificate_pdf_export_info_fragment) {
 
     private val binding: CertificatePdfExportInfoFragmentBinding by viewBinding()
+    private val args by navArgs<CertificatePdfExportInfoFragmentArgs>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -26,7 +29,10 @@ class CertificatePdfExportInfoFragment : Fragment(R.layout.certificate_pdf_expor
         binding.apply {
             toolbar.setNavigationOnClickListener { popBackStack() }
             nextButton.setOnClickListener {
-                // TODO: navigation
+                doNavigate(
+                    CertificatePdfExportInfoFragmentDirections
+                        .actionCertificatePdfExportInfoFragmentToCertificatePosterFragment(args.containerId)
+                )
             }
             appBarLayout.onOffsetChange { _, subtitleAlpha ->
                 headerImage.alpha = subtitleAlpha

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/ui/poster/CertificatePosterFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/ui/poster/CertificatePosterFragment.kt
@@ -1,0 +1,114 @@
+package de.rki.coronawarnapp.covidcertificate.pdf.ui.poster
+
+import android.os.Bundle
+import android.print.PrintAttributes
+import android.print.PrintManager
+import android.view.View
+import android.view.ViewTreeObserver
+import android.widget.Toast
+import androidx.core.content.getSystemService
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.navArgs
+import com.google.android.material.transition.MaterialSharedAxis
+import de.rki.coronawarnapp.R
+import de.rki.coronawarnapp.databinding.QrCodePosterFragmentBinding
+import de.rki.coronawarnapp.exception.ExceptionCategory
+import de.rki.coronawarnapp.exception.reporting.report
+import de.rki.coronawarnapp.ui.print.PrintingAdapter
+import de.rki.coronawarnapp.util.di.AutoInject
+import de.rki.coronawarnapp.util.files.FileSharing
+import de.rki.coronawarnapp.util.ui.popBackStack
+import de.rki.coronawarnapp.util.ui.viewBinding
+import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactoryProvider
+import de.rki.coronawarnapp.util.viewmodel.cwaViewModelsAssisted
+import timber.log.Timber
+import java.io.File
+import javax.inject.Inject
+
+class CertificatePosterFragment : Fragment(R.layout.qr_code_poster_fragment), AutoInject {
+
+    @Inject lateinit var viewModelFactory: CWAViewModelFactoryProvider.Factory
+
+    private val args by navArgs<CertificatePosterFragmentArgs>()
+    private val viewModel: CertificatePosterViewModel by cwaViewModelsAssisted(
+        factoryProducer = { viewModelFactory },
+        constructorCall = { factory, _ ->
+            factory as CertificatePosterViewModel.Factory
+            factory.create(
+                containerId = args.containerId
+            )
+        }
+    )
+
+    private val binding: QrCodePosterFragmentBinding by viewBinding()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        enterTransition = MaterialSharedAxis(MaterialSharedAxis.Z, true)
+        returnTransition = MaterialSharedAxis(MaterialSharedAxis.Z, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        with(binding) {
+            toolbar.setNavigationOnClickListener { popBackStack() }
+//             TODO: add poster observer here
+//            viewModel.poster.observe(viewLifecycleOwner) { poster ->
+//                bindPoster(poster)
+//                // Avoid creating blank PDF
+//                if (poster.hasImages()) onPosterDrawn()
+//            }
+        }
+
+        viewModel.sharingIntent.observe(viewLifecycleOwner) {
+            onShareIntent(it)
+        }
+    }
+
+    private fun onPosterDrawn() = with(binding.qrCodePoster) {
+        viewTreeObserver.addOnGlobalLayoutListener(
+            object : ViewTreeObserver.OnGlobalLayoutListener {
+                override fun onGlobalLayout() {
+                    viewModel.createPDF(binding.qrCodePoster)
+                    viewTreeObserver.removeOnGlobalLayoutListener(this)
+                }
+            }
+        )
+    }
+
+    private fun onShareIntent(fileIntent: FileSharing.FileIntentProvider) {
+        binding.toolbar.setOnMenuItemClickListener {
+            when (it.itemId) {
+                R.id.action_print -> printFile(fileIntent.file).run { true }
+                R.id.action_share -> startActivity(fileIntent.intent(requireActivity())).run { true }
+                else -> false
+            }
+        }
+    }
+
+    private fun printFile(file: File) {
+        val printingManger = context?.getSystemService<PrintManager>()
+        Timber.i("PrintingManager=$printingManger")
+        if (printingManger == null) {
+            Toast.makeText(requireContext(), R.string.errors_generic_headline, Toast.LENGTH_LONG).show()
+            return
+        }
+
+        try {
+            val job = printingManger.print(
+                getString(R.string.app_name),
+                PrintingAdapter(file),
+                PrintAttributes.Builder()
+                    .setMediaSize(PrintAttributes.MediaSize.ISO_A4)
+                    .build()
+            )
+
+            Timber.d("JobState=%s", job.info.state)
+        } catch (e: Exception) {
+            Timber.d(e, "Printing job failed")
+            e.report(ExceptionCategory.INTERNAL)
+        }
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/ui/poster/CertificatePosterFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/ui/poster/CertificatePosterFragment.kt
@@ -12,6 +12,7 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.transition.MaterialSharedAxis
 import de.rki.coronawarnapp.R
+import de.rki.coronawarnapp.bugreporting.ui.toErrorDialogBuilder
 import de.rki.coronawarnapp.databinding.CertificatePosterFragmentBinding
 import de.rki.coronawarnapp.exception.ExceptionCategory
 import de.rki.coronawarnapp.exception.reporting.report
@@ -65,6 +66,10 @@ class CertificatePosterFragment : Fragment(R.layout.certificate_poster_fragment)
 
         viewModel.sharingIntent.observe(viewLifecycleOwner) {
             onShareIntent(it)
+        }
+
+        viewModel.error.observe(viewLifecycleOwner) {
+            it.toErrorDialogBuilder(requireContext()).show()
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/ui/poster/CertificatePosterFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/ui/poster/CertificatePosterFragment.kt
@@ -3,6 +3,7 @@ package de.rki.coronawarnapp.covidcertificate.pdf.ui.poster
 import android.os.Bundle
 import android.print.PrintAttributes
 import android.print.PrintManager
+import android.view.Menu
 import android.view.View
 import android.view.ViewTreeObserver
 import android.widget.Toast
@@ -11,7 +12,7 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.transition.MaterialSharedAxis
 import de.rki.coronawarnapp.R
-import de.rki.coronawarnapp.databinding.QrCodePosterFragmentBinding
+import de.rki.coronawarnapp.databinding.CertificatePosterFragmentBinding
 import de.rki.coronawarnapp.exception.ExceptionCategory
 import de.rki.coronawarnapp.exception.reporting.report
 import de.rki.coronawarnapp.ui.print.PrintingAdapter
@@ -25,7 +26,7 @@ import timber.log.Timber
 import java.io.File
 import javax.inject.Inject
 
-class CertificatePosterFragment : Fragment(R.layout.qr_code_poster_fragment), AutoInject {
+class CertificatePosterFragment : Fragment(R.layout.certificate_poster_fragment), AutoInject {
 
     @Inject lateinit var viewModelFactory: CWAViewModelFactoryProvider.Factory
 
@@ -40,7 +41,7 @@ class CertificatePosterFragment : Fragment(R.layout.qr_code_poster_fragment), Au
         }
     )
 
-    private val binding: QrCodePosterFragmentBinding by viewBinding()
+    private val binding: CertificatePosterFragmentBinding by viewBinding()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -76,6 +77,15 @@ class CertificatePosterFragment : Fragment(R.layout.qr_code_poster_fragment), Au
                 }
             }
         )
+        // Request to redraw options menu to enable buttons
+        requireActivity().invalidateOptionsMenu()
+    }
+
+    override fun onPrepareOptionsMenu(menu: Menu) {
+        // TODO: replace true with proper flag
+        menu.findItem(R.id.action_print).isEnabled = true
+        menu.findItem(R.id.action_share).isEnabled = true
+        return super.onPrepareOptionsMenu(menu)
     }
 
     private fun onShareIntent(fileIntent: FileSharing.FileIntentProvider) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/ui/poster/CertificatePosterModule.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/ui/poster/CertificatePosterModule.kt
@@ -1,0 +1,18 @@
+package de.rki.coronawarnapp.covidcertificate.pdf.ui.poster
+
+import dagger.Binds
+import dagger.Module
+import dagger.multibindings.IntoMap
+import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
+import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactory
+import de.rki.coronawarnapp.util.viewmodel.CWAViewModelKey
+
+@Module
+abstract class CertificatePosterModule {
+    @Binds
+    @IntoMap
+    @CWAViewModelKey(CertificatePosterViewModel::class)
+    abstract fun certificatePosterFragment(
+        factory: CertificatePosterViewModel.Factory
+    ): CWAViewModelFactory<out CWAViewModel>
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/ui/poster/CertificatePosterViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/ui/poster/CertificatePosterViewModel.kt
@@ -82,6 +82,7 @@ class CertificatePosterViewModel @AssistedInject constructor(
     private fun generatePoster() = launch(context = dispatcher.IO) {
         try {
             certificateData = certificateProvider.findCertificate(containerId)
+            // TODO: remove logs after adding poster generation
             Timber.d("Certificate found: ${certificateData.fullName}")
             // TODO: generate poster here with provided certificate
         } catch (e: Exception) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/ui/poster/CertificatePosterViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/ui/poster/CertificatePosterViewModel.kt
@@ -1,0 +1,107 @@
+package de.rki.coronawarnapp.covidcertificate.pdf.ui.poster
+
+import android.graphics.pdf.PdfDocument
+import android.view.View
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import de.rki.coronawarnapp.covidcertificate.common.certificate.CertificateProvider
+import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate
+import de.rki.coronawarnapp.covidcertificate.common.repository.CertificateContainerId
+import de.rki.coronawarnapp.covidcertificate.recovery.core.RecoveryCertificate
+import de.rki.coronawarnapp.covidcertificate.test.core.TestCertificate
+import de.rki.coronawarnapp.exception.ExceptionCategory
+import de.rki.coronawarnapp.exception.reporting.report
+import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
+import de.rki.coronawarnapp.util.files.FileSharing
+import de.rki.coronawarnapp.util.ui.SingleLiveEvent
+import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
+import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactory
+import timber.log.Timber
+import java.io.File
+import java.io.FileOutputStream
+import java.lang.ref.WeakReference
+
+class CertificatePosterViewModel @AssistedInject constructor(
+    @Assisted private val containerId: CertificateContainerId,
+    private val certificateProvider: CertificateProvider,
+    private val dispatcher: DispatcherProvider,
+    private val fileSharing: FileSharing,
+) : CWAViewModel(dispatcher) {
+
+    val sharingIntent = SingleLiveEvent<FileSharing.FileIntentProvider>()
+
+    private lateinit var certificateData: CwaCovidCertificate
+
+    init {
+        generatePoster()
+    }
+
+    /**
+     * Create a new PDF file and result is delivered by [sharingIntent]
+     * as a sharing [FileSharing.ShareIntentProvider]
+     */
+    @Suppress("BlockingMethodInNonBlockingContext")
+    fun createPDF(view: View) = launch(context = dispatcher.IO) {
+        try {
+            val weakViewRef = WeakReference(view) // Accessing view in background thread
+            val directory = File(view.context.cacheDir, "certificates").apply { if (!exists()) mkdirs() }
+            val file = File(directory, "cwa-certificate.pdf") // TODO: add certificate type here
+
+            val weakView = weakViewRef.get() ?: return@launch // View is not existing anymore
+            val pageInfo = PdfDocument.PageInfo.Builder(A4_WIDTH, A4_HEIGHT, 1).create()
+            PdfDocument().apply {
+                startPage(pageInfo).apply {
+                    val sx = A4_WIDTH.toFloat() / weakView.width
+                    val sy = A4_HEIGHT.toFloat() / weakView.height
+                    canvas.scale(sx, sy)
+                    weakView.draw(canvas)
+                    finishPage(this)
+                }
+
+                FileOutputStream(file).use {
+                    writeTo(it)
+                    close()
+                }
+            }
+
+            sharingIntent.postValue(fileSharing.getFileIntentProvider(file, getPDFFileName()))
+        } catch (e: Exception) {
+            Timber.d(e, "Creating pdf failed")
+            e.report(ExceptionCategory.UI)
+        }
+    }
+
+    private fun getPDFFileName() =
+        when (certificateData) {
+            is RecoveryCertificate -> "recovery_certificate"
+            is TestCertificate -> "test_certificate"
+            else -> "vaccination_certificate"
+        }
+
+    private fun generatePoster() = launch(context = dispatcher.IO) {
+        try {
+            certificateData = certificateProvider.findCertificate(containerId)
+            Timber.d("Certificate found: ${certificateData.fullName}")
+            // TODO: generate poster here with provided certificate
+        } catch (e: Exception) {
+            Timber.d(e, "Generating poster failed")
+            // TODO: empty poster here
+            e.report(ExceptionCategory.UI)
+        }
+    }
+
+    @AssistedFactory
+    interface Factory : CWAViewModelFactory<CertificatePosterViewModel> {
+        fun create(containerId: CertificateContainerId): CertificatePosterViewModel
+    }
+
+    companion object {
+        /**
+         * A4 size in PostScript
+         * @see <a href="https://www.cl.cam.ac.uk/~mgk25/iso-paper-ps.txt">Iso-paper-ps</a>
+         */
+        private const val A4_WIDTH = 595 // PostScript
+        private const val A4_HEIGHT = 842 // PostScript
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.View
 import android.widget.LinearLayout
 import androidx.coordinatorlayout.widget.CoordinatorLayout
-import androidx.core.graphics.drawable.DrawableCompat
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.appbar.AppBarLayout
@@ -16,10 +15,10 @@ import de.rki.coronawarnapp.covidcertificate.validation.ui.common.DccValidationN
 import de.rki.coronawarnapp.databinding.PersonDetailsFragmentBinding
 import de.rki.coronawarnapp.ui.view.onOffsetChange
 import de.rki.coronawarnapp.util.ContextExtensions.getColorCompat
-import de.rki.coronawarnapp.util.ContextExtensions.getDrawableCompat
 import de.rki.coronawarnapp.util.di.AutoInject
 import de.rki.coronawarnapp.util.lists.decorations.TopBottomPaddingDecorator
 import de.rki.coronawarnapp.util.lists.diffutil.update
+import de.rki.coronawarnapp.util.mutateDrawable
 import de.rki.coronawarnapp.util.ui.doNavigate
 import de.rki.coronawarnapp.util.ui.popBackStack
 import de.rki.coronawarnapp.util.ui.viewBinding
@@ -78,13 +77,10 @@ class PersonDetailsFragment : Fragment(R.layout.person_details_fragment), AutoIn
             viewModel.currentColorShade.observe(viewLifecycleOwner) { color ->
                 expandedImage.setImageResource(color.background)
                 europaImage.setImageDrawable(
-                    requireContext().getDrawableCompat(R.drawable.ic_eu_stars_blue)?.let {
-                        DrawableCompat.wrap(it)
-                            .mutate()
-                            .apply {
-                                setTint(requireContext().getColorCompat(color.starsTint))
-                            }
-                    }
+                    resources.mutateDrawable(
+                        R.drawable.ic_eu_stars_blue,
+                        requireContext().getColorCompat(color.starsTint)
+                    )
                 )
             }
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/items/PersonCertificateCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/items/PersonCertificateCard.kt
@@ -1,7 +1,6 @@
 package de.rki.coronawarnapp.covidcertificate.person.ui.overview.items
 
 import android.view.ViewGroup
-import androidx.core.graphics.drawable.DrawableCompat
 import coil.loadAny
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate
@@ -9,10 +8,10 @@ import de.rki.coronawarnapp.covidcertificate.person.ui.overview.PersonColorShade
 import de.rki.coronawarnapp.covidcertificate.person.ui.overview.PersonOverviewAdapter
 import de.rki.coronawarnapp.databinding.PersonOverviewItemBinding
 import de.rki.coronawarnapp.util.ContextExtensions.getColorCompat
-import de.rki.coronawarnapp.util.ContextExtensions.getDrawableCompat
 import de.rki.coronawarnapp.util.bindValidityViews
 import de.rki.coronawarnapp.util.coil.loadingView
 import de.rki.coronawarnapp.util.lists.diffutil.HasPayloadDiffer
+import de.rki.coronawarnapp.util.mutateDrawable
 
 class PersonCertificateCard(parent: ViewGroup) :
     PersonOverviewAdapter.PersonOverviewItemVH<PersonCertificateCard.Item, PersonOverviewItemBinding>(
@@ -54,13 +53,10 @@ class PersonCertificateCard(parent: ViewGroup) :
     }
 
     private fun starsDrawable(colorShade: PersonColorShade) =
-        context.getDrawableCompat(R.drawable.ic_eu_stars_blue)?.let {
-            DrawableCompat.wrap(it)
-                .mutate()
-                .apply {
-                    setTint(context.getColorCompat(colorShade.starsTint))
-                }
-        }
+        resources.mutateDrawable(
+            R.drawable.ic_eu_stars_blue,
+            context.getColorCompat(colorShade.starsTint)
+        )
 
     data class Item(
         val certificate: CwaCovidCertificate,

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/details/RecoveryCertificateDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/details/RecoveryCertificateDetailsFragment.kt
@@ -1,9 +1,11 @@
 package de.rki.coronawarnapp.covidcertificate.recovery.ui.details
 
+import android.graphics.Color
 import android.os.Bundle
 import android.view.View
 import android.widget.LinearLayout
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.graphics.drawable.DrawableCompat
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.navigation.fragment.findNavController
@@ -29,6 +31,7 @@ import de.rki.coronawarnapp.util.coil.loadingView
 import de.rki.coronawarnapp.util.di.AutoInject
 import de.rki.coronawarnapp.util.europaStarsResource
 import de.rki.coronawarnapp.util.expendedImageResource
+import de.rki.coronawarnapp.util.getDrawableCompat
 import de.rki.coronawarnapp.util.ui.doNavigate
 import de.rki.coronawarnapp.util.ui.popBackStack
 import de.rki.coronawarnapp.util.ui.viewBinding
@@ -148,6 +151,7 @@ class RecoveryCertificateDetailsFragment : Fragment(R.layout.fragment_recovery_c
     }
 
     private fun FragmentRecoveryCertificateDetailsBinding.bindToolbar() = toolbar.apply {
+        toolbar.navigationIcon = backIcon()
         setNavigationOnClickListener { popBackStack() }
         setOnMenuItemClickListener {
             when (it.itemId) {
@@ -163,6 +167,18 @@ class RecoveryCertificateDetailsFragment : Fragment(R.layout.fragment_recovery_c
             }
         }
     }
+
+    private fun backIcon() =
+        resources.getDrawableCompat(R.drawable.ic_back)?.let { drawable ->
+            DrawableCompat
+                .wrap(drawable)
+                .mutate()
+                .apply {
+                    setTint(
+                        Color.WHITE
+                    )
+                }
+        }
 
     private fun setToolbarOverlay() {
         val width = requireContext().resources.displayMetrics.widthPixels

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/details/RecoveryCertificateDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/details/RecoveryCertificateDetailsFragment.kt
@@ -141,7 +141,7 @@ class RecoveryCertificateDetailsFragment : Fragment(R.layout.fragment_recovery_c
             is RecoveryCertificateDetailsNavigation.Export -> {
                 doNavigate(
                     RecoveryCertificateDetailsFragmentDirections
-                        .actionRecoveryCertificateDetailsFragmentToCertificatePdfExportInfoFragment()
+                        .actionRecoveryCertificateDetailsFragmentToCertificatePdfExportInfoFragment(event.containerId)
                 )
             }
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/details/RecoveryCertificateDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/details/RecoveryCertificateDetailsFragment.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.View
 import android.widget.LinearLayout
 import androidx.coordinatorlayout.widget.CoordinatorLayout
-import androidx.core.graphics.drawable.DrawableCompat
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.navigation.fragment.findNavController
@@ -31,7 +30,7 @@ import de.rki.coronawarnapp.util.coil.loadingView
 import de.rki.coronawarnapp.util.di.AutoInject
 import de.rki.coronawarnapp.util.europaStarsResource
 import de.rki.coronawarnapp.util.expendedImageResource
-import de.rki.coronawarnapp.util.getDrawableCompat
+import de.rki.coronawarnapp.util.mutateDrawable
 import de.rki.coronawarnapp.util.ui.doNavigate
 import de.rki.coronawarnapp.util.ui.popBackStack
 import de.rki.coronawarnapp.util.ui.viewBinding
@@ -151,7 +150,7 @@ class RecoveryCertificateDetailsFragment : Fragment(R.layout.fragment_recovery_c
     }
 
     private fun FragmentRecoveryCertificateDetailsBinding.bindToolbar() = toolbar.apply {
-        toolbar.navigationIcon = backIcon()
+        toolbar.navigationIcon = resources.mutateDrawable(R.drawable.ic_back, Color.WHITE)
         setNavigationOnClickListener { popBackStack() }
         setOnMenuItemClickListener {
             when (it.itemId) {
@@ -167,18 +166,6 @@ class RecoveryCertificateDetailsFragment : Fragment(R.layout.fragment_recovery_c
             }
         }
     }
-
-    private fun backIcon() =
-        resources.getDrawableCompat(R.drawable.ic_back)?.let { drawable ->
-            DrawableCompat
-                .wrap(drawable)
-                .mutate()
-                .apply {
-                    setTint(
-                        Color.WHITE
-                    )
-                }
-        }
 
     private fun setToolbarOverlay() {
         val width = requireContext().resources.displayMetrics.widthPixels

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/details/RecoveryCertificateDetailsNavigation.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/details/RecoveryCertificateDetailsNavigation.kt
@@ -7,5 +7,5 @@ sealed class RecoveryCertificateDetailsNavigation {
     object Back : RecoveryCertificateDetailsNavigation()
     data class FullQrCode(val qrCode: CoilQrCode) : RecoveryCertificateDetailsNavigation()
     data class ValidationStart(val containerId: CertificateContainerId) : RecoveryCertificateDetailsNavigation()
-    object Export : RecoveryCertificateDetailsNavigation() // TODO: check what we need to pass and convert to data class
+    data class Export(val containerId: CertificateContainerId) : RecoveryCertificateDetailsNavigation()
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/details/RecoveryCertificateDetailsViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/details/RecoveryCertificateDetailsViewModel.kt
@@ -66,7 +66,7 @@ class RecoveryCertificateDetailsViewModel @AssistedInject constructor(
         if (recoveryCertificate.value?.canBeExported() == false) {
             exportError.postValue(null)
         } else {
-            events.postValue(RecoveryCertificateDetailsNavigation.Export)
+            events.postValue(RecoveryCertificateDetailsNavigation.Export(containerId))
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/TestCertificateDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/TestCertificateDetailsFragment.kt
@@ -1,9 +1,11 @@
 package de.rki.coronawarnapp.covidcertificate.test.ui.details
 
+import android.graphics.Color
 import android.os.Bundle
 import android.view.View
 import android.widget.LinearLayout
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.net.toUri
 import androidx.core.view.isGone
 import androidx.fragment.app.Fragment
@@ -32,6 +34,7 @@ import de.rki.coronawarnapp.util.coil.loadingView
 import de.rki.coronawarnapp.util.di.AutoInject
 import de.rki.coronawarnapp.util.europaStarsResource
 import de.rki.coronawarnapp.util.expendedImageResource
+import de.rki.coronawarnapp.util.getDrawableCompat
 import de.rki.coronawarnapp.util.ui.doNavigate
 import de.rki.coronawarnapp.util.ui.popBackStack
 import de.rki.coronawarnapp.util.ui.viewBinding
@@ -185,6 +188,7 @@ class TestCertificateDetailsFragment : Fragment(R.layout.fragment_test_certifica
     }
 
     private fun FragmentTestCertificateDetailsBinding.bindToolbar() = toolbar.apply {
+        toolbar.navigationIcon = backIcon()
         setNavigationOnClickListener { popBackStack() }
         setOnMenuItemClickListener {
             when (it.itemId) {
@@ -200,6 +204,19 @@ class TestCertificateDetailsFragment : Fragment(R.layout.fragment_test_certifica
             }
         }
     }
+
+    private fun backIcon() =
+        resources.getDrawableCompat(R.drawable.ic_back)?.let { drawable ->
+            DrawableCompat
+                .wrap(drawable)
+                .mutate()
+                .apply {
+                    setTint(
+                        Color.WHITE
+                    )
+                }
+        }
+
 
     private fun setToolbarOverlay() {
         val width = requireContext().resources.displayMetrics.widthPixels

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/TestCertificateDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/TestCertificateDetailsFragment.kt
@@ -178,7 +178,7 @@ class TestCertificateDetailsFragment : Fragment(R.layout.fragment_test_certifica
             is TestCertificateDetailsNavigation.Export -> {
                 doNavigate(
                     TestCertificateDetailsFragmentDirections
-                        .actionTestCertificateDetailsFragmentToCertificatePdfExportInfoFragment()
+                        .actionTestCertificateDetailsFragmentToCertificatePdfExportInfoFragment(event.containerId)
                 )
             }
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/TestCertificateDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/TestCertificateDetailsFragment.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.View
 import android.widget.LinearLayout
 import androidx.coordinatorlayout.widget.CoordinatorLayout
-import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.net.toUri
 import androidx.core.view.isGone
 import androidx.fragment.app.Fragment
@@ -34,7 +33,7 @@ import de.rki.coronawarnapp.util.coil.loadingView
 import de.rki.coronawarnapp.util.di.AutoInject
 import de.rki.coronawarnapp.util.europaStarsResource
 import de.rki.coronawarnapp.util.expendedImageResource
-import de.rki.coronawarnapp.util.getDrawableCompat
+import de.rki.coronawarnapp.util.mutateDrawable
 import de.rki.coronawarnapp.util.ui.doNavigate
 import de.rki.coronawarnapp.util.ui.popBackStack
 import de.rki.coronawarnapp.util.ui.viewBinding
@@ -188,7 +187,7 @@ class TestCertificateDetailsFragment : Fragment(R.layout.fragment_test_certifica
     }
 
     private fun FragmentTestCertificateDetailsBinding.bindToolbar() = toolbar.apply {
-        toolbar.navigationIcon = backIcon()
+        toolbar.navigationIcon = resources.mutateDrawable(R.drawable.ic_back, Color.WHITE)
         setNavigationOnClickListener { popBackStack() }
         setOnMenuItemClickListener {
             when (it.itemId) {
@@ -204,19 +203,6 @@ class TestCertificateDetailsFragment : Fragment(R.layout.fragment_test_certifica
             }
         }
     }
-
-    private fun backIcon() =
-        resources.getDrawableCompat(R.drawable.ic_back)?.let { drawable ->
-            DrawableCompat
-                .wrap(drawable)
-                .mutate()
-                .apply {
-                    setTint(
-                        Color.WHITE
-                    )
-                }
-        }
-
 
     private fun setToolbarOverlay() {
         val width = requireContext().resources.displayMetrics.widthPixels

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/TestCertificateDetailsNavigation.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/TestCertificateDetailsNavigation.kt
@@ -7,5 +7,5 @@ sealed class TestCertificateDetailsNavigation {
     object Back : TestCertificateDetailsNavigation()
     data class FullQrCode(val qrCode: CoilQrCode) : TestCertificateDetailsNavigation()
     data class ValidationStart(val containerId: CertificateContainerId) : TestCertificateDetailsNavigation()
-    object Export : TestCertificateDetailsNavigation() // TODO: check what we need to pass and convert to data class
+    data class Export(val containerId: CertificateContainerId) : TestCertificateDetailsNavigation()
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/TestCertificateDetailsViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/TestCertificateDetailsViewModel.kt
@@ -67,7 +67,7 @@ class TestCertificateDetailsViewModel @AssistedInject constructor(
         if (covidCertificate.value?.canBeExported() == false) {
             exportError.postValue(null)
         } else {
-            events.postValue(TestCertificateDetailsNavigation.Export)
+            events.postValue(TestCertificateDetailsNavigation.Export(containerId))
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragment.kt
@@ -141,10 +141,8 @@ class VaccinationDetailsFragment : Fragment(R.layout.fragment_vaccination_detail
     }
 
     private fun FragmentVaccinationDetailsBinding.bindToolbar() = toolbar.apply {
-        setNavigationOnClickListener { popBackStack() }
-
         toolbar.navigationIcon = backIcon()
-
+        setNavigationOnClickListener { popBackStack() }
         setOnMenuItemClickListener {
             when (it.itemId) {
                 R.id.menu_covid_certificate_delete -> {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragment.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.View
 import android.widget.LinearLayout
 import androidx.coordinatorlayout.widget.CoordinatorLayout
-import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.FragmentNavigatorExtras
@@ -21,7 +20,6 @@ import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinationCertifi
 import de.rki.coronawarnapp.covidcertificate.validation.core.common.exception.DccValidationException
 import de.rki.coronawarnapp.covidcertificate.validation.ui.common.DccValidationNoInternetErrorDialog
 import de.rki.coronawarnapp.databinding.FragmentVaccinationDetailsBinding
-import de.rki.coronawarnapp.tracing.ui.details.TracingDetailsState
 import de.rki.coronawarnapp.ui.qrcode.fullscreen.QrCodeFullScreenFragmentArgs
 import de.rki.coronawarnapp.ui.view.onOffsetChange
 import de.rki.coronawarnapp.util.ExternalActionHelper.openUrl
@@ -31,7 +29,7 @@ import de.rki.coronawarnapp.util.TimeAndDateExtensions.toShortTimeFormat
 import de.rki.coronawarnapp.util.bindValidityViews
 import de.rki.coronawarnapp.util.coil.loadingView
 import de.rki.coronawarnapp.util.di.AutoInject
-import de.rki.coronawarnapp.util.getDrawableCompat
+import de.rki.coronawarnapp.util.mutateDrawable
 import de.rki.coronawarnapp.util.ui.doNavigate
 import de.rki.coronawarnapp.util.ui.popBackStack
 import de.rki.coronawarnapp.util.ui.viewBinding
@@ -141,7 +139,7 @@ class VaccinationDetailsFragment : Fragment(R.layout.fragment_vaccination_detail
     }
 
     private fun FragmentVaccinationDetailsBinding.bindToolbar() = toolbar.apply {
-        toolbar.navigationIcon = backIcon()
+        toolbar.navigationIcon = resources.mutateDrawable(R.drawable.ic_back, Color.WHITE)
         setNavigationOnClickListener { popBackStack() }
         setOnMenuItemClickListener {
             when (it.itemId) {
@@ -185,18 +183,6 @@ class VaccinationDetailsFragment : Fragment(R.layout.fragment_vaccination_detail
             certificate.headerExpiresAt.toLocalDateTimeUserTz().toShortTimeFormat()
         )
     }
-
-    private fun backIcon() =
-        resources.getDrawableCompat(R.drawable.ic_back)?.let { drawable ->
-            DrawableCompat
-                .wrap(drawable)
-                .mutate()
-                .apply {
-                    setTint(
-                        Color.WHITE
-                    )
-                }
-        }
 
     private fun setToolbarOverlay() {
         val width = requireContext().resources.displayMetrics.widthPixels

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragment.kt
@@ -1,9 +1,11 @@
 package de.rki.coronawarnapp.covidcertificate.vaccination.ui.details
 
+import android.graphics.Color
 import android.os.Bundle
 import android.view.View
 import android.widget.LinearLayout
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.FragmentNavigatorExtras
@@ -19,6 +21,7 @@ import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinationCertifi
 import de.rki.coronawarnapp.covidcertificate.validation.core.common.exception.DccValidationException
 import de.rki.coronawarnapp.covidcertificate.validation.ui.common.DccValidationNoInternetErrorDialog
 import de.rki.coronawarnapp.databinding.FragmentVaccinationDetailsBinding
+import de.rki.coronawarnapp.tracing.ui.details.TracingDetailsState
 import de.rki.coronawarnapp.ui.qrcode.fullscreen.QrCodeFullScreenFragmentArgs
 import de.rki.coronawarnapp.ui.view.onOffsetChange
 import de.rki.coronawarnapp.util.ExternalActionHelper.openUrl
@@ -28,6 +31,7 @@ import de.rki.coronawarnapp.util.TimeAndDateExtensions.toShortTimeFormat
 import de.rki.coronawarnapp.util.bindValidityViews
 import de.rki.coronawarnapp.util.coil.loadingView
 import de.rki.coronawarnapp.util.di.AutoInject
+import de.rki.coronawarnapp.util.getDrawableCompat
 import de.rki.coronawarnapp.util.ui.doNavigate
 import de.rki.coronawarnapp.util.ui.popBackStack
 import de.rki.coronawarnapp.util.ui.viewBinding
@@ -138,6 +142,9 @@ class VaccinationDetailsFragment : Fragment(R.layout.fragment_vaccination_detail
 
     private fun FragmentVaccinationDetailsBinding.bindToolbar() = toolbar.apply {
         setNavigationOnClickListener { popBackStack() }
+
+        toolbar.navigationIcon = backIcon()
+
         setOnMenuItemClickListener {
             when (it.itemId) {
                 R.id.menu_covid_certificate_delete -> {
@@ -180,6 +187,18 @@ class VaccinationDetailsFragment : Fragment(R.layout.fragment_vaccination_detail
             certificate.headerExpiresAt.toLocalDateTimeUserTz().toShortTimeFormat()
         )
     }
+
+    private fun backIcon() =
+        resources.getDrawableCompat(R.drawable.ic_back)?.let { drawable ->
+            DrawableCompat
+                .wrap(drawable)
+                .mutate()
+                .apply {
+                    setTint(
+                        Color.WHITE
+                    )
+                }
+        }
 
     private fun setToolbarOverlay() {
         val width = requireContext().resources.displayMetrics.widthPixels

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragment.kt
@@ -124,7 +124,7 @@ class VaccinationDetailsFragment : Fragment(R.layout.fragment_vaccination_detail
                     is VaccinationDetailsNavigation.Export -> {
                         doNavigate(
                             VaccinationDetailsFragmentDirections
-                                .actionVaccinationDetailsFragmentToCertificatePdfExportInfoFragment()
+                                .actionVaccinationDetailsFragmentToCertificatePdfExportInfoFragment(event.containerId)
                         )
                     }
                 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsNavigation.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsNavigation.kt
@@ -7,5 +7,5 @@ sealed class VaccinationDetailsNavigation {
     object Back : VaccinationDetailsNavigation()
     data class FullQrCode(val qrCode: CoilQrCode) : VaccinationDetailsNavigation()
     data class ValidationStart(val containerId: CertificateContainerId) : VaccinationDetailsNavigation()
-    object Export : VaccinationDetailsNavigation() // TODO: check what we need to pass and convert to data class
+    data class Export(val containerId: CertificateContainerId) : VaccinationDetailsNavigation()
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsViewModel.kt
@@ -92,7 +92,7 @@ class VaccinationDetailsViewModel @AssistedInject constructor(
         if (vaccinationCertificate.value?.certificate?.canBeExported() == false) {
             exportError.postValue(null)
         } else {
-            events.postValue(VaccinationDetailsNavigation.Export)
+            events.postValue(VaccinationDetailsNavigation.Export(containerId))
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/details/TracingDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/tracing/ui/details/TracingDetailsFragment.kt
@@ -3,7 +3,6 @@ package de.rki.coronawarnapp.tracing.ui.details
 import android.os.Bundle
 import android.view.View
 import android.view.accessibility.AccessibilityEvent
-import androidx.core.graphics.drawable.DrawableCompat
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -11,8 +10,8 @@ import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.TracingDetailsFragmentLayoutBinding
 import de.rki.coronawarnapp.util.ExternalActionHelper.openUrl
 import de.rki.coronawarnapp.util.di.AutoInject
-import de.rki.coronawarnapp.util.getDrawableCompat
 import de.rki.coronawarnapp.util.lists.diffutil.update
+import de.rki.coronawarnapp.util.mutateDrawable
 import de.rki.coronawarnapp.util.ui.doNavigate
 import de.rki.coronawarnapp.util.ui.observe2
 import de.rki.coronawarnapp.util.ui.popBackStack
@@ -76,16 +75,10 @@ class TracingDetailsFragment : Fragment(R.layout.tracing_details_fragment_layout
     }
 
     private fun closeIcon(it: TracingDetailsState) =
-        resources.getDrawableCompat(R.drawable.ic_close)?.let { drawable ->
-            DrawableCompat
-                .wrap(drawable)
-                .mutate()
-                .apply {
-                    setTint(
-                        it.getStableTextColor(requireContext())
-                    )
-                }
-        }
+        resources.mutateDrawable(
+            R.drawable.ic_close,
+            it.getStableTextColor(requireContext())
+        )
 
     override fun onResume() {
         super.onResume()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ContextExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ContextExtensions.kt
@@ -53,4 +53,3 @@ fun Resources.mutateDrawable(
     @DrawableRes drawable: Int,
     @ColorInt color: Int
 ): Drawable? = getDrawableCompat(drawable)?.mutate(color)
-

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ContextExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/ContextExtensions.kt
@@ -2,10 +2,13 @@ package de.rki.coronawarnapp.util
 
 import android.content.Context
 import android.content.res.Resources
+import android.graphics.drawable.Drawable
+import androidx.annotation.ColorInt
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
+import androidx.core.graphics.drawable.DrawableCompat
 
 /**
  * These context extensions provide easier access to the ContextCompat calls that we want
@@ -28,3 +31,26 @@ fun Resources.getDrawableCompat(@DrawableRes id: Int, theme: Resources.Theme? = 
     ResourcesCompat.getDrawable(this, id, theme)
 
 fun Resources.isPhone(): Boolean = configuration.smallestScreenWidthDp < 600
+
+/**
+ * Mutate drawable and provide new copy tinted with provided color
+ * @param color [Int]
+ */
+fun Drawable?.mutate(@ColorInt color: Int): Drawable? = this?.let { drawable ->
+    DrawableCompat
+        .wrap(drawable)
+        .mutate()
+        .apply {
+            setTint(color)
+        }
+}
+
+/**
+ * Mutate drawable and provide new copy tinted with provided color
+ * @param color [Int]
+ */
+fun Resources.mutateDrawable(
+    @DrawableRes drawable: Int,
+    @ColorInt color: Int
+): Drawable? = getDrawableCompat(drawable)?.mutate(color)
+

--- a/Corona-Warn-App/src/main/res/layout/certificate_poster_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/certificate_poster_fragment.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/white">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/CWAToolbar.BackArrow"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:elevation="2dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:menu="@menu/menu_certificate_poster"
+        app:title="@string/trace_location_organiser_poster_title" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/qr_code_poster"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar">
+
+        <ImageView
+            android:id="@+id/poster_image"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:adjustViewBounds="true"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:layout_constraintDimensionRatio="595:841" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/progress_bar"
+        android:layout_width="150dp"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Corona-Warn-App/src/main/res/layout/fragment_recovery_certificate_details.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_recovery_certificate_details.xml
@@ -84,7 +84,6 @@
                     app:layout_scrollFlags="scroll|enterAlways"
                     app:menu="@menu/menu_recovery_certificate_details"
                     app:navigationIcon="@drawable/ic_back"
-                    app:navigationIconTint="@android:color/white"
                     app:popupTheme="@style/Theme.MaterialComponents.DayNight">
 
                     <LinearLayout

--- a/Corona-Warn-App/src/main/res/layout/fragment_test_certificate_details.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_test_certificate_details.xml
@@ -84,7 +84,6 @@
                     app:layout_scrollFlags="scroll|enterAlways"
                     app:menu="@menu/menu_covid_certificate_detail"
                     app:navigationIcon="@drawable/ic_back"
-                    app:navigationIconTint="@android:color/white"
                     app:popupTheme="@style/Theme.MaterialComponents.DayNight">
 
                     <LinearLayout

--- a/Corona-Warn-App/src/main/res/layout/fragment_vaccination_details.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_vaccination_details.xml
@@ -84,7 +84,6 @@
                     app:layout_scrollFlags="scroll|enterAlways"
                     app:menu="@menu/menu_covid_certificate_detail"
                     app:navigationIcon="@drawable/ic_back"
-                    app:navigationIconTint="@android:color/white"
                     app:popupTheme="@style/Theme.MaterialComponents.DayNight">
 
                     <LinearLayout

--- a/Corona-Warn-App/src/main/res/menu/menu_certificate_poster.xml
+++ b/Corona-Warn-App/src/main/res/menu/menu_certificate_poster.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/action_print"
+        android:icon="@drawable/ic_print"
+        android:title="@string/trace_location_organiser_poster_print"
+        android:enabled="false"
+        app:iconTint="@color/colorOnPrimary"
+        app:showAsAction="always" />
+    <item
+        android:id="@+id/action_share"
+        android:icon="@drawable/ic_share"
+        android:title="@string/trace_location_organiser_poster_share"
+        android:enabled="false"
+        app:iconTint="@color/colorOnPrimary"
+        app:showAsAction="ifRoom" />
+</menu>

--- a/Corona-Warn-App/src/main/res/navigation/covid_certificates_graph.xml
+++ b/Corona-Warn-App/src/main/res/navigation/covid_certificates_graph.xml
@@ -223,5 +223,22 @@
         android:name="de.rki.coronawarnapp.covidcertificate.pdf.ui.CertificatePdfExportInfoFragment"
         android:label="certificate_pdf_export_info_fragment"
         tools:layout="@layout/certificate_pdf_export_info_fragment">
+        <argument
+            android:name="containerId"
+            app:argType="de.rki.coronawarnapp.covidcertificate.common.repository.CertificateContainerId" />
+        <action
+            android:id="@+id/action_certificatePdfExportInfoFragment_to_certificatePosterFragment"
+            app:destination="@id/certificatePosterFragment"
+            app:popUpTo="@id/certificatePdfExportInfoFragment"
+            app:popUpToInclusive="true" />
+    </fragment>
+    <fragment
+        android:id="@+id/certificatePosterFragment"
+        android:name="de.rki.coronawarnapp.covidcertificate.pdf.ui.poster.CertificatePosterFragment"
+        android:label="certificate_poster_fragment"
+        tools:layout="@layout/qr_code_poster_fragment">
+        <argument
+            android:name="containerId"
+            app:argType="de.rki.coronawarnapp.covidcertificate.common.repository.CertificateContainerId" />
     </fragment>
 </navigation>

--- a/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
@@ -345,4 +345,11 @@
     <string name="pdf_export_info_point_sensitive">Beachten Sie, dass das PDF-Dokument sensible Informationen enthält. Wir empfehlen Ihnen, hiermit sorgsam umzugehen und es nur Personen vorzuzeigen, denen Sie vertrauen und die zur Prüfung des Nachweises berechtigt sind.</string>
     <!-- XTXT: PDF Export: Info screen point with recommendations -->
     <string name="pdf_export_info_point_recommendations">Wir empfehlen, das PDF-Dokument nicht zu veröffentlichen und nicht per E-Mail zu versenden oder über andere Apps zu teilen.</string>
+
+    <!-- PDF Export: Error message -->
+    <!-- XHED: PDF Export: Error message title -->
+    <string name="pdf_export_error_title">Druckversion anzeigen nicht möglich</string>
+    <!-- XHED: PDF Export: Error message body -->
+    <string name="pdf_export_error_message">Die Druckversion des Zertifikats kann nicht angezeigt werden, da das Zertifikat momentan nicht abgerufen werden kann. Bitte versuchen Sie es später noch einmal.</string>
+
 </resources>

--- a/Corona-Warn-App/src/main/res/values/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/covid_certificate_strings.xml
@@ -345,4 +345,11 @@
     <string name="pdf_export_info_point_sensitive">Beachten Sie, dass das PDF-Dokument sensible Informationen enthält. Wir empfehlen Ihnen, hiermit sorgsam umzugehen und es nur Personen vorzuzeigen, denen Sie vertrauen und die zur Prüfung des Nachweises berechtigt sind.</string>
     <!-- XTXT: PDF Export: Info screen point with recommendations -->
     <string name="pdf_export_info_point_recommendations">Wir empfehlen, das PDF-Dokument nicht zu veröffentlichen und nicht per E-Mail zu versenden oder über andere Apps zu teilen.</string>
+
+    <!-- PDF Export: Error message -->
+    <!-- XHED: PDF Export: Error message title -->
+    <string name="pdf_export_error_title">Druckversion anzeigen nicht möglich</string>
+    <!-- XHED: PDF Export: Error message body -->
+    <string name="pdf_export_error_message">Die Druckversion des Zertifikats kann nicht angezeigt werden, da das Zertifikat momentan nicht abgerufen werden kann. Bitte versuchen Sie es später noch einmal.</string>
+
 </resources>


### PR DESCRIPTION
Certificate (Vaccination, Recovery and Test) poster fragment.
Actual PDF poster creation would be handled in another PR.

How to test:
For each certificate type:
1) scan certificate
2) navigate to certificate details
3) three-dots-menu -> Print
4) on Info screen press continue button
5) poster fragment should appear
6) check in logs "Certificate found: " with certificate name owner (this log is for test purpose only - would be deleted later).

TODO:
- [x] Toolbar back button mystery (back arrow does not show right now)
- [x] Check if we need to replace layout with new one