### PR TITLE
DccTicketing http logging (EXPOSUREAPP-10738)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/core/DccTicketingCoreModule.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/core/DccTicketingCoreModule.kt
@@ -31,7 +31,7 @@ class DccTicketingCoreModule {
 }
 
 // Dummy base url to satisfy Retrofit ¯\_(ツ)_/¯
-private const val BASE_URL = "http://localhost.de"
+private const val BASE_URL = "https://localhost.de"
 
 @Qualifier
 @MustBeDocumented

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/core/DccTicketingCoreModule.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/core/DccTicketingCoreModule.kt
@@ -3,7 +3,6 @@ package de.rki.coronawarnapp.dccticketing.core
 import dagger.Module
 import dagger.Provides
 import dagger.Reusable
-import de.rki.coronawarnapp.BuildConfig
 import de.rki.coronawarnapp.dccticketing.core.server.DccTicketingApiV1
 import de.rki.coronawarnapp.http.HttpErrorParser
 import de.rki.coronawarnapp.http.config.HTTPVariables

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/core/DccTicketingCoreModule.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/core/DccTicketingCoreModule.kt
@@ -3,24 +3,51 @@ package de.rki.coronawarnapp.dccticketing.core
 import dagger.Module
 import dagger.Provides
 import dagger.Reusable
+import de.rki.coronawarnapp.BuildConfig
 import de.rki.coronawarnapp.dccticketing.core.server.DccTicketingApiV1
-import de.rki.coronawarnapp.http.HttpClientDefault
+import de.rki.coronawarnapp.http.HttpErrorParser
+import de.rki.coronawarnapp.http.config.HTTPVariables
+import de.rki.coronawarnapp.http.interceptor.RetryInterceptor
+import de.rki.coronawarnapp.http.interceptor.WebSecurityVerificationInterceptor
+import de.rki.coronawarnapp.risk.TimeVariables
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import timber.log.Timber
+import java.util.concurrent.TimeUnit
 import javax.inject.Qualifier
 
 @Module
 class DccTicketingCoreModule {
 
-    @DccTicketing
+    @DccTicketingHttpClient
     @Provides
-    fun provideHttpClient(@HttpClientDefault client: OkHttpClient) = client
+    fun provideHttpClient(): OkHttpClient {
+        val interceptors: List<Interceptor> = listOf(
+            WebSecurityVerificationInterceptor(),
+            HttpLoggingInterceptor { message -> Timber.tag("OkHttp").v(message) }.apply {
+                setLevel(HttpLoggingInterceptor.Level.BODY)
+            },
+            RetryInterceptor(),
+            HttpErrorParser()
+        )
+
+        return OkHttpClient.Builder().apply {
+            connectTimeout(HTTPVariables.getHTTPConnectionTimeout(), TimeUnit.MILLISECONDS)
+            readTimeout(HTTPVariables.getHTTPReadTimeout(), TimeUnit.MILLISECONDS)
+            writeTimeout(HTTPVariables.getHTTPWriteTimeout(), TimeUnit.MILLISECONDS)
+            callTimeout(TimeVariables.getTransactionTimeout(), TimeUnit.MILLISECONDS)
+
+            interceptors.forEach { addInterceptor(it) }
+        }.build()
+    }
 
     @Reusable
     @Provides
     fun provideDccTicketingValidationApiV1(
-        @DccTicketing client: OkHttpClient,
+        @DccTicketingHttpClient client: OkHttpClient,
         gsonConverterFactory: GsonConverterFactory
     ): DccTicketingApiV1 = Retrofit.Builder()
         .client(client)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/core/DccTicketingCoreModule.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/core/DccTicketingCoreModule.kt
@@ -4,18 +4,10 @@ import dagger.Module
 import dagger.Provides
 import dagger.Reusable
 import de.rki.coronawarnapp.dccticketing.core.server.DccTicketingApiV1
-import de.rki.coronawarnapp.http.HttpErrorParser
-import de.rki.coronawarnapp.http.config.HTTPVariables
-import de.rki.coronawarnapp.http.interceptor.RetryInterceptor
-import de.rki.coronawarnapp.http.interceptor.WebSecurityVerificationInterceptor
-import de.rki.coronawarnapp.risk.TimeVariables
-import okhttp3.Interceptor
+import de.rki.coronawarnapp.http.build
 import okhttp3.OkHttpClient
-import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
-import timber.log.Timber
-import java.util.concurrent.TimeUnit
 import javax.inject.Qualifier
 
 @Module
@@ -23,25 +15,7 @@ class DccTicketingCoreModule {
 
     @DccTicketingHttpClient
     @Provides
-    fun provideHttpClient(): OkHttpClient {
-        val interceptors: List<Interceptor> = listOf(
-            WebSecurityVerificationInterceptor(),
-            HttpLoggingInterceptor { message -> Timber.tag("OkHttp").v(message) }.apply {
-                setLevel(HttpLoggingInterceptor.Level.BODY)
-            },
-            RetryInterceptor(),
-            HttpErrorParser()
-        )
-
-        return OkHttpClient.Builder().apply {
-            connectTimeout(HTTPVariables.getHTTPConnectionTimeout(), TimeUnit.MILLISECONDS)
-            readTimeout(HTTPVariables.getHTTPReadTimeout(), TimeUnit.MILLISECONDS)
-            writeTimeout(HTTPVariables.getHTTPWriteTimeout(), TimeUnit.MILLISECONDS)
-            callTimeout(TimeVariables.getTransactionTimeout(), TimeUnit.MILLISECONDS)
-
-            interceptors.forEach { addInterceptor(it) }
-        }.build()
-    }
+    fun provideHttpClient(): OkHttpClient = OkHttpClient.Builder().build(enableLogging = true)
 
     @Reusable
     @Provides

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/core/DccTicketingHttpClient.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/core/DccTicketingHttpClient.kt
@@ -1,0 +1,8 @@
+package de.rki.coronawarnapp.dccticketing.core
+
+import javax.inject.Qualifier
+
+@Qualifier
+@MustBeDocumented
+@Retention(AnnotationRetention.RUNTIME)
+annotation class DccTicketingHttpClient

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/http/HttpModule.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/http/HttpModule.kt
@@ -4,20 +4,12 @@ import dagger.Module
 import dagger.Provides
 import dagger.Reusable
 import de.rki.coronawarnapp.BuildConfig
-import de.rki.coronawarnapp.http.config.HTTPVariables
-import de.rki.coronawarnapp.http.interceptor.RetryInterceptor
-import de.rki.coronawarnapp.http.interceptor.WebSecurityVerificationInterceptor
-import de.rki.coronawarnapp.risk.TimeVariables
 import okhttp3.CipherSuite
 import okhttp3.ConnectionSpec
-import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.TlsVersion
-import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.converter.protobuf.ProtoConverterFactory
-import timber.log.Timber
-import java.util.concurrent.TimeUnit
 
 @Module
 class HttpModule {
@@ -25,25 +17,7 @@ class HttpModule {
     @Reusable
     @HttpClientDefault
     @Provides
-    fun defaultHttpClient(): OkHttpClient {
-        val interceptors: List<Interceptor> = listOf(
-            WebSecurityVerificationInterceptor(),
-            HttpLoggingInterceptor { message -> Timber.tag("OkHttp").v(message) }.apply {
-                if (BuildConfig.DEBUG) setLevel(HttpLoggingInterceptor.Level.BODY)
-            },
-            RetryInterceptor(),
-            HttpErrorParser()
-        )
-
-        return OkHttpClient.Builder().apply {
-            connectTimeout(HTTPVariables.getHTTPConnectionTimeout(), TimeUnit.MILLISECONDS)
-            readTimeout(HTTPVariables.getHTTPReadTimeout(), TimeUnit.MILLISECONDS)
-            writeTimeout(HTTPVariables.getHTTPWriteTimeout(), TimeUnit.MILLISECONDS)
-            callTimeout(TimeVariables.getTransactionTimeout(), TimeUnit.MILLISECONDS)
-
-            interceptors.forEach { addInterceptor(it) }
-        }.build()
-    }
+    fun defaultHttpClient(): OkHttpClient = OkHttpClient.Builder().build(BuildConfig.DEBUG)
 
     @Reusable
     @Provides

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/http/OkHttpClient.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/http/OkHttpClient.kt
@@ -1,0 +1,35 @@
+package de.rki.coronawarnapp.http
+
+import de.rki.coronawarnapp.http.config.HTTPVariables
+import de.rki.coronawarnapp.http.interceptor.RetryInterceptor
+import de.rki.coronawarnapp.http.interceptor.WebSecurityVerificationInterceptor
+import de.rki.coronawarnapp.risk.TimeVariables
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import timber.log.Timber
+import java.util.concurrent.TimeUnit
+
+/**
+ * Creates OkHttpClient and enables logging based on the flag
+ * @param enableLogging [Boolean]
+ */
+fun OkHttpClient.Builder.build(enableLogging: Boolean): OkHttpClient {
+    val interceptors: List<Interceptor> = listOf(
+        WebSecurityVerificationInterceptor(),
+        HttpLoggingInterceptor { message -> Timber.tag("OkHttp").v(message) }.apply {
+            if (enableLogging) setLevel(HttpLoggingInterceptor.Level.BODY)
+        },
+        RetryInterceptor(),
+        HttpErrorParser()
+    )
+
+    return apply {
+        connectTimeout(HTTPVariables.getHTTPConnectionTimeout(), TimeUnit.MILLISECONDS)
+        readTimeout(HTTPVariables.getHTTPReadTimeout(), TimeUnit.MILLISECONDS)
+        writeTimeout(HTTPVariables.getHTTPWriteTimeout(), TimeUnit.MILLISECONDS)
+        callTimeout(TimeVariables.getTransactionTimeout(), TimeUnit.MILLISECONDS)
+
+        interceptors.forEach { addInterceptor(it) }
+    }.build()
+}


### PR DESCRIPTION
- Check `DEBUG` and `PROD` that DCC Ticketing requests logs in error reporting 
such as 
```console 
2021-11-25T11:52:18.417Z V/OkHttp: --> GET https://dgca-booking-demo-eu-test.cfapps.eu10.hana.ondemand.com/api/identity
2021-11-25T11:52:18.417Z V/OkHttp: --> END GET
2021-11-25T11:52:18.716Z V/OkHttp: <-- 200 OK https://dgca-booking-demo-eu-test.cfapps.eu10.hana.ondemand.com/api/identity (298ms)
2021-11-25T11:52:18.716Z V/OkHttp: cache-control: no-cache
2021-11-25T11:52:18.716Z V/OkHttp: content-type: application/json
2021-11-25T11:52:18.716Z V/OkHttp: date: Thu, 25 Nov 2021 11:52:18 GMT
2021-11-25T11:52:18.716Z V/OkHttp: server: nginx/1.21.3
2021-11-25T11:52:18.716Z V/OkHttp: x-vcap-request-id: d618eeb1-b6be-4b5a-45b8-e702bee23d94
2021-11-25T11:52:18.717Z V/OkHttp: transfer-encoding: chunked
2021-11-25T11:52:18.717Z V/OkHttp: strict-transport-security: max-age=31536000; includeSubDomains; preload;
2021-11-25T11:52:18.719Z V/OkHttp: {"id":"https://dgca-booking-demo-eu-test.cfapps.eu10.hana.ondemand.com/api/identity","verificationMethod":[{"id":"https://dgca-booking-demo-eu-test.cfapps.eu10.hana.ondemand.com/api/identity/verificationMethod/JsonWebKey2020/AccessTokenSignKey-1","type":"JsonWebKey2020","controller":"https://dgca-booking-demo-eu-test.cfapps.eu10.hana.ondemand.com/api/
```

## Ticket
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10738