### PR TITLE
Ticketvalidation screens sometimes empty (EXPOSUREAPP-11054)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/ui/shared/DccTicketingSharedViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/ui/shared/DccTicketingSharedViewModel.kt
@@ -14,7 +14,7 @@ import timber.log.Timber
  */
 class DccTicketingSharedViewModel(private val savedState: SavedStateHandle) : ViewModel() {
 
-    private val currentTransactionContext = MutableStateFlow<DccTicketingTransactionContext?>(
+    private val currentTransactionContext = MutableStateFlow(
         getSavedTransactionContext()
     )
 
@@ -28,12 +28,17 @@ class DccTicketingSharedViewModel(private val savedState: SavedStateHandle) : Vi
         }
     }
 
+    // returns the transaction context that is stored in the savedStateHandle, or null otherwise
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    fun getSavedTransactionContext(): DccTicketingTransactionContext? =
-        savedState.get(TRANSACTION_CONTEXT_SAVED_STATE_KEY)
+    fun getSavedTransactionContext(): DccTicketingTransactionContext? {
+        val transactionContext: DccTicketingTransactionContext? = savedState.get(TRANSACTION_CONTEXT_SAVED_STATE_KEY)
+        Timber.d("DccTicketingTransactionContext: %s loaded from savedStateHandle", transactionContext)
+        return transactionContext
+    }
 
-    private fun saveTransactionContext(ctx: DccTicketingTransactionContext) {
-        savedState.set(TRANSACTION_CONTEXT_SAVED_STATE_KEY, ctx)
+    private fun saveTransactionContext(transactionContext: DccTicketingTransactionContext) {
+        Timber.d("Saving DccTicketingTransactionContext: %s into savedStateHandle", transactionContext)
+        savedState.set(TRANSACTION_CONTEXT_SAVED_STATE_KEY, transactionContext)
     }
 
     companion object {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/ui/shared/DccTicketingSharedViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/ui/shared/DccTicketingSharedViewModel.kt
@@ -1,5 +1,7 @@
 package de.rki.coronawarnapp.dccticketing.ui.shared
 
+import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import de.rki.coronawarnapp.dccticketing.core.transaction.DccTicketingTransactionContext
 import kotlinx.coroutines.flow.Flow
@@ -10,14 +12,31 @@ import timber.log.Timber
 /**
  * Shares the [DccTicketingTransactionContext] between all DccTicketing destinations.
  */
-class DccTicketingSharedViewModel : ViewModel() {
+class DccTicketingSharedViewModel(private val savedState: SavedStateHandle) : ViewModel() {
 
-    private val currentTransactionContext = MutableStateFlow<DccTicketingTransactionContext?>(null)
+    private val currentTransactionContext = MutableStateFlow<DccTicketingTransactionContext?>(
+        getSavedTransactionContext()
+    )
 
     val transactionContext: Flow<DccTicketingTransactionContext> = currentTransactionContext.filterNotNull()
 
     fun updateTransactionContext(ctx: DccTicketingTransactionContext) {
         Timber.d("updateTransactionContext(ctx=%s)", ctx)
-        currentTransactionContext.tryEmit(ctx).also { Timber.d("Update was successful? %s", it) }
+        currentTransactionContext.tryEmit(ctx).also {
+            Timber.d("Update was successful? %s", it)
+            saveTransactionContext(ctx)
+        }
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    fun getSavedTransactionContext(): DccTicketingTransactionContext? =
+        savedState.get(TRANSACTION_CONTEXT_SAVED_STATE_KEY)
+
+    private fun saveTransactionContext(ctx: DccTicketingTransactionContext) {
+        savedState.set(TRANSACTION_CONTEXT_SAVED_STATE_KEY, ctx)
+    }
+
+    companion object {
+        private const val TRANSACTION_CONTEXT_SAVED_STATE_KEY = "transaction_context_saved_state_key"
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/dccticketing/ui/shared/DccTicketingSharedViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/dccticketing/ui/shared/DccTicketingSharedViewModelTest.kt
@@ -1,5 +1,6 @@
 package de.rki.coronawarnapp.dccticketing.ui.shared
 
+import androidx.lifecycle.SavedStateHandle
 import de.rki.coronawarnapp.dccticketing.core.qrcode.DccTicketingQrCodeData
 import de.rki.coronawarnapp.dccticketing.core.transaction.DccTicketingTransactionContext
 import io.kotest.assertions.throwables.shouldThrow
@@ -12,7 +13,9 @@ import testhelpers.coroutines.runBlockingTest2
 class DccTicketingSharedViewModelTest : BaseTest() {
 
     private val instance: DccTicketingSharedViewModel
-        get() = DccTicketingSharedViewModel()
+        get() = DccTicketingSharedViewModel(
+            SavedStateHandle()
+        )
 
     @Test
     fun `Init with empty transaction context flow`() = runBlockingTest2(ignoreActive = true) {
@@ -37,6 +40,7 @@ class DccTicketingSharedViewModelTest : BaseTest() {
         instance.run {
             updateTransactionContext(ctx = ctx)
             transactionContext.first() shouldBe ctx
+            getSavedTransactionContext() shouldBe ctx
 
             val updatedCtx = ctx.copy(
                 initializationData = ctx.initializationData.copy(protocol = "Test protocol updated")


### PR DESCRIPTION
The `transactionContext` property of the ViewModel that is shared within the whole ticketing flow `DccTicketingSharedViewModel` doesn't survive process death, and therefore the testers are sometimes seeing empty screens (certificate selection and result screen) after bringing the app in background and foreground again. 

This PR adds the `savedStateHandle` to this ViewModel and stores the `transactionContext` there. Now the screens get populated correclty again even after process death. 

How to test:
- the cli command `cwa ti gen -e wru -o` currently generates a qr code with: Service Provider Allowlist: FAIL - therefore you have to currently disable the "Check against allow list" switch in the DCC Ticketing Test Menu in ordere to be able to navigate though the ticketing flow
- Go to certificate selection screen / result screen
- Put app in background
- Kill app process (e.g. Android Studio -> Logcat -> Terminate Application
- Bring app in foreground
- UI should be the same as before