### PR TITLE
Text overlapping and redundant parentheses (EXPOSUREAPP-10244)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/home_statistics_cards_infections_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_statistics_cards_infections_layout.xml
@@ -29,7 +29,9 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/spacing_normal"
             android:layout_marginTop="@dimen/spacing_normal"
+            android:maxLines="2"
             android:text="@string/statistics_card_infections_title"
+            app:autoSizeTextType="uniform"
             app:layout_constraintEnd_toStartOf="@id/info_statistics"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />

--- a/Corona-Warn-App/src/main/res/layout/home_statistics_cards_keysubmissions_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_statistics_cards_keysubmissions_layout.xml
@@ -29,7 +29,9 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/spacing_normal"
             android:layout_marginTop="@dimen/spacing_normal"
+            android:maxLines="2"
             android:text="@string/statistics_card_submission_title"
+            app:autoSizeTextType="uniform"
             app:layout_constraintEnd_toStartOf="@id/info_statistics"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
@@ -71,7 +73,7 @@
             android:layout_height="wrap_content"
             android:paddingTop="@dimen/spacing_normal"
             android:text="@string/statistics_card_infections_secondary_label"
-            android:textSize="14sp" />
+            android:textSize="14sp"/>
 
         <TextView
             android:id="@+id/secondary_value"

--- a/Corona-Warn-App/src/main/res/values-tr/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-tr/strings.xml
@@ -1536,7 +1536,7 @@
     <!-- XTXT: Nationwide text -->
     <string name="statistics_nationwide_text">"Ülke genelinde"</string>
     <!-- XTXT: Vaccination primary value footnote text -->
-    <string name="statistics_vaccination_primary_value_footnote">"(popülasyona göre)"</string>
+    <string name="statistics_vaccination_primary_value_footnote">"popülasyona göre"</string>
 
     <!-- Persons Vaccinated Completely Statistics Card -->
     <!-- XHED: Title for vaccinated completely statistics card -->

--- a/Corona-Warn-App/src/main/res/values-v28/styles.xml
+++ b/Corona-Warn-App/src/main/res/values-v28/styles.xml
@@ -30,4 +30,9 @@
         <item name="android:textColor">@color/colorTextPrimary2</item>
         <item name="android:lineHeight">@dimen/line_height_small</item>
     </style>
+
+    <style name="StatisticsCardValueLabel" parent="subtitle">
+        <item name="android:textColor">@color/colorStatisticsValueLabel</item>
+        <item name="android:lineHeight">@dimen/line_height_tiny</item>
+    </style>
 </resources>

--- a/Corona-Warn-App/src/main/res/values/dimens.xml
+++ b/Corona-Warn-App/src/main/res/values/dimens.xml
@@ -21,6 +21,7 @@
     <dimen name="line_height_large">28sp</dimen>
     <dimen name="line_height_normal">24sp</dimen>
     <dimen name="line_height_small">20sp</dimen>
+    <dimen name="line_height_tiny">16sp</dimen>
 
     <dimen name="font_line_spacing_extra">4sp</dimen>
 


### PR DESCRIPTION
Addresses [EXPOSUREAPP-10244](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10244)

- Reduces spacing of card subtitle to be able to display two lines of text without overlapping
- Avoids card title to get higher than two lines using uniform text scale
- Removes redundant parentheses