### PR TITLE
Provide allow list provider (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/core/allowlist/DccTicketingAllowListEntry.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/core/allowlist/DccTicketingAllowListEntry.kt
@@ -1,9 +1,12 @@
 package de.rki.coronawarnapp.dccticketing.core.allowlist
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 import okio.ByteString
 
+@Parcelize
 data class DccTicketingAllowListEntry(
     val serviceProvider: String, // A display name for the provider of the Validation Service
     val hostname: String, // The hostname of the Validation Service
     val fingerprint256: ByteString // The SHA-256 fingerprint of the certificate of the Validation Service
-)
+) : Parcelable

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/core/transaction/DccTicketingTransactionContext.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/core/transaction/DccTicketingTransactionContext.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.dccticketing.core.transaction
 
 import android.os.Parcelable
+import de.rki.coronawarnapp.dccticketing.core.allowlist.DccTicketingAllowListEntry
 import de.rki.coronawarnapp.dccticketing.core.qrcode.DccTicketingQrCodeData
 import kotlinx.parcelize.Parcelize
 import java.security.PrivateKey
@@ -30,4 +31,5 @@ data class DccTicketingTransactionContext(
     val signatureAlgorithm: String? = null,
     val resultToken: String? = null,
     val resultTokenPayload: DccTicketingResultToken? = null,
+    val allowlist: Set<DccTicketingAllowListEntry>? = null,
 ) : Parcelable

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/ui/consent/two/DccTicketingConsentTwoViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/ui/consent/two/DccTicketingConsentTwoViewModel.kt
@@ -94,7 +94,7 @@ class DccTicketingConsentTwoViewModel @AssistedInject constructor(
         val dccTicketingTransactionContext: DccTicketingTransactionContext,
         val certificate: CwaCovidCertificate
     ) {
-        val testPartner get() = "TBD (see allowlist PR)" // TODO: update after allowlist implementation
+        val testPartner get() = dccTicketingTransactionContext.allowlist?.first()?.serviceProvider
         val provider get() = dccTicketingTransactionContext.initializationData.serviceProvider
         val certificateItem get() = getCardItem(certificate)
 


### PR DESCRIPTION
Provide `allowlist` provider through `transactionContext`
See [specs](https://github.com/corona-warn-app/cwa-app-tech-spec/pull/126/commits/a2f350e39445099363b76d992310596f68b59027)