### PR TITLE
Registration Token visible in error report (EXPOSUREAPP-9383)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/BugReportingSharedModule.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/BugReportingSharedModule.kt
@@ -9,6 +9,7 @@ import de.rki.coronawarnapp.bugreporting.censors.contactdiary.DiaryEncounterCens
 import de.rki.coronawarnapp.bugreporting.censors.contactdiary.DiaryLocationCensor
 import de.rki.coronawarnapp.bugreporting.censors.contactdiary.DiaryPersonCensor
 import de.rki.coronawarnapp.bugreporting.censors.contactdiary.DiaryVisitCensor
+import de.rki.coronawarnapp.bugreporting.censors.contactdiary.OrganizerRegistrationTokenCensor
 import de.rki.coronawarnapp.bugreporting.censors.dcc.DccQrCodeCensor
 import de.rki.coronawarnapp.bugreporting.censors.presencetracing.CheckInsCensor
 import de.rki.coronawarnapp.bugreporting.censors.presencetracing.TraceLocationCensor
@@ -132,4 +133,8 @@ class BugReportingSharedModule {
     @Provides
     @IntoSet
     fun certificateQrCodeCensor(censor: DccQrCodeCensor): BugCensor = censor
+
+    @Provides
+    @IntoSet
+    fun organizerRegistrationTokenCensor(censor: OrganizerRegistrationTokenCensor): BugCensor = censor
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/OrganizerRegistrationTokenCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/OrganizerRegistrationTokenCensor.kt
@@ -1,0 +1,37 @@
+package de.rki.coronawarnapp.bugreporting.censors.contactdiary
+
+import dagger.Reusable
+import de.rki.coronawarnapp.bugreporting.censors.BugCensor
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import javax.inject.Inject
+
+@Reusable
+class OrganizerRegistrationTokenCensor @Inject constructor() : BugCensor {
+
+    override suspend fun checkLog(message: String): BugCensor.CensorContainer? = mutex.withLock {
+        if (registrationToken.isEmpty()) return null
+
+        var container = BugCensor.CensorContainer(message)
+
+        registrationToken.forEach {
+            container = container.censor(it, PLACEHOLDER + it.takeLast(3))
+        }
+
+        return container.nullIfEmpty()
+    }
+
+    companion object {
+        private val mutex = Mutex()
+        private val registrationToken = mutableSetOf<String>()
+        suspend fun addRegistrationToken(tan: String) = mutex.withLock {
+            registrationToken.add(tan)
+        }
+
+        suspend fun clearRegistrationTokens() = mutex.withLock {
+            registrationToken.clear()
+        }
+
+        private const val PLACEHOLDER = "########-####-####-####-########"
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/playbook/OrganizerPlaybook.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/playbook/OrganizerPlaybook.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.playbook
 
 import androidx.annotation.VisibleForTesting
+import de.rki.coronawarnapp.bugreporting.censors.contactdiary.OrganizerRegistrationTokenCensor
 import de.rki.coronawarnapp.coronatest.server.RegistrationRequest
 import de.rki.coronawarnapp.coronatest.server.VerificationKeyType
 import de.rki.coronawarnapp.coronatest.server.VerificationServer
@@ -70,6 +71,10 @@ class OrganizerPlaybook @Inject constructor(
         // Real registration token
         val (registrationToken, registrationException) = executeCapturingExceptions {
             verificationServer.retrieveRegistrationToken(tokenRequest)
+        }
+
+        if (registrationToken != null) {
+            OrganizerRegistrationTokenCensor.addRegistrationToken(registrationToken)
         }
 
         // if the registration succeeded continue with the real upload TAN retrieval

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/OrganizerRegistrationTokenCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/OrganizerRegistrationTokenCensorTest.kt
@@ -1,0 +1,51 @@
+package de.rki.coronawarnapp.bugreporting.censors.contactdiary
+
+import io.kotest.matchers.shouldBe
+import io.mockk.MockKAnnotations
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class OrganizerRegistrationTokenCensorTest {
+
+    private val testRegistrationTokens = listOf(
+        "63b4d3ff-e0de-4bd4-90c1-17c2bb683a2f",
+        "13b4d3ff-e0de-4bd4-90c1-17c2bb683a2x",
+    )
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this)
+    }
+
+    @AfterEach
+    fun teardown() {
+        runBlocking { OrganizerRegistrationTokenCensor.clearRegistrationTokens() }
+    }
+
+    private fun createInstance() = OrganizerRegistrationTokenCensor()
+
+    @Test
+    fun `censoring replaces the logline message`() = runBlockingTest {
+        val instance = createInstance()
+
+        testRegistrationTokens.forEach {
+            OrganizerRegistrationTokenCensor.addRegistrationToken(it)
+            val toCensor = "I'm a shy registrationToken: $it"
+            instance.checkLog(toCensor)!!
+                .compile()!!.censored shouldBe "I'm a shy registrationToken: ########-####-####-####-########${it.takeLast(3)}"
+        }
+    }
+
+    @Test
+    fun `censoring aborts if no qrcode was set`() = runBlockingTest {
+        val instance = createInstance()
+
+        testRegistrationTokens.forEach {
+            val toCensor = "I'm a shy registrationToken: $it"
+            instance.checkLog(toCensor) shouldBe null
+        }
+    }
+}

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/OrganizerRegistrationTokenCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/contactdiary/OrganizerRegistrationTokenCensorTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
+@Suppress("MaxLineLength")
 class OrganizerRegistrationTokenCensorTest {
 
     private val testRegistrationTokens = listOf(


### PR DESCRIPTION
## Testing
1. App Information > Error Reports > Start
2. Event Planning > Warn for Others > Next > (select event or scan qr code) > Next > Enter Tan > Send Warning
3. App Information > Error Reports > Check log file. `registrationToken` should be censored

## Jira Ticket
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9383
 