### PR TITLE
Fixing Universal (File-)Scanner does not scan files when there is no default FileManager 

### DIFF
--- a/Corona-Warn-App/src/main/AndroidManifest.xml
+++ b/Corona-Warn-App/src/main/AndroidManifest.xml
@@ -98,7 +98,7 @@
         <activity
             android:name=".ui.main.MainActivity"
             android:exported="false"
-            android:launchMode="singleInstance"
+            android:launchMode="singleTask"
             android:screenOrientation="portrait"
             android:theme="@style/AppTheme.Main"
             android:windowSoftInputMode="adjustResize" />


### PR DESCRIPTION
## Testing

- install CWA on a non-Pixel phone
- install alternative Filemanager (e.g. Dateimanager+)
 - Setup no default Filemanager in device settings 
 - Open QR Code Scanner > Open File > select any build-in or 3rd party file manager and check if the selected file is propagated into the app
 - Check for side effects of changed `launchMode`

## Testing Side Effects
- Register positive test
- Share the keys
- while accessing the keys from ENF a notification will be shown from ENF
- Click it, it should open CWA on the same fragment as 2.13

## Jira Ticket
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9805
