### PR TITLE
Fix: Recycled TAN after 30 days (EXPOSUREAPP-10495)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/CoronaTestRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/CoronaTestRepository.kt
@@ -208,8 +208,8 @@ class CoronaTestRepository @Inject constructor(
     suspend fun refresh(type: CoronaTest.Type? = null): Set<CoronaTest> {
         Timber.tag(TAG).d("refresh(type=%s)", type)
 
-        val toRefresh = internalData.data
-            .first().values
+        val toRefresh = coronaTests
+            .first()
             .filter { type == null || it.type == type }
             .map { it.identifier }
 


### PR DESCRIPTION
## Whats new
Fixed refresh method: now we use correct flow to get what needs to be removed (cheers to @mtwalli )

## Ticket
[Jira](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10495)

## How to test
1) Install the app
2) turn off Exposure Notifications
3) enter TAN
4) do not "Warn others"
5) delete the test
6) check test in Recycler Bin
7) go to main menu
8) time travel +31 days
9) go back to the application
10) Check there is no TAN error (screenshot in Jira)
11) Go back to present
12) open Contact Journal
13) check there is no entries with previously entered TAN