### PR TITLE
Wrong link in certificate infos (EXPOSUREAPP-9668)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/covpass/CovPassInfoFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/covpass/CovPassInfoFragment.kt
@@ -30,9 +30,9 @@ class CovPassInfoFragment : Fragment(R.layout.fragment_cov_pass_info) {
             toolbar.setNavigationOnClickListener { popBackStack() }
 
             linkToFaq.setTextWithUrl(
-                R.string.cov_pass_info_faq_link,
-                R.string.cov_pass_info_faq_link,
-                R.string.vaccination_card_booster_eligible_faq_link
+                R.string.cov_pass_info_faq_link_label,
+                R.string.cov_pass_info_faq_link_label,
+                R.string.cov_pass_info_faq_link
             )
 
             appBarLayout.onOffsetChange { _, subtitleAlpha ->

--- a/Corona-Warn-App/src/main/res/layout/fragment_cov_pass_info.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_cov_pass_info.xml
@@ -81,7 +81,7 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
-                    android:text="@string/cov_pass_info_faq_link"
+                    android:text="@string/cov_pass_info_faq_link_label"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/subtitle" />

--- a/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
@@ -374,9 +374,11 @@
     <!-- XHED: Cov Pass Info Fragment title -->
     <string name="cov_pass_info_title">"Zertifikatsprüfung durch Dritte"</string>
     <!-- XHED: Cov Pass Info Fragment title -->
-    <string name="cov_pass_info_subtitle">"Dritte können nur über die CovPassCheck-App verlässlich überprüfen, ob es sich um ein valides Impf-, Genesenen- oder Testzertifikat handelt."</string>
-    <!-- XHED: Cov Pass Info Fragment title -->
-    <string name="cov_pass_info_faq_link">"FAQ zur Zertifikatsprüfung durch Dritte"</string>
+    <string name="cov_pass_info_subtitle">"Dritte können nur über die CovPassCheck-App verlässlich überprüfen, ob es sich um ein valides Impf-, Genesenen-, oder Testzertifikat handelt."</string>
+    <!-- XTXT: Cov Pass Info Fragment link label -->
+    <string name="cov_pass_info_faq_link_label">"FAQ zur Zertifikatsprüfung durch Dritte"</string>
+    <!-- XTXT: Explains user about cov pass: URL, has to be "translated" into english (relevant for all languages except german) - https://www.coronawarn.app/en/faq/#eu_dcc_check -->
+    <string name="cov_pass_info_faq_link">"https://www.coronawarn.app/de/faq/#eu_dcc_check"</string>
     <!-- XHED: Cov Pass Info Fragment title -->
     <string name="cov_pass_info_section_one">"Sie selbst können Zertifikate in der Corona-Warn-App auf Gültigkeit prüfen und benötigen dazu nicht die CovPassCheck-App."</string>
     <!-- XHED: Cov Pass Info Fragment title -->

--- a/Corona-Warn-App/src/main/res/values/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/covid_certificate_strings.xml
@@ -374,8 +374,10 @@
     <string name="cov_pass_info_title">"Zertifikatsprüfung durch Dritte"</string>
     <!-- XHED: Cov Pass Info Fragment title -->
     <string name="cov_pass_info_subtitle">"Dritte können nur über die CovPassCheck-App verlässlich überprüfen, ob es sich um ein valides Impf-, Genesenen-, oder Testzertifikat handelt."</string>
-    <!-- XHED: Cov Pass Info Fragment title -->
-    <string name="cov_pass_info_faq_link">"FAQ zur Zertifikatsprüfung durch Dritte"</string>
+    <!-- XTXT: Cov Pass Info Fragment link label -->
+    <string name="cov_pass_info_faq_link_label">"FAQ zur Zertifikatsprüfung durch Dritte"</string>
+    <!-- XTXT: Explains user about cov pass: URL, has to be "translated" into english (relevant for all languages except german) - https://www.coronawarn.app/en/faq/#eu_dcc_check -->
+    <string name="cov_pass_info_faq_link">"https://www.coronawarn.app/en/faq/#eu_dcc_check"</string>
     <!-- XHED: Cov Pass Info Fragment title -->
     <string name="cov_pass_info_section_one">"Sie selbst können Zertifikate in der Corona-Warn-App auf Gültigkeit prüfen und benötigen dazu nicht die CovPassCheck-App."</string>
     <!-- XHED: Cov Pass Info Fragment title -->


### PR DESCRIPTION
This PR addresses Exposureapp-9668 (link correction)

How to test:
- Scan a QR code (certificate)
- press the info button in the topbar above the QR code
- in the info screen, press the FAQ Link
- check if the link is the expected one (Ticket)