### PR TITLE
Revert "Kathrin luecke patch 1 (EXPOSUREAPP-10246)"

### DIFF
--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -1316,7 +1316,7 @@ Sollten Sie den Test in der App gelöscht haben, können Sie ihn aus dem Papierk
     <!-- XBUT: submission status card unregistered button -->
     <string name="submission_status_card_button_unregistered">"Sie lassen sich testen?"</string>
     <!-- XBUT: submission status card show results button -->
-    <string name="submission_status_card_button_show_results">"Testergebnis abrufen"</string>
+    <string name="submission_status_card_button_show_results">"Test anzeigen"</string>
     <!-- XBUT: submission status card fetch failed button -->
     <string name="submission_status_card_button_failed">"Test löschen"</string>
     <!-- XHED: submission status card positive result subtitle -->


### PR DESCRIPTION
Reverts corona-warn-app/cwa-app-android#4310

The change also affected texts in other contexts - see comment in https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10246. Therefore it needs to be reverted and analyzed.