### PR TITLE
Fix FAQ card for multi-line headings (COMMUNITY)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/home_faq_card_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_faq_card_layout.xml
@@ -16,7 +16,6 @@
             android:layout_height="@dimen/icon_size_button"
             android:importantForAccessibility="no"
             app:srcCompat="@drawable/ic_main_about"
-            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@+id/main_card_header_headline"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
@@ -26,12 +25,11 @@
             android:id="@+id/main_card_header_headline"
             style="@style/headline5"
             android:layout_width="0dp"
-            android:layout_height="0dp"
+            android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/spacing_small"
             android:layout_marginEnd="@dimen/spacing_small"
             android:accessibilityHeading="true"
             android:text="@string/main_about_headline"
-            app:layout_constraintBottom_toBottomOf="@+id/main_card_header_icon"
             app:layout_constraintEnd_toStartOf="@+id/main_card_header_icon_end"
             app:layout_constraintStart_toEndOf="@+id/main_card_header_icon"
             app:layout_constraintTop_toTopOf="@id/main_card_header_icon" />
@@ -46,6 +44,13 @@
             app:layout_constraintTop_toTopOf="@+id/main_card_header_headline"
             app:srcCompat="@drawable/ic_link" />
 
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/top_barrier"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierDirection="bottom"
+            app:constraint_referenced_ids="main_card_header_headline, main_card_header_icon" />
+
         <TextView
             android:id="@+id/main_card_content_body"
             style="@style/subtitleMedium"
@@ -56,7 +61,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/main_card_header_icon" />
+            app:layout_constraintTop_toBottomOf="@+id/top_barrier" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </layout>


### PR DESCRIPTION
If the font size is configured so that the FAQ card's (German) headline spans multiple pages, the heading is cropped off. This PR addressed that issue.

Previously | After
---|---
![Screenshot from 2021-10-10 15-40-11](https://user-images.githubusercontent.com/16943720/136698284-801a5938-e39b-40ec-8031-a3d5622b750f.png) | ![Screenshot from 2021-10-10 15-37-54](https://user-images.githubusercontent.com/16943720/136698287-a7947251-1c83-4069-9f94-0368cc7f9855.png)
![image](https://user-images.githubusercontent.com/16943720/136698505-f9c8fdaf-7c93-433a-add7-a975ce2fa6e9.png) | ![image](https://user-images.githubusercontent.com/16943720/136698442-aa4fd44d-b371-4558-9784-73a44944a8ac.png)


Inspired by the layout for the Incompatible card.