### PR TITLE
Clean CWA flag when certs are all recycled or deleted (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesProvider.kt
@@ -48,6 +48,11 @@ class PersonCertificatesProvider @Inject constructor(
             it.personIdentifier
         }
 
+        if (!personCertificatesMap.containsKey(cwaUser)) {
+            Timber.tag(TAG).v("Resetting cwa user")
+            personCertificatesSettings.currentCwaUser.update { null }
+        }
+
         personCertificatesMap.entries.map { (personIdentifier, certs) ->
             Timber.tag(TAG).v("PersonCertificates for %s with %d certs.", personIdentifier, certs.size)
 


### PR DESCRIPTION
## Testing 
#### Scenario 1
- scan some certificates 
- switch cwa flag on 
- recycle cwa user certificates
- restore them back 
- cwa flag should be disabled 

#### Scenario 1
- scan some certificates 
- switch cwa flag on 
- recycle cwa user certificates
- delete them all 
- scan certificates again
- cwa flag should be disabled 
