### PR TITLE
Restore recycled tests without consent - fix (EXPOSUREAPP-10441)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerFragment.kt
@@ -176,32 +176,41 @@ class QrCodeScannerFragment : Fragment(R.layout.fragment_qrcode_scanner), AutoIn
 
     private fun onCoronaTestResult(scannerResult: CoronaTestResult) {
         when (scannerResult) {
-            is CoronaTestResult.ConsentTest -> doNavigate(
-                QrCodeScannerFragmentDirections.actionUniversalScannerToSubmissionConsentFragment(
-                    scannerResult.coronaTestQrCode
-                )
+            is CoronaTestResult.ConsentTest -> QrCodeScannerFragmentDirections.actionUniversalScannerToSubmissionConsentFragment(
+                scannerResult.coronaTestQrCode
             )
-            is CoronaTestResult.DuplicateTest -> doNavigate(
-                QrCodeScannerFragmentDirections.actionUniversalScannerToSubmissionDeletionWarningFragment(
-                    scannerResult.coronaTestQrCode
-                )
+            is CoronaTestResult.DuplicateTest -> QrCodeScannerFragmentDirections.actionUniversalScannerToSubmissionDeletionWarningFragment(
+                scannerResult.coronaTestQrCode
             )
-            is CoronaTestResult.InRecycleBin -> showRestoreCoronaTestConfirmation(scannerResult.recycledCoronaTest)
-            is CoronaTestResult.RestoreDuplicateTest -> {
-                doNavigate(
-                    QrCodeScannerFragmentDirections.actionUniversalScannerToSubmissionDeletionWarningFragment(
-                        scannerResult.restoreRecycledTestRequest
-                    )
-                )
+            is CoronaTestResult.InRecycleBin -> {
+                showRestoreCoronaTestConfirmation(scannerResult.recycledCoronaTest)
+                null
             }
-            is CoronaTestResult.TestResult -> doNavigate(
-                QrCodeScannerFragmentDirections.actionUniversalScannerToPendingTestResult(
-                    testType = scannerResult.coronaTest.type,
-                    testIdentifier = scannerResult.coronaTest.identifier,
-                    forceTestResultUpdate = true
-                )
+            is CoronaTestResult.RestoreDuplicateTest -> QrCodeScannerFragmentDirections.actionUniversalScannerToSubmissionDeletionWarningFragment(
+                scannerResult.restoreRecycledTestRequest
+            )
+            is CoronaTestResult.TestPending -> QrCodeScannerFragmentDirections.actionUniversalScannerToPendingTestResult(
+                testType = scannerResult.test.type,
+                testIdentifier = scannerResult.test.identifier,
+                forceTestResultUpdate = true
+            )
+            is CoronaTestResult.TestInvalid -> QrCodeScannerFragmentDirections.actionUniversalScannerToSubmissionTestResultInvalidFragment(
+                testType = scannerResult.test.type,
+                testIdentifier = scannerResult.test.identifier
+            )
+            is CoronaTestResult.TestNegative -> QrCodeScannerFragmentDirections.actionUniversalScannerToSubmissionTestResultNegativeFragment(
+                testType = scannerResult.test.type,
+                testIdentifier = scannerResult.test.identifier
+            )
+            is CoronaTestResult.TestPositive -> QrCodeScannerFragmentDirections.actionUniversalScannerToSubmissionTestResultKeysSharedFragment(
+                testType = scannerResult.test.type,
+                testIdentifier = scannerResult.test.identifier
+            )
+            is CoronaTestResult.WarnOthers -> QrCodeScannerFragmentDirections.actionUniversalScannerToSubmissionResultPositiveOtherWarningNoConsentFragment(
+                testType = scannerResult.test.type
             )
         }
+            ?.let { doNavigate(it) }
     }
 
     private fun onDccResult(scannerResult: DccResult) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerFragment.kt
@@ -176,39 +176,48 @@ class QrCodeScannerFragment : Fragment(R.layout.fragment_qrcode_scanner), AutoIn
 
     private fun onCoronaTestResult(scannerResult: CoronaTestResult) {
         when (scannerResult) {
-            is CoronaTestResult.ConsentTest -> QrCodeScannerFragmentDirections.actionUniversalScannerToSubmissionConsentFragment(
-                scannerResult.coronaTestQrCode
-            )
-            is CoronaTestResult.DuplicateTest -> QrCodeScannerFragmentDirections.actionUniversalScannerToSubmissionDeletionWarningFragment(
-                scannerResult.coronaTestQrCode
-            )
+            is CoronaTestResult.ConsentTest ->
+                QrCodeScannerFragmentDirections.actionUniversalScannerToSubmissionConsentFragment(
+                    scannerResult.coronaTestQrCode
+                )
+            is CoronaTestResult.DuplicateTest ->
+                QrCodeScannerFragmentDirections.actionUniversalScannerToSubmissionDeletionWarningFragment(
+                    scannerResult.coronaTestQrCode
+                )
             is CoronaTestResult.InRecycleBin -> {
                 showRestoreCoronaTestConfirmation(scannerResult.recycledCoronaTest)
                 null
             }
-            is CoronaTestResult.RestoreDuplicateTest -> QrCodeScannerFragmentDirections.actionUniversalScannerToSubmissionDeletionWarningFragment(
-                scannerResult.restoreRecycledTestRequest
-            )
-            is CoronaTestResult.TestPending -> QrCodeScannerFragmentDirections.actionUniversalScannerToPendingTestResult(
-                testType = scannerResult.test.type,
-                testIdentifier = scannerResult.test.identifier,
-                forceTestResultUpdate = true
-            )
-            is CoronaTestResult.TestInvalid -> QrCodeScannerFragmentDirections.actionUniversalScannerToSubmissionTestResultInvalidFragment(
-                testType = scannerResult.test.type,
-                testIdentifier = scannerResult.test.identifier
-            )
-            is CoronaTestResult.TestNegative -> QrCodeScannerFragmentDirections.actionUniversalScannerToSubmissionTestResultNegativeFragment(
-                testType = scannerResult.test.type,
-                testIdentifier = scannerResult.test.identifier
-            )
-            is CoronaTestResult.TestPositive -> QrCodeScannerFragmentDirections.actionUniversalScannerToSubmissionTestResultKeysSharedFragment(
-                testType = scannerResult.test.type,
-                testIdentifier = scannerResult.test.identifier
-            )
-            is CoronaTestResult.WarnOthers -> QrCodeScannerFragmentDirections.actionUniversalScannerToSubmissionResultPositiveOtherWarningNoConsentFragment(
-                testType = scannerResult.test.type
-            )
+            is CoronaTestResult.RestoreDuplicateTest ->
+                QrCodeScannerFragmentDirections.actionUniversalScannerToSubmissionDeletionWarningFragment(
+                    scannerResult.restoreRecycledTestRequest
+                )
+            is CoronaTestResult.TestPending ->
+                QrCodeScannerFragmentDirections.actionUniversalScannerToPendingTestResult(
+                    testType = scannerResult.test.type,
+                    testIdentifier = scannerResult.test.identifier,
+                    forceTestResultUpdate = true
+                )
+            is CoronaTestResult.TestInvalid ->
+                QrCodeScannerFragmentDirections.actionUniversalScannerToSubmissionTestResultInvalidFragment(
+                    testType = scannerResult.test.type,
+                    testIdentifier = scannerResult.test.identifier
+                )
+            is CoronaTestResult.TestNegative ->
+                QrCodeScannerFragmentDirections.actionUniversalScannerToSubmissionTestResultNegativeFragment(
+                    testType = scannerResult.test.type,
+                    testIdentifier = scannerResult.test.identifier
+                )
+            is CoronaTestResult.TestPositive ->
+                QrCodeScannerFragmentDirections.actionUniversalScannerToSubmissionTestResultKeysSharedFragment(
+                    testType = scannerResult.test.type,
+                    testIdentifier = scannerResult.test.identifier
+                )
+            is CoronaTestResult.WarnOthers ->
+                QrCodeScannerFragmentDirections
+                    .actionUniversalScannerToSubmissionResultPositiveOtherWarningNoConsentFragment(
+                        testType = scannerResult.test.type
+                    )
         }
             ?.let { doNavigate(it) }
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerViewModel.kt
@@ -109,23 +109,14 @@ class QrCodeScannerViewModel @AssistedInject constructor(
         }
     }
 
-    private fun CoronaTest.toCoronaTestResult(): CoronaTestResult = when (testResult) {
-        TestResult.PCR_OR_RAT_PENDING,
-        TestResult.RAT_PENDING -> CoronaTestResult.TestPending(test = this)
-
-        TestResult.PCR_NEGATIVE,
-        TestResult.RAT_NEGATIVE -> CoronaTestResult.TestNegative(test = this)
-
-        TestResult.PCR_POSITIVE,
-        TestResult.RAT_POSITIVE -> when (isAdvancedConsentGiven) {
+    private fun CoronaTest.toCoronaTestResult(): CoronaTestResult = when {
+        isPending -> CoronaTestResult.TestPending(test = this)
+        isNegative -> CoronaTestResult.TestNegative(test = this)
+        isPositive -> when (isAdvancedConsentGiven) {
             true -> CoronaTestResult.TestPositive(test = this)
             false -> CoronaTestResult.WarnOthers(test = this)
         }
-
-        TestResult.PCR_INVALID,
-        TestResult.PCR_OR_RAT_REDEEMED,
-        TestResult.RAT_REDEEMED,
-        TestResult.RAT_INVALID -> CoronaTestResult.TestInvalid(test = this)
+        else -> CoronaTestResult.TestInvalid(test = this)
     }
 
     private suspend fun onDccQrCode(dccQrCode: DccQrCode) {
@@ -173,5 +164,3 @@ class QrCodeScannerViewModel @AssistedInject constructor(
         private val TAG = tag<QrCodeScannerViewModel>()
     }
 }
-
-private typealias TestResult = de.rki.coronawarnapp.coronatest.server.CoronaTestResult

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/ScannerResult.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/ScannerResult.kt
@@ -3,7 +3,6 @@ package de.rki.coronawarnapp.qrcode.ui
 import android.net.Uri
 import de.rki.coronawarnapp.coronatest.qrcode.CoronaTestQRCode
 import de.rki.coronawarnapp.coronatest.type.CoronaTest
-import de.rki.coronawarnapp.coronatest.type.TestIdentifier
 import de.rki.coronawarnapp.covidcertificate.common.qrcode.DccQrCode
 import de.rki.coronawarnapp.covidcertificate.common.repository.CertificateContainerId
 import de.rki.coronawarnapp.presencetracing.checkins.qrcode.VerifiedTraceLocation
@@ -34,7 +33,7 @@ sealed class CoronaTestResult : ScannerResult {
     data class TestNegative(val test: CoronaTest) : CoronaTestResult()
     data class TestInvalid(val test: CoronaTest) : CoronaTestResult()
     data class TestPending(val test: CoronaTest) : CoronaTestResult()
-    data class WarnOthers(val test: CoronaTest): CoronaTestResult()
+    data class WarnOthers(val test: CoronaTest) : CoronaTestResult()
 }
 
 data class Error(val error: Throwable) : ScannerResult

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/ScannerResult.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/ScannerResult.kt
@@ -3,6 +3,7 @@ package de.rki.coronawarnapp.qrcode.ui
 import android.net.Uri
 import de.rki.coronawarnapp.coronatest.qrcode.CoronaTestQRCode
 import de.rki.coronawarnapp.coronatest.type.CoronaTest
+import de.rki.coronawarnapp.coronatest.type.TestIdentifier
 import de.rki.coronawarnapp.covidcertificate.common.qrcode.DccQrCode
 import de.rki.coronawarnapp.covidcertificate.common.repository.CertificateContainerId
 import de.rki.coronawarnapp.presencetracing.checkins.qrcode.VerifiedTraceLocation
@@ -27,9 +28,13 @@ sealed class CheckInResult : ScannerResult {
 sealed class CoronaTestResult : ScannerResult {
     data class DuplicateTest(val coronaTestQrCode: CoronaTestQRCode) : CoronaTestResult()
     data class RestoreDuplicateTest(val restoreRecycledTestRequest: RestoreRecycledTestRequest) : CoronaTestResult()
-    data class TestResult(val coronaTest: CoronaTest) : CoronaTestResult()
     data class ConsentTest(val coronaTestQrCode: CoronaTestQRCode) : CoronaTestResult()
     data class InRecycleBin(val recycledCoronaTest: CoronaTest) : CoronaTestResult()
+    data class TestPositive(val test: CoronaTest) : CoronaTestResult()
+    data class TestNegative(val test: CoronaTest) : CoronaTestResult()
+    data class TestInvalid(val test: CoronaTest) : CoronaTestResult()
+    data class TestPending(val test: CoronaTest) : CoronaTestResult()
+    data class WarnOthers(val test: CoronaTest): CoronaTestResult()
 }
 
 data class Error(val error: Throwable) : ScannerResult

--- a/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
+++ b/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
@@ -904,6 +904,26 @@
             app:destination="@id/mainFragment"
             app:popUpTo="@id/mainFragment"
             app:popUpToInclusive="false" />
+        <action
+            android:id="@+id/action_universalScanner_to_submissionTestResultInvalidFragment"
+            app:destination="@id/submissionTestResultInvalidFragment"
+            app:popUpTo="@id/universalScanner"
+            app:popUpToInclusive="true" />
+        <action
+            android:id="@+id/action_universalScanner_to_submissionTestResultNegativeFragment"
+            app:destination="@id/submissionTestResultNegativeFragment"
+            app:popUpTo="@id/universalScanner"
+            app:popUpToInclusive="true" />
+        <action
+            android:id="@+id/action_universalScanner_to_submissionResultPositiveOtherWarningNoConsentFragment"
+            app:destination="@id/submissionResultPositiveOtherWarningNoConsentFragment"
+            app:popUpTo="@id/universalScanner"
+            app:popUpToInclusive="true" />
+        <action
+            android:id="@+id/action_universalScanner_to_submissionTestResultKeysSharedFragment"
+            app:destination="@id/submissionTestResultKeysSharedFragment"
+            app:popUpTo="@id/universalScanner"
+            app:popUpToInclusive="true" />
     </fragment>
 
     <action

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerViewModelTest.kt
@@ -17,6 +17,9 @@ import de.rki.coronawarnapp.qrcode.scanner.QrCodeValidator
 import de.rki.coronawarnapp.qrcode.scanner.UnsupportedQrCodeException
 import de.rki.coronawarnapp.qrcode.ui.CoronaTestResult.TestPending
 import de.rki.coronawarnapp.qrcode.ui.CoronaTestResult.TestNegative
+import de.rki.coronawarnapp.qrcode.ui.CoronaTestResult.TestInvalid
+import de.rki.coronawarnapp.qrcode.ui.CoronaTestResult.TestPositive
+import de.rki.coronawarnapp.qrcode.ui.CoronaTestResult.WarnOthers
 import de.rki.coronawarnapp.reyclebin.coronatest.RecycledCoronaTestsProvider
 import de.rki.coronawarnapp.reyclebin.covidcertificate.RecycledCertificatesProvider
 import de.rki.coronawarnapp.submission.SubmissionRepository
@@ -196,9 +199,7 @@ class QrCodeScannerViewModelTest : BaseTest() {
         val recycledCoronaTest = recycledPCR.copy(testResult = CoronaTestResult.PCR_OR_RAT_PENDING)
         viewModel().apply {
             restoreCoronaTest(recycledCoronaTest)
-            result.getOrAwaitValue() shouldBe TestPending(
-                recycledCoronaTest
-            )
+            result.getOrAwaitValue() shouldBe TestPending(recycledCoronaTest)
         }
         coVerify { recycledCoronaTestsProvider.restoreCoronaTest(any()) }
     }
@@ -221,9 +222,7 @@ class QrCodeScannerViewModelTest : BaseTest() {
         val recycledCoronaTest = recycledPCR.copy(testResult = CoronaTestResult.PCR_NEGATIVE)
         viewModel().apply {
             restoreCoronaTest(recycledCoronaTest)
-            result.getOrAwaitValue() shouldBe TestNegative(
-                recycledCoronaTest
-            )
+            result.getOrAwaitValue() shouldBe TestNegative(recycledCoronaTest)
         }
         coVerify { recycledCoronaTestsProvider.restoreCoronaTest(any()) }
     }
@@ -236,6 +235,91 @@ class QrCodeScannerViewModelTest : BaseTest() {
         viewModel().apply {
             restoreCoronaTest(recycledCoronaTest)
             result.getOrAwaitValue() shouldBe TestNegative(recycledCoronaTest)
+        }
+        coVerify { recycledCoronaTestsProvider.restoreCoronaTest(any()) }
+    }
+
+    @Test
+    fun `restoreCoronaTest PCR test is invalid`() {
+        every { submissionRepository.testForType(CoronaTest.Type.PCR) } returns flowOf(null)
+        val recycledCoronaTest = recycledPCR.copy(testResult = CoronaTestResult.PCR_INVALID)
+        viewModel().apply {
+            restoreCoronaTest(recycledCoronaTest)
+            result.getOrAwaitValue() shouldBe TestInvalid(recycledCoronaTest)
+        }
+        coVerify { recycledCoronaTestsProvider.restoreCoronaTest(any()) }
+    }
+
+    @Test
+    fun `restoreCoronaTest RAT test is invalid`() {
+        every { submissionRepository.testForType(CoronaTest.Type.RAPID_ANTIGEN) } returns flowOf(null)
+
+        val recycledCoronaTest = recycledRAT.copy(testResult = CoronaTestResult.RAT_INVALID)
+        viewModel().apply {
+            restoreCoronaTest(recycledCoronaTest)
+            result.getOrAwaitValue() shouldBe TestInvalid(recycledCoronaTest)
+        }
+        coVerify { recycledCoronaTestsProvider.restoreCoronaTest(any()) }
+    }
+
+    @Test
+    fun `restoreCoronaTest PCR test is positive - warn other consent given`() {
+        every { submissionRepository.testForType(CoronaTest.Type.PCR) } returns flowOf(null)
+        val recycledCoronaTest = recycledPCR.copy(
+            testResult = CoronaTestResult.PCR_POSITIVE,
+            isAdvancedConsentGiven = true
+        )
+
+        viewModel().apply {
+            restoreCoronaTest(recycledCoronaTest)
+            result.getOrAwaitValue() shouldBe TestPositive(recycledCoronaTest)
+        }
+        coVerify { recycledCoronaTestsProvider.restoreCoronaTest(any()) }
+    }
+
+    @Test
+    fun `restoreCoronaTest RAT test is positive - warn other consent given`() {
+        every { submissionRepository.testForType(CoronaTest.Type.RAPID_ANTIGEN) } returns flowOf(null)
+
+        val recycledCoronaTest = recycledRAT.copy(
+            testResult = CoronaTestResult.RAT_POSITIVE,
+            isAdvancedConsentGiven = true
+        )
+
+        viewModel().apply {
+            restoreCoronaTest(recycledCoronaTest)
+            result.getOrAwaitValue() shouldBe TestPositive(recycledCoronaTest)
+        }
+        coVerify { recycledCoronaTestsProvider.restoreCoronaTest(any()) }
+    }
+
+    @Test
+    fun `restoreCoronaTest PCR test is positive - warn other consent not given`() {
+        every { submissionRepository.testForType(CoronaTest.Type.PCR) } returns flowOf(null)
+        val recycledCoronaTest = recycledPCR.copy(
+            testResult = CoronaTestResult.PCR_POSITIVE,
+            isAdvancedConsentGiven = false
+        )
+
+        viewModel().apply {
+            restoreCoronaTest(recycledCoronaTest)
+            result.getOrAwaitValue() shouldBe WarnOthers(recycledCoronaTest)
+        }
+        coVerify { recycledCoronaTestsProvider.restoreCoronaTest(any()) }
+    }
+
+    @Test
+    fun `restoreCoronaTest RAT test is positive - warn other consent not given`() {
+        every { submissionRepository.testForType(CoronaTest.Type.RAPID_ANTIGEN) } returns flowOf(null)
+
+        val recycledCoronaTest = recycledRAT.copy(
+            testResult = CoronaTestResult.RAT_POSITIVE,
+            isAdvancedConsentGiven = false
+        )
+
+        viewModel().apply {
+            restoreCoronaTest(recycledCoronaTest)
+            result.getOrAwaitValue() shouldBe WarnOthers(recycledCoronaTest)
         }
         coVerify { recycledCoronaTestsProvider.restoreCoronaTest(any()) }
     }


### PR DESCRIPTION
This PR addresses [Exposureapp-10441](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10441).

**Overview:**
Restoring a test by rescanning a Test-QR-Code led to a wrong screenflow (if consent to share the result was not given)

**How to test:**

- Homescreen > Sie lassen sich testen? > QR Code scannen
- scan a RAT, DGC=FALSE, POSITIV, deny the OS-Consent (PCR also possible)
- on the Screen "Ihr Testergebnis liegt vor" remove the CWA consent
- press "weiter"
- on screen "Ihr Testergebnis - positive" press "abbrechen" and confirm the decision
- on the homescreen the RiskCard is gone and the positive test is visible
- press "Test entfernen" and confirm it
- now rescan the same QR code, confirm the restore
- check the following screens

**Expected result:**

- Screen "Andere warnen" 
- Screen Positive Testresult others have been warned

Screenshot (expected with this fix, after restoring):
![image](https://user-images.githubusercontent.com/46747780/141099458-62f35b22-59f0-4433-875a-1ec0bb5428fa.png)

at the end of the user flow you shall land on the MainScreen (which is showing your positive testresult)


**to do:**
- [x] test adjustment / fix