### PR TITLE
Revert "Update recycler_bin_strings.xml (EXPOSUREAPP-10407)"

### DIFF
--- a/Corona-Warn-App/src/main/res/values-de/recycler_bin_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/recycler_bin_strings.xml
@@ -11,7 +11,7 @@
     <!-- XHED: empty recycler bin description -->
     <string name="recycler_bin_empty_description">"Wenn Sie Zertifikate entfernen, werden sie in den Papierkorb verschoben und hier angezeigt."</string>
     <!-- XHED: recycler bin remove all menu item -->
-    <string name="recycler_bin_remove_all">"Alle endgültig löschen"</string>
+    <string name="recycler_bin_remove_all">"Alle entfernen"</string>
 
     <!-- Recycle Bin  - Restore Dgc on scanning confirmation-->
     <!-- XHED: Recycle Bin  - Restore DGC dialog title -->
@@ -34,7 +34,7 @@
     <!-- XTXT: Recycle Bin - restore -->
     <string name="recycle_bin_restore">"Wiederherstellen"</string>
     <!-- XTXT: Recycle Bin - remove permanently -->
-    <string name="recycle_bin_remove_permanently">"Endgültig löschen"</string>
+    <string name="recycle_bin_remove_permanently">"Alle endgültig löschen"</string>
 
     <!-- Recycle bin remove all dialog-->
     <!-- XHED: Recycle Bin - remove all dialog title -->


### PR DESCRIPTION
Reverts corona-warn-app/cwa-app-android#4324, which was mistakenly tagged as targeting v2.13 (see [EXPOSUREAPP-10407](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10407)).