### PR TITLE
No Notification to Warn Others after Positive PCR (EXPOSUREAPP-9122)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/notification/ShareTestResultNotificationService.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/notification/ShareTestResultNotificationService.kt
@@ -7,6 +7,7 @@ import de.rki.coronawarnapp.coronatest.latestRAT
 import de.rki.coronawarnapp.coronatest.type.CoronaTest
 import de.rki.coronawarnapp.coronatest.type.CoronaTest.Type.PCR
 import de.rki.coronawarnapp.coronatest.type.CoronaTest.Type.RAPID_ANTIGEN
+import de.rki.coronawarnapp.coronatest.type.TestIdentifier
 import de.rki.coronawarnapp.main.CWASettings
 import de.rki.coronawarnapp.notification.NotificationConstants.POSITIVE_RESULT_NOTIFICATION_TOTAL_COUNT
 import de.rki.coronawarnapp.tag
@@ -19,6 +20,7 @@ import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
+@Suppress("MaxLineLength")
 @Singleton
 class ShareTestResultNotificationService @Inject constructor(
     @AppScope private val appScope: CoroutineScope,
@@ -93,7 +95,7 @@ class ShareTestResultNotificationService @Inject constructor(
                 tests.filter { test ->
                     test.isSubmissionAllowed && !test.isSubmitted
                 }.forEach { test ->
-                    maybeScheduleSharePositiveTestResultReminder(test.type)
+                    maybeScheduleSharePositiveTestResultReminder(test.type, test.identifier)
                 }
 
                 // cancel the reminder when test is submitted
@@ -105,26 +107,42 @@ class ShareTestResultNotificationService @Inject constructor(
             .launchIn(appScope)
     }
 
-    private fun maybeScheduleSharePositiveTestResultReminder(testType: CoronaTest.Type) {
+    private fun maybeScheduleSharePositiveTestResultReminder(testType: CoronaTest.Type, testId: TestIdentifier) {
         when (testType) {
             PCR -> {
-                if (cwaSettings.numberOfRemainingSharePositiveTestResultRemindersPcr < 0) {
-                    Timber.tag(TAG).v("Schedule positive test result notification for PCR test")
+                if (cwaSettings.numberOfRemainingSharePositiveTestResultRemindersPcr < 0 ||
+                    (
+                        cwaSettings.idOfPositiveTestResultRemindersPcr != null &&
+                            testId != cwaSettings.idOfPositiveTestResultRemindersPcr
+                        )
+                ) {
+                    Timber.tag(TAG)
+                        .v("Schedule positive test result notification for PCR test reminders = ${cwaSettings.numberOfRemainingSharePositiveTestResultRemindersPcr}, testId == $testId, previous testId = ${cwaSettings.idOfPositiveTestResultRemindersPcr}")
                     cwaSettings.numberOfRemainingSharePositiveTestResultRemindersPcr =
                         POSITIVE_RESULT_NOTIFICATION_TOTAL_COUNT
+                    cwaSettings.idOfPositiveTestResultRemindersPcr = testId
                     notification.scheduleSharePositiveTestResultReminder(testType)
                 } else {
-                    Timber.tag(TAG).v("Positive test result notification for PCR test has already been scheduled")
+                    Timber.tag(TAG)
+                        .v("Positive test result notification for PCR test has already been scheduled reminders = ${cwaSettings.numberOfRemainingSharePositiveTestResultRemindersPcr}, testId == $testId, previous testId = ${cwaSettings.idOfPositiveTestResultRemindersPcr}")
                 }
             }
             RAPID_ANTIGEN -> {
-                if (cwaSettings.numberOfRemainingSharePositiveTestResultRemindersRat < 0) {
-                    Timber.tag(TAG).v("Schedule positive test result notification for RAT test")
+                if (cwaSettings.numberOfRemainingSharePositiveTestResultRemindersRat < 0 ||
+                    (
+                        cwaSettings.idOfPositiveTestResultRemindersPcr != null &&
+                            testId != cwaSettings.idOfPositiveTestResultRemindersRat
+                        )
+                ) {
+                    Timber.tag(TAG)
+                        .v("Schedule positive test result notification for RAT test reminders = ${cwaSettings.numberOfRemainingSharePositiveTestResultRemindersRat}, testId == $testId, previous testId = ${cwaSettings.idOfPositiveTestResultRemindersRat}")
                     cwaSettings.numberOfRemainingSharePositiveTestResultRemindersRat =
                         POSITIVE_RESULT_NOTIFICATION_TOTAL_COUNT
+                    cwaSettings.idOfPositiveTestResultRemindersRat = testId
                     notification.scheduleSharePositiveTestResultReminder(testType)
                 } else {
-                    Timber.tag(TAG).v("Positive test result notification for RAT test has already been scheduled")
+                    Timber.tag(TAG)
+                        .v("Positive test result notification for RAT test has already been scheduled reminders = ${cwaSettings.numberOfRemainingSharePositiveTestResultRemindersRat}, testId == $testId, previous testId = ${cwaSettings.idOfPositiveTestResultRemindersRat}")
                 }
             }
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/notification/ShareTestResultNotificationService.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/notification/ShareTestResultNotificationService.kt
@@ -130,7 +130,7 @@ class ShareTestResultNotificationService @Inject constructor(
             RAPID_ANTIGEN -> {
                 if (cwaSettings.numberOfRemainingSharePositiveTestResultRemindersRat < 0 ||
                     (
-                        cwaSettings.idOfPositiveTestResultRemindersPcr != null &&
+                        cwaSettings.idOfPositiveTestResultRemindersRat != null &&
                             testId != cwaSettings.idOfPositiveTestResultRemindersRat
                         )
                 ) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/main/CWASettings.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/main/CWASettings.kt
@@ -3,6 +3,7 @@ package de.rki.coronawarnapp.main
 import android.content.Context
 import androidx.core.content.edit
 import de.rki.coronawarnapp.appconfig.ConfigData
+import de.rki.coronawarnapp.coronatest.type.TestIdentifier
 import de.rki.coronawarnapp.util.di.AppContext
 import de.rki.coronawarnapp.util.preferences.clearAndNotify
 import de.rki.coronawarnapp.util.preferences.createFlowPreference
@@ -52,9 +53,17 @@ class CWASettings @Inject constructor(
         get() = prefs.getInt(PKEY_POSITIVE_TEST_RESULT_REMINDER_COUNT_PCR, Int.MIN_VALUE)
         set(value) = prefs.edit { putInt(PKEY_POSITIVE_TEST_RESULT_REMINDER_COUNT_PCR, value) }
 
+    var idOfPositiveTestResultRemindersPcr: TestIdentifier?
+        get() = prefs.getString(PKEY_POSITIVE_TEST_RESULT_REMINDER_ID_PCR, null)
+        set(value) = prefs.edit { putString(PKEY_POSITIVE_TEST_RESULT_REMINDER_ID_PCR, value) }
+
     var numberOfRemainingSharePositiveTestResultRemindersRat: Int
         get() = prefs.getInt(PKEY_POSITIVE_TEST_RESULT_REMINDER_COUNT_RAT, Int.MIN_VALUE)
         set(value) = prefs.edit { putInt(PKEY_POSITIVE_TEST_RESULT_REMINDER_COUNT_RAT, value) }
+
+    var idOfPositiveTestResultRemindersRat: TestIdentifier?
+        get() = prefs.getString(PKEY_POSITIVE_TEST_RESULT_REMINDER_ID_RAT, null)
+        set(value) = prefs.edit { putString(PKEY_POSITIVE_TEST_RESULT_REMINDER_ID_RAT, value) }
 
     val isNotificationsRiskEnabled = prefs.createFlowPreference(
         key = PKEY_NOTIFICATIONS_RISK_ENABLED,
@@ -87,6 +96,9 @@ class CWASettings @Inject constructor(
 
         private const val PKEY_POSITIVE_TEST_RESULT_REMINDER_COUNT_PCR = "testresults.count"
         private const val PKEY_POSITIVE_TEST_RESULT_REMINDER_COUNT_RAT = "testresults.count.rat"
+
+        private const val PKEY_POSITIVE_TEST_RESULT_REMINDER_ID_PCR = "testresults.id"
+        private const val PKEY_POSITIVE_TEST_RESULT_REMINDER_ID_RAT = "testresults.id.rat"
 
         private const val LAST_CHANGELOG_VERSION = "update.changelog.lastversion"
         private const val DEFAULT_APP_VERSION = 1L

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/notification/ShareTestResultNotificationServiceTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/notification/ShareTestResultNotificationServiceTest.kt
@@ -4,6 +4,7 @@ import de.rki.coronawarnapp.coronatest.CoronaTestRepository
 import de.rki.coronawarnapp.coronatest.type.CoronaTest
 import de.rki.coronawarnapp.coronatest.type.CoronaTest.Type.PCR
 import de.rki.coronawarnapp.coronatest.type.CoronaTest.Type.RAPID_ANTIGEN
+import de.rki.coronawarnapp.coronatest.type.TestIdentifier
 import de.rki.coronawarnapp.main.CWASettings
 import io.kotest.matchers.shouldBe
 import io.mockk.MockKAnnotations
@@ -30,6 +31,8 @@ class ShareTestResultNotificationServiceTest : BaseTest() {
     )
     private var numberOfRemainingSharePositiveTestResultRemindersPcr: Int = Int.MIN_VALUE
     private var numberOfRemainingSharePositiveTestResultRemindersRat: Int = Int.MIN_VALUE
+    private var idOfPositiveTestResultRemindersPcr: TestIdentifier? = null
+    private var idOfPositiveTestResultRemindersRat: TestIdentifier? = null
 
     @BeforeEach
     fun setup() {
@@ -46,6 +49,18 @@ class ShareTestResultNotificationServiceTest : BaseTest() {
         }
         every { cwaSettings.numberOfRemainingSharePositiveTestResultRemindersRat } answers {
             numberOfRemainingSharePositiveTestResultRemindersRat
+        }
+        every { cwaSettings.idOfPositiveTestResultRemindersPcr = any() } answers {
+            idOfPositiveTestResultRemindersPcr = arg(0)
+        }
+        every { cwaSettings.idOfPositiveTestResultRemindersRat = any() } answers {
+            idOfPositiveTestResultRemindersRat = arg(0)
+        }
+        every { cwaSettings.idOfPositiveTestResultRemindersPcr } answers {
+            idOfPositiveTestResultRemindersPcr
+        }
+        every { cwaSettings.idOfPositiveTestResultRemindersRat } answers {
+            idOfPositiveTestResultRemindersRat
         }
 
         every { shareTestResultNotification.showSharePositiveTestResultNotification(any(), any()) } just Runs
@@ -66,11 +81,13 @@ class ShareTestResultNotificationServiceTest : BaseTest() {
 
         coronaTestFlow.value = setOf(
             mockk<CoronaTest>().apply {
+                every { identifier } returns "PCR-ID"
                 every { type } returns PCR
                 every { isSubmissionAllowed } returns true
                 every { isSubmitted } returns false
             },
             mockk<CoronaTest>().apply {
+                every { identifier } returns "RAT-ID"
                 every { type } returns RAPID_ANTIGEN
                 every { isSubmissionAllowed } returns true
                 every { isSubmitted } returns false
@@ -84,6 +101,8 @@ class ShareTestResultNotificationServiceTest : BaseTest() {
 
         verify { cwaSettings.numberOfRemainingSharePositiveTestResultRemindersPcr = 2 }
         verify { cwaSettings.numberOfRemainingSharePositiveTestResultRemindersRat = 2 }
+        verify { cwaSettings.idOfPositiveTestResultRemindersPcr = "PCR-ID" }
+        verify { cwaSettings.idOfPositiveTestResultRemindersRat = "RAT-ID" }
     }
 
     @Test


### PR DESCRIPTION
## Testing
- scan positive PCR or RAT test, don't share the results, and wait for cca 2h for notification
You could also update `NotificationConstants` to get the notification earlier
```kotlin
val POSITIVE_RESULT_NOTIFICATION_INITIAL_OFFSET: Duration = Duration.standardHours(2)
val POSITIVE_RESULT_NOTIFICATION_INTERVAL: Duration = Duration.standardHours(2)
```
- then you could also scan another positive PCR or RAT test and check if the notifications are still working
- It looks like we save only a number of reminding positive test result reminders, and this count is reset when the test is removed, but not when the test is replaced by another one, so I have added also a test id 


## Jira Ticket
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9122
