### PR TITLE
Added info box check for series completing vaccines over 14 days (EXPOSUREAPP-10538)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsFragmentTest.kt
@@ -295,7 +295,7 @@ class PersonDetailsFragmentTest : BaseUITest() {
             every { doseNumber } returns number
             every { totalSeriesOfDoses } returns if (booster) number else 2
             every { dateOfBirthFormatted } returns "1981-03-20"
-            every { isFinalShot } returns final
+            every { isSeriesCompletingShot } returns final
             every { qrCodeToDisplay } returns CoilQrCode(ScreenshotCertificateTestData.vaccinationCertificate)
             every { isValid } returns true
             every { getState() } returns CwaCovidCertificate.State.Valid(Instant.now().plus(20))

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragmentTest.kt
@@ -150,7 +150,7 @@ class VaccinationDetailsFragmentTest : BaseUITest() {
             every { hasNotificationBadge } returns false
             every { qrCodeToDisplay } returns CoilQrCode(ScreenshotCertificateTestData.vaccinationCertificate)
             every { fullNameFormatted } returns "Mustermann, Max"
-            every { isFinalShot } returns false
+            every { isSeriesCompletingShot } returns false
             every { isNotBlocked } returns true
         }
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensions.kt
@@ -98,7 +98,7 @@ private fun Collection<CwaCovidCertificate>.rule3FindRecentLastShot(
     }
     return this
         .filterIsInstance<VaccinationCertificate>()
-        .filter { it.isFinalShot }
+        .filter { it.isSeriesCompletingShot }
         .filter {
             with(it.rawCertificate.vaccination) {
                 when {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/items/VaccinationCertificateCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/items/VaccinationCertificateCard.kt
@@ -55,7 +55,7 @@ class VaccinationCertificateCard(parent: ViewGroup) :
             !certificate.isValid -> R.drawable.ic_certificate_invalid
 
             // Final shot
-            certificate.isFinalShot -> when (curItem.status) {
+            certificate.isSeriesCompletingShot -> when (curItem.status) {
                 IMMUNITY -> R.drawable.ic_vaccination_immune
                 else -> R.drawable.ic_vaccination_complete
             }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
@@ -84,20 +84,20 @@ data class VaccinatedPerson(
     fun getDaysUntilImmunity(nowUTC: Instant = Instant.now()): Int? {
         val newestFullDose = getNewestFullDose() ?: return null
         val today = nowUTC.toLocalDateUserTz()
-        return if (isSeriesCompletingOverTwoWeeks()) 0
+        return if (isSeriesCompletingOverTwoWeeks(nowUTC)) 0
         else IMMUNITY_WAITING_DAYS - Days.daysBetween(newestFullDose.vaccinatedOn, today).days
     }
 
     private fun getNewestDoseVaccinatedOn(): LocalDate =
         vaccinationCertificates.maxOf { it.vaccinatedOn }
 
-    private fun isSeriesCompletingOverTwoWeeks(): Boolean {
+    private fun isSeriesCompletingOverTwoWeeks(nowUTC: Instant = Instant.now()): Boolean {
         val certificate = vaccinationCertificates
-            .filter { it.isFinalShot }
+            .filter { it.isSeriesCompletingShot }
             .firstOrNull {
                 Days.daysBetween(
                     it.rawCertificate.vaccination.vaccinatedOn,
-                    Instant.now().toLocalDateUtc()
+                    nowUTC.toLocalDateUtc()
                 ).days > 14
             }
         return certificate != null

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
@@ -84,20 +84,20 @@ data class VaccinatedPerson(
     fun getDaysUntilImmunity(nowUTC: Instant = Instant.now()): Int? {
         val newestFullDose = getNewestFullDose() ?: return null
         val today = nowUTC.toLocalDateUserTz()
-        return if (isSeriesCompletingOverTwoWeeks(nowUTC)) 0
+        return if (isSeriesCompletingOverTwoWeeks(nowUTC.toLocalDateUtc())) 0
         else IMMUNITY_WAITING_DAYS - Days.daysBetween(newestFullDose.vaccinatedOn, today).days
     }
 
     private fun getNewestDoseVaccinatedOn(): LocalDate =
         vaccinationCertificates.maxOf { it.vaccinatedOn }
 
-    private fun isSeriesCompletingOverTwoWeeks(nowUTC: Instant = Instant.now()): Boolean {
+    private fun isSeriesCompletingOverTwoWeeks(today: LocalDate): Boolean {
         val certificate = vaccinationCertificates
             .filter { it.isSeriesCompletingShot }
             .firstOrNull {
                 Days.daysBetween(
                     it.rawCertificate.vaccination.vaccinatedOn,
-                    nowUTC.toLocalDateUtc()
+                    today
                 ).days > 14
             }
         return certificate != null

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
@@ -94,12 +94,7 @@ data class VaccinatedPerson(
     private fun isSeriesCompletingOverTwoWeeks(today: LocalDate): Boolean {
         val certificate = vaccinationCertificates
             .filter { it.isSeriesCompletingShot }
-            .firstOrNull {
-                Days.daysBetween(
-                    it.rawCertificate.vaccination.vaccinatedOn,
-                    today
-                ).days > 14
-            }
+            .firstOrNull { Days.daysBetween(it.rawCertificate.vaccination.vaccinatedOn, today).days > 14 }
         return certificate != null
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinationCertificate.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinationCertificate.kt
@@ -24,7 +24,7 @@ interface VaccinationCertificate : CwaCovidCertificate {
 
     override val rawCertificate: VaccinationDccV1
 
-    val isFinalShot get() = doseNumber == totalSeriesOfDoses
+    val isSeriesCompletingShot get() = doseNumber == totalSeriesOfDoses
 
     companion object {
         const val BIONTECH = "EU/1/20/1528"

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragment.kt
@@ -71,7 +71,7 @@ class VaccinationDetailsFragment : Fragment(R.layout.fragment_vaccination_detail
             viewModel.vaccinationCertificate.observe(viewLifecycleOwner) {
                 it.certificate?.let { certificate -> bindCertificateViews(certificate) }
                 val stateInValid = it.certificate?.isValid == false
-                val isFinalShot = it.certificate?.isFinalShot == true
+                val isFinalShot = it.certificate?.isSeriesCompletingShot == true
                 val (background, europaStars) = when {
                     stateInValid -> R.drawable.vaccination_incomplete to R.drawable.ic_eu_stars_grey
                     (it.isImmune && isFinalShot) ->

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensionsTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensionsTest.kt
@@ -125,7 +125,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
                 rawCertificate.vaccination.vaccinatedOn
             } returns time.minus(Duration.standardDays(25)).toLocalDateUtc()
             every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
-            every { isFinalShot } returns false
+            every { isSeriesCompletingShot } returns false
             every { getState() } returns mockk<State.Valid>()
         }
         // Vaccination certificate with dose 1/2 and < 14 days since administration
@@ -137,7 +137,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
                 rawCertificate.vaccination.vaccinatedOn
             } returns time.minus(Duration.standardDays(1)).toLocalDateUtc()
             every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
-            every { isFinalShot } returns false
+            every { isSeriesCompletingShot } returns false
             every { getState() } returns mockk<State.Valid>()
         }
         // Recovery certificate < 180 days old
@@ -158,7 +158,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
                 rawCertificate.vaccination.vaccinatedOn
             } returns time.minus(Duration.standardDays(1)).toLocalDateUtc()
             every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1525"
-            every { isFinalShot } returns true
+            every { isSeriesCompletingShot } returns true
             every { getState() } returns mockk<State.Valid>()
         }
         // Vaccination certificate of type J&J and > 14 days old
@@ -170,7 +170,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
                 rawCertificate.vaccination.vaccinatedOn
             } returns time.minus(Duration.standardDays(18)).toLocalDateUtc()
             every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1525"
-            every { isFinalShot } returns true
+            every { isSeriesCompletingShot } returns true
             every { getState() } returns mockk<State.Valid>()
         }
         // Vaccination certificate of type Pfizer/Moderna/AZ with dose 1/1 and < 14 days old
@@ -182,7 +182,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
                 rawCertificate.vaccination.vaccinatedOn
             } returns time.minus(Duration.standardDays(1)).toLocalDateUtc()
             every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
-            every { isFinalShot } returns true
+            every { isSeriesCompletingShot } returns true
             every { getState() } returns mockk<State.Valid>()
         }
         // Vaccination certificate of type Pfizer/Moderna/AZ with dose 2/2 < 14 days old
@@ -194,7 +194,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
                 rawCertificate.vaccination.vaccinatedOn
             } returns time.minus(Duration.standardDays(1)).toLocalDateUtc()
             every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
-            every { isFinalShot } returns true
+            every { isSeriesCompletingShot } returns true
             every { getState() } returns mockk<State.Valid>()
         }
         // Vaccination certificate of type Pfizer/Moderna/AZ with dose 2/2 and > 14 days old
@@ -206,7 +206,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
                 rawCertificate.vaccination.vaccinatedOn
             } returns time.minus(Duration.standardDays(16)).toLocalDateUtc()
             every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
-            every { isFinalShot } returns true
+            every { isSeriesCompletingShot } returns true
             every { getState() } returns mockk<State.Valid>()
         }
         // Vaccination certificate of type Pfizer/Moderna/AZ with dose 1/1 and > 14 days old
@@ -218,7 +218,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
                 rawCertificate.vaccination.vaccinatedOn
             } returns time.minus(Duration.standardDays(17)).toLocalDateUtc()
             every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
-            every { isFinalShot } returns true
+            every { isSeriesCompletingShot } returns true
             every { getState() } returns mockk<State.Valid>()
         }
         // Vaccination certificate of type Pfizer/Moderna/AZ with dose 3/3 < 14 days old
@@ -230,7 +230,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
                 rawCertificate.vaccination.vaccinatedOn
             } returns time.minus(Duration.standardDays(1)).toLocalDateUtc()
             every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
-            every { isFinalShot } returns true
+            every { isSeriesCompletingShot } returns true
             every { getState() } returns mockk<State.Valid>()
         }
         // Vaccination certificate of type Pfizer/Moderna/AZ with dose 3/3 < 14 days old issue at a different time
@@ -242,7 +242,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
                 rawCertificate.vaccination.vaccinatedOn
             } returns time.minus(Duration.standardDays(1)).toLocalDateUtc()
             every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
-            every { isFinalShot } returns true
+            every { isSeriesCompletingShot } returns true
             every { getState() } returns mockk<State.Valid>()
         }
         // RAT test < 24 hours old
@@ -357,7 +357,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
             every { rawCertificate.vaccination.totalSeriesOfDoses } returns 2
             every { rawCertificate.vaccination.vaccinatedOn } returns LocalDate.parse("2021-01-01")
             every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1507"
-            every { isFinalShot } returns true
+            every { isSeriesCompletingShot } returns true
             every { getState() } returns mockk<State.Expired>()
         }
 
@@ -367,7 +367,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
             every { rawCertificate.vaccination.totalSeriesOfDoses } returns 2
             every { rawCertificate.vaccination.vaccinatedOn } returns LocalDate.parse("2021-01-02")
             every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1507"
-            every { isFinalShot } returns true
+            every { isSeriesCompletingShot } returns true
             every { getState() } returns mockk<State.Expired>()
         }
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsViewModelTest.kt
@@ -208,7 +208,7 @@ class PersonDetailsViewModelTest : BaseTest() {
             every { medicalProductName } returns "EU/1/20/1528"
             every { doseNumber } returns number
             every { totalSeriesOfDoses } returns 2
-            every { isFinalShot } returns final
+            every { isSeriesCompletingShot } returns final
             every { isValid } returns true
             every { getState() } returns State.Valid(expiresAt = Instant.parse("2022-01-01T11:35:00.000Z"))
             every { qrCodeToDisplay } returns CoilQrCode("qrCode")

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPersonTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPersonTest.kt
@@ -177,7 +177,6 @@ class VaccinatedPersonTest : BaseTest() {
                             every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
                             every { rawCertificate.vaccination.vaccinatedOn } returns LocalDate.parse("2021-04-27")
                             every { isSeriesCompletingShot } returns true
-
                         }
                     every { containerId } returns VaccinationCertificateContainerId("VaccinationCertificateContainerId")
                     every { isNotRecycled } returns true
@@ -233,7 +232,6 @@ class VaccinatedPersonTest : BaseTest() {
                             every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
                             every { rawCertificate.vaccination.vaccinatedOn } returns LocalDate.parse("2021-06-13")
                             every { isSeriesCompletingShot } returns true
-
                         }
                     every { containerId } returns VaccinationCertificateContainerId("VaccinationCertificateContainerId")
                     every { isNotRecycled } returns true

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPersonTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPersonTest.kt
@@ -83,7 +83,22 @@ class VaccinatedPersonTest : BaseTest() {
             every { boosterRule } returns null
             every { lastSeenBoosterRuleIdentifier } returns null
             every { lastBoosterNotifiedAt } returns null
-            every { vaccinations } returns setOf(testData.personAVac1Container, testData.personAVac2Container)
+            every { vaccinations } returns setOf(
+                mockk<VaccinationContainer>().apply {
+                    every { toVaccinationCertificate(any(), any()) } returns
+                        mockk<VaccinationCertificate>().apply {
+                            every { vaccinatedOn } returns LocalDate.parse("2021-04-28")
+                            every { doseNumber } returns 2
+                            every { totalSeriesOfDoses } returns 2
+                            every { rawCertificate.vaccination.doseNumber } returns doseNumber
+                            every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
+                            every { rawCertificate.vaccination.vaccinatedOn } returns LocalDate.parse("2021-04-27")
+                            every { isSeriesCompletingShot } returns true
+                        }
+                    every { containerId } returns VaccinationCertificateContainerId("VaccinationCertificateContainerId")
+                    every { isNotRecycled } returns true
+                }
+            )
         }
         val vaccinatedPerson = VaccinatedPerson(
             data = personData,
@@ -98,9 +113,23 @@ class VaccinatedPersonTest : BaseTest() {
     @Test
     fun `vaccination status - IMMUNITY`() {
         // vaccinatedAt "2021-04-27"
-        val immunityContainer = testData.personAVac2Container
         val personData = mockk<VaccinatedPersonData>().apply {
-            every { vaccinations } returns setOf(testData.personAVac1Container, immunityContainer)
+            every { vaccinations } returns setOf(
+                mockk<VaccinationContainer>().apply {
+                    every { toVaccinationCertificate(any(), any()) } returns
+                        mockk<VaccinationCertificate>().apply {
+                            every { vaccinatedOn } returns LocalDate.parse("2021-04-28")
+                            every { doseNumber } returns 2
+                            every { totalSeriesOfDoses } returns 2
+                            every { rawCertificate.vaccination.doseNumber } returns doseNumber
+                            every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
+                            every { rawCertificate.vaccination.vaccinatedOn } returns LocalDate.parse("2021-04-27")
+                            every { isSeriesCompletingShot } returns true
+                        }
+                    every { containerId } returns VaccinationCertificateContainerId("VaccinationCertificateContainerId")
+                    every { isNotRecycled } returns true
+                }
+            )
             every { boosterRule } returns null
             every { lastSeenBoosterRuleIdentifier } returns null
             every { lastBoosterNotifiedAt } returns null
@@ -136,9 +165,24 @@ class VaccinatedPersonTest : BaseTest() {
     @Test
     fun `time until status IMMUNITY`() {
         // vaccinatedAt "2021-04-27"
-        val immunityContainer = testData.personAVac2Container
         val personData = mockk<VaccinatedPersonData>().apply {
-            every { vaccinations } returns setOf(testData.personAVac1Container, immunityContainer)
+            every { vaccinations } returns setOf(
+                mockk<VaccinationContainer>().apply {
+                    every { toVaccinationCertificate(any(), any()) } returns
+                        mockk<VaccinationCertificate>().apply {
+                            every { vaccinatedOn } returns LocalDate.parse("2021-04-27")
+                            every { doseNumber } returns 2
+                            every { totalSeriesOfDoses } returns 2
+                            every { rawCertificate.vaccination.doseNumber } returns doseNumber
+                            every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
+                            every { rawCertificate.vaccination.vaccinatedOn } returns LocalDate.parse("2021-04-27")
+                            every { isSeriesCompletingShot } returns true
+
+                        }
+                    every { containerId } returns VaccinationCertificateContainerId("VaccinationCertificateContainerId")
+                    every { isNotRecycled } returns true
+                }
+            )
             every { boosterRule } returns null
             every { lastSeenBoosterRuleIdentifier } returns null
             every { lastBoosterNotifiedAt } returns null
@@ -187,6 +231,9 @@ class VaccinatedPersonTest : BaseTest() {
                             every { totalSeriesOfDoses } returns 2
                             every { rawCertificate.vaccination.doseNumber } returns doseNumber
                             every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
+                            every { rawCertificate.vaccination.vaccinatedOn } returns LocalDate.parse("2021-06-13")
+                            every { isSeriesCompletingShot } returns true
+
                         }
                     every { containerId } returns VaccinationCertificateContainerId("VaccinationCertificateContainerId")
                     every { isNotRecycled } returns true
@@ -231,6 +278,8 @@ class VaccinatedPersonTest : BaseTest() {
                             every { totalSeriesOfDoses } returns 2
                             every { rawCertificate.vaccination.doseNumber } returns doseNumber
                             every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528"
+                            every { rawCertificate.vaccination.vaccinatedOn } returns LocalDate.parse("2021-01-01")
+                            every { isSeriesCompletingShot } returns true
                         }
 
                     every { containerId } returns VaccinationCertificateContainerId("VaccinationCertificateContainerId")
@@ -287,6 +336,8 @@ class VaccinatedPersonTest : BaseTest() {
                             every { totalSeriesOfDoses } returns 1
                             every { rawCertificate.vaccination.doseNumber } returns doseNumber
                             every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1528" // BIONTECH
+                            every { rawCertificate.vaccination.vaccinatedOn } returns LocalDate.parse("2021-01-01")
+                            every { isSeriesCompletingShot } returns true
                         }
 
                     every { containerId } returns VaccinationCertificateContainerId("VaccinationCertificateContainerId")
@@ -325,6 +376,8 @@ class VaccinatedPersonTest : BaseTest() {
                             every { totalSeriesOfDoses } returns 1
                             every { rawCertificate.vaccination.doseNumber } returns doseNumber
                             every { rawCertificate.vaccination.medicalProductId } returns "EU/1/20/1507" // MODERNA
+                            every { rawCertificate.vaccination.vaccinatedOn } returns LocalDate.parse("2021-01-01")
+                            every { isSeriesCompletingShot } returns true
                         }
 
                     every { containerId } returns VaccinationCertificateContainerId("VaccinationCertificateContainerId")
@@ -363,6 +416,8 @@ class VaccinatedPersonTest : BaseTest() {
                             every { totalSeriesOfDoses } returns 1
                             every { rawCertificate.vaccination.doseNumber } returns doseNumber
                             every { rawCertificate.vaccination.medicalProductId } returns "EU/1/21/1529" // ASTRA
+                            every { rawCertificate.vaccination.vaccinatedOn } returns LocalDate.parse("2021-01-01")
+                            every { isSeriesCompletingShot } returns true
                         }
 
                     every { containerId } returns VaccinationCertificateContainerId("VaccinationCertificateContainerId")


### PR DESCRIPTION
In cases where a new series completing vaccination is scanne and there's an existing series completing vaccination > 14 days, the vaccination info box should say that the vaccination protection is complete and no days counter is shown.

How to test:

1. Scan a J&J certificate > 14 days old:
`cwa vc gen --pii 42 -s v.0.dn=1 v.0.sd=1 v.0.mp='EU/1/20/1525' v.0.dt='2021-10-04' -e wru` -> info box says protection is complete, no days counter is shown.
2. Scan a Pfizer certificate < 14 days old: 
`cwa vc gen --pii 42 -s v.0.dn=2 v.0.sd=2 v.0.mp='EU/1/20/1528' v.0.dt='2021-11-04' -e wru` -> info box still says protection is complete, no days counter is shown.
3. Delete both certificates.
4. Scan a J&J certificate < 14 days old:
`cwa vc gen --pii 42 -s v.0.dn=1 v.0.sd=1 v.0.mp='EU/1/20/1525' v.0.dt='2021-11-04' -e wru` -> info box says you've received all planned vaccinations but the days counter is shown.
5. Scan a Pfizer certificate > 14 days old:
`cwa vc gen --pii 42 -s v.0.dn=2 v.0.sd=2 v.0.mp='EU/1/20/1528' v.0.dt='2021-10-04' -e wru` -> info box says protection is complete, no days counter is shown.