### PR TITLE
Fix relation between administrative units belonging to federal state Thuringia (EXPOSUREAPP-10406)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/LocalIncidenceAndHospitalizationCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/LocalIncidenceAndHospitalizationCard.kt
@@ -115,7 +115,7 @@ class LocalIncidenceAndHospitalizationCard(parent: ViewGroup) :
                             "SN" -> context.getString(R.string.analytics_userinput_federalstate_sn)
                             "ST" -> context.getString(R.string.analytics_userinput_federalstate_st)
                             "SH" -> context.getString(R.string.analytics_userinput_federalstate_sh)
-                            "TH" -> context.getString(R.string.analytics_userinput_federalstate_bw)
+                            "TH" -> context.getString(R.string.analytics_userinput_federalstate_th)
                             else -> context.getString(R.string.statistics_nationwide_text)
                         }
                     )


### PR DESCRIPTION
A small fix for the statistics tiles.

To test:
- Go to statistics tyles
- `Add Local 7-Day Incidence`
-  Choose federal state `Thuringia`
- Choose any district but not entire state
- Check the Local 7-Day Incidence card for the country you have selected. The text at the bottom of the card "Hospitalizations in ..." shoud say "Hospitalizations in Thuringia".