### PR TITLE
Extend repositories to recycle and restore certificates (EXPOSUREAPP-9858)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/RecoveryCertificateRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/RecoveryCertificateRepository.kt
@@ -217,12 +217,46 @@ class RecoveryCertificateRepository @Inject constructor(
         }
     }
 
+    /**
+     * Move Recovery certificate to recycled state.
+     * it does not throw any exception if certificate is not found
+     */
     suspend fun recycleCertificate(containerId: RecoveryCertificateContainerId) {
-        // TODO
+        Timber.tag(TAG).d("recycleCertificate(containerId=$containerId)")
+        internalData.updateBlocking {
+            val toUpdate = singleOrNull { it.containerId == containerId }
+            if (toUpdate == null) {
+                Timber.tag(TAG).w("recycleCertificate couldn't find %s", containerId)
+                return@updateBlocking this
+            }
+
+            this.minus(toUpdate).plus(
+                toUpdate.copy(data = toUpdate.data.copy(recycledAt = timeStamper.nowUTC)).also {
+                    Timber.tag(TAG).d("recycleCertificate updated %s", it)
+                }
+            )
+        }
     }
 
+    /**
+     * Restore Recovery certificate from recycled state.
+     * it does not throw any exception if certificate is not found
+     */
     suspend fun restoreCertificate(containerId: RecoveryCertificateContainerId) {
-        // TODO
+        Timber.tag(TAG).d("restoreCertificate(containerId=$containerId)")
+        internalData.updateBlocking {
+            val toUpdate = singleOrNull { it.containerId == containerId }
+            if (toUpdate == null) {
+                Timber.tag(TAG).w("restoreCertificate couldn't find %s", containerId)
+                return@updateBlocking this
+            }
+
+            this.minus(toUpdate).plus(
+                toUpdate.copy(data = toUpdate.data.copy(recycledAt = null)).also {
+                    Timber.tag(TAG).d("restoreCertificate updated %s", it)
+                }
+            )
+        }
     }
 
     companion object {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepository.kt
@@ -463,12 +463,56 @@ class TestCertificateRepository @Inject constructor(
         }
     }
 
+    /**
+     * Move Test certificate to recycled state.
+     * it does not throw any exception if certificate is not found
+     */
     suspend fun recycleCertificate(containerId: TestCertificateContainerId) {
-        // TODO
+        Timber.tag(TAG).d("recycleCertificate(containerId=%s)", containerId)
+        internalData.updateBlocking {
+            val current = this[containerId]
+            if (current == null) {
+                Timber.tag(TAG).w("recycleCertificate couldn't find %s", containerId)
+                return@updateBlocking this
+            }
+
+            if (current.isCertificateRetrievalPending) {
+                Timber.tag(TAG).w("recycleCertificate couldn't recycle pending TC %s", containerId)
+                return@updateBlocking this
+            }
+
+            val updated = current.copy(
+                data = updateRecycledAt(current.data, timeStamper.nowUTC)
+            )
+
+            mutate { this[containerId] = updated }
+        }
     }
 
+    /**
+     * Restore Test certificate from recycled state.
+     * it does not throw any exception if certificate is not found
+     */
     suspend fun restoreCertificate(containerId: TestCertificateContainerId) {
-        // TODO
+        Timber.tag(TAG).d("restoreCertificate(containerId=%s)", containerId)
+        internalData.updateBlocking {
+            val current = this[containerId]
+            if (current == null) {
+                Timber.tag(TAG).w("restoreCertificate couldn't find %s", containerId)
+                return@updateBlocking this
+            }
+
+            if (current.isCertificateRetrievalPending) {
+                Timber.tag(TAG).w("restoreCertificate couldn't restore pending TC %s", containerId)
+                return@updateBlocking this
+            }
+
+            val updated = current.copy(
+                data = updateRecycledAt(current.data, null)
+            )
+
+            mutate { this[containerId] = updated }
+        }
     }
 
     private fun updateLastSeenStateData(
@@ -499,6 +543,17 @@ class TestCertificateRepository @Inject constructor(
             is PCRCertificateData -> data.copy(notifiedInvalidAt = now)
             is RACertificateData -> data.copy(notifiedInvalidAt = now)
             is GenericTestCertificateData -> data.copy(notifiedInvalidAt = now)
+        }
+    }
+
+    private fun updateRecycledAt(
+        data: BaseTestCertificateData,
+        time: Instant?
+    ): BaseTestCertificateData {
+        return when (data) {
+            is PCRCertificateData -> data.copy(recycledAt = time)
+            is RACertificateData -> data.copy(recycledAt = time)
+            is GenericTestCertificateData -> data.copy(recycledAt = time)
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/VaccinationRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/VaccinationRepository.kt
@@ -367,12 +367,56 @@ class VaccinationRepository @Inject constructor(
         }
     }
 
+    /**
+     * Move Vaccination certificate to recycled state.
+     * it does not throw any exception if certificate is not found
+     */
     suspend fun recycleCertificate(containerId: VaccinationCertificateContainerId) {
-        // TODO
+        Timber.tag(TAG).d("recycleCertificate(containerId=$containerId)")
+        internalData.updateBlocking {
+            val toUpdatePerson = singleOrNull { it.findVaccination(containerId) != null }
+
+            if (toUpdatePerson == null) {
+                Timber.tag(TAG).w("recycleCertificate couldn't find %s", containerId)
+                return@updateBlocking this
+            }
+
+            val toUpdateVaccination = toUpdatePerson.findVaccination(containerId)!!
+            val newVaccination = toUpdateVaccination.copy(recycledAt = timeStamper.nowUTC)
+            newVaccination.qrCodeExtractor = qrCodeExtractor
+            val newPerson = toUpdatePerson.copy(
+                data = toUpdatePerson.data.copy(
+                    vaccinations = toUpdatePerson.data.vaccinations.minus(toUpdateVaccination).plus(newVaccination)
+                )
+            )
+            this.minus(toUpdatePerson).plus(newPerson)
+        }
     }
 
+    /**
+     * Restore Vaccination certificate from recycled state.
+     * it does not throw any exception if certificate is not found
+     */
     suspend fun restoreCertificate(containerId: VaccinationCertificateContainerId) {
-        // TODO
+        Timber.tag(TAG).d("restoreCertificate(containerId=$containerId)")
+        internalData.updateBlocking {
+            val toUpdatePerson = singleOrNull { it.findVaccination(containerId) != null }
+
+            if (toUpdatePerson == null) {
+                Timber.tag(TAG).w("restoreCertificate couldn't find %s", containerId)
+                return@updateBlocking this
+            }
+
+            val toUpdateVaccination = toUpdatePerson.findVaccination(containerId)!!
+            val newVaccination = toUpdateVaccination.copy(recycledAt = null)
+            newVaccination.qrCodeExtractor = qrCodeExtractor
+            val newPerson = toUpdatePerson.copy(
+                data = toUpdatePerson.data.copy(
+                    vaccinations = toUpdatePerson.data.vaccinations.minus(toUpdateVaccination).plus(newVaccination)
+                )
+            )
+            this.minus(toUpdatePerson).plus(newPerson)
+        }
     }
 
     companion object {


### PR DESCRIPTION
For all Certificates repositories , there is `recycleCertificate` and `restoreCertificate` to move the certificate in / out the recycled state  
## Ticket
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9858