### PR TITLE
Restore Corona Test dialogs on scanning (EXPOSUREAPP-10106)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerFragmentTest.kt
@@ -49,6 +49,15 @@ class QrCodeScannerFragmentTest : BaseUITest() {
         takeScreenshot<QrCodeScannerFragment>()
     }
 
+    @Screenshot
+    @Test
+    fun restoreCoronaTestDialog() {
+        every { qrcodeScannerViewModel.result } returns SingleLiveEvent<ScannerResult>()
+            .apply { postValue(CoronaTestResult.InRecycleBin(mockk())) }
+        launchFragmentInContainer2<QrCodeScannerFragment>()
+        takeScreenshot<QrCodeScannerFragment>()
+    }
+
     @Test
     fun launch() {
         launchFragment2<QrCodeScannerFragment>()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerFragment.kt
@@ -23,6 +23,7 @@ import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.covidcertificate.common.repository.CertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.ui.onboarding.CovidCertificateOnboardingFragment
 import de.rki.coronawarnapp.databinding.FragmentQrcodeScannerBinding
+import de.rki.coronawarnapp.reyclebin.coronatest.RecycledCoronaTest
 import de.rki.coronawarnapp.tag
 import de.rki.coronawarnapp.ui.presencetracing.attendee.confirm.ConfirmCheckInFragment
 import de.rki.coronawarnapp.ui.presencetracing.attendee.onboarding.CheckInOnboardingFragment
@@ -175,16 +176,17 @@ class QrCodeScannerFragment : Fragment(R.layout.fragment_qrcode_scanner), AutoIn
 
     private fun onCoronaTestResult(scannerResult: CoronaTestResult) {
         when (scannerResult) {
-            is CoronaTestResult.ConsentTest ->
+            is CoronaTestResult.ConsentTest -> doNavigate(
                 QrCodeScannerFragmentDirections.actionUniversalScannerToSubmissionConsentFragment(
                     scannerResult.coronaTestQrCode
                 )
-            is CoronaTestResult.DuplicateTest ->
+            )
+            is CoronaTestResult.DuplicateTest -> doNavigate(
                 QrCodeScannerFragmentDirections.actionUniversalScannerToSubmissionDeletionWarningFragment(
                     scannerResult.coronaTestQrCode
                 )
-        }.also {
-            doNavigate(it)
+            )
+            is CoronaTestResult.InRecycleBin -> showRestoreCoronaTestConfirmation(scannerResult.recycledCoronaTest)
         }
     }
 
@@ -248,6 +250,15 @@ class QrCodeScannerFragment : Fragment(R.layout.fragment_qrcode_scanner), AutoIn
             .setCancelable(false)
             .setMessage(R.string.recycle_bin_restore_dgc_dialog_message)
             .setPositiveButton(android.R.string.ok) { _, _ -> viewModel.restoreCertificate(containerId) }
+            .show()
+    }
+
+    private fun showRestoreCoronaTestConfirmation(recycledCoronaTest: RecycledCoronaTest) {
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.recycle_bin_restore_corona_test_dialog_title)
+            .setCancelable(false)
+            .setMessage(R.string.recycle_bin_restore_corona_test_dialog_message)
+            .setPositiveButton(android.R.string.ok) { _, _ -> viewModel.restoreCoronaTest(recycledCoronaTest) }
             .show()
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerViewModel.kt
@@ -125,15 +125,10 @@ class QrCodeScannerViewModel @AssistedInject constructor(
         Timber.tag(TAG).d("onCoronaTestQrCode()")
         val recycledCoronaTest = recycledCoronaTestsRepository.findCoronaTest(qrCode.rawQrCode.toSHA256())
 
-        if (recycledCoronaTest != null) {
-            // TODO show the dialog
-        }
-        // TODO navigate to right destination based on recycled Corona
-        val coronaTest = submissionRepository.testForType(qrCode.type).first()
-        val coronaTestResult = if (coronaTest != null) {
-            CoronaTestResult.DuplicateTest(qrCode)
-        } else {
-            CoronaTestResult.ConsentTest(qrCode)
+        val coronaTestResult = when {
+            recycledCoronaTest != null -> CoronaTestResult.InRecycleBin(recycledCoronaTest)
+            submissionRepository.testForType(qrCode.type).first() != null -> CoronaTestResult.DuplicateTest(qrCode)
+            else -> CoronaTestResult.ConsentTest(qrCode)
         }
         Timber.tag(TAG).d("coronaTestResult=${coronaTestResult::class.simpleName}")
         result.postValue(coronaTestResult)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/ScannerResult.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/ScannerResult.kt
@@ -5,6 +5,7 @@ import de.rki.coronawarnapp.coronatest.qrcode.CoronaTestQRCode
 import de.rki.coronawarnapp.covidcertificate.common.qrcode.DccQrCode
 import de.rki.coronawarnapp.covidcertificate.common.repository.CertificateContainerId
 import de.rki.coronawarnapp.presencetracing.checkins.qrcode.VerifiedTraceLocation
+import de.rki.coronawarnapp.reyclebin.coronatest.RecycledCoronaTest
 import de.rki.coronawarnapp.util.ui.LazyString
 
 sealed interface ScannerResult
@@ -25,6 +26,7 @@ sealed class CheckInResult : ScannerResult {
 sealed class CoronaTestResult : ScannerResult {
     data class DuplicateTest(val coronaTestQrCode: CoronaTestQRCode) : CoronaTestResult()
     data class ConsentTest(val coronaTestQrCode: CoronaTestQRCode) : CoronaTestResult()
+    data class InRecycleBin(val recycledCoronaTest: RecycledCoronaTest) : CoronaTestResult()
 }
 
 data class Error(val error: Throwable) : ScannerResult

--- a/Corona-Warn-App/src/main/res/values-de/recycler_bin_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/recycler_bin_strings.xml
@@ -65,4 +65,10 @@
     <string name="recycle_bin_restore_test_dialog_positive_button">"Wiederherstellen"</string>
     <!-- XBUT: Recycle Bin - restore test dialog negative button -->
     <string name="recycle_bin_restore_test_dialog_negative_button">"Abbrechen"</string>
+
+    <!-- XHED: Recycle Bin  - Restore Corona Test dialog title -->
+    <string name="recycle_bin_restore_corona_test_dialog_title">"Test wiederherstellen"</string>
+    <!-- XTXT: Recycle Bin  - Restore Corona Test dialog message -->
+    <string name="recycle_bin_restore_corona_test_dialog_message">"Der QR-Code wurde bereits auf Ihrem Smartphone registriert.  Der Test wird aus dem Papierkorb wiederhergestellt."</string>
+
 </resources>

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -905,7 +905,9 @@
     <!-- XHED: Dialog headline for invalid QR code  -->
     <string name="submission_qr_code_scan_invalid_dialog_headline">"QR-Code ist ungültig"</string>
     <!-- YTXT: Dialog Body text for invalid QR code -->
-    <string name="submission_qr_code_scan_invalid_dialog_body">"Der QR-Code ist ungültig oder wurde bereits auf einem Smartphone registriert. Ihr Testergebnis bekommen Sie vom Testcenter oder Labor, unabhängig von der Gültigkeit des QR-Codes. Bei einem positiven Testergebnis wird auch das zuständige Gesundheitsamt auf dem gesetzlich vorgeschriebenen Weg informiert und sich an Sie wenden."</string>
+    <string name="submission_qr_code_scan_invalid_dialog_body">"Der QR-Code ist ungültig oder wurde bereits auf Ihrem Smartphone registriert.
+Ihr Testergebnis bekommen Sie vom Testcenter oder Labor, unabhängig von der Gültigkeit des QR-Codes. Bei einem positiven Testergebnis wird auch das zuständige Gesundheitsamt auf dem gesetzlich vorgeschriebenen Weg informiert und sich an Sie wenden.
+Sollten Sie den Test in der App gelöscht haben, können Sie ihn aus dem Papierkorb wiederherstellen."</string>
     <!-- XBUT: Dialog(Invalid QR code) - positive button (right) -->
     <string name="submission_qr_code_scan_invalid_dialog_button_positive">"Erneut versuchen"</string>
     <!-- XBUT: Dialog(Invalid QR code) - negative button (left) -->

--- a/Corona-Warn-App/src/main/res/values/recycler_bin_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/recycler_bin_strings.xml
@@ -64,4 +64,10 @@
     <string name="recycle_bin_restore_test_dialog_positive_button">"Restore"</string>
     <!-- XBUT: Recycle Bin - restore test dialog negative button -->
     <string name="recycle_bin_restore_test_dialog_negative_button">"Cancel"</string>
+
+    <!-- XHED: Recycle Bin  - Restore Corona Test dialog title -->
+    <string name="recycle_bin_restore_corona_test_dialog_title">"Test wiederherstellen"</string>
+    <!-- XTXT: Recycle Bin  - Restore Corona Test dialog message -->
+    <string name="recycle_bin_restore_corona_test_dialog_message">"Der QR-Code wurde bereits auf Ihrem Smartphone registriert.  Der Test wird aus dem Papierkorb wiederhergestellt."</string>
+
 </resources>


### PR DESCRIPTION
### Dialogs
<img width="330" alt="Screenshot 2021-10-25 at 12 19 14" src="https://user-images.githubusercontent.com/25054729/138679710-358c6291-39fa-4abe-810f-56d6a5176570.png">
<img width="334" alt="Screenshot 2021-10-25 at 12 24 59" src="https://user-images.githubusercontent.com/25054729/138679715-16c010bc-cb4b-47ae-b185-25bf70e10bf5.png">

### Testing
1- Register test twice to the updated text 
2- For restore confirmation dialog , you can run the screenshot test . logic is not ready yet to show it 
## Ticket
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10106