### PR TITLE
Fix duplicate certificate list item (EXPOSUREAPP-11052)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/dccticketing/ui/certificateselection/DccTicketingCertificateSelectionHelperUiTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/dccticketing/ui/certificateselection/DccTicketingCertificateSelectionHelperUiTest.kt
@@ -1,0 +1,62 @@
+package de.rki.coronawarnapp.dccticketing.ui.certificateselection
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import de.rki.coronawarnapp.R
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.BaseTestInstrumentation
+
+class DccTicketingCertificateSelectionHelperUiTest : BaseTestInstrumentation() {
+
+    private val context by lazy { ApplicationProvider.getApplicationContext<Context>() }
+
+    @Test
+    fun certificateTypesText() = with(context) {
+        certificateTypesText(listOf("v", "r", "t", "tp", "tr")) shouldBe
+            listOf(
+                getString(R.string.vaccination_certificate_name),
+                getString(R.string.recovery_certificate_name),
+                getString(R.string.rat_test_certificate),
+                getString(R.string.pcr_test_certificate)
+            ).joinToString(", ")
+
+        certificateTypesText(listOf("v", "r", "tp")) shouldBe
+            listOf(
+                getString(R.string.vaccination_certificate_name),
+                getString(R.string.recovery_certificate_name),
+                getString(R.string.pcr_test_certificate)
+            ).joinToString(", ")
+
+        certificateTypesText(listOf("v", "r", "tr")) shouldBe
+            listOf(
+                getString(R.string.vaccination_certificate_name),
+                getString(R.string.recovery_certificate_name),
+                getString(R.string.rat_test_certificate)
+            ).joinToString(", ")
+
+        certificateTypesText(listOf("v", "r")) shouldBe
+            listOf(
+                getString(R.string.vaccination_certificate_name),
+                getString(R.string.recovery_certificate_name)
+            ).joinToString(", ")
+
+        certificateTypesText(listOf("r")) shouldBe
+            listOf(
+                getString(R.string.recovery_certificate_name)
+            ).joinToString(", ")
+
+        certificateTypesText(listOf("v")) shouldBe
+            listOf(
+                getString(R.string.vaccination_certificate_name)
+            ).joinToString(", ")
+
+        certificateTypesText(listOf("v", "r", "tp", "tr")) shouldBe
+            listOf(
+                getString(R.string.vaccination_certificate_name),
+                getString(R.string.recovery_certificate_name),
+                getString(R.string.pcr_test_certificate),
+                getString(R.string.rat_test_certificate)
+            ).joinToString(", ")
+    }
+}

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/dccticketing/ui/certificateselection/DccTicketingCertificateSelectionHelperUiTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/dccticketing/ui/certificateselection/DccTicketingCertificateSelectionHelperUiTest.kt
@@ -58,5 +58,7 @@ class DccTicketingCertificateSelectionHelperUiTest : BaseTestInstrumentation() {
                 getString(R.string.pcr_test_certificate),
                 getString(R.string.rat_test_certificate)
             ).joinToString(", ")
+
+        certificateTypesText(listOf()) shouldBe ""
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/ui/certificateselection/DccTicketingCertificateSelectionHelperFunctions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/ui/certificateselection/DccTicketingCertificateSelectionHelperFunctions.kt
@@ -3,26 +3,24 @@ package de.rki.coronawarnapp.dccticketing.ui.certificateselection
 import android.content.Context
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.dccticketing.core.certificateselection.DccTicketingCertificatesFilterType
-import de.rki.coronawarnapp.dccticketing.core.certificateselection.DccTicketingCertificatesFilterType.PCR_TEST
-import de.rki.coronawarnapp.dccticketing.core.certificateselection.DccTicketingCertificatesFilterType.RA_TEST
-import de.rki.coronawarnapp.dccticketing.core.certificateselection.DccTicketingCertificatesFilterType.RECOVERY
-import de.rki.coronawarnapp.dccticketing.core.certificateselection.DccTicketingCertificatesFilterType.TEST
-import de.rki.coronawarnapp.dccticketing.core.certificateselection.DccTicketingCertificatesFilterType.VACCINATION
+import de.rki.coronawarnapp.dccticketing.core.certificateselection.DccTicketingCertificatesFilterType.*
 
 fun Context.certificateTypesText(certificateTypes: List<String>, separator: String = ", "): String =
-    certificateTypes.joinToString(separator) { type ->
-        when (DccTicketingCertificatesFilterType.typeOf(type)) {
-            VACCINATION -> getString(R.string.vaccination_certificate_name)
-            RECOVERY -> getString(R.string.recovery_certificate_name)
-            PCR_TEST -> getString(R.string.pcr_test_certificate)
-            RA_TEST -> getString(R.string.rat_test_certificate)
-            TEST -> listOf(
-                getString(R.string.rat_test_certificate),
-                getString(R.string.pcr_test_certificate)
-            ).joinToString(separator)
-            else -> ""
-        }
-    }
+        certificateTypes
+                .filter { it !in arrayOf(PCR_TEST.type, RA_TEST.type) || !certificateTypes.contains(TEST.type) }
+                .joinToString(separator) { type ->
+                    when (DccTicketingCertificatesFilterType.typeOf(type)) {
+                        VACCINATION -> getString(R.string.vaccination_certificate_name)
+                        RECOVERY -> getString(R.string.recovery_certificate_name)
+                        PCR_TEST -> getString(R.string.pcr_test_certificate)
+                        RA_TEST -> getString(R.string.rat_test_certificate)
+                        TEST -> listOf(
+                                getString(R.string.rat_test_certificate),
+                                getString(R.string.pcr_test_certificate)
+                        ).joinToString(separator)
+                        else -> ""
+                    }
+                }
 
 fun getFullName(familyName: String?, givenName: String?): String =
     listOfNotNull(familyName, givenName).joinToString("<<")

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/ui/certificateselection/DccTicketingCertificateSelectionHelperFunctions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/ui/certificateselection/DccTicketingCertificateSelectionHelperFunctions.kt
@@ -10,21 +10,21 @@ import de.rki.coronawarnapp.dccticketing.core.certificateselection.DccTicketingC
 import de.rki.coronawarnapp.dccticketing.core.certificateselection.DccTicketingCertificatesFilterType.VACCINATION
 
 fun Context.certificateTypesText(certificateTypes: List<String>, separator: String = ", "): String =
-        certificateTypes
-                .filter { it !in arrayOf(PCR_TEST.type, RA_TEST.type) || !certificateTypes.contains(TEST.type) }
-                .joinToString(separator) { type ->
-                    when (DccTicketingCertificatesFilterType.typeOf(type)) {
-                        VACCINATION -> getString(R.string.vaccination_certificate_name)
-                        RECOVERY -> getString(R.string.recovery_certificate_name)
-                        PCR_TEST -> getString(R.string.pcr_test_certificate)
-                        RA_TEST -> getString(R.string.rat_test_certificate)
-                        TEST -> listOf(
-                                getString(R.string.rat_test_certificate),
-                                getString(R.string.pcr_test_certificate)
-                        ).joinToString(separator)
-                        else -> ""
-                    }
-                }
+    certificateTypes
+        .filter { it !in arrayOf(PCR_TEST.type, RA_TEST.type) || !certificateTypes.contains(TEST.type) }
+        .joinToString(separator) { type ->
+            when (DccTicketingCertificatesFilterType.typeOf(type)) {
+                VACCINATION -> getString(R.string.vaccination_certificate_name)
+                RECOVERY -> getString(R.string.recovery_certificate_name)
+                PCR_TEST -> getString(R.string.pcr_test_certificate)
+                RA_TEST -> getString(R.string.rat_test_certificate)
+                TEST -> listOf(
+                    getString(R.string.rat_test_certificate),
+                    getString(R.string.pcr_test_certificate)
+                ).joinToString(separator)
+                else -> ""
+            }
+        }
 
 fun getFullName(familyName: String?, givenName: String?): String =
     listOfNotNull(familyName, givenName).joinToString("<<")

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/ui/certificateselection/DccTicketingCertificateSelectionHelperFunctions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/ui/certificateselection/DccTicketingCertificateSelectionHelperFunctions.kt
@@ -3,7 +3,11 @@ package de.rki.coronawarnapp.dccticketing.ui.certificateselection
 import android.content.Context
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.dccticketing.core.certificateselection.DccTicketingCertificatesFilterType
-import de.rki.coronawarnapp.dccticketing.core.certificateselection.DccTicketingCertificatesFilterType.*
+import de.rki.coronawarnapp.dccticketing.core.certificateselection.DccTicketingCertificatesFilterType.PCR_TEST
+import de.rki.coronawarnapp.dccticketing.core.certificateselection.DccTicketingCertificatesFilterType.RA_TEST
+import de.rki.coronawarnapp.dccticketing.core.certificateselection.DccTicketingCertificatesFilterType.RECOVERY
+import de.rki.coronawarnapp.dccticketing.core.certificateselection.DccTicketingCertificatesFilterType.TEST
+import de.rki.coronawarnapp.dccticketing.core.certificateselection.DccTicketingCertificatesFilterType.VACCINATION
 
 fun Context.certificateTypesText(certificateTypes: List<String>, separator: String = ", "): String =
         certificateTypes

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/dccticketing/ui/certificateselection/DccTicketingCertificateSelectionHelperTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/dccticketing/ui/certificateselection/DccTicketingCertificateSelectionHelperTest.kt
@@ -1,0 +1,15 @@
+package de.rki.coronawarnapp.dccticketing.ui.certificateselection
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+import testhelpers.BaseTest
+
+internal class DccTicketingCertificateSelectionHelperTest : BaseTest() {
+    @Test
+    fun getFullNameTest() {
+        getFullName(null, null) shouldBe ""
+        getFullName(null, "First") shouldBe "First"
+        getFullName("Last", null) shouldBe "Last"
+    }
+}


### PR DESCRIPTION
Addresses [EXPOSUREAPP-11052](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-11052).

This fixes the edge case that a RA test certificate and a PCR test certificate is required, but the certificate type list contains `PCR_TEST`, `RA_TEST` and `TEST`.

The previous result was:
```
PCR-Testzertifikat, Schnelltest-Testzertifikat,
PCR-Testzertifikat, Schnelltest-Testzertifikat
```

The new result should be:
```
PCR-Testzertifikat, Schnelltest-Testzertifikat
```
because `PCR_TEST` and `RA_TEST` are filtered as soon as `TEST` is present.