### PR TITLE
Correct typos in CODEOWNERS comment (COMMUNITY)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,5 +7,5 @@
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
 * @corona-warn-app/cwa-app-android-maintainers
 
-# Code Onwer of all german texts
+# Code Owner of all German texts
 /Corona-Warn-App/src/main/res/values-de/ @corona-warn-app/cwa-app-user-assistance


### PR DESCRIPTION
This PR corrects minor typos in a comment line of the [CODEOWNERS](https://github.com/corona-warn-app/cwa-app-android/blob/main/CODEOWNERS) document.

Onwer => Owner
german => German
(the language "German" is a proper noun, so it needs to be capitalized).
