### PR TITLE
Fix profile deletion (EXPOSUREAPP-9905)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/antigen/profile/RATProfileSettings.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/antigen/profile/RATProfileSettings.kt
@@ -1,7 +1,6 @@
 package de.rki.coronawarnapp.coronatest.antigen.profile
 
 import android.content.Context
-import androidx.core.content.edit
 import com.google.gson.Gson
 import dagger.Reusable
 import de.rki.coronawarnapp.util.di.AppContext
@@ -41,8 +40,10 @@ class RATProfileSettings @Inject constructor(
         defaultValue = false
     )
 
-    fun deleteProfile() = prefs.edit(commit = true) {
-        remove(PREFS_KEY_PROFILE)
+    fun deleteProfile() {
+        prefs.apply {
+            profile.update { null }
+        }
     }
 
     fun clear() = prefs.clearAndNotify()


### PR DESCRIPTION
Could not reproduce, so I'm guessing that deleting the prefs may lead to the value still being in memory for some time on some devices. So instead I overwrite with null as we do with all other shared prefs.

https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9905