### PR TITLE
Notification badges on cards and details (EXPOSUREAPP-9195)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/items/RecoveryCertificateCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/items/RecoveryCertificateCard.kt
@@ -53,6 +53,8 @@ class RecoveryCertificateCard(parent: ViewGroup) :
             else -> color.defaultCertificateBg
         }.also { certificateBg.setImageResource(it) }
 
+        notificationBadge.isVisible = curItem.certificate.hasNotificationBadge
+
         certificateExpiration.displayExpirationState(curItem.certificate)
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/items/TestCertificateCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/items/TestCertificateCard.kt
@@ -60,6 +60,8 @@ class TestCertificateCard(parent: ViewGroup) :
         }
         certificateBg.setImageResource(background)
 
+        notificationBadge.isVisible = curItem.certificate.hasNotificationBadge
+
         certificateExpiration.displayExpirationState(curItem.certificate)
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/items/VaccinationCertificateCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/items/VaccinationCertificateCard.kt
@@ -69,6 +69,8 @@ class VaccinationCertificateCard(parent: ViewGroup) :
             else -> color.defaultCertificateBg
         }.also { certificateBg.setImageResource(it) }
 
+        notificationBadge.isVisible = curItem.certificate.hasNotificationBadge
+
         certificateExpiration.displayExpirationState(curItem.certificate)
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CertificateStateHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CertificateStateHelper.kt
@@ -36,6 +36,7 @@ fun IncludeCertificateQrcodeCardBinding.bindValidityViews(
             qrTitle.text = context.getString(R.string.test_certificate_name)
             qrSubtitle.isVisible = !isPersonOverview
             qrSubtitle.text = context.getString(R.string.test_certificate_qrcode_card_sampled_on, dateTime)
+            notificationBadge.isVisible = !isPersonOverview && certificate.hasNotificationBadge
         }
         is VaccinationCertificate -> {
             qrTitle.isVisible = !isPersonOverview
@@ -45,6 +46,7 @@ fun IncludeCertificateQrcodeCardBinding.bindValidityViews(
                 R.string.vaccination_certificate_vaccinated_on,
                 certificate.vaccinatedOn.toShortDayFormat()
             )
+            notificationBadge.isVisible = !isPersonOverview && certificate.hasNotificationBadge
         }
         is RecoveryCertificate -> {
             qrTitle.isVisible = !isPersonOverview
@@ -54,6 +56,7 @@ fun IncludeCertificateQrcodeCardBinding.bindValidityViews(
                 R.string.recovery_certificate_valid_until,
                 certificate.validUntil.toShortDayFormat()
             )
+            notificationBadge.isVisible = !isPersonOverview && certificate.hasNotificationBadge
         }
     }
     when (certificate.displayedState()) {

--- a/Corona-Warn-App/src/main/res/drawable/circle_certificate_notification_badge.xml
+++ b/Corona-Warn-App/src/main/res/drawable/circle_certificate_notification_badge.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="#ED382F" />
+    <stroke
+        android:width="2dp"
+        android:color="@color/colorVaccinationCardBackground" />
+</shape>

--- a/Corona-Warn-App/src/main/res/layout/include_certificate_qrcode_card.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_certificate_qrcode_card.xml
@@ -75,6 +75,19 @@
         app:layout_constraintTop_toBottomOf="@id/image"
         tools:text="@string/test_certificate_name" />
 
+    <ImageView
+        android:id="@+id/notification_badge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginStart="8dp"
+        android:src="@drawable/ic_booster_badge"
+        android:visibility="gone"
+        app:layout_constraintStart_toEndOf="@id/qr_title"
+        app:layout_constraintTop_toTopOf="@id/qr_title"
+        app:layout_constraintBottom_toBottomOf="@id/qr_title"
+        tools:visibility="visible" />
+
     <TextView
         android:id="@+id/qr_subtitle"
         android:layout_width="0dp"

--- a/Corona-Warn-App/src/main/res/layout/recovery_certificate_card.xml
+++ b/Corona-Warn-App/src/main/res/layout/recovery_certificate_card.xml
@@ -20,6 +20,19 @@
         app:srcCompat="@drawable/bg_certificate_grey" />
 
     <ImageView
+        android:id="@+id/notification_badge"
+        android:layout_width="14dp"
+        android:layout_height="14dp"
+        android:translationX="7dp"
+        android:translationY="-7dp"
+        android:importantForAccessibility="no"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="@id/certificate_bg"
+        app:layout_constraintEnd_toEndOf="@id/certificate_bg"
+        app:srcCompat="@drawable/circle_certificate_notification_badge"
+        tools:visibility="visible"/>
+
+    <ImageView
         android:id="@+id/certificate_icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/Corona-Warn-App/src/main/res/layout/test_certificate_card.xml
+++ b/Corona-Warn-App/src/main/res/layout/test_certificate_card.xml
@@ -20,6 +20,19 @@
         app:srcCompat="@drawable/bg_certificate_grey" />
 
     <ImageView
+        android:id="@+id/notification_badge"
+        android:layout_width="14dp"
+        android:layout_height="14dp"
+        android:translationX="7dp"
+        android:translationY="-7dp"
+        android:importantForAccessibility="no"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="@id/certificate_bg"
+        app:layout_constraintEnd_toEndOf="@id/certificate_bg"
+        app:srcCompat="@drawable/circle_certificate_notification_badge"
+        tools:visibility="visible"/>
+
+    <ImageView
         android:id="@+id/certificate_icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/Corona-Warn-App/src/main/res/layout/vaccination_certificate_card.xml
+++ b/Corona-Warn-App/src/main/res/layout/vaccination_certificate_card.xml
@@ -20,6 +20,19 @@
         app:srcCompat="@drawable/bg_certificate_grey" />
 
     <ImageView
+        android:id="@+id/notification_badge"
+        android:layout_width="14dp"
+        android:layout_height="14dp"
+        android:translationX="7dp"
+        android:translationY="-7dp"
+        android:importantForAccessibility="no"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="@id/certificate_bg"
+        app:layout_constraintEnd_toEndOf="@id/certificate_bg"
+        app:srcCompat="@drawable/circle_certificate_notification_badge"
+        tools:visibility="visible"/>
+
+    <ImageView
         android:id="@+id/certificate_icon"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
Notification badges for cards and details.

<img width="202" alt="Screenshot 2021-09-03 at 20 42 34" src="https://user-images.githubusercontent.com/64849422/132046620-03f92340-35aa-4633-b128-0a5e07e81301.png"> <img width="203" alt="Screenshot 2021-09-03 at 20 42 50" src="https://user-images.githubusercontent.com/64849422/132046609-8e5ddc2b-f83f-4967-aa93-42044699bc65.png">

How to test:
1) use cloud mock env
2) scan all certificates type
3) go to main screen
4) go to the future (+13 month)
5) go back to the application
6) there should be notifications for vaccination and recovery
7) switch cloud mock to any other env
8) all certificates should have notifications by now
9) go to person details screen -> check red notification badge on certificate card
10) go to certificate details -> check red notification badge on the right of certificate title