### PR TITLE
Delta onboarding notifications fix (EXPOSUREAPP-10138)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/onboarding/OnboardingNotificationsFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/onboarding/OnboardingNotificationsFragmentTest.kt
@@ -3,6 +3,9 @@ package de.rki.coronawarnapp.ui.onboarding
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import dagger.Module
 import dagger.android.ContributesAndroidInjector
+import de.rki.coronawarnapp.main.CWASettings
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.MockK
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -16,11 +19,14 @@ import testhelpers.takeScreenshot
 @RunWith(AndroidJUnit4::class)
 class OnboardingNotificationsFragmentTest : BaseUITest() {
 
+    @MockK lateinit var cwaSettings: CWASettings
+
     @Before
     fun setup() {
+        MockKAnnotations.init(this)
         setupMockViewModel(
             object : OnboardingNotificationsViewModel.Factory {
-                override fun create(): OnboardingNotificationsViewModel = OnboardingNotificationsViewModel()
+                override fun create(): OnboardingNotificationsViewModel = OnboardingNotificationsViewModel(cwaSettings)
             }
         )
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingNotificationsViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingNotificationsViewModel.kt
@@ -2,15 +2,20 @@ package de.rki.coronawarnapp.ui.onboarding
 
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import de.rki.coronawarnapp.environment.BuildConfigWrap
+import de.rki.coronawarnapp.main.CWASettings
 import de.rki.coronawarnapp.util.ui.SingleLiveEvent
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
 import de.rki.coronawarnapp.util.viewmodel.SimpleCWAViewModelFactory
 
-class OnboardingNotificationsViewModel @AssistedInject constructor() : CWAViewModel() {
+class OnboardingNotificationsViewModel @AssistedInject constructor(
+    private val settings: CWASettings
+) : CWAViewModel() {
 
     val routeToScreen: SingleLiveEvent<OnboardingNavigationEvents> = SingleLiveEvent()
 
     fun onNextButtonClick() {
+        settings.lastNotificationsOnboardingVersionCode.update { BuildConfigWrap.VERSION_CODE }
         routeToScreen.postValue(OnboardingNavigationEvents.NavigateToOnboardingAnalytics)
     }
 


### PR DESCRIPTION
This fix will prevent the delta onboarding notifications screen to show up after the new release screen when updating the app from version 2.13 to a higher version, if the user already finished the onboarding flow in 2.13.

To test, do a fresh install with this branch, go through the onboarding process and then update to 2.14. You should only see the new release screen when opening up the 2.14 version.
