### PR TITLE
Fix Crash in booster rules test menu (EXPOSUREAPP-10609)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
@@ -39,6 +39,10 @@ data class VaccinatedPerson(
             .mapToVaccinationCertificateSet(state = CwaCovidCertificate.State.Recycled)
     }
 
+    private val allVaccinationCertificates: Set<VaccinationCertificate> by lazy {
+        vaccinationContainers.mapToVaccinationCertificateSet()
+    }
+
     private fun Collection<VaccinationContainer>.mapToVaccinationCertificateSet(
         state: CwaCovidCertificate.State? = null
     ): Set<VaccinationCertificate> = map {
@@ -64,10 +68,10 @@ data class VaccinatedPerson(
     }
 
     val fullName: String
-        get() = vaccinationCertificates.first().fullName
+        get() = allVaccinationCertificates.first().fullName
 
     val dateOfBirthFormatted: String
-        get() = vaccinationCertificates.first().dateOfBirthFormatted
+        get() = allVaccinationCertificates.first().dateOfBirthFormatted
 
     fun getVaccinationStatus(nowUTC: Instant = Instant.now()): Status {
         if (boosterRule != null) return Status.BOOSTER_ELIGIBLE

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
@@ -70,9 +70,6 @@ data class VaccinatedPerson(
     val fullName: String
         get() = allVaccinationCertificates.first().fullName
 
-    val dateOfBirthFormatted: String
-        get() = allVaccinationCertificates.first().dateOfBirthFormatted
-
     fun getVaccinationStatus(nowUTC: Instant = Instant.now()): Status {
         if (boosterRule != null) return Status.BOOSTER_ELIGIBLE
 


### PR DESCRIPTION
Once there was a deleted vaccination certificate on the device, the Booster Rules Test screen started to crash. 
This was because the screen determined the full name from the first non-recycled certificate, but since there now is a  `VaccinatedPerson` with zero non-recycled certificate, `certificates.first()` threw a `NoSuchElementException`.

This PR fixes this by determining the `fullname` from all certificates, not from non-recycled ones.