### PR TITLE
Incorrect booster vaccination screenshots (EXPOSUREAPP-9398)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsFragmentTest.kt
@@ -286,7 +286,7 @@ class PersonDetailsFragmentTest : BaseUITest() {
                 dateOfBirthFormatted = "1943-04-18"
             )
             every { doseNumber } returns number
-            every { totalSeriesOfDoses } returns 2
+            every { totalSeriesOfDoses } returns if (booster) number else 2
             every { dateOfBirthFormatted } returns "1981-03-20"
             every { isFinalShot } returns final
             every { qrCodeToDisplay } returns CoilQrCode(ScreenshotCertificateTestData.vaccinationCertificate)


### PR DESCRIPTION
Addresses [EXPOSUREAPP-9398](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9398)

Screenshots now display `3 of 3` instead of `3 of 2` in alignment to Figma.