### PR TITLE
Bugfix: Universal Scanner Button moves to the center of the screen (EXPOSUREAPP-10250)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/activity_main.xml
+++ b/Corona-Warn-App/src/main/res/layout/activity_main.xml
@@ -42,7 +42,8 @@
         android:contentDescription="@string/bottom_nav_scanner_title"
         app:backgroundTint="@color/fab_tint"
         app:elevation="2dp"
-        app:layout_anchor="@id/bottom_app_bar"
+        android:layout_marginBottom="32dp"
+        android:layout_gravity="bottom|center"
         app:srcCompat="@drawable/ic_nav_qrcode"
         app:tint="@android:color/white" />
 

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_tan.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_tan.xml
@@ -3,7 +3,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
-
     <data>
         <variable
             name="uiState"


### PR DESCRIPTION
## Description
- Universal Scanner FAB jumps in the middle of the screen when the software keyboard is opened on some screens 

## Testing

- go to "In Vertretung warnen" 
- scan an event but stop at tan
-  move back to the home screen

## Jira Link
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10250