### PR TITLE
RecycleBin (Tests) - recycle / restore tests (EXPOSUREAPP-10118, EXPOSUREAPP-10113)

### DIFF
--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/CoronaTestRepositoryTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/CoronaTestRepositoryTest.kt
@@ -21,6 +21,7 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.just
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.first
 import org.joda.time.Instant
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -134,6 +135,23 @@ class CoronaTestRepositoryTest : BaseTest() {
 
         shouldThrow<DuplicateCoronaTestException> {
             instance.registerTest(pcrRegistrationRequest) shouldBe pcrTest
+        }
+    }
+
+    @Test
+    fun `Filter corona tests by recycle state`() = runBlockingTest2(ignoreActive = true) {
+        val recycledTest = pcrTest.copy(recycledAt = Instant.EPOCH)
+        val notRecycledTest = raTest.copy(recycledAt = null)
+        val tests = setOf(recycledTest, notRecycledTest)
+        coronaTestsInStorage.apply {
+            clear()
+            addAll(tests)
+        }
+
+        createInstance(this).run {
+            allCoronaTests.first() shouldBe tests
+            coronaTests.first() shouldBe setOf(notRecycledTest)
+            recycledCoronaTests.first() shouldBe setOf(recycledTest)
         }
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRCoronaTestTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRCoronaTestTest.kt
@@ -1,7 +1,6 @@
 package de.rki.coronawarnapp.coronatest.type.pcr
 
 import de.rki.coronawarnapp.coronatest.server.CoronaTestResult
-import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.joda.time.Instant

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRCoronaTestTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRCoronaTestTest.kt
@@ -1,7 +1,9 @@
 package de.rki.coronawarnapp.coronatest.type.pcr
 
 import de.rki.coronawarnapp.coronatest.server.CoronaTestResult
+import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import org.joda.time.Instant
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
@@ -21,5 +23,21 @@ class PCRCoronaTestTest : BaseTest() {
         instance.isFinal shouldBe true
         instance.copy(testResult = CoronaTestResult.PCR_POSITIVE).isFinal shouldBe false
         instance.copy(testResult = CoronaTestResult.RAT_POSITIVE).isFinal shouldBe false
+    }
+
+    @Test
+    fun `Recycled test state is RECYCLED`() {
+        val instance = PCRCoronaTest(
+            identifier = "identifier",
+            lastUpdatedAt = Instant.EPOCH,
+            registeredAt = Instant.EPOCH,
+            registrationToken = "token",
+            testResult = CoronaTestResult.PCR_OR_RAT_REDEEMED,
+        )
+
+        instance.state shouldNotBe PCRCoronaTest.State.RECYCLED
+
+        instance.recycledAt = Instant.EPOCH
+        instance.state shouldBe PCRCoronaTest.State.RECYCLED
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRProcessorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/pcr/PCRProcessorTest.kt
@@ -392,4 +392,22 @@ class PCRProcessorTest : BaseTest() {
             labId shouldBe "labId"
         }
     }
+
+    @Test
+    fun `recycle sets recycledAt`() = runBlockingTest {
+        val pcrTest = defaultTest.copy(recycledAt = null)
+
+        createInstance().run {
+            recycle(pcrTest) shouldBe pcrTest.copy(recycledAt = nowUTC)
+        }
+    }
+
+    @Test
+    fun `restore clears recycledAt`() = runBlockingTest {
+        val pcrTest = defaultTest.copy(recycledAt = nowUTC)
+
+        createInstance().run {
+            restore(pcrTest) shouldBe pcrTest.copy(recycledAt = null)
+        }
+    }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RACoronaTestTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RACoronaTestTest.kt
@@ -1,7 +1,9 @@
 package de.rki.coronawarnapp.coronatest.type.rapidantigen
 
+import de.rki.coronawarnapp.appconfig.CoronaTestConfigContainer
 import de.rki.coronawarnapp.coronatest.server.CoronaTestResult
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import org.joda.time.Instant
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
@@ -22,5 +24,24 @@ class RACoronaTestTest : BaseTest() {
         instance.isFinal shouldBe true
         instance.copy(testResult = CoronaTestResult.RAT_POSITIVE).isFinal shouldBe false
         instance.copy(testResult = CoronaTestResult.PCR_OR_RAT_REDEEMED).isFinal shouldBe true
+    }
+
+    @Test
+    fun `Recycled test state is RECYCLED`() {
+        val instance = RACoronaTest(
+            identifier = "identifier",
+            lastUpdatedAt = Instant.EPOCH,
+            registeredAt = Instant.EPOCH,
+            registrationToken = "token",
+            testResult = CoronaTestResult.PCR_OR_RAT_REDEEMED,
+            testedAt = Instant.EPOCH,
+        )
+        val testConfig = CoronaTestConfigContainer()
+
+
+        instance.getState(Instant.EPOCH, testConfig) shouldNotBe RACoronaTest.State.RECYCLED
+
+        instance.recycledAt = Instant.EPOCH
+        instance.getState(Instant.EPOCH, testConfig) shouldBe RACoronaTest.State.RECYCLED
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RACoronaTestTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RACoronaTestTest.kt
@@ -37,8 +37,7 @@ class RACoronaTestTest : BaseTest() {
             testedAt = Instant.EPOCH,
         )
         val testConfig = CoronaTestConfigContainer()
-
-
+        
         instance.getState(Instant.EPOCH, testConfig) shouldNotBe RACoronaTest.State.RECYCLED
 
         instance.recycledAt = Instant.EPOCH

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RACoronaTestTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RACoronaTestTest.kt
@@ -37,7 +37,7 @@ class RACoronaTestTest : BaseTest() {
             testedAt = Instant.EPOCH,
         )
         val testConfig = CoronaTestConfigContainer()
-        
+
         instance.getState(Instant.EPOCH, testConfig) shouldNotBe RACoronaTest.State.RECYCLED
 
         instance.recycledAt = Instant.EPOCH

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RAProcessorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RAProcessorTest.kt
@@ -402,4 +402,22 @@ class RAProcessorTest : BaseTest() {
             labId shouldBe "labId"
         }
     }
+
+    @Test
+    fun `recycle sets recycledAt`() = runBlockingTest {
+        val raTest = defaultTest.copy(recycledAt = null)
+
+        createInstance().run {
+            recycle(raTest) shouldBe raTest.copy(recycledAt = nowUTC)
+        }
+    }
+
+    @Test
+    fun `restore clears recycledAt`() = runBlockingTest {
+        val raTest = defaultTest.copy(recycledAt = nowUTC)
+
+        createInstance().run {
+            restore(raTest) shouldBe raTest.copy(recycledAt = null)
+        }
+    }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/DataResetTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/DataResetTest.kt
@@ -26,7 +26,6 @@ import de.rki.coronawarnapp.presencetracing.TraceLocationSettings
 import de.rki.coronawarnapp.presencetracing.checkins.CheckInRepository
 import de.rki.coronawarnapp.presencetracing.storage.repo.TraceLocationRepository
 import de.rki.coronawarnapp.presencetracing.warning.storage.TraceWarningRepository
-import de.rki.coronawarnapp.reyclebin.coronatest.RecycledCoronaTestsProvider
 import de.rki.coronawarnapp.risk.storage.RiskLevelStorage
 import de.rki.coronawarnapp.statistics.local.source.LocalStatisticsProvider
 import de.rki.coronawarnapp.statistics.source.StatisticsProvider
@@ -79,7 +78,6 @@ internal class DataResetTest : BaseTest() {
     @MockK lateinit var recoveryCertificateRepository: RecoveryCertificateRepository
     @MockK lateinit var dscRepository: DscRepository
     @MockK lateinit var boosterRulesRepository: BoosterRulesRepository
-    @MockK lateinit var recycledCoronaTestsProvider: RecycledCoronaTestsProvider
 
     @BeforeEach
     fun setUp() {


### PR DESCRIPTION
This PR addresses EXPOSUREAPP-10118, EXPSOUREAPP-10113.

Containing missing tests for 
- Recycled Test / not found
- filtering for recycled tests & states
- setting & clearing the recycledAt attribut by RA/PCR Tests (restore & recycle)

Note: logic has been implemented here:
https://github.com/corona-warn-app/cwa-app-android/pull/4274