### PR TITLE
Wrong color shade dcc tile ticket validation (EXPOSUREAPP-10941)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/dcc_ticketing_vaccination_card.xml
+++ b/Corona-Warn-App/src/main/res/layout/dcc_ticketing_vaccination_card.xml
@@ -20,7 +20,7 @@
         app:layout_constraintBottom_toBottomOf="@id/bottom_barrier"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:srcCompat="@drawable/bg_certificate_blue_3" />
+        app:srcCompat="@drawable/bg_certificate_blue_1" />
 
     <ImageView
         android:id="@+id/certificate_icon"


### PR DESCRIPTION
Fixing the color shade of the certificate icon in the dcc ticket validation selection screen.