### PR TITLE
Fix: TAN error message (EXPOSUREAPP-10958)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/TestRegistrationStateProcessor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/TestRegistrationStateProcessor.kt
@@ -35,22 +35,32 @@ class TestRegistrationStateProcessor @Inject constructor(
         data class TestRegistered(val test: CoronaTest) : State()
 
         data class Error(val exception: Exception) : State() {
-            fun getDialogBuilder(context: Context): MaterialAlertDialogBuilder {
+            fun getDialogBuilder(context: Context, comingFromTan: Boolean = false): MaterialAlertDialogBuilder {
                 val builder = MaterialAlertDialogBuilder(context).apply {
                     setCancelable(true)
                 }
 
                 return when (exception) {
                     is AlreadyRedeemedException -> builder.apply {
-                        setTitle(R.string.submission_error_dialog_web_tan_redeemed_title)
-                        setMessage(R.string.submission_error_dialog_web_tan_redeemed_body)
+                        if (comingFromTan) {
+                            setTitle(R.string.submission_error_dialog_web_test_paired_title_tan)
+                            setMessage(R.string.submission_error_dialog_web_test_paired_body_tan)
+                        } else {
+                            setTitle(R.string.submission_error_dialog_web_tan_redeemed_title)
+                            setMessage(R.string.submission_error_dialog_web_tan_redeemed_body)
+                        }
                         setPositiveButton(android.R.string.ok) { _, _ ->
                             /* dismiss */
                         }
                     }
                     is BadRequestException -> builder.apply {
-                        setTitle(R.string.submission_qr_code_scan_invalid_dialog_headline)
-                        setMessage(R.string.submission_qr_code_scan_invalid_dialog_body)
+                        if (comingFromTan) {
+                            setTitle(R.string.submission_error_dialog_web_test_paired_title_tan)
+                            setMessage(R.string.submission_error_dialog_web_test_paired_body_tan)
+                        } else {
+                            setTitle(R.string.submission_qr_code_scan_invalid_dialog_headline)
+                            setMessage(R.string.submission_qr_code_scan_invalid_dialog_body)
+                        }
                         setPositiveButton(android.R.string.ok) { _, _ ->
                             /* dismiss */
                         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/deletionwarning/SubmissionDeletionWarningFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/deletionwarning/SubmissionDeletionWarningFragment.kt
@@ -76,7 +76,7 @@ class SubmissionDeletionWarningFragment : Fragment(R.layout.fragment_submission_
                     // Handled above
                 }
                 is State.Error -> {
-                    state.getDialogBuilder(requireContext()).show()
+                    state.getDialogBuilder(requireContext(), args.testRegistrationRequest is CoronaTestTAN).show()
                     popBackStack()
                 }
                 is State.TestRegistered -> when {


### PR DESCRIPTION
### Testing
- have already registered PCR test in the app
- Homescreen > Sie lassen sich testen? > TAN für PCR-Test-eingeben
- fill in an already used TAN and press weiter (e.g. HGPXEN99R9 or 37GESE3KRG)
- you should see an error message with the title "TAN is invalid"
- scan any invalid PCR test using QR code and you should see an error message with the title "QR code is invalid"

## Jira Ticket
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10958