### PR TITLE
FIX: Going back from "Print Version" to "Display print version" does not work (EXPOSUREAPP-11001)

### DIFF
--- a/Corona-Warn-App/src/main/res/navigation/covid_certificates_graph.xml
+++ b/Corona-Warn-App/src/main/res/navigation/covid_certificates_graph.xml
@@ -244,9 +244,7 @@
             app:argType="de.rki.coronawarnapp.covidcertificate.common.repository.CertificateContainerId" />
         <action
             android:id="@+id/action_certificatePdfExportInfoFragment_to_certificatePosterFragment"
-            app:destination="@id/certificatePosterFragment"
-            app:popUpTo="@id/certificatePdfExportInfoFragment"
-            app:popUpToInclusive="true" />
+            app:destination="@id/certificatePosterFragment" />
     </fragment>
     <fragment
         android:id="@+id/certificatePosterFragment"


### PR DESCRIPTION
### Testing
 
    Go to a Vaccination Certificate
    Click to "Display Print Version"
    Click "Next"
    The print version is shown. Now click on the arrow in the left corner <- 
     "Display Print Version" is shown again 

### Jira Issue
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-11001
