### PR TITLE
Fix url link replacement (EXPOSUREAPP-9385)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/TextViewUrlExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/TextViewUrlExtensions.kt
@@ -36,7 +36,7 @@ fun TextView.setTextWithUrls(
             it.label.get(context) to it.url.get(context)
         }
         .forEach { (label, url) ->
-            val index = contentResolved.indexOf(label)
+            val index = contentResolved.lowercase().indexOf(label.lowercase())
             if (index == -1) {
                 Timber.w("Label $label was not found in $content")
                 return@forEach


### PR DESCRIPTION
Addresses [EXPOSUREAPP-9385](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9385)

Example: `... blog ...` will be replaced now, even when the placeholder has the key `Blog`.