### PR TITLE
Remove duplicate items from statistics info (EXPOSUREAPP-10225)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/fragment_statistics_explanation.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_statistics_explanation.xml
@@ -250,50 +250,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="@dimen/guideline_start"
-                    android:layout_marginTop="36dp"
-                    android:layout_marginEnd="@dimen/guideline_end"
-                    android:contentDescription="@string/statistics_explanation_seven_day_incidence_title"
-                    android:focusable="true"
-                    android:text="@string/statistics_explanation_seven_day_hospitalization_title" />
-
-                <TextView
-                    style="@style/body2"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/guideline_start"
-                    android:layout_marginTop="8dp"
-                    android:layout_marginEnd="@dimen/guideline_end"
-                    android:contentDescription="@string/statistics_explanation_seven_day_incidence_text"
-                    android:focusable="true"
-                    android:text="@string/statistics_explanation_seven_day_hospitalization_text" />
-
-                <TextView
-                    style="@style/headline5"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/guideline_start"
-                    android:layout_marginTop="36dp"
-                    android:layout_marginEnd="@dimen/guideline_end"
-                    android:contentDescription="@string/statistics_explanation_seven_day_incidence_title"
-                    android:focusable="true"
-                    android:text="@string/statistics_explanation_occupied_beds_in_intensive_care_title" />
-
-                <TextView
-                    style="@style/body2"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/guideline_start"
-                    android:layout_marginTop="8dp"
-                    android:layout_marginEnd="@dimen/guideline_end"
-                    android:contentDescription="@string/statistics_explanation_seven_day_incidence_text"
-                    android:focusable="true"
-                    android:text="@string/statistics_explanation_occupied_beds_in_intensive_care_text" />
-
-                <TextView
-                    style="@style/headline5"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/guideline_start"
                     android:layout_marginTop="32dp"
                     android:layout_marginEnd="@dimen/guideline_end"
                     android:contentDescription="@string/statistics_explanation_confirmed_new_infection_title"


### PR DESCRIPTION
removes duplicate items
- 7-day incidence Hospitalization
- People suffering from COVID-19 in intensive care units
on statistics info screen

https://www.figma.com/file/KuDEcMSREg3VhZRhC3FXTY/COVID19_Master_2.11?node-id=34217%3A42095

![device-2021-10-28-150206](https://user-images.githubusercontent.com/49635654/139260574-c82d3631-943d-4d6e-80ff-99a6393b7a92.png)
