### PR TITLE
Fix re-arranging issue of Vax certs that have the same vaccinationOn (EXPOSUREAPP-8756)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensions.kt
@@ -13,19 +13,31 @@ import timber.log.Timber
 
 /*
     The list items shall be sorted descending by the following date attributes depending on the type of the DGC:
-    for Vaccination Certificates (i.e. DGC with v[0]): the date of the vaccination v[0].dt
+    for Vaccination Certificates (i.e. DGC with v[0]): the date of the vaccination v[0].dt and issuedAt date
     for Test Certificates (i.e. DGC with t[0]): the date of the sample collection t[0].sc
     for Recovery Certificates (i.e. DGC with r[0]): the date of begin of the validity r[0].df
  */
 fun Collection<CwaCovidCertificate>.toCertificateSortOrder(): List<CwaCovidCertificate> {
-    return this.sortedByDescending {
-        when (it) {
-            is VaccinationCertificate -> it.vaccinatedOn
-            is TestCertificate -> it.sampleCollectedAt.toLocalDateUserTz()
-            is RecoveryCertificate -> it.validFrom
-            else -> throw IllegalStateException("Can't sort $it")
-        }
-    }
+    return this.sortedWith(
+        compareBy(
+            {
+                when (it) {
+                    is VaccinationCertificate -> it.vaccinatedOn
+                    is TestCertificate -> it.sampleCollectedAt.toLocalDateUserTz()
+                    is RecoveryCertificate -> it.validFrom
+                    else -> throw IllegalStateException("Can't sort $it")
+                }
+            },
+            {
+                when (it) {
+                    is VaccinationCertificate -> it.headerIssuedAt
+                    is TestCertificate -> it.sampleCollectedAt.toLocalDateUserTz()
+                    is RecoveryCertificate -> it.validFrom
+                    else -> throw IllegalStateException("Can't sort $it")
+                }
+            }
+        )
+    ).reversed()
 }
 
 /**

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensionsTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensionsTest.kt
@@ -25,6 +25,12 @@ class PersonCertificatesExtensionsTest : BaseTest() {
     fun `certificate sort order`() {
 
         val certificateFirst = mockk<VaccinationCertificate>().apply {
+            every { headerIssuedAt } returns Instant.parse("2021-09-20T10:00:00.000Z")
+            every { vaccinatedOn } returns time.plus(oneDayDuration).toLocalDateUtc()
+        }
+
+        val certificateFirstIssuedAtAnotherDate = mockk<VaccinationCertificate>().apply {
+            every { headerIssuedAt } returns Instant.parse("2021-07-20T10:00:00.000Z")
             every { vaccinatedOn } returns time.plus(oneDayDuration).toLocalDateUtc()
         }
 
@@ -36,9 +42,12 @@ class PersonCertificatesExtensionsTest : BaseTest() {
             every { validFrom } returns time.minus(oneDayDuration).toLocalDateUtc()
         }
 
-        val expectedOrder = listOf(certificateFirst, certificateSecond, certificateThird)
-        val wrongOrder = listOf(certificateSecond, certificateFirst, certificateThird)
-        val wrongOrder2 = listOf(certificateThird, certificateSecond, certificateFirst)
+        val expectedOrder =
+            listOf(certificateFirstIssuedAtAnotherDate, certificateFirst, certificateSecond, certificateThird)
+        val wrongOrder =
+            listOf(certificateSecond, certificateFirst, certificateThird, certificateFirstIssuedAtAnotherDate)
+        val wrongOrder2 =
+            listOf(certificateThird, certificateSecond, certificateFirstIssuedAtAnotherDate, certificateFirst)
 
         expectedOrder.toCertificateSortOrder() shouldBe expectedOrder
         wrongOrder.toCertificateSortOrder() shouldBe expectedOrder

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensionsTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensionsTest.kt
@@ -43,7 +43,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
         }
 
         val expectedOrder =
-            listOf(certificateFirstIssuedAtAnotherDate, certificateFirst, certificateSecond, certificateThird)
+            listOf(certificateFirst, certificateFirstIssuedAtAnotherDate, certificateSecond, certificateThird)
         val wrongOrder =
             listOf(certificateSecond, certificateFirst, certificateThird, certificateFirstIssuedAtAnotherDate)
         val wrongOrder2 =


### PR DESCRIPTION
Re: https://github.com/corona-warn-app/cwa-app-android/issues/4000#issuecomment-929185338

More info: https://github.com/corona-warn-app/cwa-app-android/issues/4000#issuecomment-929535241