### PR TITLE
Fix: DCC ticketing error dialog (EXPOSUREAPP-10962)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/ui/consent/one/DccTicketingConsentOneFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/ui/consent/one/DccTicketingConsentOneFragment.kt
@@ -118,8 +118,7 @@ class DccTicketingConsentOneFragment : Fragment(R.layout.fragment_dcc_ticketing_
     private fun showErrorDialog(lazyErrorMessage: LazyString) {
         val msg = lazyErrorMessage.get(requireContext())
         DccTicketingDialogType.ErrorDialog(msg = msg).show(
-            fragment = this,
-            positiveButtonAction = { viewModel.goBack() }
+            fragment = this
         )
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/ui/consent/two/DccTicketingConsentTwoFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/ui/consent/two/DccTicketingConsentTwoFragment.kt
@@ -117,8 +117,7 @@ class DccTicketingConsentTwoFragment : Fragment(R.layout.fragment_dcc_ticketing_
     private fun showErrorDialog(lazyErrorMessage: LazyString) {
         val msg = lazyErrorMessage.get(requireContext())
         DccTicketingDialogType.ErrorDialog(msg = msg).show(
-            fragment = this,
-            positiveButtonAction = { viewModel.goBack() }
+            fragment = this
         )
     }
 }


### PR DESCRIPTION
## What's new
No navigation on error dialog button in Consent I and Consent II screens (no errors on other screens in DCC Ticketing Validation process).

## Jira
[Ticket](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10962)

## How to test
Either code manipulation or cwa cli preset (e.g. `cwa ti gen --preset RTR_SERVER_ERR -e wru`).