### PR TITLE
Remove first hint from submission consent screen (EXPOSUREAPP-9820)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/include_submission_consent_intro.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_submission_consent_intro.xml
@@ -19,7 +19,7 @@
 
         <TextView
             android:id="@+id/submission_consent_call_test_result_body"
-            style="@style/subtitle"
+            style="@style/subtitleMedium"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/spacing_normal"
@@ -27,31 +27,6 @@
             app:layout_constraintEnd_toEndOf="@id/guideline_end"
             app:layout_constraintStart_toStartOf="@id/guideline_start"
             app:layout_constraintTop_toBottomOf="@id/submission_consent_call_test_result" />
-
-        <ImageView
-            android:id="@+id/submission_consent_icon_scan"
-            android:layout_width="@dimen/circle_icon"
-            android:layout_height="@dimen/circle_icon"
-            android:layout_marginTop="@dimen/spacing_normal"
-            android:background="@drawable/circle"
-            android:backgroundTint="@color/card_dark"
-            android:importantForAccessibility="no"
-            android:padding="@dimen/circle_icon_padding"
-            app:layout_constraintStart_toStartOf="@id/guideline_start"
-            app:layout_constraintTop_toBottomOf="@+id/submission_consent_call_test_result_body"
-            app:srcCompat="@drawable/ic_qr_code" />
-
-        <TextView
-            android:id="@+id/submission_consent_call_test_result_scan_your_test_only"
-            style="@style/subtitle"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/spacing_tiny"
-            android:layout_marginTop="@dimen/spacing_normal"
-            android:text="@string/submission_consent_call_test_result_scan_your_test_only"
-            app:layout_constraintEnd_toEndOf="@id/guideline_end"
-            app:layout_constraintStart_toEndOf="@id/submission_consent_icon_scan"
-            app:layout_constraintTop_toBottomOf="@+id/submission_consent_call_test_result_body" />
 
         <ImageView
             android:id="@+id/submission_consent_icon_single_test"
@@ -63,7 +38,7 @@
             android:importantForAccessibility="no"
             android:padding="8dp"
             app:layout_constraintStart_toStartOf="@id/guideline_start"
-            app:layout_constraintTop_toBottomOf="@+id/submission_consent_call_test_result_scan_your_test_only"
+            app:layout_constraintTop_toBottomOf="@+id/submission_consent_call_test_result_body"
             app:srcCompat="@drawable/ic_qr_1x_test" />
 
         <TextView
@@ -76,7 +51,7 @@
             android:text="@string/submission_consent_call_test_result_scan_test_only_once"
             app:layout_constraintEnd_toEndOf="@id/guideline_end"
             app:layout_constraintStart_toEndOf="@id/submission_consent_icon_single_test"
-            app:layout_constraintTop_toBottomOf="@+id/submission_consent_call_test_result_scan_your_test_only" />
+            app:layout_constraintTop_toBottomOf="@+id/submission_consent_call_test_result_body" />
 
         <ImageView
             android:id="@+id/submission_star_checkmark"


### PR DESCRIPTION
Small change that removes the first hint.

<img width="255" alt="2021-10-05_12-08-26" src="https://user-images.githubusercontent.com/19816790/136042621-eae3e67b-e3c3-4144-8ade-7d217a4577a1.png">


