### PR TITLE
Ticket Validation - missing navigation (EXPOSUREAPP-10919)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/ui/consent/two/DccTicketingConsentTwoEvent.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/ui/consent/two/DccTicketingConsentTwoEvent.kt
@@ -10,3 +10,4 @@ data class ShowErrorDialog(val lazyErrorMessage: LazyString) : DccTicketingConse
 object NavigateToValidationResult : DccTicketingConsentTwoEvent()
 object NavigateToPrivacyInformation : DccTicketingConsentTwoEvent()
 object NavigateBack : DccTicketingConsentTwoEvent()
+object NavigateToHome : DccTicketingConsentTwoEvent()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/ui/consent/two/DccTicketingConsentTwoFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/ui/consent/two/DccTicketingConsentTwoFragment.kt
@@ -56,10 +56,10 @@ class DccTicketingConsentTwoFragment : Fragment(R.layout.fragment_dcc_ticketing_
     override fun onViewCreated(view: View, savedInstanceState: Bundle?): Unit = with(binding) {
         super.onViewCreated(view, savedInstanceState)
 
-        val onUserCancelAction = { viewModel.onUserCancel() }
+        val onBackAction = { viewModel.goBack() }
 
-        toolbar.setNavigationOnClickListener { onUserCancelAction() }
-        cancelButton.setOnClickListener { onUserCancelAction() }
+        toolbar.setNavigationOnClickListener { onBackAction() }
+        cancelButton.setOnClickListener { viewModel.showCancelConfirmationDialog() }
         agreeButton.setOnClickListener { viewModel.onUserConsent() }
 
         privacyInformation.setOnClickListener {
@@ -89,12 +89,13 @@ class DccTicketingConsentTwoFragment : Fragment(R.layout.fragment_dcc_ticketing_
             agreeButton.isLoading = it
         }
 
-        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) { onUserCancelAction() }
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) { onBackAction() }
     }
 
     private fun handleEvents(event: DccTicketingConsentTwoEvent) {
         Timber.d("handleEvents(event=%s)", event)
         when (event) {
+            NavigateToHome -> findNavController().navigate(R.id.action_dcc_ticketing_nav_graph_pop)
             NavigateBack -> popBackStack()
             NavigateToValidationResult -> doNavigate(
                 DccTicketingConsentTwoFragmentDirections.actionConsentTwoFragmentToValidationResultFragment()
@@ -109,7 +110,7 @@ class DccTicketingConsentTwoFragment : Fragment(R.layout.fragment_dcc_ticketing_
     private fun showCloseDialog() {
         DccTicketingDialogType.ConfirmCancelation.show(
             fragment = this,
-            negativeButtonAction = { viewModel.goBack() }
+            negativeButtonAction = { viewModel.cancel() }
         )
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/ui/consent/two/DccTicketingConsentTwoViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/ui/consent/two/DccTicketingConsentTwoViewModel.kt
@@ -52,12 +52,14 @@ class DccTicketingConsentTwoViewModel @AssistedInject constructor(
     }
     val uiState = uiStateFlow.asLiveData2()
 
-    fun onUserCancel() {
-        Timber.d("onUserCancel()")
+    fun showCancelConfirmationDialog() {
+        Timber.d("showCancelConfirmationDialog()")
         postEvent(ShowCancelConfirmationDialog)
     }
 
     fun goBack() = postEvent(NavigateBack)
+
+    fun cancel() = postEvent(NavigateToHome)
 
     fun showPrivacyInformation() = postEvent(NavigateToPrivacyInformation)
 

--- a/Corona-Warn-App/src/main/res/navigation/dcc_ticketing_nav_graph.xml
+++ b/Corona-Warn-App/src/main/res/navigation/dcc_ticketing_nav_graph.xml
@@ -29,9 +29,7 @@
         tools:layout="@layout/fragment_dcc_ticketing_certificate_selection">
         <action
             android:id="@+id/action_dccTicketingCertificateSelectionFragment_to_dccTicketingConsentTwoFragment"
-            app:destination="@id/dccTicketingConsentTwoFragment"
-            app:popUpTo="@id/dccTicketingCertificateSelectionFragment"
-            app:popUpToInclusive="true" />
+            app:destination="@id/dccTicketingConsentTwoFragment" />
     </fragment>
     <fragment
         android:id="@+id/dccTicketingConsentTwoFragment"
@@ -52,4 +50,8 @@
         android:name="de.rki.coronawarnapp.dccticketing.ui.validationresult.DccTicketingValidationResultFragment"
         android:label="fragment_dcc_ticketing_validation_result"
         tools:layout="@layout/fragment_dcc_ticketing_validation_result" />
+    <action
+        android:id="@+id/action_dcc_ticketing_nav_graph_pop"
+        app:popUpTo="@id/dcc_ticketing_nav_graph"
+        app:popUpToInclusive="true" />
 </navigation>


### PR DESCRIPTION
This PR addresses EXPOSUREAPP-10919.
Navigation Issue in Validation Flow.

**How to test:**
see ticket for details yet

_Preconditions:_
App installed, Onboarding done
certificates of ticket booking person scanned already

_Steps:_

- open the Universal scanner from Tab Bar
- scan a ticket booking 
- press "Einverstanden"
- choose a certificate 
- on screen Consent II/II go back to choose another certificate (via OS navigation or the <- in the Header)

_Expected result:_

back navigation to "Zertifikate auswählen" 

_before this change:_
- cancelation popup