### PR TITLE
Redundant cancel button in QR scanner dialog (EXPOSUREAPP-10963)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/organizer/warn/qrcode/OrganizerWarnQrCodeScannerFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/organizer/warn/qrcode/OrganizerWarnQrCodeScannerFragment.kt
@@ -149,9 +149,6 @@ class OrganizerWarnQrCodeScannerFragment : Fragment(R.layout.fragment_qrcode_sca
             setPositiveButton(R.string.trace_location_attendee_invalid_qr_code_dialog_positive_button) { _, _ ->
                 startDecode()
             }
-            setNegativeButton(R.string.trace_location_attendee_invalid_qr_code_dialog_negative_button) { _, _ ->
-                popBackStack()
-            }
         }.show()
     }
 


### PR DESCRIPTION
[Ticket](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10963)

As an event organizer, when trying to warn others by scanning a QR code, if the QR is invalid, the error dialog contains a redundant "Cancel" button. Pr removes this button and only leaves the "OK" functioning.

Steps to test are found in the ticket.