### PR TITLE
Update covid_certificate_strings.xml

### DIFF
--- a/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
@@ -388,7 +388,7 @@
     <!-- XTXT: Explains user about cov pass: URL, has to be "translated" into english (relevant for all languages except german) - https://www.coronawarn.app/en/faq/#eu_dcc_check -->
     <string name="cov_pass_info_faq_link">"https://www.coronawarn.app/de/faq/#eu_dcc_check"</string>
     <!-- XHED: Cov Pass Info Fragment title -->
-    <string name="cov_pass_info_section_one">"Sie selbst können Ihre Zertifikate in der Corona-Warn-App auf Gültigkeit prüfen und benötigen dazu nicht die CovPassCheck-App."</string>
+    <string name="cov_pass_info_section_one">"Sie selbst können Ihre Zertifikate in der Corona-Warn-App vor einer Reise auf Gültigkeit prüfen und benötigen dazu nicht die CovPassCheck-App."</string>
     <!-- XHED: Cov Pass Info Fragment title -->
     <string name="cov_pass_info_section_two">"Für Dritte reicht eine Sichtprüfung der Zertifikate nicht aus. Sie müssen in Deutschland die CovPassCheck-App nutzen."</string>
     <!-- XHED: Cov Pass Info Fragment title -->


### PR DESCRIPTION
Changed string  "cov_pass_info_section_one"
"Sie selbst können Ihre Zertifikate in der Corona-Warn-App auf Gültigkeit prüfen..." --> "Sie selbst können Ihre Zertifikate in der Corona-Warn-App vor einer Reise auf Gültigkeit prüfen..."
