### PR TITLE
Fix statistics text (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/home_statistics_cards_seven_day_hospitalization_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_statistics_cards_seven_day_hospitalization_layout.xml
@@ -89,6 +89,7 @@
             android:id="@+id/primary_subtitle"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:hyphenationFrequency="full"
             android:text="@string/statistics_seven_day_hospitalization_per_inhabitants_text"
             app:layout_constraintEnd_toStartOf="@id/background_image"
             app:layout_constraintStart_toStartOf="@id/primary_value"


### PR DESCRIPTION
Very small change on how we display a string in the statistics cards.

Changed from:
 
![Screen Shot 2021-10-06 at 15 32 59](https://user-images.githubusercontent.com/19816790/136345144-b3e5a631-8341-4b07-886a-3c1a1c29975a.png)

to

![Screen Shot 2021-10-06 at 15 32 39](https://user-images.githubusercontent.com/19816790/136345240-ddb0af0f-d15a-4eb7-a2d5-bf1452465280.png)

