### PR TITLE
Double percentage (EXPOSUREAPP-10214)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/StatisticsExplanationFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/StatisticsExplanationFragment.kt
@@ -32,7 +32,7 @@ class StatisticsExplanationFragment : Fragment(R.layout.fragment_statistics_expl
             )
 
             statisticsExplanationTrendText.apply {
-                val label = context.getString(R.string.statistics_explanation_trend_text)
+                val label = String.format(context.getString(R.string.statistics_explanation_trend_text))
                 text = label
                 contentDescription = label
             }


### PR DESCRIPTION
## Whats new
Double percentage fix:

<img width="247" alt="Screenshot 2021-10-27 at 17 17 02" src="https://user-images.githubusercontent.com/64849422/139084248-207b0550-a220-4ea6-942b-6627deb28102.png">

## How to test
1) Install the app
2) Open Statistics Information screen
3) Scroll down 
4) Check that there is no `%%` (look up for 1% and 5% in text)
5) Test with German, English, Polish, Romanian and Turkish language