### PR TITLE
Added missing text in statistics info screen (EXPOSUREAPP-10162)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/StatisticsExplanationFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/StatisticsExplanationFragment.kt
@@ -32,7 +32,7 @@ class StatisticsExplanationFragment : Fragment(R.layout.fragment_statistics_expl
             )
 
             statisticsExplanationTrendText.apply {
-                val label = String.format(getString(R.string.statistics_explanation_trend_text))
+                val label = context.getString(R.string.statistics_explanation_trend_text)
                 text = label
                 contentDescription = label
             }

--- a/Corona-Warn-App/src/main/res/layout/fragment_statistics_explanation.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_statistics_explanation.xml
@@ -195,6 +195,50 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="@dimen/guideline_start"
+                    android:layout_marginTop="36dp"
+                    android:layout_marginEnd="@dimen/guideline_end"
+                    android:contentDescription="@string/statistics_explanation_seven_day_incidence_title"
+                    android:focusable="true"
+                    android:text="@string/statistics_explanation_seven_day_hospitalization_title" />
+
+                <TextView
+                    style="@style/body2"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/guideline_start"
+                    android:layout_marginTop="8dp"
+                    android:layout_marginEnd="@dimen/guideline_end"
+                    android:contentDescription="@string/statistics_explanation_seven_day_incidence_text"
+                    android:focusable="true"
+                    android:text="@string/statistics_explanation_seven_day_hospitalization_text" />
+
+                <TextView
+                    style="@style/headline5"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/guideline_start"
+                    android:layout_marginTop="36dp"
+                    android:layout_marginEnd="@dimen/guideline_end"
+                    android:contentDescription="@string/statistics_explanation_seven_day_incidence_title"
+                    android:focusable="true"
+                    android:text="@string/statistics_explanation_occupied_beds_in_intensive_care_title" />
+
+                <TextView
+                    style="@style/body2"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/guideline_start"
+                    android:layout_marginTop="8dp"
+                    android:layout_marginEnd="@dimen/guideline_end"
+                    android:contentDescription="@string/statistics_explanation_seven_day_incidence_text"
+                    android:focusable="true"
+                    android:text="@string/statistics_explanation_occupied_beds_in_intensive_care_text" />
+
+                <TextView
+                    style="@style/headline5"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/guideline_start"
                     android:layout_marginTop="41dp"
                     android:layout_marginEnd="@dimen/guideline_end"
                     android:contentDescription="@string/statistics_explanation_confirmed_new_infection_title"

--- a/Corona-Warn-App/src/main/res/layout/fragment_statistics_explanation.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_statistics_explanation.xml
@@ -502,7 +502,7 @@
                     android:layout_marginTop="14dp"
                     android:layout_marginEnd="@dimen/guideline_end"
                     android:focusable="true"
-                    tools:text="@string/statistics_explanation_trend" />
+                    android:text="@string/statistics_explanation_trend" />
 
                 <TextView
                     android:id="@+id/statistics_explanation_trend_text"
@@ -512,8 +512,9 @@
                     android:layout_marginStart="@dimen/guideline_start"
                     android:layout_marginTop="14dp"
                     android:layout_marginEnd="@dimen/guideline_end"
+                    android:contentDescription="@string/statistics_explanation_trend_text"
                     android:focusable="true"
-                    tools:text="@string/statistics_explanation_trend_text" />
+                    android:text="@string/statistics_explanation_trend_text" />
 
                 <TextView
                     style="@style/headline6"

--- a/Corona-Warn-App/src/main/res/layout/fragment_statistics_explanation.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_statistics_explanation.xml
@@ -495,6 +495,16 @@
                     android:text="@string/statistics_explanation_trend_title" />
 
                 <TextView
+                    style="@style/body2"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/guideline_start"
+                    android:layout_marginTop="14dp"
+                    android:layout_marginEnd="@dimen/guideline_end"
+                    android:focusable="true"
+                    tools:text="@string/statistics_explanation_trend" />
+
+                <TextView
                     android:id="@+id/statistics_explanation_trend_text"
                     style="@style/body2"
                     android:layout_width="match_parent"

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -1449,8 +1449,16 @@
     <string name="statistics_explanation_local_incidence_text">"Gesamtzahl der bestätigten Neuinfektionen der letzten 7 Tage (nach Meldedatum) pro 100.000 Einwohner im konfigurierten Kreis oder Bundesland."</string>
     <!-- XHED: Explanation screen seven day incidence title -->
     <string name="statistics_explanation_seven_day_incidence_title">"7-Tage-Inzidenz"</string>
+    <!-- XHED: Explanation screen seven day hospitalization title -->
+    <string name="statistics_explanation_seven_day_hospitalization_title">"7-Tage-Inzidenz Hospitalisierung"</string>
+    <!-- XHED: Explanation screen occupied beds in intensive care title -->
+    <string name="statistics_explanation_occupied_beds_in_intensive_care_title">"COVID-19-Erkrankte auf Intensivstationen"</string>
     <!-- XTXT: Explanation screen seven day incidence text -->
     <string name="statistics_explanation_seven_day_incidence_text">"Gesamtzahl der bestätigten Neuinfektionen der letzten 7 Tage (nach Meldedatum) pro 100.000 Einwohner."</string>
+    <!-- XTXT: Explanation screen seven day hospitalization text -->
+    <string name="statistics_explanation_seven_day_hospitalization_text">"Gesamtzahl der Krankenhausaufnahmen aufgrund von COVID-19 der letzten 7 Tage (nach Meldedatum) pro 100.000 Einwohner."</string>
+    <!-- XHED: Explanation screen occupied beds in intensive care text -->
+    <string name="statistics_explanation_occupied_beds_in_intensive_care_text">"Anteil der an COVID-19 erkrankten Personen auf Intensivstationen im Verhältnis zur Gesamtbettenanzahl."</string>
     <!-- XHED: Explanation screen seven day r-value title -->
     <string name="statistics_explanation_seven_day_r_value_title">"7-Tage-R-Wert"</string>
     <!-- XTXT: Explanation screen seven day r-value text -->

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -1483,8 +1483,10 @@
     <string name="statistics_explanation_period_total_text">"Gesamtzahl seit Jahresbeginn 2020 bzw. Einführung der App (15. Juni 2020)"</string>
     <!-- XHED: Explanation screen trend title -->
     <string name="statistics_explanation_trend_title">"Trend"</string>
+    <!-- XTXT: Explanation screen trend text -->
+    <string name="statistics_explanation_trend">"Der Trend vergleicht den Wert vom Vortag mit dem Wert von vor zwei Tagen (betr. 7-Tage-Inzidenz, 7-Tage-Inzidenz Hospitalisierung, COVID-19-Erkrankte auf Intensivstationen, 7-Tage-R-Wert) bzw. für die 7-Tage-Trends den Mittelwert der letzten 7 Tage mit dem der vorausgegangenen 7 Tage (7-Tage-Mittelwert der bestätigten Neuinfektionen, der warnenden Personen, der verabreichten Impfdosen). Dabei wird jeweils der Datenstand der Erstveröffentlichung genommen; nachfolgende Aktualisierungen werden nicht berücksichtigt."</string>
     <!-- YTXT: Explanation screen trend text -->
-    <string name="statistics_explanation_trend_text">"Die Pfeilrichtung zeigt an, ob der Trend nach oben oder nach unten geht oder relativ stabil ist, d.h. eine Abweichung von weniger als 1%% im Vortagesvergleich bzw. 5%% im Vorwochenvergleich aufweist. Die Farbe bewertet diesen Trend als positiv (grün), negativ (rot) oder neutral (grau). Der Trend vergleicht den Wert vom Vortag mit dem Wert von vor zwei Tagen bzw. für die 7-Tage-Trends den Mittelwert der letzten 7 Tage mit dem der vorausgegangenen 7 Tage."</string>
+    <string name="statistics_explanation_trend_text">"Die Pfeilrichtung zeigt an, ob der Trend nach oben oder nach unten geht oder relativ stabil ist, d.h. eine Abweichung (jeweils unter Berücksichtigung nur der angezeigten Nachkommastellen) von weniger als 1% im Vortagesvergleich bzw. 5% im Vorwochenvergleich aufweist. Die Farbe bewertet diesen Trend als positiv (grün), negativ (rot) oder neutral (grau)."</string>
     <!-- XHED: Explanation screen trend icons title -->
     <string name="statistics_explanation_trend_icons_title">"Beispiele für die angezeigten Trends:"</string>
     <!-- XHED: Explanation screen trend increasing title -->

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -1482,8 +1482,10 @@
     <string name="statistics_explanation_period_total_text">"Total number since the start of the year or launch of the app (June 15, 2020)"</string>
     <!-- XHED: Explanation screen trend title -->
     <string name="statistics_explanation_trend_title">"Trend"</string>
+    <!-- XTXT: Explanation screen trend text -->
+    <string name="statistics_explanation_trend">"Der Trend vergleicht den Wert vom Vortag mit dem Wert von vor zwei Tagen (betr. 7-Tage-Inzidenz, 7-Tage-Inzidenz Hospitalisierung, COVID-19-Erkrankte auf Intensivstationen, 7-Tage-R-Wert) bzw. für die 7-Tage-Trends den Mittelwert der letzten 7 Tage mit dem der vorausgegangenen 7 Tage (7-Tage-Mittelwert der bestätigten Neuinfektionen, der warnenden Personen, der verabreichten Impfdosen). Dabei wird jeweils der Datenstand der Erstveröffentlichung genommen; nachfolgende Aktualisierungen werden nicht berücksichtigt."</string>
     <!-- YTXT: Explanation screen trend text -->
-    <string name="statistics_explanation_trend_text">"The arrow direction indicates whether the trend is increasing, decreasing, or remaining steady – that is, demonstrates a deviation of less than 1%% compared to the previous day or 5%% compared to the previous week. The color indicates this trend as positive (green), negative (red), or neutral (gray). The trend compares the value from the previous day with the value from two days ago or, for the 7-day trends, the average value from the last 7 days with the average value from the 7 days prior to that."</string>
+    <string name="statistics_explanation_trend_text">"Die Pfeilrichtung zeigt an, ob der Trend nach oben oder nach unten geht oder relativ stabil ist, d.h. eine Abweichung (jeweils unter Berücksichtigung nur der angezeigten Nachkommastellen) von weniger als 1% im Vortagesvergleich bzw. 5% im Vorwochenvergleich aufweist. Die Farbe bewertet diesen Trend als positiv (grün), negativ (rot) oder neutral (grau)."</string>
     <!-- XHED: Explanation screen trend icons title -->
     <string name="statistics_explanation_trend_icons_title">"The following trends can be shown:"</string>
     <!-- XHED: Explanation screen trend increasing title -->

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -1448,8 +1448,16 @@
     <string name="statistics_explanation_local_incidence_text">"Total number of confirmed new infections in the last 7 days (by reporting date) per 100,000 residents in the configured district or federal state."</string>
     <!-- XHED: Explanation screen seven day incidence title -->
     <string name="statistics_explanation_seven_day_incidence_title">"7-Day Incidence"</string>
+    <!-- XHED: Explanation screen seven day hospitalization title -->
+    <string name="statistics_explanation_seven_day_hospitalization_title">"7-Tage-Inzidenz Hospitalisierung"</string>
+    <!-- XHED: Explanation screen occupied beds in intensive care title -->
+    <string name="statistics_explanation_occupied_beds_in_intensive_care_title">"COVID-19-Erkrankte auf Intensivstationen"</string>
     <!-- XTXT: Explanation screen seven day incidence text -->
     <string name="statistics_explanation_seven_day_incidence_text">"Total number of confirmed new infections in the last 7 days (by reporting date) per 100,000 residents."</string>
+    <!-- XTXT: Explanation screen seven day hospitalization text -->
+    <string name="statistics_explanation_seven_day_hospitalization_text">"Gesamtzahl der Krankenhausaufnahmen aufgrund von COVID-19 der letzten 7 Tage (nach Meldedatum) pro 100.000 Einwohner."</string>
+    <!-- XHED: Explanation screen occupied beds in intensive care text -->
+    <string name="statistics_explanation_occupied_beds_in_intensive_care_text">"Anteil der an COVID-19 erkrankten Personen auf Intensivstationen im Verhältnis zur Gesamtbettenanzahl."</string>
     <!-- XHED: Explanation screen seven day r-value title -->
     <string name="statistics_explanation_seven_day_r_value_title">"7-Day R Value"</string>
     <!-- XTXT: Explanation screen seven day r-value text -->


### PR DESCRIPTION
Go to stats info screen and compare with [figma](https://www.figma.com/file/KuDEcMSREg3VhZRhC3FXTY/COVID19_Master_2.11?node-id=29774%3A26990)