### PR TITLE
FIX: Correct legal texts for dcc ticketing validation consent II screen (EXPOSUREAPP-11049)

### DIFF
--- a/Corona-Warn-App/src/main/res/values-tr/legal_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-tr/legal_strings.xml
@@ -208,20 +208,20 @@
 
     <!-- DCC Ticketing Consent Two Screen -->
     <!-- XTXT: DCC Ticketing: Consent Two: Legal: Title -->
-    <string name="dcc_ticketing_consent_two_legal_title" translatable="false">"Ihr Einverständnis "</string>
+    <string name="dcc_ticketing_consent_two_legal_title" translatable="false">"Rıza beyanınız"</string>
     <!-- XTXT: DCC Ticketing: Consent Two: Legal: Body -->
-    <string name="dcc_ticketing_consent_two_legal_body" translatable="false">"Durch Antippen von „Einverstanden“ willigen Sie in die Übermittlung der folgenden Daten an den Prüfpartner ein:"</string>
+    <string name="dcc_ticketing_consent_two_legal_body" translatable="false">"“Kabul ediyorum” üzerine tıklayarak aşağıdaki bilgilerin kontrol ortağına aktarılmasına onay verirsiniz:"</string>
     <!-- XTXT: DCC Ticketing: Consent Two: Legal: Point 1 -->
-    <string name="dcc_ticketing_consent_two_legal_point_1" translatable="false">"Zertifikatsinhalt und elektronische Signatur des ausgewählten Zertifikats (u.a. Name und Geburtsdatum des Zertifikatsinhabers, Gültigkeitsdauer, Aussteller und Ausstellungsdatum, Angaben zu Impfstoff/Test/Genesung)."</string>
+    <string name="dcc_ticketing_consent_two_legal_point_1" translatable="false">"Seçilen sertifikanın (özellikle sertifika sahibinin adı ve doğum tarihi, geçerlilik süresi, düzenleyen ve düzenleme tarihi, aşı/test/iyileşme ile ilgili bilgiler) sertifika içeriği ve elektronik imza."</string>
     <!-- XTXT: DCC Ticketing: Consent Two: Legal: Point 2 -->
-    <string name="dcc_ticketing_consent_two_legal_point_2" translatable="false">"Die bei dem Anbieter abgerufenen Buchungsdaten:"</string>
+    <string name="dcc_ticketing_consent_two_legal_point_2" translatable="false">"Sağlayıcı tarafından açılan rezervasyon bilgileri:"</string>
     <!-- XTXT: DCC Ticketing: Consent Two: Legal: Point 2-1 -->
-    <string name="dcc_ticketing_consent_two_legal_point_2_1" translatable="false">"Zeitraum, in dem das Zertifikat gültig sein muss (Reisedauer oder Veranstaltungsdatum)"</string>
+    <string name="dcc_ticketing_consent_two_legal_point_2_1" translatable="false">"Sertifikanın geçerli olması gereken süre (seyahat süresi ya da etkinlik süresi)"</string>
     <!-- XTXT: DCC Ticketing: Consent Two: Legal: Point 2-2 -->
-    <string name="dcc_ticketing_consent_two_legal_point_2_2" translatable="false">"bei Reisebuchungen: Ausgangsland und Zielland der Reise"</string>
+    <string name="dcc_ticketing_consent_two_legal_point_2_2" translatable="false">"Seyahat rezervasyonlarında: Seyahate çıkılan çıkış ve varış ülkesi"</string>
     <!-- XTXT: DCC Ticketing: Consent Two: Legal: Point 2-3 -->
-    <string name="dcc_ticketing_consent_two_legal_point_2_3" translatable="false">"bei grenzüberschreitenden Reisen: Anforderungen des Ziellandes an das Zertifikat"</string>
+    <string name="dcc_ticketing_consent_two_legal_point_2_3" translatable="false">"Sınırları aşan seyahatlerde: gidilen ülkenin sertifikaya ilişkin talepleri"</string>
     <!-- XTXT: DCC Ticketing: Consent Two: Legal: Point 2-4 -->
-    <string name="dcc_ticketing_consent_two_legal_point_2_4" translatable="false">"weitere Anforderungen des Anbieters an das Zertifikat (z.B. welche Impfstoffe oder Testverfahren akzeptiert werden)"</string>
+    <string name="dcc_ticketing_consent_two_legal_point_2_4" translatable="false">"Sağlayıcının sertifikaya ilişkin talepleri (örn. hangi aşılar veya test yöntemleri kabul edilir)"</string>
 
 </resources>

--- a/Corona-Warn-App/src/main/res/values/legal_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/legal_strings.xml
@@ -209,20 +209,20 @@
 
     <!-- DCC Ticketing Consent Two Screen -->
     <!-- XTXT: DCC Ticketing: Consent Two: Legal: Title -->
-    <string name="dcc_ticketing_consent_two_legal_title" translatable="false">"Ihr Einverständnis "</string>
+    <string name="dcc_ticketing_consent_two_legal_title" translatable="false">"Your consent"</string>
     <!-- XTXT: DCC Ticketing: Consent Two: Legal: Body -->
-    <string name="dcc_ticketing_consent_two_legal_body" translatable="false">"Durch Antippen von „Einverstanden“ willigen Sie in die Übermittlung der folgenden Daten an den Prüfpartner ein:"</string>
+    <string name="dcc_ticketing_consent_two_legal_body" translatable="false">"By tapping on “Accept”, you consent to the transfer of the following data to the verification partner:"</string>
     <!-- XTXT: DCC Ticketing: Consent Two: Legal: Point 1 -->
-    <string name="dcc_ticketing_consent_two_legal_point_1" translatable="false">"Zertifikatsinhalt und elektronische Signatur des ausgewählten Zertifikats (u.a. Name und Geburtsdatum des Zertifikatsinhabers, Gültigkeitsdauer, Aussteller und Ausstellungsdatum, Angaben zu Impfstoff/Test/Genesung)."</string>
+    <string name="dcc_ticketing_consent_two_legal_point_1" translatable="false">"Content and electronic signature of the selected certificate (including name and date of birth of the certificate holder, validity period, issuer and date of issue, vaccine/test/recovery details)."</string>
     <!-- XTXT: DCC Ticketing: Consent Two: Legal: Point 2 -->
-    <string name="dcc_ticketing_consent_two_legal_point_2" translatable="false">"Die bei dem Anbieter abgerufenen Buchungsdaten:"</string>
+    <string name="dcc_ticketing_consent_two_legal_point_2" translatable="false">"The booking details retrieved from the provider:"</string>
     <!-- XTXT: DCC Ticketing: Consent Two: Legal: Point 2-1 -->
-    <string name="dcc_ticketing_consent_two_legal_point_2_1" translatable="false">"Zeitraum, in dem das Zertifikat gültig sein muss (Reisedauer oder Veranstaltungsdatum)"</string>
+    <string name="dcc_ticketing_consent_two_legal_point_2_1" translatable="false">"Period during which the certificate must be valid (travel duration or event date)"</string>
     <!-- XTXT: DCC Ticketing: Consent Two: Legal: Point 2-2 -->
-    <string name="dcc_ticketing_consent_two_legal_point_2_2" translatable="false">"bei Reisebuchungen: Ausgangsland und Zielland der Reise"</string>
+    <string name="dcc_ticketing_consent_two_legal_point_2_2" translatable="false">"For travel bookings: Country of origin and country of destination or journey"</string>
     <!-- XTXT: DCC Ticketing: Consent Two: Legal: Point 2-3 -->
-    <string name="dcc_ticketing_consent_two_legal_point_2_3" translatable="false">"bei grenzüberschreitenden Reisen: Anforderungen des Ziellandes an das Zertifikat"</string>
+    <string name="dcc_ticketing_consent_two_legal_point_2_3" translatable="false">"For cross-border travel: Certificate requirements imposed by the destination country"</string>
     <!-- XTXT: DCC Ticketing: Consent Two: Legal: Point 2-4 -->
-    <string name="dcc_ticketing_consent_two_legal_point_2_4" translatable="false">"weitere Anforderungen des Anbieters an das Zertifikat (z.B. welche Impfstoffe oder Testverfahren akzeptiert werden)"</string>
+    <string name="dcc_ticketing_consent_two_legal_point_2_4" translatable="false">"Further certificate requirements on the part of the provider (e.g. which vaccines or test procedures are accepted)"</string>
 
 </resources>


### PR DESCRIPTION
## What's new
Correct legal texts for dcc ticketing validation consent II screen.
![Screenshot 2021-12-15 at 12 57 06](https://user-images.githubusercontent.com/64849422/146165857-a21870df-113e-4d0f-a961-abeaafbcc713.png)![Screenshot 2021-12-15 at 12 57 46](https://user-images.githubusercontent.com/64849422/146165866-85141fd1-d825-4292-b8d8-20e0cfb308c3.png)
![Screenshot 2021-12-15 at 12 58 22](https://user-images.githubusercontent.com/64849422/146165873-2668bfcb-9593-45b8-8a09-91d8b8824365.png)![Screenshot 2021-12-15 at 12 59 03](https://user-images.githubusercontent.com/64849422/146165876-95c6407f-776b-402d-bfbc-d93c194b5cfe.png)


## Jira
[Ticket](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-11049)

## How to test

1. Run DCC Ticketing validation process up to Consent II screen.
2. Switch between multiple languages and check legal text (grey box)