### PR TITLE
Restrict number of persons (EXPOSUREAPP-10613)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/appconfig/CWAConfig.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/appconfig/CWAConfig.kt
@@ -16,5 +16,9 @@ interface CWAConfig {
 
     val validationServiceMinVersion: Int
 
+    val dccPersonWarnThreshold: Int
+
+    val dccPersonCountMax: Int
+
     interface Mapper : ConfigMapper<CWAConfig>
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/appconfig/mapping/CWAConfigMapper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/appconfig/mapping/CWAConfigMapper.kt
@@ -16,7 +16,9 @@ class CWAConfigMapper @Inject constructor() : CWAConfig.Mapper {
             supportedCountries = rawConfig.getMappedSupportedCountries(),
             isDeviceTimeCheckEnabled = !rawConfig.isDeviceTimeCheckDisabled(),
             isUnencryptedCheckInsEnabled = rawConfig.isUnencryptedCheckInsEnabled(),
-            validationServiceMinVersion = rawConfig.validationServiceMinVersionCode()
+            validationServiceMinVersion = rawConfig.validationServiceMinVersionCode(),
+            dccPersonCountMax = rawConfig.dccPersonCountMax(),
+            dccPersonWarnThreshold = rawConfig.dccPersonWarnThreshold(),
         )
     }
 
@@ -72,6 +74,32 @@ class CWAConfigMapper @Inject constructor() : CWAConfig.Mapper {
         }
     }
 
+    private fun ApplicationConfigurationAndroid.dccPersonWarnThreshold(): Int {
+        if (!hasAppFeatures()) return DCC_PERSON_WARN_THRESHOLD
+        return try {
+            (0 until appFeatures.appFeaturesCount)
+                .map { appFeatures.getAppFeatures(it) }
+                .firstOrNull { it.label == "dcc-person-warn-threshold" }?.value
+                ?: DCC_PERSON_WARN_THRESHOLD
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to find `dcc-person-warn-threshold` from %s", this)
+            DCC_PERSON_WARN_THRESHOLD
+        }
+    }
+
+    private fun ApplicationConfigurationAndroid.dccPersonCountMax(): Int {
+        if (!hasAppFeatures()) return DCC_PERSON_COUNT_MAX
+        return try {
+            (0 until appFeatures.appFeaturesCount)
+                .map { appFeatures.getAppFeatures(it) }
+                .firstOrNull { it.label == "dcc-person-count-max" }?.value
+                ?: DCC_PERSON_COUNT_MAX
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to find `dcc-person-count-max` from %s", this)
+            DCC_PERSON_COUNT_MAX
+        }
+    }
+
     data class CWAConfigContainer(
         override val latestVersionCode: Long,
         override val minVersionCode: Long,
@@ -79,10 +107,15 @@ class CWAConfigMapper @Inject constructor() : CWAConfig.Mapper {
         override val isDeviceTimeCheckEnabled: Boolean,
         override val isUnencryptedCheckInsEnabled: Boolean,
         override val validationServiceMinVersion: Int,
+        override val dccPersonWarnThreshold: Int,
+        override val dccPersonCountMax: Int,
     ) : CWAConfig
 
     companion object {
         private val VALID_CC = "^([A-Z]{2,3})$".toRegex()
         private const val DEFAULT_VALIDATION_SERVICE_MIN_VERSION = 0
+
+        private const val DCC_PERSON_WARN_THRESHOLD: Int = 10
+        private const val DCC_PERSON_COUNT_MAX: Int = 20
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/appconfig/mapping/CWAConfigMapper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/appconfig/mapping/CWAConfigMapper.kt
@@ -80,6 +80,7 @@ class CWAConfigMapper @Inject constructor() : CWAConfig.Mapper {
             (0 until appFeatures.appFeaturesCount)
                 .map { appFeatures.getAppFeatures(it) }
                 .firstOrNull { it.label == "dcc-person-warn-threshold" }?.value
+                ?.takeIf { it >= 0 }
                 ?: DCC_PERSON_WARN_THRESHOLD
         } catch (e: Exception) {
             Timber.e(e, "Failed to find `dcc-person-warn-threshold` from %s", this)
@@ -93,6 +94,7 @@ class CWAConfigMapper @Inject constructor() : CWAConfig.Mapper {
             (0 until appFeatures.appFeaturesCount)
                 .map { appFeatures.getAppFeatures(it) }
                 .firstOrNull { it.label == "dcc-person-count-max" }?.value
+                ?.takeIf { it >= 0 }
                 ?: DCC_PERSON_COUNT_MAX
         } catch (e: Exception) {
             Timber.e(e, "Failed to find `dcc-person-count-max` from %s", this)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/DccMaxPersonChecker.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/DccMaxPersonChecker.kt
@@ -1,0 +1,54 @@
+package de.rki.coronawarnapp.covidcertificate.common.certificate
+
+import de.rki.coronawarnapp.appconfig.AppConfigProvider
+import de.rki.coronawarnapp.covidcertificate.common.qrcode.DccQrCode
+import de.rki.coronawarnapp.covidcertificate.person.core.PersonCertificatesProvider
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+
+class DccMaxPersonChecker @Inject constructor(
+    private val personCertificatesProvider: PersonCertificatesProvider,
+    private val configProvider: AppConfigProvider
+) {
+
+    suspend fun checkForMaxPersons(dccQrCode: DccQrCode): Result {
+
+        val config = configProvider.currentConfig.first()
+
+        val threshold = config.dccPersonWarnThreshold
+        val max = config.dccPersonCountMax
+
+        val importedPersons = personCertificatesProvider.personCertificates.first()
+        val allIdentifiers = importedPersons.map {
+            it.personIdentifier
+        }.toSet()
+
+        val allIdentifiersWithNew = allIdentifiers.plus(
+            dccQrCode.personIdentifier
+        ).toSet()
+
+        // below threshold -> allow import
+        if (allIdentifiersWithNew.size <= threshold) return Result.PASSED
+
+        // not a new person -> allow import
+        if (allIdentifiers.size == allIdentifiersWithNew.size) return Result.PASSED
+
+        // adding the certificate results in exceeding max -> block import
+        if (allIdentifiersWithNew.size > max) {
+            return Result.EXCEEDS_MAX
+        }
+
+        // adding the certificate results in exceeding threshold -> allow import
+        if (allIdentifiersWithNew.size > threshold) {
+            return Result.EXCEEDS_THRESHOLD
+        }
+
+        return Result.PASSED
+    }
+
+    enum class Result {
+        PASSED,
+        EXCEEDS_THRESHOLD,
+        EXCEEDS_MAX
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerFragment.kt
@@ -286,6 +286,13 @@ class QrCodeScannerFragment : Fragment(R.layout.fragment_qrcode_scanner), AutoIn
                 )
             }
             is DccResult.InRecycleBin -> showRestoreDgcConfirmation(scannerResult.recycledContainerId)
+            DccResult.MaxPersonsBlock -> {
+                // TODO show block dialog
+            }
+            is DccResult.MaxPersonsWarning -> {
+                // TODO show warning dialog and on dismiss
+                //  findNavController().navigate(scannerResult.uri, navOptions)
+            }
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerFragment.kt
@@ -2,6 +2,7 @@ package de.rki.coronawarnapp.qrcode.ui
 
 import android.Manifest
 import android.graphics.Color
+import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import android.view.accessibility.AccessibilityEvent
@@ -32,6 +33,7 @@ import de.rki.coronawarnapp.ui.presencetracing.attendee.confirm.ConfirmCheckInFr
 import de.rki.coronawarnapp.ui.presencetracing.attendee.onboarding.CheckInOnboardingFragment
 import de.rki.coronawarnapp.util.ExternalActionHelper.openAppDetailsSettings
 import de.rki.coronawarnapp.util.ExternalActionHelper.openGooglePlay
+import de.rki.coronawarnapp.util.ExternalActionHelper.openUrl
 import de.rki.coronawarnapp.util.HumanReadableError
 import de.rki.coronawarnapp.util.di.AutoInject
 import de.rki.coronawarnapp.util.permission.CameraPermissionHelper
@@ -286,12 +288,11 @@ class QrCodeScannerFragment : Fragment(R.layout.fragment_qrcode_scanner), AutoIn
                 )
             }
             is DccResult.InRecycleBin -> showRestoreDgcConfirmation(scannerResult.recycledContainerId)
-            DccResult.MaxPersonsBlock -> {
-                // TODO show block dialog
+            is DccResult.MaxPersonsBlock -> {
+                showMaxPersonExceedsMaxResult(scannerResult.max)
             }
             is DccResult.MaxPersonsWarning -> {
-                // TODO show warning dialog and on dismiss
-                //  findNavController().navigate(scannerResult.uri, navOptions)
+                showMaxPersonExceedsThresholdResult(scannerResult.max, scannerResult.uri, navOptions)
             }
         }
     }
@@ -349,6 +350,40 @@ class QrCodeScannerFragment : Fragment(R.layout.fragment_qrcode_scanner), AutoIn
             .setPositiveButton(android.R.string.ok) { _, _ ->
                 viewModel.restoreCoronaTest(recycledCoronaTest)
             }
+            .show()
+    }
+
+    private fun showMaxPersonExceedsThresholdResult(max: Int, deeplink: Uri, navOptions: NavOptions) {
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.qr_code_error_max_person_threshold_title)
+            .setCancelable(false)
+            .setMessage(getString(R.string.qr_code_error_max_person_threshold_body, max))
+            .setOnDismissListener {
+                findNavController().navigate(deeplink, navOptions)
+            }
+            .setPositiveButton(R.string.qr_code_error_max_person_covpasscheck_button) { _, _ ->
+                openUrl(R.string.qr_code_error_max_person_covpasscheck_link)
+            }
+            .setNegativeButton(R.string.qr_code_error_max_person_faq_button) { _, _ ->
+                openUrl(R.string.qr_code_error_max_person_faq_link)
+            }
+            .setNeutralButton(android.R.string.ok) { _, _ -> }
+            .show()
+    }
+
+    private fun showMaxPersonExceedsMaxResult(max: Int) {
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(R.string.qr_code_error_max_person_max_title)
+            .setCancelable(false)
+            .setMessage(getString(R.string.qr_code_error_max_person_max_body, max))
+            .setOnDismissListener { popBackStack() }
+            .setPositiveButton(R.string.qr_code_error_max_person_covpasscheck_button) { _, _ ->
+                openUrl(R.string.qr_code_error_max_person_covpasscheck_link)
+            }
+            .setNegativeButton(R.string.qr_code_error_max_person_faq_button) { _, _ ->
+                openUrl(R.string.qr_code_error_max_person_faq_link)
+            }
+            .setNeutralButton(android.R.string.ok) { _, _ -> }
             .show()
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerViewModel.kt
@@ -158,17 +158,17 @@ class QrCodeScannerViewModel @AssistedInject constructor(
             }
             dccSettings.isOnboarded.value -> {
                 when (val checkerResult = dccMaxPersonChecker.checkForMaxPersons(dccQrCode)) {
-                    DccMaxPersonChecker.Result.PASSED -> {
+                    DccMaxPersonChecker.Result.Passed -> {
                         val containerId = dccHandler.handleQrCode(dccQrCode = dccQrCode)
                         Timber.tag(TAG).d("containerId=$containerId,checkerResult=$checkerResult")
                         containerId.toDccDetails()
                     }
-                    DccMaxPersonChecker.Result.EXCEEDS_THRESHOLD -> {
+                    is DccMaxPersonChecker.Result.ExceedsThreshold -> {
                         val containerId = dccHandler.handleQrCode(dccQrCode = dccQrCode)
                         Timber.tag(TAG).d("containerId=$containerId,checkerResult=$checkerResult")
                         containerId.toMaxPersonsWarning()
                     }
-                    DccMaxPersonChecker.Result.EXCEEDS_MAX -> {
+                    is DccMaxPersonChecker.Result.ExceedsMax -> {
                         Timber.tag(TAG).w("Importing new certificate is blocked")
                         DccResult.MaxPersonsBlock
                     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerViewModel.kt
@@ -160,17 +160,17 @@ class QrCodeScannerViewModel @AssistedInject constructor(
                 when (val checkerResult = dccMaxPersonChecker.checkForMaxPersons(dccQrCode)) {
                     DccMaxPersonChecker.Result.Passed -> {
                         val containerId = dccHandler.handleQrCode(dccQrCode = dccQrCode)
-                        Timber.tag(TAG).d("containerId=$containerId,checkerResult=$checkerResult")
+                        Timber.tag(TAG).d("containerId=%s,checkerResult=%s", containerId, checkerResult)
                         containerId.toDccDetails()
                     }
                     is DccMaxPersonChecker.Result.ExceedsThreshold -> {
                         val containerId = dccHandler.handleQrCode(dccQrCode = dccQrCode)
-                        Timber.tag(TAG).d("containerId=$containerId,checkerResult=$checkerResult")
-                        containerId.toMaxPersonsWarning()
+                        Timber.tag(TAG).d("containerId=%s,checkerResult=%s", containerId, checkerResult)
+                        containerId.toMaxPersonsWarning(checkerResult.max)
                     }
                     is DccMaxPersonChecker.Result.ExceedsMax -> {
                         Timber.tag(TAG).w("Importing new certificate is blocked")
-                        DccResult.MaxPersonsBlock
+                        DccResult.MaxPersonsBlock(checkerResult.max)
                     }
                 }
             }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerViewModel.kt
@@ -147,6 +147,7 @@ class QrCodeScannerViewModel @AssistedInject constructor(
 
     private suspend fun onDccQrCode(dccQrCode: DccQrCode) {
         Timber.tag(TAG).d("onDccQrCode()")
+        // TODO: Check number of persons
         val recycledContainerId = recycledCertificatesProvider.findCertificate(dccQrCode.qrCode)
         val event = when {
             recycledContainerId != null -> {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerViewModel.kt
@@ -5,6 +5,7 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import de.rki.coronawarnapp.coronatest.qrcode.CoronaTestQRCode
 import de.rki.coronawarnapp.coronatest.type.CoronaTest
+import de.rki.coronawarnapp.covidcertificate.common.certificate.DccMaxPersonChecker
 import de.rki.coronawarnapp.covidcertificate.common.qrcode.DccQrCode
 import de.rki.coronawarnapp.covidcertificate.common.repository.CertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.CovidCertificateSettings
@@ -47,6 +48,7 @@ class QrCodeScannerViewModel @AssistedInject constructor(
     private val traceLocationSettings: TraceLocationSettings,
     private val recycledCertificatesProvider: RecycledCertificatesProvider,
     private val recycledCoronaTestsProvider: RecycledCoronaTestsProvider,
+    private val dccMaxPersonChecker: DccMaxPersonChecker
 ) : CWAViewModel(dispatcherProvider) {
 
     val result = SingleLiveEvent<ScannerResult>()
@@ -147,8 +149,18 @@ class QrCodeScannerViewModel @AssistedInject constructor(
 
     private suspend fun onDccQrCode(dccQrCode: DccQrCode) {
         Timber.tag(TAG).d("onDccQrCode()")
-        // TODO: Check number of persons
+
         val recycledContainerId = recycledCertificatesProvider.findCertificate(dccQrCode.qrCode)
+
+        when (dccMaxPersonChecker.checkForMaxPersons(dccQrCode)) {
+            DccMaxPersonChecker.Result.PASSED -> { /*continue*/
+            }
+            DccMaxPersonChecker.Result.EXCEEDS_THRESHOLD -> { /* TODO*/
+            }
+            DccMaxPersonChecker.Result.EXCEEDS_MAX -> { /*TODO*/
+            }
+        }
+
         val event = when {
             recycledContainerId != null -> {
                 Timber.tag(TAG).d("recycledContainerId=$recycledContainerId")

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/ScannerExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/ScannerExtensions.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.qrcode.ui
 
 import android.content.Context
+import android.net.Uri
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.bugreporting.ui.toErrorDialogBuilder
@@ -44,13 +45,13 @@ fun Throwable.toQrCodeErrorDialogBuilder(context: Context): MaterialAlertDialogB
     }
 }
 
-fun CertificateContainerId.toDccDetails(): DccResult {
-    val uri = when (this) {
-        is RecoveryCertificateContainerId -> RecoveryCertificateDetailsFragment.uri(identifier)
-        is TestCertificateContainerId -> TestCertificateDetailsFragment.uri(identifier)
-        is VaccinationCertificateContainerId -> VaccinationDetailsFragment.uri(identifier)
-    }
-    return DccResult.Details(uri)
+fun CertificateContainerId.toDccDetails(): DccResult = DccResult.Details(uri())
+fun CertificateContainerId.toMaxPersonsWarning(): DccResult = DccResult.MaxPersonsWarning(uri())
+
+private fun CertificateContainerId.uri(): Uri = when (this) {
+    is RecoveryCertificateContainerId -> RecoveryCertificateDetailsFragment.uri(identifier)
+    is TestCertificateContainerId -> TestCertificateDetailsFragment.uri(identifier)
+    is VaccinationCertificateContainerId -> VaccinationDetailsFragment.uri(identifier)
 }
 
 fun CheckInQrCodeHandler.Result.toCheckInResult(requireOnboarding: Boolean): CheckInResult = when (this) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/ScannerExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/ScannerExtensions.kt
@@ -46,7 +46,7 @@ fun Throwable.toQrCodeErrorDialogBuilder(context: Context): MaterialAlertDialogB
 }
 
 fun CertificateContainerId.toDccDetails(): DccResult = DccResult.Details(uri())
-fun CertificateContainerId.toMaxPersonsWarning(): DccResult = DccResult.MaxPersonsWarning(uri())
+fun CertificateContainerId.toMaxPersonsWarning(max: Int): DccResult = DccResult.MaxPersonsWarning(uri(), max)
 
 private fun CertificateContainerId.uri(): Uri = when (this) {
     is RecoveryCertificateContainerId -> RecoveryCertificateDetailsFragment.uri(identifier)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/ScannerResult.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/ScannerResult.kt
@@ -23,6 +23,8 @@ sealed class DccResult : ScannerResult {
     data class Details(val uri: Uri) : DccResult()
     data class Onboarding(val dccQrCode: DccQrCode) : DccResult()
     data class InRecycleBin(val recycledContainerId: CertificateContainerId) : DccResult()
+    data class MaxPersonsWarning(val uri: Uri) : DccResult()
+    object MaxPersonsBlock : DccResult()
 }
 
 sealed class CheckInResult : ScannerResult {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/ScannerResult.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/ScannerResult.kt
@@ -23,8 +23,8 @@ sealed class DccResult : ScannerResult {
     data class Details(val uri: Uri) : DccResult()
     data class Onboarding(val dccQrCode: DccQrCode) : DccResult()
     data class InRecycleBin(val recycledContainerId: CertificateContainerId) : DccResult()
-    data class MaxPersonsWarning(val uri: Uri) : DccResult()
-    object MaxPersonsBlock : DccResult()
+    data class MaxPersonsWarning(val uri: Uri, val max: Int) : DccResult()
+    data class MaxPersonsBlock(val max: Int) : DccResult()
 }
 
 sealed class CheckInResult : ScannerResult {

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -947,6 +947,22 @@ Sollten Sie den Test in der App gelöscht haben, können Sie ihn aus dem Papierk
     <string name="qr_code_no_suitable_qr_code_title">Kein geeigneter QR-Code</string>
     <!-- XTXT: QR Code error message title  -->
     <string name="qr_code_no_suitable_qr_code_body">Der QR-Code wird nicht von der Corona-Warn-App unterstützt. Bitte wählen Sie einen geeigneten QR-Code.</string>
+    <!-- XTXT: QR Code error message: halfway title (10+ people already scanned)  -->
+    <string name="qr_code_error_max_person_threshold_title">"Warnung"</string>
+    <!-- XTXT: QR Code error message: halfway body (10+ people already scanned)  -->
+    <string name="qr_code_error_max_person_threshold_body">"Die Corona-Warn-App darf nicht zur Zertifikatsprüfung durch Dritte verwendet werden. Nutzen Sie dafür die CovPassCheck-App.\n\nSie können maximal für %d Personen Zertifikate hinzufügen. Danach können Sie keine neuen Zertifikate mehr für weitere Personen einscannen.\n\nWeitere Informationen zum Impfzertifikat finden Sie in den FAQ."</string>
+    <!-- XTXT: QR Code error message: halfway title (10+ people already scanned)  -->
+    <string name="qr_code_error_max_person_max_title">"Fehler"</string>
+    <!-- XTXT: QR Code error message: halfway body (10+ people already scanned)  -->
+    <string name="qr_code_error_max_person_max_body">"Die Corona-Warn-App darf nicht zur Zertifikatsprüfung durch Dritte verwendet werden. Nutzen Sie dafür die CovPassCheck-App.\n\nSie können maximal für %d Personen Zertifikate hinzufügen. Sie können keine neuen Zertifikate mehr für weitere Personen einscannen.\n\nWeitere Informationen zum Impfzertifikat finden Sie in den FAQ."</string>
+    <!-- XBUT: QR Code error message: covpasscheck app button  -->
+    <string name="qr_code_error_max_person_covpasscheck_button">"Download CovPassCheck"</string>
+    <!-- XTXT: QR Code error message: covpasscheck app link  -->
+    <string name="qr_code_error_max_person_covpasscheck_link">"https://play.google.com/store/apps/details?id=de.rki.covpass.checkapp"</string>
+    <!-- XBUT: QR Code error message: FAQ button  -->
+    <string name="qr_code_error_max_person_faq_button">"FAQ zur Zertifikatsprüfung"</string>
+    <!-- XTXT: QR Code error message: FAQ link  -->
+    <string name="qr_code_error_max_person_faq_link">"https://www.coronawarn.app/de/faq/#eu_dcc_check"</string>
 
     <!-- QR Code Info Screen -->
     <!-- XHED: Title for info screen -->

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -950,6 +950,22 @@
     <string name="qr_code_no_suitable_qr_code_title">"No Suitable QR Code"</string>
     <!-- XTXT: QR Code error message title  -->
     <string name="qr_code_no_suitable_qr_code_body">"The QR code is not supported by the Corona-Warn-App. Please select a suitable QR code."</string>
+    <!-- XTXT: QR Code error message: halfway title (10+ people already scanned)  -->
+    <string name="qr_code_error_max_person_threshold_title">"Warnung"</string>
+    <!-- XTXT: QR Code error message: halfway body (10+ people already scanned)  -->
+    <string name="qr_code_error_max_person_threshold_body">"Die Corona-Warn-App darf nicht zur Zertifikatsprüfung durch Dritte verwendet werden. Nutzen Sie dafür die CovPassCheck-App.\n\nSie können maximal für %d Personen Zertifikate hinzufügen. Danach können Sie keine neuen Zertifikate mehr für weitere Personen einscannen.\n\nWeitere Informationen zum Impfzertifikat finden Sie in den FAQ."</string>
+    <!-- XTXT: QR Code error message: halfway title (10+ people already scanned)  -->
+    <string name="qr_code_error_max_person_max_title">"Fehler"</string>
+    <!-- XTXT: QR Code error message: halfway body (10+ people already scanned)  -->
+    <string name="qr_code_error_max_person_max_body">"Die Corona-Warn-App darf nicht zur Zertifikatsprüfung durch Dritte verwendet werden. Nutzen Sie dafür die CovPassCheck-App.\n\nSie können maximal für %d Personen Zertifikate hinzufügen. Sie können keine neuen Zertifikate mehr für weitere Personen einscannen.\n\nWeitere Informationen zum Impfzertifikat finden Sie in den FAQ."</string>
+    <!-- XBUT: QR Code error message: covpasscheck app button  -->
+    <string name="qr_code_error_max_person_covpasscheck_button">"Download CovPassCheck"</string>
+    <!-- XTXT: QR Code error message: covpasscheck app link  -->
+    <string name="qr_code_error_max_person_covpasscheck_link">"https://play.google.com/store/apps/details?id=de.rki.covpass.checkapp"</string>
+    <!-- XBUT: QR Code error message: FAQ button  -->
+    <string name="qr_code_error_max_person_faq_button">"FAQ zur Zertifikatsprüfung"</string>
+    <!-- XTXT: QR Code error message: FAQ link  -->
+    <string name="qr_code_error_max_person_faq_link">"https://www.coronawarn.app/en/faq/#eu_dcc_check"</string>
 
     <!-- QR Code Info Screen -->
     <!-- XHED: Title for info screen -->

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/appconfig/mapping/CWAConfigMapperTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/appconfig/mapping/CWAConfigMapperTest.kt
@@ -149,6 +149,26 @@ class CWAConfigMapperTest : BaseTest() {
     }
 
     @Test
+    fun `feature, dcc-person-warn-threshold - negative`() {
+        val rawConfig = ApplicationConfigurationAndroid.newBuilder()
+            .setAppFeatures(
+                AppFeatures.newBuilder().apply {
+                    addAppFeatures(
+                        AppFeature.newBuilder().apply {
+                            label = "dcc-person-warn-threshold"
+                            value = -1
+                        }.build()
+                    )
+                }
+            )
+            .build()
+        createInstance().map(rawConfig).apply {
+            dccPersonCountMax shouldBe 20
+            dccPersonWarnThreshold shouldBe 10
+        }
+    }
+
+    @Test
     fun `feature, dcc-person-count-max`() {
         val rawConfig = ApplicationConfigurationAndroid.newBuilder()
             .setAppFeatures(
@@ -164,6 +184,26 @@ class CWAConfigMapperTest : BaseTest() {
             .build()
         createInstance().map(rawConfig).apply {
             dccPersonCountMax shouldBe 30
+            dccPersonWarnThreshold shouldBe 10
+        }
+    }
+
+    @Test
+    fun `feature, dcc-person-count-max - negative`() {
+        val rawConfig = ApplicationConfigurationAndroid.newBuilder()
+            .setAppFeatures(
+                AppFeatures.newBuilder().apply {
+                    addAppFeatures(
+                        AppFeature.newBuilder().apply {
+                            label = "dcc-person-count-max"
+                            value = -1
+                        }.build()
+                    )
+                }
+            )
+            .build()
+        createInstance().map(rawConfig).apply {
+            dccPersonCountMax shouldBe 20
             dccPersonWarnThreshold shouldBe 10
         }
     }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/appconfig/mapping/CWAConfigMapperTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/appconfig/mapping/CWAConfigMapperTest.kt
@@ -129,6 +129,74 @@ class CWAConfigMapperTest : BaseTest() {
     }
 
     @Test
+    fun `feature, dcc-person-warn-threshold`() {
+        val rawConfig = ApplicationConfigurationAndroid.newBuilder()
+            .setAppFeatures(
+                AppFeatures.newBuilder().apply {
+                    addAppFeatures(
+                        AppFeature.newBuilder().apply {
+                            label = "dcc-person-warn-threshold"
+                            value = 3
+                        }.build()
+                    )
+                }
+            )
+            .build()
+        createInstance().map(rawConfig).apply {
+            dccPersonCountMax shouldBe 20
+            dccPersonWarnThreshold shouldBe 3
+        }
+    }
+
+    @Test
+    fun `feature, dcc-person-count-max`() {
+        val rawConfig = ApplicationConfigurationAndroid.newBuilder()
+            .setAppFeatures(
+                AppFeatures.newBuilder().apply {
+                    addAppFeatures(
+                        AppFeature.newBuilder().apply {
+                            label = "dcc-person-count-max"
+                            value = 30
+                        }.build()
+                    )
+                }
+            )
+            .build()
+        createInstance().map(rawConfig).apply {
+            dccPersonCountMax shouldBe 30
+            dccPersonWarnThreshold shouldBe 10
+        }
+    }
+
+    @Test
+    fun `feature, validation-service-android-min-version-code defaults to 0`() {
+        val rawConfig = ApplicationConfigurationAndroid.newBuilder()
+            .build()
+        createInstance().map(rawConfig).apply {
+            validationServiceMinVersion shouldBe 0
+        }
+    }
+
+    @Test
+    fun `feature, validation-service-android-min-version-code`() {
+        val rawConfig = ApplicationConfigurationAndroid.newBuilder()
+            .setAppFeatures(
+                AppFeatures.newBuilder().apply {
+                    addAppFeatures(
+                        AppFeature.newBuilder().apply {
+                            label = "validation-service-android-min-version-code"
+                            value = 3_00_000
+                        }.build()
+                    )
+                }
+            )
+            .build()
+        createInstance().map(rawConfig).apply {
+            validationServiceMinVersion shouldBe 3_00_000
+        }
+    }
+
+    @Test
     fun `feature, unencrypted checkins disabled`() {
         val rawConfig = ApplicationConfigurationAndroid.newBuilder()
             .setAppFeatures(

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/common/certificate/DccMaxPersonCheckerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/common/certificate/DccMaxPersonCheckerTest.kt
@@ -1,0 +1,126 @@
+package de.rki.coronawarnapp.covidcertificate.common.certificate
+
+import de.rki.coronawarnapp.appconfig.AppConfigProvider
+import de.rki.coronawarnapp.appconfig.ConfigData
+import de.rki.coronawarnapp.covidcertificate.person.core.PersonCertificates
+import de.rki.coronawarnapp.covidcertificate.person.core.PersonCertificatesProvider
+import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinationCertificate
+import de.rki.coronawarnapp.covidcertificate.vaccination.core.qrcode.VaccinationCertificateQRCode
+import io.kotest.matchers.shouldBe
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class DccMaxPersonCheckerTest : BaseTest() {
+
+    @MockK lateinit var personCertificatesProvider: PersonCertificatesProvider
+    @MockK lateinit var configProvider: AppConfigProvider
+    @MockK lateinit var configData: ConfigData
+    @MockK lateinit var qrCode: VaccinationCertificateQRCode
+
+    val existingIdentifier = CertificatePersonIdentifier(
+        dateOfBirthFormatted = "1980-10-10",
+        firstNameStandardized = "firstNameStandardized",
+        lastNameStandardized = "lastNameStandardized"
+    )
+
+    val existingIdentifier2 = CertificatePersonIdentifier(
+        dateOfBirthFormatted = "1980-10-10",
+        firstNameStandardized = "firstNameStandardized2",
+        lastNameStandardized = "lastNameStandardized2"
+    )
+
+    val newIdentifier = CertificatePersonIdentifier(
+        dateOfBirthFormatted = "1990-10-10",
+        firstNameStandardized = "firstNameStandardized1",
+        lastNameStandardized = "lastNameStandardized1"
+    )
+
+    val vaccinationCertificate = mockk<VaccinationCertificate>().apply {
+        every { personIdentifier } returns existingIdentifier
+    }
+    val personCertificate = PersonCertificates(certificates = listOf(vaccinationCertificate))
+
+    val vaccinationCertificate2 = mockk<VaccinationCertificate>().apply {
+        every { personIdentifier } returns existingIdentifier2
+    }
+    val personCertificate2 = PersonCertificates(certificates = listOf(vaccinationCertificate2))
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this)
+        every { personCertificatesProvider.personCertificates } returns flowOf(
+            setOf(
+                personCertificate,
+                personCertificate2
+            )
+        )
+    }
+
+    @Test
+    fun `happy path below threshold results in PASSED`() = runBlockingTest {
+        every { configData.dccPersonWarnThreshold } returns 3
+        every { configData.dccPersonCountMax } returns 4
+        coEvery { configProvider.currentConfig } returns flowOf(configData)
+        every { qrCode.personIdentifier } returns newIdentifier
+        createInstance().checkForMaxPersons(
+            qrCode
+        ) shouldBe DccMaxPersonChecker.Result.PASSED
+    }
+
+    @Test
+    fun `new person exceeds threshold results in EXCEEDS_THRESHOLD`() = runBlockingTest {
+        every { configData.dccPersonWarnThreshold } returns 1
+        every { configData.dccPersonCountMax } returns 3
+        coEvery { configProvider.currentConfig } returns flowOf(configData)
+        every { qrCode.personIdentifier } returns newIdentifier
+        createInstance().checkForMaxPersons(
+            qrCode
+        ) shouldBe DccMaxPersonChecker.Result.EXCEEDS_THRESHOLD
+    }
+
+    @Test
+    fun `exceeds threshold but not a new person results in PASSED`() = runBlockingTest {
+        every { configData.dccPersonWarnThreshold } returns 1
+        every { configData.dccPersonCountMax } returns 3
+        coEvery { configProvider.currentConfig } returns flowOf(configData)
+        every { qrCode.personIdentifier } returns existingIdentifier
+        createInstance().checkForMaxPersons(
+            qrCode
+        ) shouldBe DccMaxPersonChecker.Result.PASSED
+    }
+
+    @Test
+    fun `new person exceeds max results in EXCEEDS_MAX`() = runBlockingTest {
+        every { configData.dccPersonWarnThreshold } returns 1
+        every { configData.dccPersonCountMax } returns 2
+        coEvery { configProvider.currentConfig } returns flowOf(configData)
+        every { qrCode.personIdentifier } returns newIdentifier
+        createInstance().checkForMaxPersons(
+            qrCode
+        ) shouldBe DccMaxPersonChecker.Result.EXCEEDS_MAX
+    }
+
+    @Test
+    fun `exceeds max but not a new person results in PASSED`() = runBlockingTest {
+        every { configData.dccPersonWarnThreshold } returns 1
+        every { configData.dccPersonCountMax } returns 1
+        coEvery { configProvider.currentConfig } returns flowOf(configData)
+        every { qrCode.personIdentifier } returns existingIdentifier
+        createInstance().checkForMaxPersons(
+            qrCode
+        ) shouldBe DccMaxPersonChecker.Result.PASSED
+    }
+
+    private fun createInstance() = DccMaxPersonChecker(
+        personCertificatesProvider,
+        configProvider
+    )
+}

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/common/certificate/DccMaxPersonCheckerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/common/certificate/DccMaxPersonCheckerTest.kt
@@ -25,33 +25,33 @@ class DccMaxPersonCheckerTest : BaseTest() {
     @MockK lateinit var configData: ConfigData
     @MockK lateinit var qrCode: VaccinationCertificateQRCode
 
-    val existingIdentifier = CertificatePersonIdentifier(
+    private val existingIdentifier = CertificatePersonIdentifier(
         dateOfBirthFormatted = "1980-10-10",
         firstNameStandardized = "firstNameStandardized",
         lastNameStandardized = "lastNameStandardized"
     )
 
-    val existingIdentifier2 = CertificatePersonIdentifier(
+    private val existingIdentifier2 = CertificatePersonIdentifier(
         dateOfBirthFormatted = "1980-10-10",
         firstNameStandardized = "firstNameStandardized2",
         lastNameStandardized = "lastNameStandardized2"
     )
 
-    val newIdentifier = CertificatePersonIdentifier(
+    private val newIdentifier = CertificatePersonIdentifier(
         dateOfBirthFormatted = "1990-10-10",
         firstNameStandardized = "firstNameStandardized1",
         lastNameStandardized = "lastNameStandardized1"
     )
 
-    val vaccinationCertificate = mockk<VaccinationCertificate>().apply {
+    private val vaccinationCertificate = mockk<VaccinationCertificate>().apply {
         every { personIdentifier } returns existingIdentifier
     }
-    val personCertificate = PersonCertificates(certificates = listOf(vaccinationCertificate))
+    private val personCertificate = PersonCertificates(certificates = listOf(vaccinationCertificate))
 
-    val vaccinationCertificate2 = mockk<VaccinationCertificate>().apply {
+    private val vaccinationCertificate2 = mockk<VaccinationCertificate>().apply {
         every { personIdentifier } returns existingIdentifier2
     }
-    val personCertificate2 = PersonCertificates(certificates = listOf(vaccinationCertificate2))
+    private val personCertificate2 = PersonCertificates(certificates = listOf(vaccinationCertificate2))
 
     @BeforeEach
     fun setup() {
@@ -72,7 +72,7 @@ class DccMaxPersonCheckerTest : BaseTest() {
         every { qrCode.personIdentifier } returns newIdentifier
         createInstance().checkForMaxPersons(
             qrCode
-        ) shouldBe DccMaxPersonChecker.Result.PASSED
+        ) shouldBe DccMaxPersonChecker.Result.Passed
     }
 
     @Test
@@ -83,7 +83,10 @@ class DccMaxPersonCheckerTest : BaseTest() {
         every { qrCode.personIdentifier } returns newIdentifier
         createInstance().checkForMaxPersons(
             qrCode
-        ) shouldBe DccMaxPersonChecker.Result.EXCEEDS_THRESHOLD
+        ) shouldBe DccMaxPersonChecker.Result.ExceedsThreshold(
+            max = 3,
+            threshold = 1
+        )
     }
 
     @Test
@@ -94,7 +97,7 @@ class DccMaxPersonCheckerTest : BaseTest() {
         every { qrCode.personIdentifier } returns existingIdentifier
         createInstance().checkForMaxPersons(
             qrCode
-        ) shouldBe DccMaxPersonChecker.Result.PASSED
+        ) shouldBe DccMaxPersonChecker.Result.Passed
     }
 
     @Test
@@ -105,7 +108,10 @@ class DccMaxPersonCheckerTest : BaseTest() {
         every { qrCode.personIdentifier } returns newIdentifier
         createInstance().checkForMaxPersons(
             qrCode
-        ) shouldBe DccMaxPersonChecker.Result.EXCEEDS_MAX
+        ) shouldBe DccMaxPersonChecker.Result.ExceedsMax(
+            max = 2,
+            threshold = 1
+        )
     }
 
     @Test
@@ -116,7 +122,7 @@ class DccMaxPersonCheckerTest : BaseTest() {
         every { qrCode.personIdentifier } returns existingIdentifier
         createInstance().checkForMaxPersons(
             qrCode
-        ) shouldBe DccMaxPersonChecker.Result.PASSED
+        ) shouldBe DccMaxPersonChecker.Result.Passed
     }
 
     private fun createInstance() = DccMaxPersonChecker(

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerViewModelTest.kt
@@ -5,6 +5,7 @@ import de.rki.coronawarnapp.coronatest.server.CoronaTestResult
 import de.rki.coronawarnapp.coronatest.type.CoronaTest
 import de.rki.coronawarnapp.coronatest.type.pcr.PCRCoronaTest
 import de.rki.coronawarnapp.coronatest.type.rapidantigen.RACoronaTest
+import de.rki.coronawarnapp.covidcertificate.common.certificate.DccMaxPersonChecker
 import de.rki.coronawarnapp.covidcertificate.common.repository.TestCertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.CovidCertificateSettings
 import de.rki.coronawarnapp.dccticketing.core.allowlist.internal.DccTicketingAllowListException
@@ -20,26 +21,26 @@ import de.rki.coronawarnapp.qrcode.handler.DccQrCodeHandler
 import de.rki.coronawarnapp.qrcode.scanner.ImportDocumentException
 import de.rki.coronawarnapp.qrcode.scanner.QrCodeValidator
 import de.rki.coronawarnapp.qrcode.scanner.UnsupportedQrCodeException
-import de.rki.coronawarnapp.qrcode.ui.CoronaTestResult.TestPending
-import de.rki.coronawarnapp.qrcode.ui.CoronaTestResult.TestNegative
+import de.rki.coronawarnapp.qrcode.ui.CoronaTestResult.RestoreDuplicateTest
 import de.rki.coronawarnapp.qrcode.ui.CoronaTestResult.TestInvalid
+import de.rki.coronawarnapp.qrcode.ui.CoronaTestResult.TestNegative
+import de.rki.coronawarnapp.qrcode.ui.CoronaTestResult.TestPending
 import de.rki.coronawarnapp.qrcode.ui.CoronaTestResult.TestPositive
 import de.rki.coronawarnapp.qrcode.ui.CoronaTestResult.WarnOthers
 import de.rki.coronawarnapp.reyclebin.coronatest.RecycledCoronaTestsProvider
+import de.rki.coronawarnapp.reyclebin.coronatest.request.toRestoreRecycledTestRequest
 import de.rki.coronawarnapp.reyclebin.covidcertificate.RecycledCertificatesProvider
 import de.rki.coronawarnapp.submission.SubmissionRepository
 import de.rki.coronawarnapp.util.permission.CameraSettings
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.beInstanceOf
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.MockKAnnotations
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
-import de.rki.coronawarnapp.qrcode.ui.CoronaTestResult.RestoreDuplicateTest
-import de.rki.coronawarnapp.reyclebin.coronatest.request.toRestoreRecycledTestRequest
-import io.kotest.matchers.should
-import io.kotest.matchers.types.beInstanceOf
 import io.mockk.impl.annotations.MockK
 import io.mockk.just
 import io.mockk.mockk
@@ -69,6 +70,7 @@ class QrCodeScannerViewModelTest : BaseTest() {
     @MockK lateinit var traceLocationSettings: TraceLocationSettings
     @MockK lateinit var recycledCertificatesProvider: RecycledCertificatesProvider
     @MockK lateinit var recycledCoronaTestsProvider: RecycledCoronaTestsProvider
+    @MockK lateinit var dccMaxPersonChecker: DccMaxPersonChecker
 
     private val recycledRAT = RACoronaTest(
         identifier = "rat-identifier",
@@ -418,6 +420,7 @@ class QrCodeScannerViewModelTest : BaseTest() {
         qrCodeValidator = qrCodeValidator,
         recycledCertificatesProvider = recycledCertificatesProvider,
         recycledCoronaTestsProvider = recycledCoronaTestsProvider,
-        dccTicketingQrCodeHandler = dccTicketingQrCodeHandler
+        dccTicketingQrCodeHandler = dccTicketingQrCodeHandler,
+        dccMaxPersonChecker = dccMaxPersonChecker
     )
 }


### PR DESCRIPTION
## Test against LOCAL mock server (`Max=5 ,threshold=2`)
- Scan certificates for different persons
- When threshold is `numberOfDistinctPersons + 1` > `threshold` -> warning should appear with every new person added 
   - Certificate is still imported 
- When `numberOfDistinctPersons` >=  `Max ` Block dialog should appear 
   - Certificate is NOT imported 


### Ticket
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10613