### PR TITLE
Fix: TAN in PCR-replacement scenario (EXPOSUREAPP-10964)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/deletionwarning/SubmissionDeletionWarningFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/deletionwarning/SubmissionDeletionWarningFragment.kt
@@ -83,7 +83,9 @@ class SubmissionDeletionWarningFragment : Fragment(R.layout.fragment_submission_
                     state.test.isPositive -> {
                         if (args.testRegistrationRequest is CoronaTestTAN) {
                             SubmissionDeletionWarningFragmentDirections
-                                .actionSubmissionDeletionFragmentToSubmissionTestResultNoConsentFragment(testType = state.test.type)
+                                .actionSubmissionDeletionFragmentToSubmissionTestResultNoConsentFragment(
+                                    testType = state.test.type
+                                ).run { findNavController().navigate(this, navOptions) }
                         } else {
                             NavGraphDirections.actionToSubmissionTestResultAvailableFragment(testType = state.test.type)
                                 .run { findNavController().navigate(this, navOptions) }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/deletionwarning/SubmissionDeletionWarningFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/deletionwarning/SubmissionDeletionWarningFragment.kt
@@ -85,19 +85,16 @@ class SubmissionDeletionWarningFragment : Fragment(R.layout.fragment_submission_
                             SubmissionDeletionWarningFragmentDirections
                                 .actionSubmissionDeletionFragmentToSubmissionTestResultNoConsentFragment(
                                     testType = state.test.type
-                                ).run { findNavController().navigate(this, navOptions) }
+                                )
                         } else {
                             NavGraphDirections.actionToSubmissionTestResultAvailableFragment(testType = state.test.type)
-                                .run { findNavController().navigate(this, navOptions) }
                         }
                     }
-                    else ->
-                        NavGraphDirections.actionSubmissionTestResultPendingFragment(
-                            testType = state.test.type,
-                            testIdentifier = state.test.identifier
-                        )
-                            .run { findNavController().navigate(this, navOptions) }
-                }
+                    else -> NavGraphDirections.actionSubmissionTestResultPendingFragment(
+                        testType = state.test.type,
+                        testIdentifier = state.test.identifier
+                    )
+                }.also { findNavController().navigate(it, navOptions) }
             }
 
             viewModel.routeToScreen.observe2(this) { event ->

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/deletionwarning/SubmissionDeletionWarningFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/deletionwarning/SubmissionDeletionWarningFragment.kt
@@ -10,6 +10,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import de.rki.coronawarnapp.NavGraphDirections
 import de.rki.coronawarnapp.R
+import de.rki.coronawarnapp.coronatest.tan.CoronaTestTAN
 import de.rki.coronawarnapp.coronatest.type.CoronaTest
 import de.rki.coronawarnapp.databinding.FragmentSubmissionDeletionWarningBinding
 import de.rki.coronawarnapp.submission.TestRegistrationStateProcessor.State
@@ -79,10 +80,15 @@ class SubmissionDeletionWarningFragment : Fragment(R.layout.fragment_submission_
                     popBackStack()
                 }
                 is State.TestRegistered -> when {
-                    state.test.isPositive ->
-                        NavGraphDirections.actionToSubmissionTestResultAvailableFragment(testType = state.test.type)
-                            .run { findNavController().navigate(this, navOptions) }
-
+                    state.test.isPositive -> {
+                        if (args.testRegistrationRequest is CoronaTestTAN) {
+                            SubmissionDeletionWarningFragmentDirections
+                                .actionSubmissionDeletionFragmentToSubmissionTestResultNoConsentFragment(testType = state.test.type)
+                        } else {
+                            NavGraphDirections.actionToSubmissionTestResultAvailableFragment(testType = state.test.type)
+                                .run { findNavController().navigate(this, navOptions) }
+                        }
+                    }
                     else ->
                         NavGraphDirections.actionSubmissionTestResultPendingFragment(
                             testType = state.test.type,

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/deletionwarning/SubmissionDeletionWarningViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/deletionwarning/SubmissionDeletionWarningViewModel.kt
@@ -48,13 +48,6 @@ class SubmissionDeletionWarningViewModel @AssistedInject constructor(
                 } else {
                     Timber.d("Continuing with our new CoronaTest: %s", newTest)
                 }
-
-                routeToScreen.postValue(
-                    DuplicateWarningEvent.Direction(
-                        SubmissionDeletionWarningFragmentDirections
-                            .actionSubmissionDeletionFragmentToSubmissionTestResultNoConsentFragment(newTest.type)
-                    )
-                )
             }
 
             is CoronaTestQRCode -> routeToScreen.postValue(


### PR DESCRIPTION
### Testing
- have CWA with already registered PCR test
- Homescreen > Sie lassen sich testen? > TAN für PCR-Test-eingeben
- fill in a valid TAN and press weiter
- confirm the Screen "Hinweis, Sie haben bereits einen anderen PCR-Test registriert" (replacement)
- "Ihr Testergebnis – POSITIV" screen should appear

### Jira Link
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10964