### PR TITLE
Statistics Turkish formatting issue (EXPOSUREAPP-10330)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/OccupiedIntensiveCareCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/OccupiedIntensiveCareCard.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.statistics.ui.homecards.cards
 
 import android.view.ViewGroup
+import androidx.core.os.ConfigurationCompat
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.HomeStatisticsCardsOccupiedIntensiveCareBedsBinding
 import de.rki.coronawarnapp.server.protocols.internal.stats.KeyFigureCardOuterClass
@@ -36,6 +37,8 @@ class OccupiedIntensiveCareCard(parent: ViewGroup) :
             item.onClickListener(item.stats)
         }
 
+        val currentSelectedLocale = ConfigurationCompat.getLocales(resources.configuration).get(0)
+
         with(item.stats as OccupiedIntensiveCareStats) {
             occupiedIntensiveCareContainer.contentDescription =
                 buildAccessibilityStringForOccupiedIntensiveCareCard(
@@ -44,7 +47,7 @@ class OccupiedIntensiveCareCard(parent: ViewGroup) :
                 )
 
             primaryLabel.text = getPrimaryLabel(context)
-            primaryValue.text = formatPercentageValue(occupationRatio.value)
+            primaryValue.text = formatPercentageValue(occupationRatio.value, currentSelectedLocale)
             primaryValue.contentDescription = StringBuilder()
                 .appendWithTrailingSpace(
                     context.getString(R.string.statistics_occupied_intensive_care_card_title)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/PersonsVaccinatedCompletelyCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/PersonsVaccinatedCompletelyCard.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.statistics.ui.homecards.cards
 
 import android.view.ViewGroup
+import androidx.core.os.ConfigurationCompat
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.HomeStatisticsCardsVaccinatedCompletelyLayoutBinding
 import de.rki.coronawarnapp.server.protocols.internal.stats.KeyFigureCardOuterClass
@@ -36,12 +37,14 @@ class PersonsVaccinatedCompletelyCard(parent: ViewGroup) :
             item.onClickListener(item.stats)
         }
 
+        val currentSelectedLocale = ConfigurationCompat.getLocales(resources.configuration).get(0)
+
         with(item.stats as PersonsVaccinatedCompletelyStats) {
             personsVaccinatedCompletelyContainer.contentDescription =
                 buildAccessibilityStringForPersonsVaccinatedCompletelyCard(item.stats, allDoses, total)
 
             primaryLabel.text = getPrimaryLabel(context)
-            primaryValue.text = formatPercentageValue(allDoses.value)
+            primaryValue.text = formatPercentageValue(allDoses.value, currentSelectedLocale)
             primaryValue.contentDescription = StringBuilder()
                 .appendWithTrailingSpace(getPrimaryLabel(context))
                 .appendWithTrailingSpace(formatStatisticalValue(context, allDoses.value, allDoses.decimals))

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/PersonsVaccinatedOnceCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/cards/PersonsVaccinatedOnceCard.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.statistics.ui.homecards.cards
 
 import android.view.ViewGroup
+import androidx.core.os.ConfigurationCompat
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.HomeStatisticsCardsVaccinatedOnceLayoutBinding
 import de.rki.coronawarnapp.server.protocols.internal.stats.KeyFigureCardOuterClass
@@ -37,12 +38,14 @@ class PersonsVaccinatedOnceCard(parent: ViewGroup) :
             item.onClickListener(item.stats)
         }
 
+        val currentSelectedLocale = ConfigurationCompat.getLocales(resources.configuration).get(0)
+
         with(item.stats as PersonsVaccinatedOnceStats) {
             personsVaccinatedOnceContainer.contentDescription =
                 buildAccessibilityStringForPersonsVaccinatedOnceCard(item.stats, firstDose, total)
 
             primaryLabel.text = getPrimaryLabel(context)
-            primaryValue.text = formatPercentageValue(firstDose.value)
+            primaryValue.text = formatPercentageValue(firstDose.value, currentSelectedLocale)
             primaryValue.contentDescription = StringBuilder()
                 .appendWithTrailingSpace(getPrimaryLabel(context))
                 .appendWithTrailingSpace(formatStatisticalValue(context, firstDose.value, firstDose.decimals))

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/util/StatisticsNumberValueFormatter.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/util/StatisticsNumberValueFormatter.kt
@@ -5,6 +5,7 @@ import de.rki.coronawarnapp.contactdiary.util.getLocale
 import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
 import java.text.NumberFormat
+import java.util.Locale
 
 fun formatStatisticalValue(
     context: Context,
@@ -27,6 +28,10 @@ fun formatStatisticalValue(
     }.format(value)
 }
 
-fun formatPercentageValue(value: Double): String = percentInstance.format(value)
+fun formatPercentageValue(value: Double, locale: Locale): String {
+    val percentInstance = getPercentInstance(locale)
+    return percentInstance.format(value)
+}
 
-private val percentInstance = NumberFormat.getPercentInstance().apply { minimumFractionDigits = 1 }
+private fun getPercentInstance(locale: Locale) =
+    NumberFormat.getPercentInstance(locale).apply { minimumFractionDigits = 1 }


### PR DESCRIPTION
When changing language to Turkish, the percentage values on the statistics cards used to have the percent symbol on the right side of the value. Only after closing the app completely, the percent symbol showed up on the left side of the value.

This PR updates the percent sybmol position at runtime and doesn't requqire the app to be restarted. 

How to test:

- Have your app set in German/English.
- Change system language to Turkish and go back to the app. 
- Scroll through the statistics tyles and check the percentage value on the ones that have it. It should show up on the left side right away. 

Ticket: https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10330