### PR TITLE
Fix new release back navigation (EXPOSUREAPP-9971, 10005)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/release/NewReleaseInfoFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/release/NewReleaseInfoFragment.kt
@@ -35,11 +35,11 @@ class NewReleaseInfoFragment : Fragment(R.layout.new_release_info_screen_fragmen
         super.onViewCreated(view, savedInstanceState)
         binding.apply {
             newReleaseInfoNextButton.setOnClickListener {
-                vm.onNextButtonClick()
+                vm.onNextButtonClick(args.comesFromInfoScreen)
             }
 
             toolbar.setNavigationOnClickListener {
-                vm.onNextButtonClick()
+                vm.onNextButtonClick(args.comesFromInfoScreen)
             }
 
             headline.text = vm.title.get(requireContext())
@@ -55,7 +55,7 @@ class NewReleaseInfoFragment : Fragment(R.layout.new_release_info_screen_fragmen
 
         // Override android back button to bypass the infinite loop
         val backCallback = object : OnBackPressedCallback(true) {
-            override fun handleOnBackPressed() = vm.onNextButtonClick()
+            override fun handleOnBackPressed() = vm.onNextButtonClick(args.comesFromInfoScreen)
         }
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, backCallback)
 
@@ -96,18 +96,18 @@ private class ItemAdapter(
         BindableVH<NewReleaseInfoItem, NewReleaseInfoItemBinding> {
         override val viewBinding:
             Lazy<NewReleaseInfoItemBinding> =
-                lazy { NewReleaseInfoItemBinding.bind(itemView) }
+            lazy { NewReleaseInfoItemBinding.bind(itemView) }
 
         override val onBindData:
             NewReleaseInfoItemBinding.(item: NewReleaseInfoItem, payloads: List<Any>) -> Unit =
-                { item, _ ->
-                    title.text = item.title
-                    if (item is NewReleaseInfoItemLinked) {
-                        body.setTextWithUrl(item.body, item.linkifiedLabel, item.linkTarget)
-                    } else {
-                        body.text = item.body
-                    }
+            { item, _ ->
+                title.text = item.title
+                if (item is NewReleaseInfoItemLinked) {
+                    body.setTextWithUrl(item.body, item.linkifiedLabel, item.linkTarget)
+                } else {
+                    body.text = item.body
                 }
+            }
     }
 
     override fun onCreateBaseVH(parent: ViewGroup, viewType: Int): ViewHolder = ViewHolder(parent)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/release/NewReleaseInfoFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/release/NewReleaseInfoFragment.kt
@@ -96,18 +96,18 @@ private class ItemAdapter(
         BindableVH<NewReleaseInfoItem, NewReleaseInfoItemBinding> {
         override val viewBinding:
             Lazy<NewReleaseInfoItemBinding> =
-            lazy { NewReleaseInfoItemBinding.bind(itemView) }
+                lazy { NewReleaseInfoItemBinding.bind(itemView) }
 
         override val onBindData:
             NewReleaseInfoItemBinding.(item: NewReleaseInfoItem, payloads: List<Any>) -> Unit =
-            { item, _ ->
-                title.text = item.title
-                if (item is NewReleaseInfoItemLinked) {
-                    body.setTextWithUrl(item.body, item.linkifiedLabel, item.linkTarget)
-                } else {
-                    body.text = item.body
+                { item, _ ->
+                    title.text = item.title
+                    if (item is NewReleaseInfoItemLinked) {
+                        body.setTextWithUrl(item.body, item.linkifiedLabel, item.linkTarget)
+                    } else {
+                        body.text = item.body
+                    }
                 }
-            }
     }
 
     override fun onCreateBaseVH(parent: ViewGroup, viewType: Int): ViewHolder = ViewHolder(parent)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/release/NewReleaseInfoViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/release/NewReleaseInfoViewModel.kt
@@ -22,9 +22,9 @@ class NewReleaseInfoViewModel @AssistedInject constructor(
 
     val title = R.string.release_info_version_title.toResolvingString(BuildConfig.VERSION_NAME)
 
-    fun onNextButtonClick() {
+    fun onNextButtonClick(comesFromInfoScreen: Boolean) {
         appSettings.lastChangelogVersion.update { BuildConfigWrap.VERSION_CODE }
-        if (appSettings.lastNotificationsOnboardingVersionCode.value == 0L) {
+        if (appSettings.lastNotificationsOnboardingVersionCode.value == 0L && !comesFromInfoScreen) {
             routeToScreen.postValue(
                 NewReleaseInfoNavigationEvents.NavigateToOnboardingDeltaNotificationsFragment
             )

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/release/NewReleaseInfoViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/release/NewReleaseInfoViewModelTest.kt
@@ -40,7 +40,7 @@ class NewReleaseInfoViewModelTest : BaseTest() {
     fun `if notifications onboarding has not yet been done, navigate to it`() {
         lastOnboardingVersionCode.value shouldBe 0L
 
-        viewModel.onNextButtonClick()
+        viewModel.onNextButtonClick(false)
         viewModel.routeToScreen.value shouldBe NewReleaseInfoNavigationEvents
             .NavigateToOnboardingDeltaNotificationsFragment
     }
@@ -49,7 +49,7 @@ class NewReleaseInfoViewModelTest : BaseTest() {
     fun `if notifications onboarding is done, just close the release screen`() {
         lastOnboardingVersionCode.update { 1130000L }
 
-        viewModel.onNextButtonClick()
+        viewModel.onNextButtonClick(false)
         viewModel.routeToScreen.value shouldBe NewReleaseInfoNavigationEvents.CloseScreen
 
         lastOnboardingVersionCode.value shouldBe 1130000L


### PR DESCRIPTION
Fixes issue with navigation from new release screen back to info screen if user opened the screen from the info screen.

Test navigation by going to info screen -> new features and then go back.

Please also test by installing an updated version. You can increase the VERSION_MINOR from gradle.properties. Try pressing the X button. It should continue to the next screen.

