### PR TITLE
Use << in standardized name (EXPOSUREAPP-10140)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/RecoveryCertificateDetailFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/RecoveryCertificateDetailFragmentTest.kt
@@ -116,7 +116,7 @@ class RecoveryCertificateDetailFragmentTest : BaseUITest() {
 
     private fun mockCertificate() = mockk<RecoveryCertificate>().apply {
         every { fullName } returns "Max Mustermann"
-        every { fullNameStandardizedFormatted } returns "MUSTERMANN, MAX"
+        every { fullNameStandardizedFormatted } returns "MUSTERMANN<<MAX"
         every { dateOfBirthFormatted } returns "1969-01-08"
         every { targetDisease } returns "COVID-19"
         every { testedPositiveOnFormatted } returns "2021-05-24"

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/test/ui/TestCertificateDetailsFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/test/ui/TestCertificateDetailsFragmentTest.kt
@@ -164,7 +164,7 @@ class TestCertificateDetailsFragmentTest : BaseUITest() {
         override val fullNameFormatted: String
             get() = "Schneider, Andrea"
         override val fullNameStandardizedFormatted: String
-            get() = "SCHNEIDER, ANDREA"
+            get() = "SCHNEIDER<<ANDREA"
         override val dateOfBirthFormatted: String
             get() = "1943-04-18"
         override val personIdentifier: CertificatePersonIdentifier

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragmentTest.kt
@@ -132,7 +132,7 @@ class VaccinationDetailsFragmentTest : BaseUITest() {
         val formatter = DateTimeFormat.forPattern("dd.MM.yyyy")
         return mockk<VaccinationCertificate>().apply {
             every { fullName } returns "Max Mustermann"
-            every { fullNameStandardizedFormatted } returns "MUSTERMANN, MAX"
+            every { fullNameStandardizedFormatted } returns "MUSTERMANN<<MAX"
             every { dateOfBirthFormatted } returns "1976-02-01"
             every { vaccinatedOnFormatted } returns "2021-02-18"
             every { vaccinatedOn } returns LocalDate.parse("18.02.2021", formatter)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/DccV1.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/DccV1.kt
@@ -33,13 +33,13 @@ data class DccV1(
         val fullNameFormatted: String
             get() = when {
                 firstName.isNullOrBlank() -> lastName
-                else -> "$lastName, $firstName "
+                else -> "$lastName, $firstName"
             }
 
         val fullNameStandardizedFormatted: String
             get() = when {
-                givenNameStandardized.isNullOrBlank() -> familyNameStandardized
-                else -> "$familyNameStandardized, $givenNameStandardized"
+                givenNameStandardized.isNullOrBlank() -> familyNameStandardized.trim()
+                else -> familyNameStandardized.trim() + "<<" + givenNameStandardized.trim()
             }
     }
 


### PR DESCRIPTION
uses << as separator in the standardized name of certificate