### PR TITLE
Certificate display switches to expired-view (if expired) after opening the certificate view (EXPOSUREAPP-8837)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/expiration/DccExpirationNotificationService.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/expiration/DccExpirationNotificationService.kt
@@ -95,9 +95,9 @@ class DccExpirationNotificationService @Inject constructor(
     }
 
     private suspend fun getCertificates(): Set<CwaCovidCertificate> {
-        val vacCerts = vaccinationRepository.vaccinationInfos.first().map { it.vaccinationCertificates }.flatten()
+        val vacCerts = vaccinationRepository.freshVaccinationInfos.first().map { it.vaccinationCertificates }.flatten()
         Timber.tag(TAG).d("Checking %d vaccination certificates", vacCerts.size)
-        val recCerts = recoveryRepository.certificates.first().map { it.recoveryCertificate }
+        val recCerts = recoveryRepository.freshCertificates.first().map { it.recoveryCertificate }
         Timber.tag(TAG).d("Checking %d recovery certificates", recCerts.size)
 
         return (vacCerts + recCerts).toSet()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/expiration/DccExpirationNotificationService.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/expiration/DccExpirationNotificationService.kt
@@ -28,12 +28,12 @@ class DccExpirationNotificationService @Inject constructor(
 ) {
     private val mutex = Mutex()
 
-    suspend fun showNotificationIfStateChanged() = mutex.withLock {
-        Timber.tag(TAG).v("showNotificationIfStateChanged()")
+    suspend fun showNotificationIfStateChanged(ignoreLastCheck: Boolean = false) = mutex.withLock {
+        Timber.tag(TAG).v("showNotificationIfStateChanged(ignoreLastCheck=%s)", ignoreLastCheck)
 
         val lastCheck = covidCertificateSettings.lastDccStateBackgroundCheck.value
 
-        if (lastCheck.toLocalDateUtc() == timeStamper.nowUTC.toLocalDateUtc()) {
+        if (!ignoreLastCheck && lastCheck.toLocalDateUtc() == timeStamper.nowUTC.toLocalDateUtc()) {
             Timber.tag(TAG).d("Last check was within 24h, skipping.")
             return
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragment.kt
@@ -50,6 +50,11 @@ class PersonOverviewFragment : Fragment(R.layout.person_overview_fragment), Auto
         viewModel.events.observe(viewLifecycleOwner) { onNavEvent(it) }
     }
 
+    override fun onStart() {
+        super.onStart()
+        viewModel.checkExpiration()
+    }
+
     private fun onNavEvent(event: PersonOverviewFragmentEvents) {
         Timber.tag(TAG).d(" onNavEvent(event=%s)", event)
         when (event) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewViewModel.kt
@@ -7,6 +7,7 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import de.rki.coronawarnapp.contactdiary.util.getLocale
 import de.rki.coronawarnapp.covidcertificate.common.repository.TestCertificateContainerId
+import de.rki.coronawarnapp.covidcertificate.expiration.DccExpirationNotificationService
 import de.rki.coronawarnapp.covidcertificate.person.core.PersonCertificates
 import de.rki.coronawarnapp.covidcertificate.person.core.PersonCertificatesProvider
 import de.rki.coronawarnapp.covidcertificate.person.ui.overview.items.CameraPermissionCard
@@ -35,7 +36,8 @@ class PersonOverviewViewModel @AssistedInject constructor(
     valueSetsRepository: ValueSetsRepository,
     private val testCertificateRepository: TestCertificateRepository,
     @AppContext context: Context,
-    @AppScope private val appScope: CoroutineScope
+    @AppScope private val appScope: CoroutineScope,
+    private val expirationNotificationService: DccExpirationNotificationService
 ) : CWAViewModel(dispatcherProvider) {
 
     init {
@@ -120,6 +122,11 @@ class PersonOverviewViewModel @AssistedInject constructor(
     fun refreshCertificate(containerId: TestCertificateContainerId) = launch(scope = appScope) {
         val error = testCertificateRepository.refresh(containerId).mapNotNull { it.error }.singleOrNull()
         error?.let { events.postValue(ShowRefreshErrorDialog(error)) }
+    }
+
+    fun checkExpiration() = launch(scope = appScope) {
+        Timber.d("checkExpiration()")
+        expirationNotificationService.showNotificationIfStateChanged(ignoreLastCheck = true)
     }
 
     @AssistedFactory

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/VaccinationRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/VaccinationRepository.kt
@@ -83,7 +83,7 @@ class VaccinationRepository @Inject constructor(
             .launchIn(appScope + dispatcherProvider.IO)
     }
 
-    val vaccinationInfos: Flow<Set<VaccinatedPerson>> = combine(
+    val freshVaccinationInfos: Flow<Set<VaccinatedPerson>> = combine(
         internalData.data,
         valueSetsRepository.latestVaccinationValueSets,
         dscRepository.dscData
@@ -91,8 +91,10 @@ class VaccinationRepository @Inject constructor(
         personDatas.map { person ->
             val stateMap = person.data.getStates()
             person.copy(valueSet = currentValueSet, certificateStates = stateMap)
-        }.toSet()
+        }.toSet().also { Timber.d("Test: $it") }
     }
+
+    val vaccinationInfos: Flow<Set<VaccinatedPerson>> = freshVaccinationInfos
         .shareLatest(
             tag = TAG,
             scope = appScope


### PR DESCRIPTION
This PR addresses Exposureapp-[8337](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8837).
"Certificate display switches to "expired-view" only after app re-start"

**About:**
The check whether a certificate has expired or not usually runs every 24hours.
This PR adds a second check which is triggered opening the certificate-overview.

**How-to-test:**
- scan a Certificate which will expire in some minutes (can be found in the QR-Example Folder "Special QRs" or CLI Tool-> vc gen --exp 1minute)
- opening the CertView (MainScreen->BottomBar) will show a list of your certificates. 
- if the certificate is expired it should show up already in the certificate overview screen

**Screenshot**
![image](https://user-images.githubusercontent.com/46747780/133111744-e67a7ad9-9aca-4599-b584-c731e805a836.png)
