### PR TITLE
Statistics cards polishing (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/LocalIncidenceAndHospitalizationCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/LocalIncidenceAndHospitalizationCard.kt
@@ -120,9 +120,7 @@ class LocalIncidenceAndHospitalizationCard(parent: ViewGroup) :
                         }
                     )
                 is SelectedStatisticsLocation.SelectedFederalState ->
-                    context.getString(R.string.statistics_card_local_hospitalization_text).format(
-                        context.getString(selectedLocation.federalState.labelStringRes)
-                    )
+                    context.getString(R.string.statistics_secondary_value_description)
             }
         }
     }

--- a/Corona-Warn-App/src/main/res/layout/home_statistics_cards_applied_vaccination_rates_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_statistics_cards_applied_vaccination_rates_layout.xml
@@ -33,7 +33,7 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/spacing_small"
             android:text="@string/statistics_nationwide_text"
-            android:textSize="@dimen/font_small"
+            android:textSize="14sp"
             app:layout_constraintStart_toStartOf="@id/title"
             app:layout_constraintTop_toBottomOf="@id/title" />
 
@@ -63,6 +63,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/statistics_primary_value_yesterday"
+            android:textSize="14sp"
             app:layout_constraintStart_toStartOf="@id/nationwide_text"
             app:layout_constraintTop_toTopOf="@id/background_image" />
 
@@ -87,6 +88,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/statistics_card_infections_secondary_label"
+            android:textSize="14sp"
             app:layout_constraintBottom_toTopOf="@id/secondary_value"
             app:layout_constraintStart_toStartOf="@id/primary_value" />
 
@@ -118,6 +120,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/statistics_card_infections_tertiary_label"
+            android:textSize="14sp"
             app:layout_constraintStart_toStartOf="@id/secondary_value"
             app:layout_constraintTop_toBottomOf="@id/background_image" />
 

--- a/Corona-Warn-App/src/main/res/layout/home_statistics_cards_incidence_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_statistics_cards_incidence_layout.xml
@@ -32,7 +32,7 @@
             android:layout_marginStart="@dimen/card_padding"
             android:layout_marginBottom="@dimen/spacing_small"
             android:text="@string/statistics_nationwide_text"
-            android:textSize="@dimen/font_small"
+            android:textSize="14sp"
             app:layout_constraintEnd_toStartOf="@id/info_statistics"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/title" />
@@ -56,6 +56,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="42dp"
+            android:textSize="14sp"
             app:layout_constraintStart_toStartOf="@id/nationwide_text"
             app:layout_constraintTop_toBottomOf="@id/nationwide_text"
             tools:text="Bis gestern" />
@@ -86,6 +87,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/statistics_primary_value_description"
+            android:textSize="14sp"
             app:layout_constraintStart_toStartOf="@id/primary_value"
             app:layout_constraintTop_toBottomOf="@id/primary_value" />
 
@@ -95,6 +97,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="18dp"
+            android:textSize="14sp"
             app:layout_constraintStart_toStartOf="@id/primary_description"
             app:layout_constraintTop_toBottomOf="@id/primary_description"
             tools:text="Bis gestern" />
@@ -126,6 +129,7 @@
             android:layout_height="wrap_content"
             android:paddingBottom="@dimen/spacing_small"
             android:text="@string/statistics_secondary_value_description"
+            android:textSize="14sp"
             app:layout_constraintStart_toStartOf="@id/secondary_value"
             app:layout_constraintTop_toBottomOf="@id/secondary_value" />
 

--- a/Corona-Warn-App/src/main/res/layout/home_statistics_cards_infections_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_statistics_cards_infections_layout.xml
@@ -41,7 +41,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/spacing_normal"
             android:text="@string/statistics_nationwide_text"
-            android:textSize="@dimen/font_small"
+            android:textSize="14sp"
             app:layout_constraintEnd_toStartOf="@id/info_statistics"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/title" />
@@ -51,6 +51,7 @@
             style="@style/StatisticsCardValueLabel"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:textSize="14sp"
             tools:text="Gestern" />
 
         <TextView
@@ -68,7 +69,8 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:paddingTop="@dimen/spacing_normal"
-            android:text="@string/statistics_card_infections_secondary_label" />
+            android:text="@string/statistics_card_infections_secondary_label"
+            android:textSize="14sp" />
 
         <TextView
             android:id="@+id/secondary_value"
@@ -93,7 +95,8 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:paddingTop="@dimen/spacing_tiny"
-            android:text="@string/statistics_card_infections_tertiary_label" />
+            android:text="@string/statistics_card_infections_tertiary_label"
+            android:textSize="14sp" />
 
         <TextView
             android:id="@+id/tertiary_value"

--- a/Corona-Warn-App/src/main/res/layout/home_statistics_cards_keysubmissions_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_statistics_cards_keysubmissions_layout.xml
@@ -42,7 +42,7 @@
             android:layout_marginStart="@dimen/card_padding"
             android:layout_marginBottom="@dimen/spacing_small"
             android:text="@string/statistics_card_submission_bottom_text"
-            android:textSize="@dimen/font_small"
+            android:textSize="14sp"
             app:layout_constraintEnd_toStartOf="@id/info_statistics"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/title" />
@@ -52,6 +52,7 @@
             style="@style/StatisticsCardValueLabel"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:textSize="14sp"
             tools:text="Gestern" />
 
         <TextView
@@ -69,7 +70,8 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:paddingTop="@dimen/spacing_normal"
-            android:text="@string/statistics_card_infections_secondary_label" />
+            android:text="@string/statistics_card_infections_secondary_label"
+            android:textSize="14sp" />
 
         <TextView
             android:id="@+id/secondary_value"
@@ -94,7 +96,8 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:paddingTop="@dimen/spacing_tiny"
-            android:text="@string/statistics_card_infections_tertiary_label" />
+            android:text="@string/statistics_card_infections_tertiary_label"
+            android:textSize="14sp" />
 
         <TextView
             android:id="@+id/tertiary_value"

--- a/Corona-Warn-App/src/main/res/layout/home_statistics_cards_occupied_intensive_care_beds.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_statistics_cards_occupied_intensive_care_beds.xml
@@ -42,7 +42,7 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/spacing_small"
             android:text="@string/statistics_nationwide_text"
-            android:textSize="@dimen/font_small"
+            android:textSize="14sp"
             app:layout_constraintStart_toStartOf="@id/title"
             app:layout_constraintTop_toBottomOf="@id/title" />
 
@@ -62,6 +62,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/statistics_primary_value_until_yesterday"
+            android:textSize="14sp"
             app:layout_constraintStart_toStartOf="@id/nationwide_text"
             app:layout_constraintTop_toTopOf="@id/background_image" />
 
@@ -89,6 +90,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/statistics_occupied_intensive_care_beds_text"
+            android:textSize="14sp"
             app:layout_constraintEnd_toStartOf="@id/background_image"
             app:layout_constraintStart_toStartOf="@id/primary_value"
             app:layout_constraintTop_toBottomOf="@id/primary_value" />

--- a/Corona-Warn-App/src/main/res/layout/home_statistics_cards_sevendayrvalue_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_statistics_cards_sevendayrvalue_layout.xml
@@ -42,7 +42,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/spacing_normal"
             android:text="@string/statistics_nationwide_text"
-            android:textSize="@dimen/font_small"
+            android:textSize="14sp"
             app:layout_constraintEnd_toStartOf="@id/info_statistics"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/title" />
@@ -52,6 +52,7 @@
             style="@style/StatisticsCardValueLabel"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:textSize="14sp"
             tools:text="Aktuell" />
 
         <TextView
@@ -69,7 +70,8 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:paddingTop="@dimen/spacing_normal"
-            android:text="@string/statistics_reproduction_average" />
+            android:text="@string/statistics_reproduction_average"
+            android:textSize="14sp" />
 
         <de.rki.coronawarnapp.statistics.ui.TrendArrowView
             android:id="@+id/trend_arrow"

--- a/Corona-Warn-App/src/main/res/layout/home_statistics_cards_vaccinated_completely_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_statistics_cards_vaccinated_completely_layout.xml
@@ -33,7 +33,7 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/spacing_small"
             android:text="@string/statistics_nationwide_text"
-            android:textSize="@dimen/font_small"
+            android:textSize="14sp"
             app:layout_constraintStart_toStartOf="@id/title"
             app:layout_constraintTop_toBottomOf="@id/title" />
 
@@ -63,6 +63,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/statistics_primary_value_until_yesterday"
+            android:textSize="14sp"
             app:layout_constraintStart_toStartOf="@id/nationwide_text"
             app:layout_constraintTop_toTopOf="@id/background_image" />
 
@@ -84,6 +85,7 @@
             android:layout_height="wrap_content"
             android:layout_marginEnd="@dimen/spacing_small"
             android:text="@string/statistics_vaccination_primary_value_footnote"
+            android:textSize="14sp"
             app:layout_constraintEnd_toStartOf="@id/background_image"
             app:layout_constraintStart_toStartOf="@id/primary_value"
             app:layout_constraintTop_toBottomOf="@id/primary_value" />
@@ -94,6 +96,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/statistics_card_infections_tertiary_label"
+            android:textSize="14sp"
             app:layout_constraintStart_toStartOf="@id/primary_footnote"
             app:layout_constraintTop_toBottomOf="@id/background_image" />
 

--- a/Corona-Warn-App/src/main/res/layout/home_statistics_cards_vaccinated_once_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_statistics_cards_vaccinated_once_layout.xml
@@ -33,7 +33,7 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/spacing_small"
             android:text="@string/statistics_nationwide_text"
-            android:textSize="@dimen/font_small"
+            android:textSize="14sp"
             app:layout_constraintStart_toStartOf="@id/title"
             app:layout_constraintTop_toBottomOf="@id/title" />
 
@@ -63,6 +63,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/statistics_primary_value_until_yesterday"
+            android:textSize="14sp"
             app:layout_constraintStart_toStartOf="@id/nationwide_text"
             app:layout_constraintTop_toTopOf="@id/background_image" />
 
@@ -83,6 +84,7 @@
             android:layout_height="wrap_content"
             android:layout_marginEnd="@dimen/spacing_small"
             android:text="@string/statistics_vaccination_primary_value_footnote"
+            android:textSize="14sp"
             app:layout_constraintEnd_toStartOf="@id/background_image"
             app:layout_constraintStart_toStartOf="@id/primary_value"
             app:layout_constraintTop_toBottomOf="@id/primary_value" />
@@ -93,6 +95,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/statistics_card_infections_tertiary_label"
+            android:textSize="14sp"
             app:layout_constraintStart_toStartOf="@id/primary_footnote"
             app:layout_constraintTop_toBottomOf="@id/background_image" />
 


### PR DESCRIPTION
When the whole federal state is selected for the local incidence cards, the text at the bottom for hospitalizations only displayes "Hospitalizations" and not the state name again.

+ adjusted the text size on all cards to figma design.