### PR TITLE
Fix vaccination certificates priority (EXPOSUREAPP-9982)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensions.kt
@@ -74,24 +74,6 @@ private fun Collection<CwaCovidCertificate>.rule2FindRecentRaCertificate(
     .filter { Duration(it.rawCertificate.test.sampleCollectedAt, nowUtc) <= Duration.standardHours(24) }
     .maxByOrNull { it.rawCertificate.test.sampleCollectedAt }
 
-//private fun Collection<CwaCovidCertificate>.rule3FindBoosterShot(
-//    nowUtc: Instant
-//): CwaCovidCertificate? {
-//    val vaccinesWithTwoDoses = listOf("EU/1/20/1528", "EU/1/21/1529", "EU/1/20/1507")
-//    return this
-//        .filterIsInstance<VaccinationCertificate>()
-//        .filter {
-//            with(it.rawCertificate.vaccination) { doseNumber == totalSeriesOfDoses }
-//        }
-//        .filter {
-//            with(it.rawCertificate.vaccination) {
-//                if(totalSeriesOfDoses > 2 && vaccinesWithTwoDoses.contains(medicalProductId)) {
-//                    return it
-//                } else if (totalSeriesOfDoses <= 2 && !vaccinesWithTwoDoses.contains(medicalProductId))
-//            }
-//        }
-//}
-
 /**
  * 3
  * Series-completing Vaccination Certificate > 14 days:

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensions.kt
@@ -74,6 +74,24 @@ private fun Collection<CwaCovidCertificate>.rule2FindRecentRaCertificate(
     .filter { Duration(it.rawCertificate.test.sampleCollectedAt, nowUtc) <= Duration.standardHours(24) }
     .maxByOrNull { it.rawCertificate.test.sampleCollectedAt }
 
+//private fun Collection<CwaCovidCertificate>.rule3FindBoosterShot(
+//    nowUtc: Instant
+//): CwaCovidCertificate? {
+//    val vaccinesWithTwoDoses = listOf("EU/1/20/1528", "EU/1/21/1529", "EU/1/20/1507")
+//    return this
+//        .filterIsInstance<VaccinationCertificate>()
+//        .filter {
+//            with(it.rawCertificate.vaccination) { doseNumber == totalSeriesOfDoses }
+//        }
+//        .filter {
+//            with(it.rawCertificate.vaccination) {
+//                if(totalSeriesOfDoses > 2 && vaccinesWithTwoDoses.contains(medicalProductId)) {
+//                    return it
+//                } else if (totalSeriesOfDoses <= 2 && !vaccinesWithTwoDoses.contains(medicalProductId))
+//            }
+//        }
+//}
+
 /**
  * 3
  * Series-completing Vaccination Certificate > 14 days:
@@ -85,20 +103,31 @@ private fun Collection<CwaCovidCertificate>.rule2FindRecentRaCertificate(
  */
 private fun Collection<CwaCovidCertificate>.rule3FindRecentLastShot(
     nowUtc: Instant
-): CwaCovidCertificate? = this
-    .filterIsInstance<VaccinationCertificate>()
-    .filter {
-        with(it.rawCertificate.vaccination) { doseNumber == totalSeriesOfDoses }
-    }
-    .filter {
-        Days.daysBetween(it.rawCertificate.vaccination.vaccinatedOn, nowUtc.toLocalDateUtc()).days > 14
-    }
-    .maxWithOrNull(
-        compareBy(
-            { it.rawCertificate.vaccination.vaccinatedOn },
-            { it.headerIssuedAt }
+): CwaCovidCertificate? {
+    val vaccinesWithTwoDoses = listOf("EU/1/20/1528", "EU/1/21/1529", "EU/1/20/1507")
+    return this
+        .filterIsInstance<VaccinationCertificate>()
+        .filter {
+            with(it.rawCertificate.vaccination) { doseNumber == totalSeriesOfDoses }
+        }
+        .filter {
+            with(it.rawCertificate.vaccination) {
+                if (totalSeriesOfDoses > 2 && vaccinesWithTwoDoses.contains(medicalProductId)) {
+                    return it
+                } else if (totalSeriesOfDoses <= 2 && !vaccinesWithTwoDoses.contains(medicalProductId)) {
+                    return it
+                } else {
+                    Days.daysBetween(it.rawCertificate.vaccination.vaccinatedOn, nowUtc.toLocalDateUtc()).days > 14
+                }
+            }
+        }
+        .maxWithOrNull(
+            compareBy(
+                { it.rawCertificate.vaccination.vaccinatedOn },
+                { it.headerIssuedAt }
+            )
         )
-    )
+}
 
 /**
  * 4

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensionsTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensionsTest.kt
@@ -117,6 +117,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
             every {
                 rawCertificate.vaccination.vaccinatedOn
             } returns time.minus(Duration.standardDays(25)).toLocalDateUtc()
+            every {rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
             every { getState() } returns mockk<State.Valid>()
         }
 
@@ -127,6 +128,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
             every {
                 rawCertificate.vaccination.vaccinatedOn
             } returns time.minus(Duration.standardDays(25)).toLocalDateUtc()
+            every {rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
             every { getState() } returns mockk<State.Valid>()
         }
 
@@ -137,6 +139,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
             every {
                 rawCertificate.vaccination.vaccinatedOn
             } returns time.minus(Duration.standardDays(15)).toLocalDateUtc()
+            every {rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
             every { getState() } returns mockk<State.Valid>()
         }
 
@@ -147,6 +150,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
             every {
                 rawCertificate.vaccination.vaccinatedOn
             } returns time.minus(Duration.standardDays(15)).toLocalDateUtc()
+            every {rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
             every { getState() } returns mockk<State.Valid>()
         }
 
@@ -160,6 +164,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
             every { rawCertificate.vaccination.doseNumber } returns 2
             every { rawCertificate.vaccination.totalSeriesOfDoses } returns 2
             every { rawCertificate.vaccination.vaccinatedOn } returns time.toLocalDateUtc()
+            every {rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
             every { getState() } returns mockk<State.Valid>()
         }
 
@@ -168,6 +173,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
             every { rawCertificate.vaccination.doseNumber } returns 2
             every { rawCertificate.vaccination.totalSeriesOfDoses } returns 2
             every { rawCertificate.vaccination.vaccinatedOn } returns time.toLocalDateUtc()
+            every {rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
             every { getState() } returns mockk<State.Valid>()
         }
 
@@ -176,6 +182,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
             every { rawCertificate.vaccination.doseNumber } returns 3
             every { rawCertificate.vaccination.totalSeriesOfDoses } returns 3
             every { rawCertificate.vaccination.vaccinatedOn } returns time.plus(oneDayDuration).toLocalDateUtc()
+            every {rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
             every { getState() } returns mockk<State.Valid>()
         }
 
@@ -184,6 +191,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
             every { rawCertificate.vaccination.doseNumber } returns 3
             every { rawCertificate.vaccination.totalSeriesOfDoses } returns 3
             every { rawCertificate.vaccination.vaccinatedOn } returns time.plus(oneDayDuration).toLocalDateUtc()
+            every {rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
             every { getState() } returns mockk<State.Valid>()
         }
 
@@ -192,6 +200,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
             every { rawCertificate.vaccination.doseNumber } returns 1
             every { rawCertificate.vaccination.totalSeriesOfDoses } returns 2
             every { rawCertificate.vaccination.vaccinatedOn } returns time.toLocalDateUtc()
+            every {rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
             every { getState() } returns mockk<State.Valid>()
         }
 
@@ -200,6 +209,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
             every { rawCertificate.vaccination.doseNumber } returns 1
             every { rawCertificate.vaccination.totalSeriesOfDoses } returns 2
             every { rawCertificate.vaccination.vaccinatedOn } returns time.toLocalDateUtc()
+            every {rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
             every { getState() } returns mockk<State.Valid>()
         }
 
@@ -351,6 +361,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
             every { rawCertificate.vaccination.doseNumber } returns 2
             every { rawCertificate.vaccination.totalSeriesOfDoses } returns 2
             every { rawCertificate.vaccination.vaccinatedOn } returns LocalDate.parse("2021-01-01")
+            every {rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
             every { getState() } returns mockk<State.Expired>()
         }
 
@@ -359,6 +370,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
             every { rawCertificate.vaccination.doseNumber } returns 2
             every { rawCertificate.vaccination.totalSeriesOfDoses } returns 2
             every { rawCertificate.vaccination.vaccinatedOn } returns LocalDate.parse("2021-01-02")
+            every {rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
             every { getState() } returns mockk<State.Expired>()
         }
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensionsTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensionsTest.kt
@@ -110,121 +110,121 @@ class PersonCertificatesExtensionsTest : BaseTest() {
             every { getState() } returns mockk<State.Invalid>()
         }
 
-        val third = mockk<VaccinationCertificate>().apply {
+        val fourth = mockk<VaccinationCertificate>().apply {
             every { headerIssuedAt } returns Instant.parse("2021-06-24T14:00:00.000Z")
             every { rawCertificate.vaccination.doseNumber } returns 2
             every { rawCertificate.vaccination.totalSeriesOfDoses } returns 2
             every {
                 rawCertificate.vaccination.vaccinatedOn
             } returns time.minus(Duration.standardDays(25)).toLocalDateUtc()
-            every {rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
+            every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
             every { getState() } returns mockk<State.Valid>()
         }
 
-        val thirdIssuedAtAnotherDate = mockk<VaccinationCertificate>().apply {
+        val fourthIssuedAtAnotherDate = mockk<VaccinationCertificate>().apply {
             every { headerIssuedAt } returns Instant.parse("2021-07-20T10:00:00.000Z")
             every { rawCertificate.vaccination.doseNumber } returns 2
             every { rawCertificate.vaccination.totalSeriesOfDoses } returns 2
             every {
                 rawCertificate.vaccination.vaccinatedOn
             } returns time.minus(Duration.standardDays(25)).toLocalDateUtc()
-            every {rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
+            every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
             every { getState() } returns mockk<State.Valid>()
         }
 
-        val thirdIsBooster = mockk<VaccinationCertificate>().apply {
+        val fourthBooster = mockk<VaccinationCertificate>().apply {
             every { headerIssuedAt } returns Instant.parse("2021-11-05T14:00:00.000Z")
             every { rawCertificate.vaccination.doseNumber } returns 3
             every { rawCertificate.vaccination.totalSeriesOfDoses } returns 3
             every {
                 rawCertificate.vaccination.vaccinatedOn
             } returns time.minus(Duration.standardDays(15)).toLocalDateUtc()
-            every {rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
+            every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
             every { getState() } returns mockk<State.Valid>()
         }
 
-        val thirdIsBoosterIssuedAtAnotherDate = mockk<VaccinationCertificate>().apply {
+        val fourthBoosterIssuedAtAnotherDate = mockk<VaccinationCertificate>().apply {
             every { headerIssuedAt } returns Instant.parse("2021-12-02T14:00:00.000Z")
             every { rawCertificate.vaccination.doseNumber } returns 3
             every { rawCertificate.vaccination.totalSeriesOfDoses } returns 3
             every {
                 rawCertificate.vaccination.vaccinatedOn
             } returns time.minus(Duration.standardDays(15)).toLocalDateUtc()
-            every {rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
+            every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
             every { getState() } returns mockk<State.Valid>()
         }
 
-        val fourth = mockk<RecoveryCertificate>().apply {
+        val fifth = mockk<RecoveryCertificate>().apply {
             every { rawCertificate.recovery.validFrom } returns time.toLocalDateUtc()
             every { getState() } returns mockk<State.Valid>()
         }
 
-        val fifth = mockk<VaccinationCertificate>().apply {
-            every { headerIssuedAt } returns Instant.parse("2021-06-24T14:00:00.000Z")
-            every { rawCertificate.vaccination.doseNumber } returns 2
-            every { rawCertificate.vaccination.totalSeriesOfDoses } returns 2
-            every { rawCertificate.vaccination.vaccinatedOn } returns time.toLocalDateUtc()
-            every {rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
-            every { getState() } returns mockk<State.Valid>()
-        }
-
-        val fifthIssuedAtAnotherDate = mockk<VaccinationCertificate>().apply {
-            every { headerIssuedAt } returns Instant.parse("2021-07-24T10:00:00.000Z")
-            every { rawCertificate.vaccination.doseNumber } returns 2
-            every { rawCertificate.vaccination.totalSeriesOfDoses } returns 2
-            every { rawCertificate.vaccination.vaccinatedOn } returns time.toLocalDateUtc()
-            every {rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
-            every { getState() } returns mockk<State.Valid>()
-        }
-
-        val fifthIsBooster = mockk<VaccinationCertificate>().apply {
-            every { headerIssuedAt } returns Instant.parse("2021-06-24T14:00:00.000Z")
-            every { rawCertificate.vaccination.doseNumber } returns 3
-            every { rawCertificate.vaccination.totalSeriesOfDoses } returns 3
-            every { rawCertificate.vaccination.vaccinatedOn } returns time.plus(oneDayDuration).toLocalDateUtc()
-            every {rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
-            every { getState() } returns mockk<State.Valid>()
-        }
-
-        val fifthIsBoosterIssuedAtAnotherDate = mockk<VaccinationCertificate>().apply {
-            every { headerIssuedAt } returns Instant.parse("2021-07-24T10:00:00.000Z")
-            every { rawCertificate.vaccination.doseNumber } returns 3
-            every { rawCertificate.vaccination.totalSeriesOfDoses } returns 3
-            every { rawCertificate.vaccination.vaccinatedOn } returns time.plus(oneDayDuration).toLocalDateUtc()
-            every {rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
-            every { getState() } returns mockk<State.Valid>()
-        }
-
         val sixth = mockk<VaccinationCertificate>().apply {
-            every { headerIssuedAt } returns Instant.parse("2021-06-24T10:00:00.000Z")
-            every { rawCertificate.vaccination.doseNumber } returns 1
+            every { headerIssuedAt } returns Instant.parse("2021-06-24T14:00:00.000Z")
+            every { rawCertificate.vaccination.doseNumber } returns 2
             every { rawCertificate.vaccination.totalSeriesOfDoses } returns 2
             every { rawCertificate.vaccination.vaccinatedOn } returns time.toLocalDateUtc()
-            every {rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
+            every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
             every { getState() } returns mockk<State.Valid>()
         }
 
         val sixthIssuedAtAnotherDate = mockk<VaccinationCertificate>().apply {
+            every { headerIssuedAt } returns Instant.parse("2021-07-24T10:00:00.000Z")
+            every { rawCertificate.vaccination.doseNumber } returns 2
+            every { rawCertificate.vaccination.totalSeriesOfDoses } returns 2
+            every { rawCertificate.vaccination.vaccinatedOn } returns time.toLocalDateUtc()
+            every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
+            every { getState() } returns mockk<State.Valid>()
+        }
+
+        val thirdBooster = mockk<VaccinationCertificate>().apply {
+            every { headerIssuedAt } returns Instant.parse("2021-06-24T14:00:00.000Z")
+            every { rawCertificate.vaccination.doseNumber } returns 3
+            every { rawCertificate.vaccination.totalSeriesOfDoses } returns 3
+            every { rawCertificate.vaccination.vaccinatedOn } returns time.plus(oneDayDuration).toLocalDateUtc()
+            every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
+            every { getState() } returns mockk<State.Valid>()
+        }
+
+        val thirdBoosterIssuedAtAnotherDate = mockk<VaccinationCertificate>().apply {
+            every { headerIssuedAt } returns Instant.parse("2021-07-24T10:00:00.000Z")
+            every { rawCertificate.vaccination.doseNumber } returns 3
+            every { rawCertificate.vaccination.totalSeriesOfDoses } returns 3
+            every { rawCertificate.vaccination.vaccinatedOn } returns time.plus(oneDayDuration).toLocalDateUtc()
+            every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
+            every { getState() } returns mockk<State.Valid>()
+        }
+
+        val seventh = mockk<VaccinationCertificate>().apply {
+            every { headerIssuedAt } returns Instant.parse("2021-06-24T10:00:00.000Z")
+            every { rawCertificate.vaccination.doseNumber } returns 1
+            every { rawCertificate.vaccination.totalSeriesOfDoses } returns 2
+            every { rawCertificate.vaccination.vaccinatedOn } returns time.toLocalDateUtc()
+            every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
+            every { getState() } returns mockk<State.Valid>()
+        }
+
+        val seventhIssuedAtAnotherDate = mockk<VaccinationCertificate>().apply {
             every { headerIssuedAt } returns Instant.parse("2021-06-24T14:00:00.000Z")
             every { rawCertificate.vaccination.doseNumber } returns 1
             every { rawCertificate.vaccination.totalSeriesOfDoses } returns 2
             every { rawCertificate.vaccination.vaccinatedOn } returns time.toLocalDateUtc()
-            every {rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
+            every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
             every { getState() } returns mockk<State.Valid>()
         }
 
-        val seventh = mockk<RecoveryCertificate>().apply {
+        val eighth = mockk<RecoveryCertificate>().apply {
             every { rawCertificate.recovery.validFrom } returns time.minus(Duration.standardDays(181)).toLocalDateUtc()
             every { getState() } returns mockk<State.Valid>()
         }
 
-        val eighth = mockk<TestCertificate>().apply {
+        val nineth = mockk<TestCertificate>().apply {
             every { rawCertificate.test.testType } returns "LP6464-4"
             every { rawCertificate.test.sampleCollectedAt } returns time.minus(Duration.standardHours(149))
             every { getState() } returns mockk<State.Valid>()
         }
 
-        val ninth = mockk<TestCertificate>().apply {
+        val tenth = mockk<TestCertificate>().apply {
             every { rawCertificate.test.testType } returns "LP217198-3"
             every { rawCertificate.test.sampleCollectedAt } returns time.minus(Duration.standardHours(25))
             every { getState() } returns mockk<State.Valid>()
@@ -240,31 +240,31 @@ class PersonCertificatesExtensionsTest : BaseTest() {
             firstButExpired,
             secondButInvalid,
             fallback,
-            ninth,
+            tenth,
+            nineth,
             eighth,
-            seventh,
 
             // First shot 1/2, same shot that has two different certificates issued on different dates
+            seventh,
+            seventhIssuedAtAnotherDate,
+
+            // Complete shot 2/2, same shot that has two different certificates issued on different dates  <= 14
             sixth,
             sixthIssuedAtAnotherDate,
 
-            // Complete shot 2/2, same shot that has two different certificates issued on different dates  <= 14
-            fifth,
-            fifthIssuedAtAnotherDate,
-
             // Complete shot 3/3, same shot that has two different certificates issued on different dates  <= 14
-            fifthIsBooster,
-            fifthIsBoosterIssuedAtAnotherDate,
+            thirdBooster,
+            thirdBoosterIssuedAtAnotherDate,
 
-            fourth,
+            fifth,
 
             // Complete shot 2/2, same shot that has two different certificates issued on different dates > 14
-            third,
-            thirdIssuedAtAnotherDate,
+            fourth,
+            fourthIssuedAtAnotherDate,
 
             // Booster shot 3/3, same shot that has two different certificates issued on different dates  > 14
-            thirdIsBooster,
-            thirdIsBoosterIssuedAtAnotherDate,
+            fourthBooster,
+            fourthBoosterIssuedAtAnotherDate,
 
             second,
             first,
@@ -277,29 +277,23 @@ class PersonCertificatesExtensionsTest : BaseTest() {
         certificates.findHighestPriorityCertificate(time) shouldBe second
         certificates.remove(second)
 
-        certificates.findHighestPriorityCertificate(time) shouldBe thirdIsBoosterIssuedAtAnotherDate
-        certificates.remove(thirdIsBoosterIssuedAtAnotherDate)
+        certificates.findHighestPriorityCertificate(time) shouldBe thirdBooster
+        certificates.remove(thirdBooster)
 
-        certificates.findHighestPriorityCertificate(time) shouldBe thirdIsBooster
-        certificates.remove(thirdIsBooster)
+        certificates.findHighestPriorityCertificate(time) shouldBe thirdBoosterIssuedAtAnotherDate
+        certificates.remove(thirdBoosterIssuedAtAnotherDate)
 
-        certificates.findHighestPriorityCertificate(time) shouldBe thirdIssuedAtAnotherDate
-        certificates.remove(thirdIssuedAtAnotherDate)
+        certificates.findHighestPriorityCertificate(time) shouldBe fourthBooster
+        certificates.remove(fourthBooster)
 
-        certificates.findHighestPriorityCertificate(time) shouldBe third
-        certificates.remove(third)
+        certificates.findHighestPriorityCertificate(time) shouldBe fourthBoosterIssuedAtAnotherDate
+        certificates.remove(fourthBoosterIssuedAtAnotherDate)
+
+        certificates.findHighestPriorityCertificate(time) shouldBe fourthIssuedAtAnotherDate
+        certificates.remove(fourthIssuedAtAnotherDate)
 
         certificates.findHighestPriorityCertificate(time) shouldBe fourth
         certificates.remove(fourth)
-
-        certificates.findHighestPriorityCertificate(time) shouldBe fifthIsBoosterIssuedAtAnotherDate
-        certificates.remove(fifthIsBoosterIssuedAtAnotherDate)
-
-        certificates.findHighestPriorityCertificate(time) shouldBe fifthIsBooster
-        certificates.remove(fifthIsBooster)
-
-        certificates.findHighestPriorityCertificate(time) shouldBe fifthIssuedAtAnotherDate
-        certificates.remove(fifthIssuedAtAnotherDate)
 
         certificates.findHighestPriorityCertificate(time) shouldBe fifth
         certificates.remove(fifth)
@@ -310,14 +304,20 @@ class PersonCertificatesExtensionsTest : BaseTest() {
         certificates.findHighestPriorityCertificate(time) shouldBe sixth
         certificates.remove(sixth)
 
+        certificates.findHighestPriorityCertificate(time) shouldBe seventhIssuedAtAnotherDate
+        certificates.remove(seventhIssuedAtAnotherDate)
+
         certificates.findHighestPriorityCertificate(time) shouldBe seventh
         certificates.remove(seventh)
 
         certificates.findHighestPriorityCertificate(time) shouldBe eighth
         certificates.remove(eighth)
 
-        certificates.findHighestPriorityCertificate(time) shouldBe ninth
-        certificates.remove(ninth)
+        certificates.findHighestPriorityCertificate(time) shouldBe nineth
+        certificates.remove(nineth)
+
+        certificates.findHighestPriorityCertificate(time) shouldBe tenth
+        certificates.remove(tenth)
 
         // Expired
         certificates.findHighestPriorityCertificate(time) shouldBe firstButExpired
@@ -361,7 +361,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
             every { rawCertificate.vaccination.doseNumber } returns 2
             every { rawCertificate.vaccination.totalSeriesOfDoses } returns 2
             every { rawCertificate.vaccination.vaccinatedOn } returns LocalDate.parse("2021-01-01")
-            every {rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
+            every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
             every { getState() } returns mockk<State.Expired>()
         }
 
@@ -370,7 +370,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
             every { rawCertificate.vaccination.doseNumber } returns 2
             every { rawCertificate.vaccination.totalSeriesOfDoses } returns 2
             every { rawCertificate.vaccination.vaccinatedOn } returns LocalDate.parse("2021-01-02")
-            every {rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
+            every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
             every { getState() } returns mockk<State.Expired>()
         }
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsViewModelTest.kt
@@ -199,12 +199,14 @@ class PersonDetailsViewModelTest : BaseTest() {
                     every { doseNumber } returns number
                     every { totalSeriesOfDoses } returns 2
                     every { vaccinatedOn } returns localDate
+                    every { medicalProductId } returns "EU/1/20/1528"
                 }
             }
             every { containerId } returns vcContainerId
             every { vaccinatedOn } returns localDate
             every { personIdentifier } returns certificatePersonIdentifier
             every { doseNumber } returns number
+            every { medicalProductName } returns "EU/1/20/1528"
             every { totalSeriesOfDoses } returns 2
             every { isFinalShot } returns final
             every { isValid } returns true


### PR DESCRIPTION
Fixed the vaccination priorities for boosters. 

How to test:

- first scan a vacc cert with dose 1/2 that's < 14 days old: 
`cwa vc gen --pii 42 -s v.0.dn=1 v.0.sd=2 v.0.mp='EU/1/20/1528' v.0.dt='2021-10-12' -e wru`, this has prio as it's the only vacc cert.
- then scan a vacc cert with dose 2/2 that's < 14 days old: 
`cwa vc gen --pii 42 -s v.0.dn=2 v.0.sd=2 v.0.mp='EU/1/20/1528' v.0.dt='2021-10-12' -e wru`, this has prio now as dose is 2/2.
- then scan a vacc cert with dose 2/2 that's > 14 days old: 
`cwa vc gen --pii 42 -s v.0.dn=2 v.0.sd=2 v.0.mp='EU/1/20/1528' v.0.dt='2021-09-12' -e wru`, this has prio now as dose is 2/2 and immunity is reached.
- then scan a vacc cert with dose 3/3 that's < 14 days old: 
`cwa vc gen --pii 42 -s v.0.dn=3 v.0.sd=3 v.0.mp='EU/1/20/1528' v.0.dt='2021-10-12' -e wru`, this has prio now as dose is 3/3
- then scan a vacc cert with dose 3/3 that's > 14 days old: 
`cwa vc gen --pii 42 -s v.0.dn=3 v.0.sd=3 v.0.mp='EU/1/20/1528' v.0.dt='2021-09-12' -e wru`, the prio remains unchanged because for booster vaccinations, the latest booster has highest prio.