### PR TITLE
UQS Certificate Scan - "Neu" ist missing on Vacc und Rec Certificates (EXPOSUREAPP-9756) 

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsFragmentTest.kt
@@ -300,6 +300,7 @@ class PersonDetailsFragmentTest : BaseUITest() {
             every { isValid } returns true
             every { getState() } returns CwaCovidCertificate.State.Valid(Instant.now().plus(20))
             every { hasNotificationBadge } returns false
+            every { isNew } returns false
         }
 
     private fun mockRecoveryCertificate(): RecoveryCertificate =
@@ -314,6 +315,7 @@ class PersonDetailsFragmentTest : BaseUITest() {
             every { isValid } returns true
             every { getState() } returns CwaCovidCertificate.State.Valid(Instant.now().plus(20))
             every { hasNotificationBadge } returns false
+            every { isNew } returns false
         }
 
     private val certificatePersonIdentifier = CertificatePersonIdentifier(

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsFragmentTest.kt
@@ -263,7 +263,7 @@ class PersonDetailsFragmentTest : BaseUITest() {
         every { isValid } returns true
         every { sampleCollectedAt } returns Instant.parse("2021-05-21T11:35:00.000Z")
         every { getState() } returns CwaCovidCertificate.State.Valid(headerExpiresAt)
-        every { isNewlyRetrieved } returns false
+        every { isNew } returns false
         every { hasNotificationBadge } returns false
     }
 

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragmentTest.kt
@@ -252,7 +252,7 @@ class PersonOverviewFragmentTest : BaseUITest() {
         every { isValid } returns true
         every { sampleCollectedAt } returns Instant.parse("2021-05-21T11:35:00.000Z")
         every { getState() } returns CwaCovidCertificate.State.Valid(headerExpiresAt)
-        every { isNewlyRetrieved } returns false
+        every { isNew } returns false
     }
 
     private fun mockTestCertificateWrapper(isUpdating: Boolean) = mockk<TestCertificateWrapper>().apply {

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/test/ui/TestCertificateDetailsFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/test/ui/TestCertificateDetailsFragmentTest.kt
@@ -195,6 +195,8 @@ class TestCertificateDetailsFragmentTest : BaseUITest() {
         val testDate = DateTime.parse("12.05.2021 19:00", formatter).toInstant()
 
         return object : AbstractTestCertificate(testDate, certificatePersonIdentifier) {
+            override val isNew: Boolean get() = false
+
             override fun getState(): CwaCovidCertificate.State = state
         }
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/CwaCovidCertificate.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/CwaCovidCertificate.kt
@@ -54,6 +54,11 @@ interface CwaCovidCertificate {
     val hasNotificationBadge: Boolean
 
     /**
+     * Certificate is newly scanned or retrieved from server in case of TC
+     */
+    val isNew: Boolean
+
+    /**
      * The current state of the certificate, see [State]
      */
     fun getState(): State

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/storage/RecoveryCertificateContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/storage/RecoveryCertificateContainer.kt
@@ -141,8 +141,11 @@ data class RecoveryCertificateContainer(
             override val hasNotificationBadge: Boolean
                 get() {
                     val state = getState()
-                    return (state !is State.Valid && state != lastSeenStateChange) || !data.certificateSeenByUser
+                    return (state !is State.Valid && state != lastSeenStateChange) || isNew
                 }
+
+            override val isNew: Boolean
+                get() = !data.certificateSeenByUser
 
             override fun toString(): String = "RecoveryCertificate($containerId)"
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificate.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificate.kt
@@ -32,11 +32,6 @@ interface TestCertificate : CwaCovidCertificate {
     val isCertificateRetrievalPending: Boolean
 
     /**
-     * Newly retrieved from backend and user has not seen it yet
-     */
-    val isNewlyRetrieved: Boolean get() = false
-
-    /**
      * Not supported by this type of certificate (at the moment)
      */
     override val notifiedExpiredAt: Instant?

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateContainer.kt
@@ -158,14 +158,13 @@ data class TestCertificateContainer(
             override val lastSeenStateChangeAt: Instant?
                 get() = data.lastSeenStateChangeAt
 
-            override val isNewlyRetrieved: Boolean
+            override val isNew: Boolean
                 get() = !certificateSeenByUser && !isCertificateRetrievalPending
 
             override val hasNotificationBadge: Boolean
                 get() {
                     val state = getState()
-                    return isNewlyRetrieved ||
-                        (state is State.Invalid && state != lastSeenStateChange)
+                    return (state is State.Invalid && state != lastSeenStateChange) || isNew
                 }
 
             override fun toString(): String = "TestCertificate($containerId)"

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/TestCertificateDetailsViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/TestCertificateDetailsViewModel.kt
@@ -61,7 +61,7 @@ class TestCertificateDetailsViewModel @AssistedInject constructor(
 
     fun refreshCertState() = launch(scope = appScope) {
         Timber.v("refreshCertState()")
-        if (covidCertificate.value?.isNewlyRetrieved == true && !fromScanner) {
+        if (covidCertificate.value?.isNew == true && !fromScanner) {
             testCertificateRepository.markCertificateAsSeenByUser(containerId)
         } else {
             testCertificateRepository.acknowledgeState(containerId)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/storage/VaccinationContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/storage/VaccinationContainer.kt
@@ -171,8 +171,10 @@ data class VaccinationContainer internal constructor(
         override val hasNotificationBadge: Boolean
             get() {
                 val state = getState()
-                return (state !is State.Valid && state != lastSeenStateChange) || !certificateSeenByUser
+                return (state !is State.Valid && state != lastSeenStateChange) || isNew
             }
+
+        override val isNew: Boolean get() = !certificateSeenByUser
 
         override fun toString(): String = "VaccinationCertificate($containerId)"
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CertificateStateHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CertificateStateHelper.kt
@@ -33,7 +33,7 @@ fun IncludeCertificateQrcodeCardBinding.bindValidityViews(
     invalidOverlay.isGone = valid
     image.isEnabled = isCertificateDetails && valid // Disable Qr-Code image from opening full-screen mode
 
-    val isNewTestCertificate = certificate is TestCertificate && certificate.isNewlyRetrieved
+    val isNewTestCertificate = certificate is TestCertificate && certificate.isNew
     notificationBadge.isVisible = if (isNewTestCertificate) {
         false
     } else {
@@ -146,7 +146,7 @@ fun TextView.displayExpirationState(certificate: CwaCovidCertificate) {
 
         is CwaCovidCertificate.State.Valid -> {
             isVisible = false
-            if (certificate is TestCertificate && certificate.isNewlyRetrieved) {
+            if (certificate.isNew) {
                 isVisible = true
                 text = context.getText(R.string.test_certificate_qr_new)
             }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonCertificatesData.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonCertificatesData.kt
@@ -97,4 +97,6 @@ fun testCertificate(
 
     override val dccData: DccData<*>
         get() = mockk()
+    override val isNew: Boolean
+        get() = false
 }


### PR DESCRIPTION
- `isNew` flag is introduced to indicate that the certificate is added newly in the App whether it is TC, VC, or RC
- Renamed `isNewlyRetreived` of TC  to match the new way
- Now all certificates should have `Neu` label once they are newly scanned or requested from server for TC case

- [x] Update Instrumentation tests


## Ticket 
- https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9756