### PR TITLE
Fix booster notification FAQ link (EXPOSUREAPP-10143)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/items/VaccinationInfoCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/items/VaccinationInfoCard.kt
@@ -10,6 +10,7 @@ import de.rki.coronawarnapp.covidcertificate.validation.ui.validationresult.comm
 import de.rki.coronawarnapp.databinding.VaccinationInfoCardBinding
 import de.rki.coronawarnapp.util.lists.diffutil.HasPayloadDiffer
 import setTextWithUrl
+import java.util.Locale
 
 class VaccinationInfoCard(parent: ViewGroup) :
     PersonDetailsAdapter.PersonDetailsItemVH<VaccinationInfoCard.Item, VaccinationInfoCardBinding>(
@@ -64,10 +65,14 @@ class VaccinationInfoCard(parent: ViewGroup) :
 
                 body2Faq.isVisible = true
                 boosterBadge.isVisible = curItem.hasBoosterNotification
+                val faqLink = when (Locale.getDefault().language) {
+                    Locale.GERMAN.language -> R.string.vaccination_card_booster_eligible_faq_link_german
+                    else -> R.string.vaccination_card_booster_eligible_faq_link_english
+                }
                 body2Faq.setTextWithUrl(
                     R.string.vaccination_card_booster_eligible_faq,
                     R.string.vaccination_card_booster_eligible_faq_link_container,
-                    R.string.vaccination_card_booster_eligible_faq_link
+                    faqLink
                 )
             }
 

--- a/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
@@ -72,8 +72,10 @@
     <string name="vaccination_card_booster_eligible_description">"%1$s (Regel-ID: %2$s)."</string>
     <!-- XTXT: Vaccination card booster eligible FAQ -->
     <string name="vaccination_card_booster_eligible_faq">"Mehr Informationen finden Sie in den FAQ."</string>
-    <!-- XTXT: Vaccination card booster eligible FAQ Link -->
-    <string name="vaccination_card_booster_eligible_faq_link">"https://www.bundesregierung.de/breg-de/themen/corona-warn-app/corona-warn-app-faq-1758392"</string>
+    <!-- XTXT: Vaccination card booster eligible FAQ Link English-->
+    <string name="vaccination_card_booster_eligible_faq_link_english">"https://www.coronawarn.app/en/faq/#vac_booster"</string>
+    <!-- XTXT: Vaccination card booster eligible FAQ Link German-->
+    <string name="vaccination_card_booster_eligible_faq_link_german">"https://www.coronawarn.app/de/faq/#vac_booster"</string>
     <!-- XTXT: Vaccination card booster eligible faq link keyword -->
     <string name="vaccination_card_booster_eligible_faq_link_container">"FAQ"</string>
 

--- a/Corona-Warn-App/src/main/res/values/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/covid_certificate_strings.xml
@@ -73,6 +73,10 @@
     <string name="vaccination_card_booster_eligible_faq">"For further information, please see our FAQ page."</string>
     <!-- XTXT: Vaccination card booster eligible FAQ Link -->
     <string name="vaccination_card_booster_eligible_faq_link">"https://www.bundesregierung.de/breg-de/themen/corona-warn-app/corona-warn-app-englisch/corona-warn-app-faq-1758636"</string>
+    <!-- XTXT: Vaccination card booster eligible FAQ Link English -->
+    <string name="vaccination_card_booster_eligible_faq_link_english">"https://www.coronawarn.app/en/faq/#vac_booster"</string>
+    <!-- XTXT: Vaccination card booster eligible FAQ Link German-->
+    <string name="vaccination_card_booster_eligible_faq_link_german">"https://www.coronawarn.app/de/faq/#vac_booster"</string>
     <!-- XTXT: Vaccination card booster eligible faq link keyword -->
     <string name="vaccination_card_booster_eligible_faq_link_container">"FAQ"</string>
 


### PR DESCRIPTION
Changes the link of the FAQ link from the booster notification card to point to the right section from the coronawarnapp website.

To test, register a test older than 150 days: `cwa vc gen -s v.0.dt=-150days` and then go to test settings -> booster rules -> click "run booster rules". The cli tool doesn't always generate a certificate with a booster rules so please keep generating one with the above command until you get a certificate that gets the booster notification. You will just have to repeat the cycle of generate cert -> go to test settings to run the booster rules until you get one that has the rules.

After that, just go to the certificate with the notification and press on the faq link. 
It should open https://www.coronawarn.app/de/faq/#vac_booster if you have you phone's language set to German and https://www.coronawarn.app/en/faq/#vac_booster if you have it set to any other language.