### PR TITLE
Fix/9452 Correct RKI spelling in recovery certificate screenshot (COMMUNITY)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/RecoveryCertificateDetailFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/RecoveryCertificateDetailFragmentTest.kt
@@ -122,7 +122,7 @@ class RecoveryCertificateDetailFragmentTest : BaseUITest() {
         every { targetDisease } returns "COVID-19"
         every { testedPositiveOnFormatted } returns "2021-05-24"
         every { certificateCountry } returns "Deutschland"
-        every { certificateIssuer } returns "Robert-Koch-Institut"
+        every { certificateIssuer } returns "Robert Koch-Institut"
         every { validFromFormatted } returns "2021-06-07"
         every { validUntilFormatted } returns "2021-11-10"
         every { hasNotificationBadge } returns false


### PR DESCRIPTION
### Description

This PR resolves issue #4071. The spelling in `RecoveryCertificateDetailFragmentTest.kt` for recovery certificate screenshots in the field "Zertifikataussteller / Certificate Issuer" is corrected to read "Robert Koch-Institut" (removal of hyphen between "Robert" and "Koch").

### Steps to verify

In Android Studio
1. Connect to larger display, such as a tablet
2. Run `RecoveryCertificateDetailFragmentTest.kt`
3. View screenshots in `/data/data/de.rki.coronawarnapp.test/screenshots`
4. Check for the correct spelling "Robert Koch-Institut"


---
Internal Tracking ID: [EXPOSUREAPP-9452](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9452)
