### PR TITLE
UQS smart back navigation (EXPOSUREAPP-9325)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragment.kt
@@ -7,6 +7,7 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.navGraphViewModels
 import androidx.recyclerview.widget.DefaultItemAnimator
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.transition.Hold
@@ -17,6 +18,8 @@ import de.rki.coronawarnapp.covidcertificate.person.ui.details.PersonDetailsFrag
 import de.rki.coronawarnapp.covidcertificate.person.ui.overview.items.CameraPermissionCard
 import de.rki.coronawarnapp.covidcertificate.person.ui.overview.items.PersonCertificatesItem
 import de.rki.coronawarnapp.databinding.PersonOverviewFragmentBinding
+import de.rki.coronawarnapp.qrcode.caller.QrCodeScannerCaller
+import de.rki.coronawarnapp.qrcode.caller.QrCodeScannerCallerViewModel
 import de.rki.coronawarnapp.util.ExternalActionHelper.openAppDetailsSettings
 import de.rki.coronawarnapp.util.ExternalActionHelper.openUrl
 import de.rki.coronawarnapp.util.di.AutoInject
@@ -31,11 +34,12 @@ import timber.log.Timber
 import javax.inject.Inject
 
 // Shows a list of multiple persons
-class PersonOverviewFragment : Fragment(R.layout.person_overview_fragment), AutoInject {
+class PersonOverviewFragment : Fragment(R.layout.person_overview_fragment), AutoInject, QrCodeScannerCaller {
     @Inject lateinit var viewModelFactory: CWAViewModelFactoryProvider.Factory
     private val viewModel: PersonOverviewViewModel by cwaViewModels { viewModelFactory }
     private val binding by viewBinding<PersonOverviewFragmentBinding>()
     private val personOverviewAdapter = PersonOverviewAdapter()
+    private val qrCodeScannerCallerViewModel: QrCodeScannerCallerViewModel by navGraphViewModels(R.id.nav_graph)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         Timber.tag(TAG).d("onViewCreated(view=%s, savedInstanceState=%s)", view, savedInstanceState)
@@ -85,6 +89,7 @@ class PersonOverviewFragment : Fragment(R.layout.person_overview_fragment), Auto
             }.show()
 
             ScanQrCode -> {
+                updateQrCodeCallerViewModel()
                 setupHoldTransition()
                 findNavController().navigate(
                     R.id.action_to_universal_scanner,
@@ -140,6 +145,10 @@ class PersonOverviewFragment : Fragment(R.layout.person_overview_fragment), Auto
         itemAnimator = DefaultItemAnimator()
 
         with(scanQrcodeFab) { onScroll { extend -> if (extend) extend() else shrink() } }
+    }
+
+    override fun updateQrCodeCallerViewModel() {
+        qrCodeScannerCallerViewModel.putCallerGlobalAction(R.id.action_to_covid_certificates)
     }
 
     companion object {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/caller/QrCodeScannerCaller.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/caller/QrCodeScannerCaller.kt
@@ -1,0 +1,5 @@
+package de.rki.coronawarnapp.qrcode.caller
+
+interface QrCodeScannerCaller {
+    fun updateQrCodeCallerViewModel()
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/caller/QrCodeScannerCallerViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/caller/QrCodeScannerCallerViewModel.kt
@@ -1,0 +1,28 @@
+package de.rki.coronawarnapp.qrcode.caller
+
+import androidx.lifecycle.ViewModel
+
+/**
+ * Shares global action from camera caller between start and end destinations
+ * to have ability to navigate back to caller after camera flow complete.
+ */
+class QrCodeScannerCallerViewModel : ViewModel() {
+
+    private val callerGlobalActionCache = mutableListOf<Int?>()
+
+    fun callerGlobalAction(): Int? {
+        return if (callerGlobalActionCache.size > 0) {
+            val action = callerGlobalActionCache.first()
+            callerGlobalActionCache.removeFirst()
+            action
+        } else {
+            null
+        }
+    }
+
+    fun putCallerGlobalAction(
+        action: Int
+    ) {
+        callerGlobalActionCache.add(action)
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/CheckInsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/CheckInsFragment.kt
@@ -19,6 +19,8 @@ import com.google.android.material.transition.MaterialSharedAxis
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.TraceLocationAttendeeCheckinsFragmentBinding
 import de.rki.coronawarnapp.presencetracing.checkins.CheckIn
+import de.rki.coronawarnapp.qrcode.caller.QrCodeScannerCaller
+import de.rki.coronawarnapp.qrcode.caller.QrCodeScannerCallerViewModel
 import de.rki.coronawarnapp.qrcode.ui.VerifiedLocationViewModel
 import de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.items.CameraPermissionVH
 import de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.items.CheckInsItem
@@ -40,7 +42,7 @@ import timber.log.Timber
 import java.net.URLEncoder
 import javax.inject.Inject
 
-class CheckInsFragment : Fragment(R.layout.trace_location_attendee_checkins_fragment), AutoInject {
+class CheckInsFragment : Fragment(R.layout.trace_location_attendee_checkins_fragment), AutoInject, QrCodeScannerCaller {
 
     private val navArgs by navArgs<CheckInsFragmentArgs>()
 
@@ -59,6 +61,7 @@ class CheckInsFragment : Fragment(R.layout.trace_location_attendee_checkins_frag
     private val binding: TraceLocationAttendeeCheckinsFragmentBinding by viewBinding()
     private val checkInsAdapter = CheckInsAdapter()
     private val locationViewModel by navGraphViewModels<VerifiedLocationViewModel>(R.id.nav_graph)
+    private val qrCodeScannerCallerViewModel: QrCodeScannerCallerViewModel by navGraphViewModels(R.id.nav_graph)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -153,6 +156,7 @@ class CheckInsFragment : Fragment(R.layout.trace_location_attendee_checkins_frag
     private fun bindFAB() {
         binding.scanCheckinQrcodeFab.apply {
             setOnClickListener {
+                updateQrCodeCallerViewModel()
                 setupHoldTransition()
                 findNavController().navigate(
                     R.id.action_to_universal_scanner,
@@ -220,6 +224,10 @@ class CheckInsFragment : Fragment(R.layout.trace_location_attendee_checkins_frag
                 else -> onOptionsItemSelected(it)
             }
         }
+    }
+
+    override fun updateQrCodeCallerViewModel() {
+        qrCodeScannerCallerViewModel.putCallerGlobalAction(R.id.action_to_trace_location_attendee)
     }
 
     companion object {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/fragment/SubmissionDispatcherFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/fragment/SubmissionDispatcherFragment.kt
@@ -8,8 +8,11 @@ import androidx.navigation.NavGraph
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.navGraphViewModels
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.FragmentSubmissionDispatcherBinding
+import de.rki.coronawarnapp.qrcode.caller.QrCodeScannerCaller
+import de.rki.coronawarnapp.qrcode.caller.QrCodeScannerCallerViewModel
 import de.rki.coronawarnapp.ui.submission.viewmodel.SubmissionDispatcherViewModel
 import de.rki.coronawarnapp.ui.submission.viewmodel.SubmissionNavigationEvents
 import de.rki.coronawarnapp.util.ExternalActionHelper.openUrl
@@ -23,11 +26,15 @@ import de.rki.coronawarnapp.util.viewmodel.cwaViewModels
 import timber.log.Timber
 import javax.inject.Inject
 
-class SubmissionDispatcherFragment : Fragment(R.layout.fragment_submission_dispatcher), AutoInject {
+class SubmissionDispatcherFragment :
+    Fragment(R.layout.fragment_submission_dispatcher),
+    AutoInject,
+    QrCodeScannerCaller {
 
     @Inject lateinit var viewModelFactory: CWAViewModelFactoryProvider.Factory
     private val viewModel: SubmissionDispatcherViewModel by cwaViewModels { viewModelFactory }
     private val binding: FragmentSubmissionDispatcherBinding by viewBinding()
+    private val qrCodeScannerCallerViewModel: QrCodeScannerCallerViewModel by navGraphViewModels(R.id.nav_graph)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -85,6 +92,7 @@ class SubmissionDispatcherFragment : Fragment(R.layout.fragment_submission_dispa
     }
 
     private fun openUniversalScanner() {
+        updateQrCodeCallerViewModel()
         val dispatcherCard = binding.submissionDispatcherQr.dispatcherCard.apply {
             transitionName = "shared_element_container"
         }
@@ -120,5 +128,9 @@ class SubmissionDispatcherFragment : Fragment(R.layout.fragment_submission_dispa
         binding.submissionDispatcherTestCenter.dispatcherCard.setOnClickListener {
             viewModel.onTestCenterPressed()
         }
+    }
+
+    override fun updateQrCodeCallerViewModel() {
+        qrCodeScannerCallerViewModel.putCallerGlobalAction(R.id.action_to_main_screen)
     }
 }

--- a/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
+++ b/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
@@ -854,4 +854,16 @@
         android:id="@+id/action_to_universal_scanner"
         app:destination="@id/universalScanner" />
 
+    <action
+        android:id="@+id/action_to_main_screen"
+        app:destination="@id/mainFragment" />
+
+    <action
+        android:id="@+id/action_to_covid_certificates"
+        app:destination="@id/covid_certificates_graph" />
+
+    <action
+        android:id="@+id/action_to_trace_location_attendee"
+        app:destination="@id/trace_location_attendee_nav_graph" />
+
 </navigation>


### PR DESCRIPTION
### Changes
Navigation back from negative and pending test results.

### ToDo
⚠️  Important ⚠️  : verify back navigation behaviour on final screen (should back stack be wiped after navigation from test results?)

### Story
[EXPOSUREAPP-8903](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8903)

### Subtasks
[EXPOSUREAPP-9325](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9325)

### How to test
For pending and negative test results: 
1. Scan them from all scanning start points (Submission Dispatcher fragment, CheckIns tab, Certificates tab)
2. Proceed with submission flow
3. Check that troll bar and device button leads to the point where you start


⚠️  Note for testers ⚠️  : as for acceptance criteria, starting with submission dispatcher fragment would lead to main fragment at the end of the flow and not submission dispatcher.
