### PR TITLE
Display Unique Vaccination Certificate/Assertion Identifier (UVCI) (EXPOSUREAPP-11108)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsFragmentTest.kt
@@ -257,7 +257,7 @@ class PersonDetailsFragmentTest : BaseUITest() {
     }
 
     private fun mockTestCertificate(): TestCertificate = mockk<TestCertificate>().apply {
-        every { certificateId } returns "testCertificateId"
+        every { uniqueCertificateIdentifier } returns "RN:UVCI:01:AT:858CC18CFCF5965EF82F60E493349AA5#K"
         every { fullName } returns "Andrea Schneider"
         every { rawCertificate } returns mockk<TestDccV1>().apply {
             every { test } returns mockk<DccV1.TestCertificateData>().apply {
@@ -294,7 +294,8 @@ class PersonDetailsFragmentTest : BaseUITest() {
         mockk<VaccinationCertificate>().apply {
             val localDate = Instant.parse("2021-06-01T11:35:00.000Z").toLocalDateUserTz()
             every { fullName } returns "Andrea Schneider"
-            every { certificateId } returns "vaccinationCertificateId$number"
+            every { uniqueCertificateIdentifier } returns
+                "RN:UVCI:01:AT:858CC${number}8CFCF5965EF82F60E493349AA5#K"
             every { rawCertificate } returns mockk<VaccinationDccV1>().apply {
                 every { vaccination } returns mockk<DccV1.VaccinationData>().apply {
                     every { doseNumber } returns number
@@ -327,7 +328,7 @@ class PersonDetailsFragmentTest : BaseUITest() {
     private fun mockRecoveryCertificate(): RecoveryCertificate =
         mockk<RecoveryCertificate>().apply {
             every { fullName } returns "Andrea Schneider"
-            every { certificateId } returns "recoveryCertificateId"
+            every { uniqueCertificateIdentifier } returns "RN:UVCI:01:AT:858CC18CFCF5965EF82F60E493349AA5#K"
             every { dateOfBirthFormatted } returns "1981-03-20"
             every { validUntil } returns Instant.parse("2021-03-31T11:35:00.000Z").toLocalDateUserTz()
             every { personIdentifier } returns certificatePersonIdentifier

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/RecoveryCertificateDetailFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/RecoveryCertificateDetailFragmentTest.kt
@@ -128,7 +128,7 @@ class RecoveryCertificateDetailFragmentTest : BaseUITest() {
         every { validFromFormatted } returns "2021-06-07"
         every { validUntilFormatted } returns "2021-11-10"
         every { hasNotificationBadge } returns false
-        every { certificateId } returns "05930482748454836478695764787841"
+        every { uniqueCertificateIdentifier } returns "URN:UVCI:01:AT:858CC18CFCF5965EF82F60E493349AA5#K"
         every { qrCodeToDisplay } returns CoilQrCode(ScreenshotCertificateTestData.recoveryCertificate)
         every { validUntil } returns
             LocalDate.parse("2021-11-10", DateTimeFormat.forPattern("yyyy-MM-dd"))

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/test/ui/TestCertificateDetailsFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/test/ui/TestCertificateDetailsFragmentTest.kt
@@ -173,8 +173,11 @@ class TestCertificateDetailsFragmentTest : BaseUITest() {
             get() = "G0593048274845483647869576478784"
         override val certificateCountry: String
             get() = "Germany"
-        override val certificateId: String
+        override val qrcodeHash: String
             get() = "05930482748454836478695764787840"
+
+        override val uniqueCertificateIdentifier: String
+            get() = "URN:UVCI:01:AT:858CC18CFCF5965EF82F60E493349AA5#K"
         override val dccData: DccData<*>
             get() = mockk()
 

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/test/ui/TestCertificateDetailsFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/test/ui/TestCertificateDetailsFragmentTest.kt
@@ -173,7 +173,7 @@ class TestCertificateDetailsFragmentTest : BaseUITest() {
             get() = "G0593048274845483647869576478784"
         override val certificateCountry: String
             get() = "Germany"
-        override val qrcodeHash: String
+        override val qrCodeHash: String
             get() = "05930482748454836478695764787840"
 
         override val uniqueCertificateIdentifier: String

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragmentTest.kt
@@ -144,7 +144,7 @@ class VaccinationDetailsFragmentTest : BaseUITest() {
             every { vaccineManufacturer } returns "BioNTech"
             every { certificateIssuer } returns "Landratsamt Musterstadt"
             every { certificateCountry } returns "Deutschland"
-            every { certificateId } returns "05930482748454836478695764787841"
+            every { uniqueCertificateIdentifier } returns "URN:UVCI:01:AT:858CC18CFCF5965EF82F60E493349AA5#K"
             every { headerExpiresAt } returns Instant.parse("2021-05-16T00:00:00.000Z")
             every { totalSeriesOfDoses } returns 2
             every { hasNotificationBadge } returns false

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/dccticketing/ui/consent/two/DccTicketingConsentTwoFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/dccticketing/ui/consent/two/DccTicketingConsentTwoFragmentTest.kt
@@ -115,7 +115,7 @@ class DccTicketingConsentTwoFragmentTest : BaseUITest() {
         mockk<VaccinationCertificate>().apply {
             val localDate = Instant.parse("2021-06-01T11:35:00.000Z").toLocalDateUserTz()
             every { fullName } returns "Andrea Schneider"
-            every { certificateId } returns "vaccinationCertificateId$number"
+            every { uniqueCertificateIdentifier } returns "URN:UVCI:01:AT:858CC18CFCF5965EF82F60E4${number}3349AA5#K"
             every { rawCertificate } returns mockk<VaccinationDccV1>().apply {
                 every { vaccination } returns mockk<DccV1.VaccinationData>().apply {
                     every { doseNumber } returns number

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/submission/SubmissionTestResultNegativeFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/submission/SubmissionTestResultNegativeFragmentTest.kt
@@ -109,7 +109,7 @@ class SubmissionTestResultNegativeFragmentTest : BaseUITest() {
         takeScreenshot<SubmissionTestResultNegativeFragment>()
     }
 
-    fun mockTestCertificateWrapper(isUpdating: Boolean) = mockk<TestCertificateWrapper>().apply {
+    private fun mockTestCertificateWrapper(isUpdating: Boolean) = mockk<TestCertificateWrapper>().apply {
         every { isCertificateRetrievalPending } returns true
         every { isUpdatingData } returns isUpdating
         every { registeredAt } returns Instant.EPOCH
@@ -118,7 +118,7 @@ class SubmissionTestResultNegativeFragmentTest : BaseUITest() {
     }
 
     private fun mockTestCertificate(): TestCertificate = mockk<TestCertificate>().apply {
-        every { certificateId } returns "testCertificateId"
+        every { uniqueCertificateIdentifier } returns "URN:UVCI:01:AT:858CC18CFCF5965EF82F60E493349AA5#K"
         every { fullName } returns "Andrea Schneider"
         every { rawCertificate } returns mockk<TestDccV1>().apply {
             every { test } returns mockk<DccV1.TestCertificateData>().apply {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/CoronaTestCertificateCensor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/submission/CoronaTestCertificateCensor.kt
@@ -31,7 +31,7 @@ class CoronaTestCertificateCensor @Inject constructor(
             .onEach { cert ->
                 mutex.withLock {
                     tokenHistory.addAll(cert.mapNotNull { it.registrationToken })
-                    identifierHistory.addAll(cert.map { it.containerId.identifier })
+                    identifierHistory.addAll(cert.map { it.containerId.qrCodeHash })
                 }
             }.launchIn(debugScope)
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/booster/DccBoosterRulesValidator.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/booster/DccBoosterRulesValidator.kt
@@ -49,11 +49,17 @@ class DccBoosterRulesValidator @Inject constructor(
             Timber.tag(TAG).d("No vaccination certificate found")
             return null
         }
-        Timber.tag(TAG).d("Most recent vaccination certificate=%s", vaccinationCertificate.certificateId)
+        Timber.tag(TAG).d(
+            "Most recent vaccination certificate=%s",
+            vaccinationCertificate.uniqueCertificateIdentifier
+        )
 
         // Find recent recovery certificate
         val recoveryCertificate = findRecentRecoveryCertificate(dccList)
-        Timber.tag(TAG).d("Most recent recovery certificate=%s", recoveryCertificate?.certificateId)
+        Timber.tag(TAG).d(
+            "Most recent recovery certificate=%s",
+            recoveryCertificate?.uniqueCertificateIdentifier
+        )
 
         val vacDccData = vaccinationCertificate.dccData
         val recDccData = recoveryCertificate?.dccData

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/CwaCovidCertificate.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/CwaCovidCertificate.kt
@@ -29,7 +29,12 @@ interface CwaCovidCertificate : Recyclable {
     val personIdentifier: CertificatePersonIdentifier
     val certificateIssuer: String
     val certificateCountry: String
-    val certificateId: String
+    val qrcodeHash: String
+
+    /**
+     * `ci` field
+     */
+    val uniqueCertificateIdentifier: String
 
     /**
      * The ID of the container holding this certificate in the CWA.

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/CwaCovidCertificate.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/CwaCovidCertificate.kt
@@ -29,7 +29,7 @@ interface CwaCovidCertificate : Recyclable {
     val personIdentifier: CertificatePersonIdentifier
     val certificateIssuer: String
     val certificateCountry: String
-    val qrcodeHash: String
+    val qrCodeHash: String
 
     /**
      * `ci` field

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/qrcode/DccQrCode.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/qrcode/DccQrCode.kt
@@ -4,6 +4,7 @@ import de.rki.coronawarnapp.covidcertificate.common.certificate.CertificatePerso
 import de.rki.coronawarnapp.covidcertificate.common.certificate.DccData
 import de.rki.coronawarnapp.covidcertificate.common.certificate.DccV1
 import de.rki.coronawarnapp.qrcode.scanner.QrCode
+import de.rki.coronawarnapp.util.HashExtensions.toSHA256
 
 interface DccQrCode : QrCode {
     val qrCode: QrCodeString
@@ -12,5 +13,6 @@ interface DccQrCode : QrCode {
     val personIdentifier: CertificatePersonIdentifier
         get() = data.certificate.personIdentifier
 
-    val uniqueCertificateIdentifier: String
+    val hash: String
+        get() = qrCode.toSHA256()
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/repository/CertificateContainerId.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/repository/CertificateContainerId.kt
@@ -10,7 +10,7 @@ import kotlin.reflect.KClass
  * We can't use uniqueCertificateId because we also handle `TestCertificate`'s that have not been retrieved yet.
  */
 sealed class CertificateContainerId : Parcelable {
-    abstract val identifier: String
+    abstract val qrCodeHash: String
 
     val idType: KClass<out CertificateContainerId> = this::class
 
@@ -18,14 +18,14 @@ sealed class CertificateContainerId : Parcelable {
         if (this === other) return true
         if (other !is CertificateContainerId) return false
 
-        if (identifier != other.identifier) return false
+        if (qrCodeHash != other.qrCodeHash) return false
         if (idType != other.idType) return false
 
         return true
     }
 
     override fun hashCode(): Int {
-        var result = identifier.hashCode()
+        var result = qrCodeHash.hashCode()
         result = 31 * result + idType.hashCode()
         return result
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/repository/CertificateRepoContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/repository/CertificateRepoContainer.kt
@@ -7,6 +7,8 @@ import java.util.Locale
 interface CertificateRepoContainer : Recyclable {
     val containerId: CertificateContainerId
 
+    val qrCodeHash: String
+
     /**
      * Returns what qr code to display based on certificate state
      * @param state Certificate state

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/repository/RecoveryCertificateContainerId.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/repository/RecoveryCertificateContainerId.kt
@@ -4,8 +4,8 @@ import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-class RecoveryCertificateContainerId(private val qrcodeHash: String) : CertificateContainerId() {
+class RecoveryCertificateContainerId(private val qrCodeHash: String) : CertificateContainerId() {
     @IgnoredOnParcel
     override val identifier: String
-        get() = qrcodeHash
+        get() = qrCodeHash
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/repository/RecoveryCertificateContainerId.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/repository/RecoveryCertificateContainerId.kt
@@ -4,8 +4,8 @@ import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-class RecoveryCertificateContainerId(private val certificateId: String) : CertificateContainerId() {
+class RecoveryCertificateContainerId(private val qrcodeHash: String) : CertificateContainerId() {
     @IgnoredOnParcel
     override val identifier: String
-        get() = certificateId
+        get() = qrcodeHash
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/repository/RecoveryCertificateContainerId.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/repository/RecoveryCertificateContainerId.kt
@@ -1,11 +1,6 @@
 package de.rki.coronawarnapp.covidcertificate.common.repository
 
-import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-class RecoveryCertificateContainerId(private val qrCodeHash: String) : CertificateContainerId() {
-    @IgnoredOnParcel
-    override val identifier: String
-        get() = qrCodeHash
-}
+class RecoveryCertificateContainerId(override val qrCodeHash: String) : CertificateContainerId()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/repository/TestCertificateContainerId.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/repository/TestCertificateContainerId.kt
@@ -1,11 +1,6 @@
 package de.rki.coronawarnapp.covidcertificate.common.repository
 
-import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-class TestCertificateContainerId(private val certificateId: String) : CertificateContainerId() {
-    @IgnoredOnParcel
-    override val identifier: String
-        get() = certificateId
-}
+class TestCertificateContainerId(override val qrCodeHash: String) : CertificateContainerId()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/repository/VaccinationCertificateContainerId.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/repository/VaccinationCertificateContainerId.kt
@@ -4,8 +4,8 @@ import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-class VaccinationCertificateContainerId(private val certificateId: String) : CertificateContainerId() {
+class VaccinationCertificateContainerId(private val qrcodeHash: String) : CertificateContainerId() {
     @IgnoredOnParcel
     override val identifier: String
-        get() = certificateId
+        get() = qrcodeHash
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/repository/VaccinationCertificateContainerId.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/repository/VaccinationCertificateContainerId.kt
@@ -1,11 +1,6 @@
 package de.rki.coronawarnapp.covidcertificate.common.repository
 
-import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-class VaccinationCertificateContainerId(private val qrcodeHash: String) : CertificateContainerId() {
-    @IgnoredOnParcel
-    override val identifier: String
-        get() = qrcodeHash
-}
+class VaccinationCertificateContainerId(override val qrCodeHash: String) : CertificateContainerId()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/expiration/DccExpirationNotification.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/expiration/DccExpirationNotification.kt
@@ -62,11 +62,11 @@ class DccExpirationNotification @Inject constructor(
 
         val args: Bundle = when (containerId) {
             is VaccinationCertificateContainerId ->
-                VaccinationDetailsFragmentArgs(containerId.identifier).toBundle()
+                VaccinationDetailsFragmentArgs(containerId.qrCodeHash).toBundle()
             is TestCertificateContainerId ->
-                TestCertificateDetailsFragmentArgs(containerId.identifier).toBundle()
+                TestCertificateDetailsFragmentArgs(containerId.qrCodeHash).toBundle()
             is RecoveryCertificateContainerId ->
-                RecoveryCertificateDetailsFragmentArgs(containerId.identifier).toBundle()
+                RecoveryCertificateDetailsFragmentArgs(containerId.qrCodeHash).toBundle()
         }
 
         return deepLinkBuilderFactory.create(context)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/core/CertificateDrawHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/core/CertificateDrawHelper.kt
@@ -25,7 +25,7 @@ class CertificateDrawHelper @Inject constructor(
         with(canvas) {
             drawTextIntoRectangle(certificate.fullNameFormatted, paint, TextArea(28.78f, 693.31f, 267.5f))
             drawTextIntoRectangle(certificate.dateOfBirthFormatted, paint, TextArea(28.78f, 738.89f, 267.5f))
-            drawTextIntoRectangle(certificate.certificateId, paint, TextArea(28.78f, 783.27f, 267.5f))
+            drawTextIntoRectangle(certificate.uniqueCertificateIdentifier, paint, TextArea(28.78f, 783.27f, 267.5f))
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsFragment.kt
@@ -96,7 +96,7 @@ class PersonDetailsFragment : Fragment(R.layout.person_details_fragment), AutoIn
             is OpenRecoveryCertificateDetails -> doNavigate(
                 PersonDetailsFragmentDirections
                     .actionPersonDetailsFragmentToRecoveryCertificateDetailsFragment(
-                        certIdentifier = event.containerId.identifier,
+                        certIdentifier = event.containerId.qrCodeHash,
                         fromScanner = false,
                         colorShade = event.colorShade
                     )
@@ -104,7 +104,7 @@ class PersonDetailsFragment : Fragment(R.layout.person_details_fragment), AutoIn
             is OpenTestCertificateDetails -> doNavigate(
                 PersonDetailsFragmentDirections
                     .actionPersonDetailsFragmentToTestCertificateDetailsFragment(
-                        certIdentifier = event.containerId.identifier,
+                        certIdentifier = event.containerId.qrCodeHash,
                         fromScanner = false,
                         colorShade = event.colorShade
                     )
@@ -112,7 +112,7 @@ class PersonDetailsFragment : Fragment(R.layout.person_details_fragment), AutoIn
             is OpenVaccinationCertificateDetails -> doNavigate(
                 PersonDetailsFragmentDirections
                     .actionPersonDetailsFragmentToVaccinationDetailsFragment(
-                        certIdentifier = event.containerId.identifier,
+                        certIdentifier = event.containerId.qrCodeHash,
                         fromScanner = false,
                         colorShade = event.colorShade
                     )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/RecoveryCertificateRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/RecoveryCertificateRepository.kt
@@ -124,7 +124,7 @@ class RecoveryCertificateRepository @Inject constructor(
         Timber.tag(TAG).d("registerCertificate(qrCode=%s)", qrCode)
         val newContainer = qrCode.toContainer()
         internalData.updateBlocking {
-            if (any { it.certificateId == newContainer.certificateId }) {
+            if (any { it.qrcodeHash == newContainer.qrcodeHash }) {
                 throw InvalidRecoveryCertificateException(
                     InvalidHealthCertificateException.ErrorCode.ALREADY_REGISTERED
                 )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/RecoveryCertificateRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/RecoveryCertificateRepository.kt
@@ -124,7 +124,7 @@ class RecoveryCertificateRepository @Inject constructor(
         Timber.tag(TAG).d("registerCertificate(qrCode=%s)", qrCode)
         val newContainer = qrCode.toContainer()
         internalData.updateBlocking {
-            if (any { it.qrcodeHash == newContainer.qrcodeHash }) {
+            if (any { it.qrCodeHash == newContainer.qrCodeHash }) {
                 throw InvalidRecoveryCertificateException(
                     InvalidHealthCertificateException.ErrorCode.ALREADY_REGISTERED
                 )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/qrcode/RecoveryCertificateQRCode.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/qrcode/RecoveryCertificateQRCode.kt
@@ -4,12 +4,8 @@ import de.rki.coronawarnapp.covidcertificate.common.certificate.DccData
 import de.rki.coronawarnapp.covidcertificate.common.certificate.RecoveryDccV1
 import de.rki.coronawarnapp.covidcertificate.common.qrcode.DccQrCode
 import de.rki.coronawarnapp.covidcertificate.common.qrcode.QrCodeString
-import de.rki.coronawarnapp.util.HashExtensions.toSHA256
 
 data class RecoveryCertificateQRCode(
     override val qrCode: QrCodeString,
     override val data: DccData<RecoveryDccV1>,
-) : DccQrCode {
-    override val uniqueCertificateIdentifier: String
-        get() = qrCode.toSHA256()
-}
+) : DccQrCode

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/storage/RecoveryCertificateContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/storage/RecoveryCertificateContainer.kt
@@ -40,9 +40,9 @@ data class RecoveryCertificateContainer(
     }
 
     override val containerId: RecoveryCertificateContainerId
-        get() = RecoveryCertificateContainerId(certificateId)
+        get() = RecoveryCertificateContainerId(qrcodeHash)
 
-    val certificateId: String
+    val qrcodeHash: String
         get() = data.recoveryCertificateQrCode.toSHA256()
 
     val personIdentifier: CertificatePersonIdentifier
@@ -132,8 +132,11 @@ data class RecoveryCertificateContainer(
                 get() = Locale(userLocale.language, recoveryCertificate.certificateCountry.uppercase())
                     .getDisplayCountry(userLocale)
 
-            override val certificateId: String
-                get() = this@RecoveryCertificateContainer.certificateId
+            override val qrcodeHash: String
+                get() = this@RecoveryCertificateContainer.qrcodeHash
+
+            override val uniqueCertificateIdentifier: String
+                get() = recoveryCertificate.uniqueCertificateIdentifier
 
             override val headerIssuer: String
                 get() = header.issuer

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/storage/RecoveryCertificateContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/storage/RecoveryCertificateContainer.kt
@@ -39,11 +39,11 @@ data class RecoveryCertificateContainer(
         }
     }
 
-    override val containerId: RecoveryCertificateContainerId
-        get() = RecoveryCertificateContainerId(qrcodeHash)
-
-    val qrcodeHash: String
+    override val qrCodeHash: String
         get() = data.recoveryCertificateQrCode.toSHA256()
+
+    override val containerId: RecoveryCertificateContainerId
+        get() = RecoveryCertificateContainerId(qrCodeHash)
 
     val personIdentifier: CertificatePersonIdentifier
         get() = certificateData.certificate.personIdentifier
@@ -132,8 +132,8 @@ data class RecoveryCertificateContainer(
                 get() = Locale(userLocale.language, recoveryCertificate.certificateCountry.uppercase())
                     .getDisplayCountry(userLocale)
 
-            override val qrcodeHash: String
-                get() = this@RecoveryCertificateContainer.qrcodeHash
+            override val qrCodeHash: String
+                get() = this@RecoveryCertificateContainer.qrCodeHash
 
             override val uniqueCertificateIdentifier: String
                 get() = recoveryCertificate.uniqueCertificateIdentifier

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/details/RecoveryCertificateDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/details/RecoveryCertificateDetailsFragment.kt
@@ -115,7 +115,7 @@ class RecoveryCertificateDetailsFragment : Fragment(R.layout.fragment_recovery_c
         certificateIssuer.text = certificate.certificateIssuer
         certificationPeriodStart.text = certificate.validFromFormatted
         certificationPeriodEnd.text = certificate.validUntilFormatted
-        certificateId.text = certificate.certificateId
+        certificateId.text = certificate.uniqueCertificateIdentifier
         expirationNotice.expirationDate.text = getString(
             R.string.expiration_date,
             certificate.headerExpiresAt.toLocalDateTimeUserTz().toShortDayFormat(),

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepository.kt
@@ -214,7 +214,7 @@ class TestCertificateRepository @Inject constructor(
 
         val updatedData = internalData.updateBlocking {
 
-            if (values.any { it.qrcodeHash == qrCode.hash }) {
+            if (values.any { it.qrCodeHash == qrCode.hash }) {
                 Timber.tag(TAG).e("Certificate entry already exists for %s", qrCode)
                 throw InvalidTestCertificateException(InvalidHealthCertificateException.ErrorCode.ALREADY_REGISTERED)
             }
@@ -237,7 +237,7 @@ class TestCertificateRepository @Inject constructor(
         }
 
         // We just registered it, it MUST be available.
-        return updatedData.values.single { it.qrcodeHash == qrCode.hash }
+        return updatedData.values.single { it.qrCodeHash == qrCode.hash }
     }
 
     /**

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepository.kt
@@ -214,7 +214,7 @@ class TestCertificateRepository @Inject constructor(
 
         val updatedData = internalData.updateBlocking {
 
-            if (values.any { it.certificateId == qrCode.uniqueCertificateIdentifier }) {
+            if (values.any { it.qrcodeHash == qrCode.hash }) {
                 Timber.tag(TAG).e("Certificate entry already exists for %s", qrCode)
                 throw InvalidTestCertificateException(InvalidHealthCertificateException.ErrorCode.ALREADY_REGISTERED)
             }
@@ -237,8 +237,7 @@ class TestCertificateRepository @Inject constructor(
         }
 
         // We just registered it, it MUST be available.
-        return updatedData.values
-            .single { it.certificateId == qrCode.uniqueCertificateIdentifier }
+        return updatedData.values.single { it.qrcodeHash == qrCode.hash }
     }
 
     /**

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/qrcode/TestCertificateQRCode.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/qrcode/TestCertificateQRCode.kt
@@ -4,12 +4,8 @@ import de.rki.coronawarnapp.covidcertificate.common.certificate.DccData
 import de.rki.coronawarnapp.covidcertificate.common.certificate.TestDccV1
 import de.rki.coronawarnapp.covidcertificate.common.qrcode.DccQrCode
 import de.rki.coronawarnapp.covidcertificate.common.qrcode.QrCodeString
-import de.rki.coronawarnapp.util.HashExtensions.toSHA256
 
 data class TestCertificateQRCode(
     override val qrCode: QrCodeString,
     override val data: DccData<TestDccV1>,
-) : DccQrCode {
-    override val uniqueCertificateIdentifier: String
-        get() = qrCode.toSHA256()
-}
+) : DccQrCode

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateContainer.kt
@@ -40,7 +40,7 @@ data class TestCertificateContainer(
     }
 
     override val containerId: TestCertificateContainerId
-        get() = TestCertificateContainerId(certificateId)
+        get() = TestCertificateContainerId(qrcodeHash)
 
     override val recycledAt: Instant?
         get() = data.recycledAt
@@ -63,7 +63,7 @@ data class TestCertificateContainer(
     val isCertificateRetrievalPending: Boolean
         get() = data.certificateReceivedAt == null
 
-    val certificateId: String
+    val qrcodeHash: String
         get() = data.testCertificateQrCode?.toSHA256() ?: data.identifier
 
     fun toTestCertificate(
@@ -129,8 +129,11 @@ data class TestCertificateContainer(
             override val certificateCountry: String
                 get() = Locale(userLocale.language, testCertificate.certificateCountry.uppercase())
                     .getDisplayCountry(userLocale)
-            override val certificateId: String
-                get() = this@TestCertificateContainer.certificateId
+            override val qrcodeHash: String
+                get() = this@TestCertificateContainer.qrcodeHash
+
+            override val uniqueCertificateIdentifier: String
+                get() = testCertificateQRCode!!.hash
 
             override val headerIssuer: String
                 get() = header.issuer

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateContainer.kt
@@ -40,7 +40,7 @@ data class TestCertificateContainer(
     }
 
     override val containerId: TestCertificateContainerId
-        get() = TestCertificateContainerId(qrcodeHash)
+        get() = TestCertificateContainerId(qrCodeHash)
 
     override val recycledAt: Instant?
         get() = data.recycledAt
@@ -63,7 +63,11 @@ data class TestCertificateContainer(
     val isCertificateRetrievalPending: Boolean
         get() = data.certificateReceivedAt == null
 
-    val qrcodeHash: String
+    /**
+     * Retrieved Test certificate container at beginning does not have QR Code. Until QR Code exist UUID is provided
+     * and in this is case it is not yet considered as certificate
+     */
+    override val qrCodeHash: String
         get() = data.testCertificateQrCode?.toSHA256() ?: data.identifier
 
     fun toTestCertificate(
@@ -129,8 +133,8 @@ data class TestCertificateContainer(
             override val certificateCountry: String
                 get() = Locale(userLocale.language, testCertificate.certificateCountry.uppercase())
                     .getDisplayCountry(userLocale)
-            override val qrcodeHash: String
-                get() = this@TestCertificateContainer.qrcodeHash
+            override val qrCodeHash: String
+                get() = this@TestCertificateContainer.qrCodeHash
 
             override val uniqueCertificateIdentifier: String
                 get() = testCertificate.uniqueCertificateIdentifier

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateContainer.kt
@@ -133,7 +133,7 @@ data class TestCertificateContainer(
                 get() = this@TestCertificateContainer.qrcodeHash
 
             override val uniqueCertificateIdentifier: String
-                get() = testCertificateQRCode!!.hash
+                get() = testCertificate.uniqueCertificateIdentifier
 
             override val headerIssuer: String
                 get() = header.issuer

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/TestCertificateDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/TestCertificateDetailsFragment.kt
@@ -113,7 +113,7 @@ class TestCertificateDetailsFragment : Fragment(R.layout.fragment_test_certifica
         testResult.text = certificate.testResult
         certificateCountry.text = certificate.certificateCountry
         certificateIssuer.text = certificate.certificateIssuer
-        certificateId.text = certificate.certificateId
+        certificateId.text = certificate.uniqueCertificateIdentifier
         expirationNotice.expirationDate.text = getString(
             R.string.expiration_date,
             certificate.headerExpiresAt.toLocalDateTimeUserTz().toShortDayFormat(),

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/ui/onboarding/CovidCertificateOnboardingFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/ui/onboarding/CovidCertificateOnboardingFragment.kt
@@ -82,11 +82,11 @@ class CovidCertificateOnboardingFragment : Fragment(R.layout.covid_certificate_o
                 is CovidCertificateOnboardingViewModel.Event.NavigateToDccDetailsScreen -> {
                     val uri = when (event.containerId) {
                         is VaccinationCertificateContainerId ->
-                            VaccinationDetailsFragment.uri(event.containerId.identifier)
+                            VaccinationDetailsFragment.uri(event.containerId.qrCodeHash)
                         is TestCertificateContainerId ->
-                            TestCertificateDetailsFragment.uri(event.containerId.identifier)
+                            TestCertificateDetailsFragment.uri(event.containerId.qrCodeHash)
                         is RecoveryCertificateContainerId ->
-                            RecoveryCertificateDetailsFragment.uri(event.containerId.identifier)
+                            RecoveryCertificateDetailsFragment.uri(event.containerId.qrCodeHash)
                     }
                     val navOption = NavOptions.Builder()
                         .setPopUpTo(R.id.covidCertificateOnboardingFragment, true)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/qrcode/VaccinationCertificateQRCode.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/qrcode/VaccinationCertificateQRCode.kt
@@ -4,12 +4,8 @@ import de.rki.coronawarnapp.covidcertificate.common.certificate.DccData
 import de.rki.coronawarnapp.covidcertificate.common.certificate.VaccinationDccV1
 import de.rki.coronawarnapp.covidcertificate.common.qrcode.DccQrCode
 import de.rki.coronawarnapp.covidcertificate.common.qrcode.QrCodeString
-import de.rki.coronawarnapp.util.HashExtensions.toSHA256
 
 data class VaccinationCertificateQRCode(
     override val qrCode: QrCodeString,
     override val data: DccData<VaccinationDccV1>
-) : DccQrCode {
-    override val uniqueCertificateIdentifier: String
-        get() = qrCode.toSHA256()
-}
+) : DccQrCode

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/VaccinationRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/VaccinationRepository.kt
@@ -138,8 +138,8 @@ class VaccinationRepository @Inject constructor(
                 valueSet = null,
             ).also { Timber.tag(TAG).i("Creating new person for %s", qrCode) }
 
-            if (matchingPerson.data.vaccinations.any { it.certificateId == qrCode.uniqueCertificateIdentifier }) {
-                Timber.tag(TAG).e("Certificate is already registered: %s", qrCode.uniqueCertificateIdentifier)
+            if (matchingPerson.data.vaccinations.any { it.qrcodeHash == qrCode.hash }) {
+                Timber.tag(TAG).e("Certificate is already registered: %s", qrCode.hash)
                 throw InvalidVaccinationCertificateException(ALREADY_REGISTERED)
             }
 
@@ -167,7 +167,7 @@ class VaccinationRepository @Inject constructor(
         val updatedPerson = updatedData.single { it.identifier == qrCode.personIdentifier }
 
         return updatedPerson.vaccinationCertificates.single {
-            it.certificateId == qrCode.uniqueCertificateIdentifier
+            it.qrcodeHash == qrCode.hash
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/VaccinationRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/VaccinationRepository.kt
@@ -138,7 +138,7 @@ class VaccinationRepository @Inject constructor(
                 valueSet = null,
             ).also { Timber.tag(TAG).i("Creating new person for %s", qrCode) }
 
-            if (matchingPerson.data.vaccinations.any { it.qrcodeHash == qrCode.hash }) {
+            if (matchingPerson.data.vaccinations.any { it.qrCodeHash == qrCode.hash }) {
                 Timber.tag(TAG).e("Certificate is already registered: %s", qrCode.hash)
                 throw InvalidVaccinationCertificateException(ALREADY_REGISTERED)
             }
@@ -167,7 +167,7 @@ class VaccinationRepository @Inject constructor(
         val updatedPerson = updatedData.single { it.identifier == qrCode.personIdentifier }
 
         return updatedPerson.vaccinationCertificates.single {
-            it.qrcodeHash == qrCode.hash
+            it.qrCodeHash == qrCode.hash
         }
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/storage/VaccinationContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/storage/VaccinationContainer.kt
@@ -58,8 +58,11 @@ data class VaccinationContainer internal constructor(
         }
     }
 
+    override val qrCodeHash: String
+        get() = vaccinationQrCode.toSHA256()
+
     override val containerId: VaccinationCertificateContainerId
-        get() = VaccinationCertificateContainerId(qrcodeHash)
+        get() = VaccinationCertificateContainerId(qrCodeHash)
 
     val header: DccHeader
         get() = certificateData.header
@@ -69,9 +72,6 @@ data class VaccinationContainer internal constructor(
 
     val vaccination: DccV1.VaccinationData
         get() = certificate.vaccination
-
-    val qrcodeHash: String
-        get() = vaccinationQrCode.toSHA256()
 
     val personIdentifier: CertificatePersonIdentifier
         get() = certificate.personIdentifier
@@ -162,8 +162,8 @@ data class VaccinationContainer internal constructor(
                 vaccination.certificateCountry.uppercase()
             ).getDisplayCountry(userLocale)
 
-        override val qrcodeHash: String
-            get() = this@VaccinationContainer.qrcodeHash
+        override val qrCodeHash: String
+            get() = this@VaccinationContainer.qrCodeHash
 
         override val uniqueCertificateIdentifier: String
             get() = vaccination.uniqueCertificateIdentifier

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/storage/VaccinationContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/storage/VaccinationContainer.kt
@@ -59,7 +59,7 @@ data class VaccinationContainer internal constructor(
     }
 
     override val containerId: VaccinationCertificateContainerId
-        get() = VaccinationCertificateContainerId(certificateId)
+        get() = VaccinationCertificateContainerId(qrcodeHash)
 
     val header: DccHeader
         get() = certificateData.header
@@ -70,7 +70,7 @@ data class VaccinationContainer internal constructor(
     val vaccination: DccV1.VaccinationData
         get() = certificate.vaccination
 
-    val certificateId: String
+    val qrcodeHash: String
         get() = vaccinationQrCode.toSHA256()
 
     val personIdentifier: CertificatePersonIdentifier
@@ -162,8 +162,11 @@ data class VaccinationContainer internal constructor(
                 vaccination.certificateCountry.uppercase()
             ).getDisplayCountry(userLocale)
 
-        override val certificateId: String
-            get() = this@VaccinationContainer.certificateId
+        override val qrcodeHash: String
+            get() = this@VaccinationContainer.qrcodeHash
+
+        override val uniqueCertificateIdentifier: String
+            get() = vaccination.uniqueCertificateIdentifier
 
         override val headerIssuer: String
             get() = header.issuer

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragment.kt
@@ -208,7 +208,7 @@ class VaccinationDetailsFragment : Fragment(R.layout.fragment_vaccination_detail
         vaccinatedAt.text = certificate.vaccinatedOnFormatted
         certificateCountry.text = certificate.certificateCountry
         certificateIssuer.text = certificate.certificateIssuer
-        certificateId.text = certificate.certificateId
+        certificateId.text = certificate.uniqueCertificateIdentifier
         oneShotInfo.isVisible = certificate.totalSeriesOfDoses == 1
         expirationNotice.expirationDate.text = getString(
             R.string.expiration_date,

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/listitem/AffectedFieldsMapper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/listitem/AffectedFieldsMapper.kt
@@ -81,7 +81,7 @@ private fun certificateValue(field: String, certificate: CwaCovidCertificate): S
             "v.0.dt" -> certificate.vaccinatedOnFormatted
             "v.0.co" -> certificate.certificateCountry
             "v.0.is" -> certificate.certificateIssuer
-            "v.0.ci" -> certificate.certificateId
+            "v.0.ci" -> certificate.uniqueCertificateIdentifier
             else -> null
         }
 
@@ -95,7 +95,7 @@ private fun certificateValue(field: String, certificate: CwaCovidCertificate): S
             "t.0.tc" -> certificate.testCenter
             "t.0.co" -> certificate.certificateCountry
             "t.0.is" -> certificate.certificateIssuer
-            "t.0.ci" -> certificate.certificateId
+            "t.0.ci" -> certificate.uniqueCertificateIdentifier
             else -> null
         }
 
@@ -106,7 +106,7 @@ private fun certificateValue(field: String, certificate: CwaCovidCertificate): S
             "r.0.du" -> certificate.validUntilFormatted
             "r.0.co" -> certificate.certificateCountry
             "r.0.is" -> certificate.certificateIssuer
-            "r.0.ci" -> certificate.certificateId
+            "r.0.ci" -> certificate.uniqueCertificateIdentifier
             else -> null
         }
         else -> null

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerFragment.kt
@@ -283,7 +283,7 @@ class QrCodeScannerFragment : Fragment(R.layout.fragment_qrcode_scanner), AutoIn
             is DccResult.Onboarding -> {
                 qrcodeSharedViewModel.putDccQrCode(scannerResult.dccQrCode)
                 findNavController().navigate(
-                    CovidCertificateOnboardingFragment.uri(scannerResult.dccQrCode.uniqueCertificateIdentifier),
+                    CovidCertificateOnboardingFragment.uri(scannerResult.dccQrCode.hash),
                     navOptions
                 )
             }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrcodeSharedViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrcodeSharedViewModel.kt
@@ -32,7 +32,7 @@ class QrcodeSharedViewModel : ViewModel() {
     }
 
     fun putDccQrCode(dccQrCode: DccQrCode) {
-        dccQrCodeCache[dccQrCode.uniqueCertificateIdentifier] = dccQrCode
+        dccQrCodeCache[dccQrCode.hash] = dccQrCode
     }
 
     fun dccQrCode(certificateIdentifier: String): DccQrCode {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/ScannerExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/ScannerExtensions.kt
@@ -49,9 +49,9 @@ fun CertificateContainerId.toDccDetails(): DccResult = DccResult.Details(uri())
 fun CertificateContainerId.toMaxPersonsWarning(max: Int): DccResult = DccResult.MaxPersonsWarning(uri(), max)
 
 private fun CertificateContainerId.uri(): Uri = when (this) {
-    is RecoveryCertificateContainerId -> RecoveryCertificateDetailsFragment.uri(identifier)
-    is TestCertificateContainerId -> TestCertificateDetailsFragment.uri(identifier)
-    is VaccinationCertificateContainerId -> VaccinationDetailsFragment.uri(identifier)
+    is RecoveryCertificateContainerId -> RecoveryCertificateDetailsFragment.uri(qrCodeHash)
+    is TestCertificateContainerId -> TestCertificateDetailsFragment.uri(qrCodeHash)
+    is VaccinationCertificateContainerId -> VaccinationDetailsFragment.uri(qrCodeHash)
 }
 
 fun CheckInQrCodeHandler.Result.toCheckInResult(requireOnboarding: Boolean): CheckInResult = when (this) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/ui/testresults/negative/RATResultNegativeFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/ui/testresults/negative/RATResultNegativeFragment.kt
@@ -63,7 +63,7 @@ class RATResultNegativeFragment : Fragment(R.layout.fragment_submission_antigen_
                     }
                     is RATResultNegativeNavigation.Back -> popBackStack()
                     is RATResultNegativeNavigation.OpenTestCertificateDetails ->
-                        findNavController().navigate(TestCertificateDetailsFragment.uri(it.containerId.identifier))
+                        findNavController().navigate(TestCertificateDetailsFragment.uri(it.containerId.qrCodeHash))
                 }
             }
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/testresult/negative/SubmissionTestResultNegativeFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/testresult/negative/SubmissionTestResultNegativeFragment.kt
@@ -93,7 +93,7 @@ class SubmissionTestResultNegativeFragment : Fragment(R.layout.fragment_submissi
             when (it) {
                 is SubmissionTestResultNegativeNavigation.Back -> popBackStack()
                 is SubmissionTestResultNegativeNavigation.OpenTestCertificateDetails ->
-                    findNavController().navigate(TestCertificateDetailsFragment.uri(it.containerId.identifier))
+                    findNavController().navigate(TestCertificateDetailsFragment.uri(it.containerId.qrCodeHash))
             }
         }
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/booster/DccBoosterRulesValidatorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/booster/DccBoosterRulesValidatorTest.kt
@@ -236,14 +236,14 @@ class DccBoosterRulesValidatorTest : BaseTest() {
             every { testedPositiveOn } returns LocalDate.parse("2021.03.01", dateTime)
             every { headerIssuedAt } returns Instant.parse("2021-04-01T00:00:00.000Z")
             every { dccData } returns recDccData
-            every { certificateId } returns "1"
+            every { uniqueCertificateIdentifier } returns "1"
         }
 
         val mockVac2 = mockk<VaccinationCertificate>().apply {
             every { vaccinatedOn } returns LocalDate.parse("2021.02.01", dateTime)
             every { headerIssuedAt } returns Instant.parse("2021-04-01T00:00:00.000Z")
             every { dccData } returns vacDccData
-            every { certificateId } returns "2"
+            every { uniqueCertificateIdentifier } returns "2"
         }
 
         coEvery { dccBoosterRulesRepository.rules } returns flowOf(listOf(rule))
@@ -302,7 +302,7 @@ class DccBoosterRulesValidatorTest : BaseTest() {
             every { vaccinatedOn } returns LocalDate.parse("2021.02.01", dateTime)
             every { headerIssuedAt } returns Instant.parse("2021-04-01T00:00:00.000Z")
             every { dccData } returns vacDccData
-            every { certificateId } returns "2"
+            every { uniqueCertificateIdentifier } returns "2"
         }
 
         coEvery { dccBoosterRulesRepository.updateBoosterNotificationRules() } returns listOf(rule)
@@ -343,7 +343,7 @@ class DccBoosterRulesValidatorTest : BaseTest() {
             every { vaccinatedOn } returns LocalDate.parse("2021.02.01", dateTime)
             every { headerIssuedAt } returns Instant.parse("2021-04-01T00:00:00.000Z")
             every { dccData } returns vacDccData
-            every { certificateId } returns "2"
+            every { uniqueCertificateIdentifier } returns "2"
         }
 
         coEvery { dccBoosterRulesRepository.updateBoosterNotificationRules() } returns listOf(rule)

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsViewModelTest.kt
@@ -184,7 +184,7 @@ class PersonDetailsViewModelTest : BaseTest() {
     )
 
     private fun mockTestCertificate(): TestCertificate = mockk<TestCertificate>().apply {
-        every { certificateId } returns "testCertificateId"
+        every { uniqueCertificateIdentifier } returns "RN:UVCI:01:AT:858CC18CFCF5965EF82F60E493349AA5#K"
         every { fullName } returns "Andrea Schneider"
         every { rawCertificate } returns mockk<TestDccV1>().apply {
             every { test } returns mockk<DccV1.TestCertificateData>().apply {
@@ -207,7 +207,7 @@ class PersonDetailsViewModelTest : BaseTest() {
     private fun mockVaccinationCertificate(number: Int = 1, final: Boolean = false): VaccinationCertificate =
         mockk<VaccinationCertificate>().apply {
             val localDate = Instant.parse("2021-06-01T11:35:00.000Z").toLocalDateUserTz()
-            every { certificateId } returns "vaccinationCertificateId$number"
+            every { uniqueCertificateIdentifier } returns "RN:UVCI:01:AT:858CC18CFCF5965EF82F60E493349AA5#K"
             every { fullName } returns "Andrea Schneider"
             every { rawCertificate } returns mockk<VaccinationDccV1>().apply {
                 every { vaccination } returns mockk<DccV1.VaccinationData>().apply {
@@ -231,7 +231,7 @@ class PersonDetailsViewModelTest : BaseTest() {
 
     private fun mockRecoveryCertificate(): RecoveryCertificate =
         mockk<RecoveryCertificate>().apply {
-            every { certificateId } returns "recoveryCertificateId"
+            every { uniqueCertificateIdentifier } returns "RN:UVCI:01:AT:858CC18CFCF5965EF82F60E493349AA5#K"
             every { validUntil } returns Instant.parse("2021-05-31T11:35:00.000Z").toLocalDateUserTz()
             every { personIdentifier } returns certificatePersonIdentifier
             every { qrCodeToDisplay } returns CoilQrCode("qrCode")

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonCertificatesData.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonCertificatesData.kt
@@ -82,7 +82,10 @@ fun testCertificate(
     )
     override val certificateIssuer: String = "certificateIssuer"
     override val certificateCountry: String = "certificateCountry"
-    override val certificateId: String = "certificateId"
+    override val qrcodeHash: String = "certificateId"
+    override val uniqueCertificateIdentifier: String
+        get() = "URN:UVCI:01:AT:858CC18CFCF5965EF82F60E493349AA5#K"
+
     override val hasNotificationBadge: Boolean
         get() = false
     override val notifiedInvalidAt: Instant?

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonCertificatesData.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonCertificatesData.kt
@@ -82,7 +82,7 @@ fun testCertificate(
     )
     override val certificateIssuer: String = "certificateIssuer"
     override val certificateCountry: String = "certificateCountry"
-    override val qrcodeHash: String = "certificateId"
+    override val qrCodeHash: String = "certificateId"
     override val uniqueCertificateIdentifier: String
         get() = "URN:UVCI:01:AT:858CC18CFCF5965EF82F60E493349AA5#K"
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/recovery/core/storage/RecoveryCertificateContainerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/recovery/core/storage/RecoveryCertificateContainerTest.kt
@@ -32,7 +32,7 @@ class RecoveryCertificateContainerTest : BaseTest() {
             qrCodeExtractor = extractorSpy
         )
 
-        container.qrcodeHash shouldNotBe null
+        container.qrCodeHash shouldNotBe null
         container.personIdentifier shouldNotBe null
 
         coVerify {

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/recovery/core/storage/RecoveryCertificateContainerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/recovery/core/storage/RecoveryCertificateContainerTest.kt
@@ -32,7 +32,7 @@ class RecoveryCertificateContainerTest : BaseTest() {
             qrCodeExtractor = extractorSpy
         )
 
-        container.certificateId shouldNotBe null
+        container.qrcodeHash shouldNotBe null
         container.personIdentifier shouldNotBe null
 
         coVerify {

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepositoryTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepositoryTest.kt
@@ -127,7 +127,7 @@ class TestCertificateRepositoryTest : BaseTest() {
         ).apply {
             this.qrCodeExtractor shouldBe qrCodeExtractor
 
-            qrcodeHash shouldBe data.identifier
+            qrCodeHash shouldBe data.identifier
             data.testCertificateQrCode shouldBe null
 
             isCertificateRetrievalPending shouldBe true
@@ -161,7 +161,7 @@ class TestCertificateRepositoryTest : BaseTest() {
             this.qrCodeExtractor shouldBe qrCodeExtractor
 
             data.testCertificateQrCode shouldBe testData.personATest1CertQRCodeString
-            qrcodeHash shouldBe testData.personATest1CertQRCode().hash
+            qrCodeHash shouldBe testData.personATest1CertQRCode().hash
 
             isCertificateRetrievalPending shouldBe false
             isUpdatingData shouldBe false

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepositoryTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepositoryTest.kt
@@ -211,7 +211,7 @@ class TestCertificateRepositoryTest : BaseTest() {
                 it.size shouldBe 1
 
                 val wrapper = it.first()
-                wrapper.containerId.identifier shouldBe notRecycled.identifier
+                wrapper.containerId.qrCodeHash shouldBe notRecycled.identifier
                 wrapper.recycleInfo.isNotRecycled shouldBe true
                 wrapper.testCertificate!!.getState() shouldBe CwaCovidCertificate.State.Invalid()
             }
@@ -220,7 +220,7 @@ class TestCertificateRepositoryTest : BaseTest() {
                 it.size shouldBe 1
 
                 val cert = it.first()
-                cert.containerId.identifier shouldBe recycled.identifier
+                cert.containerId.qrCodeHash shouldBe recycled.identifier
                 cert.isRecycled shouldBe true
                 cert.getState() shouldBe CwaCovidCertificate.State.Recycled
             }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepositoryTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepositoryTest.kt
@@ -127,7 +127,7 @@ class TestCertificateRepositoryTest : BaseTest() {
         ).apply {
             this.qrCodeExtractor shouldBe qrCodeExtractor
 
-            certificateId shouldBe data.identifier
+            qrcodeHash shouldBe data.identifier
             data.testCertificateQrCode shouldBe null
 
             isCertificateRetrievalPending shouldBe true
@@ -161,7 +161,7 @@ class TestCertificateRepositoryTest : BaseTest() {
             this.qrCodeExtractor shouldBe qrCodeExtractor
 
             data.testCertificateQrCode shouldBe testData.personATest1CertQRCodeString
-            certificateId shouldBe testData.personATest1CertQRCode().uniqueCertificateIdentifier
+            qrcodeHash shouldBe testData.personATest1CertQRCode().hash
 
             isCertificateRetrievalPending shouldBe false
             isUpdatingData shouldBe false

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateContainerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateContainerTest.kt
@@ -35,7 +35,7 @@ class TestCertificateContainerTest : BaseTest() {
     fun `ui facing test certificate creation and fallbacks`() {
         certificateTestData.personATest2CertContainer.apply {
             isCertificateRetrievalPending shouldBe false
-            certificateId shouldBe
+            qrcodeHash shouldBe
                 certificateTestData.personATest2CertContainer.testCertificateQRCode?.qrCode?.toSHA256()
             data.testCertificateQrCode shouldBe certificateTestData.personATest2CertQRCodeString
             data.certificateReceivedAt shouldBe Instant.parse("1970-01-02T10:17:36.789Z")
@@ -47,7 +47,7 @@ class TestCertificateContainerTest : BaseTest() {
     fun `pending check and nullability`() {
         certificateTestData.personATest3CertNokeyContainer.apply {
             isCertificateRetrievalPending shouldBe true
-            certificateId shouldBe data.identifier
+            qrcodeHash shouldBe data.identifier
             data.testCertificateQrCode shouldBe null
             data.certificateReceivedAt shouldBe null
             toTestCertificate(mockk(), mockk()) shouldBe null
@@ -55,7 +55,7 @@ class TestCertificateContainerTest : BaseTest() {
 
         certificateTestData.personATest4CertPendingContainer.apply {
             isCertificateRetrievalPending shouldBe true
-            certificateId shouldBe data.identifier
+            qrcodeHash shouldBe data.identifier
             data.testCertificateQrCode shouldBe null
             data.certificateReceivedAt shouldBe null
             toTestCertificate(mockk(), mockk()) shouldBe null
@@ -86,7 +86,7 @@ class TestCertificateContainerTest : BaseTest() {
             qrCodeExtractor = extractorSpy
         )
 
-        container.certificateId shouldNotBe null
+        container.qrcodeHash shouldNotBe null
         container.personIdentifier shouldNotBe null
 
         coVerify {

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateContainerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateContainerTest.kt
@@ -35,7 +35,7 @@ class TestCertificateContainerTest : BaseTest() {
     fun `ui facing test certificate creation and fallbacks`() {
         certificateTestData.personATest2CertContainer.apply {
             isCertificateRetrievalPending shouldBe false
-            qrcodeHash shouldBe
+            qrCodeHash shouldBe
                 certificateTestData.personATest2CertContainer.testCertificateQRCode?.qrCode?.toSHA256()
             data.testCertificateQrCode shouldBe certificateTestData.personATest2CertQRCodeString
             data.certificateReceivedAt shouldBe Instant.parse("1970-01-02T10:17:36.789Z")
@@ -47,7 +47,7 @@ class TestCertificateContainerTest : BaseTest() {
     fun `pending check and nullability`() {
         certificateTestData.personATest3CertNokeyContainer.apply {
             isCertificateRetrievalPending shouldBe true
-            qrcodeHash shouldBe data.identifier
+            qrCodeHash shouldBe data.identifier
             data.testCertificateQrCode shouldBe null
             data.certificateReceivedAt shouldBe null
             toTestCertificate(mockk(), mockk()) shouldBe null
@@ -55,7 +55,7 @@ class TestCertificateContainerTest : BaseTest() {
 
         certificateTestData.personATest4CertPendingContainer.apply {
             isCertificateRetrievalPending shouldBe true
-            qrcodeHash shouldBe data.identifier
+            qrCodeHash shouldBe data.identifier
             data.testCertificateQrCode shouldBe null
             data.certificateReceivedAt shouldBe null
             toTestCertificate(mockk(), mockk()) shouldBe null
@@ -86,7 +86,7 @@ class TestCertificateContainerTest : BaseTest() {
             qrCodeExtractor = extractorSpy
         )
 
-        container.qrcodeHash shouldNotBe null
+        container.qrCodeHash shouldNotBe null
         container.personIdentifier shouldNotBe null
 
         coVerify {

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPersonTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPersonTest.kt
@@ -529,7 +529,7 @@ class VaccinatedPersonTest : BaseTest() {
                 it.size shouldBe 1
 
                 val cert = it.first()
-                cert.containerId.identifier shouldBe "Recycled"
+                cert.containerId.qrCodeHash shouldBe "Recycled"
                 cert.isRecycled shouldBe true
             }
 
@@ -537,7 +537,7 @@ class VaccinatedPersonTest : BaseTest() {
                 it.size shouldBe 1
 
                 val cert = it.first()
-                cert.containerId.identifier shouldBe "NotRecycled"
+                cert.containerId.qrCodeHash shouldBe "NotRecycled"
                 cert.isNotRecycled shouldBe true
             }
         }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/VaccinationRepositoryTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/VaccinationRepositoryTest.kt
@@ -207,7 +207,7 @@ class VaccinationRepositoryTest : BaseTest() {
         instance.vaccinationInfos.first().single().data shouldBe vaccinationTestData.personAData2Vac
 
         instance.deleteCertificate(
-            VaccinationCertificateContainerId(toRemove.certificateId)
+            VaccinationCertificateContainerId(toRemove.qrcodeHash)
         ) shouldBe vaccinationTestData.personAVac2Container
         advanceUntilIdle()
 
@@ -225,7 +225,7 @@ class VaccinationRepositoryTest : BaseTest() {
         instance.vaccinationInfos.first().single().data shouldBe vaccinationTestData.personAData2Vac
 
         instance.deleteCertificate(
-            VaccinationCertificateContainerId(vaccinationTestData.personBVac1Container.certificateId)
+            VaccinationCertificateContainerId(vaccinationTestData.personBVac1Container.qrcodeHash)
         ) shouldBe null
     }
 
@@ -239,7 +239,7 @@ class VaccinationRepositoryTest : BaseTest() {
         instance.vaccinationInfos.first().single().data shouldBe vaccinationTestData.personBData1Vac
 
         instance.deleteCertificate(
-            VaccinationCertificateContainerId(vaccinationTestData.personBVac1Container.certificateId)
+            VaccinationCertificateContainerId(vaccinationTestData.personBVac1Container.qrcodeHash)
         )
         advanceUntilIdle()
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/VaccinationRepositoryTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/VaccinationRepositoryTest.kt
@@ -207,7 +207,7 @@ class VaccinationRepositoryTest : BaseTest() {
         instance.vaccinationInfos.first().single().data shouldBe vaccinationTestData.personAData2Vac
 
         instance.deleteCertificate(
-            VaccinationCertificateContainerId(toRemove.qrcodeHash)
+            VaccinationCertificateContainerId(toRemove.qrCodeHash)
         ) shouldBe vaccinationTestData.personAVac2Container
         advanceUntilIdle()
 
@@ -225,7 +225,7 @@ class VaccinationRepositoryTest : BaseTest() {
         instance.vaccinationInfos.first().single().data shouldBe vaccinationTestData.personAData2Vac
 
         instance.deleteCertificate(
-            VaccinationCertificateContainerId(vaccinationTestData.personBVac1Container.qrcodeHash)
+            VaccinationCertificateContainerId(vaccinationTestData.personBVac1Container.qrCodeHash)
         ) shouldBe null
     }
 
@@ -239,7 +239,7 @@ class VaccinationRepositoryTest : BaseTest() {
         instance.vaccinationInfos.first().single().data shouldBe vaccinationTestData.personBData1Vac
 
         instance.deleteCertificate(
-            VaccinationCertificateContainerId(vaccinationTestData.personBVac1Container.qrcodeHash)
+            VaccinationCertificateContainerId(vaccinationTestData.personBVac1Container.qrCodeHash)
         )
         advanceUntilIdle()
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/storage/VaccinationContainerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/storage/VaccinationContainerTest.kt
@@ -54,7 +54,7 @@ class VaccinationContainerTest : BaseTest() {
     fun `full property decoding - 1 of 2`() {
         testData.personAVac1Container.apply {
             certificate shouldBe testData.personAVac1Certificate
-            certificateId shouldBe testData.personAVac1Container.vaccinationQrCode.toSHA256()
+            qrcodeHash shouldBe testData.personAVac1Container.vaccinationQrCode.toSHA256()
         }
     }
 
@@ -62,7 +62,7 @@ class VaccinationContainerTest : BaseTest() {
     fun `full property decoding - 2 of 2`() {
         testData.personAVac2Container.apply {
             certificate shouldBe testData.personAVac2Certificate
-            certificateId shouldBe testData.personAVac2Container.vaccinationQrCode.toSHA256()
+            qrcodeHash shouldBe testData.personAVac2Container.vaccinationQrCode.toSHA256()
         }
     }
 
@@ -85,7 +85,9 @@ class VaccinationContainerTest : BaseTest() {
             totalSeriesOfDoses shouldBe 2
             certificateIssuer shouldBe "Bundesministerium für Gesundheit - Test01"
             certificateCountry shouldBe "Deutschland"
-            certificateId shouldBe testData.personAVac1Container.vaccinationQrCode.toSHA256()
+            qrcodeHash shouldBe testData.personAVac1Container.vaccinationQrCode.toSHA256()
+            uniqueCertificateIdentifier shouldBe
+                testData.personAVac1Container.certificate.vaccination.uniqueCertificateIdentifier
             personIdentifier shouldBe CertificatePersonIdentifier(
                 dateOfBirthFormatted = "1966-11-11",
                 firstNameStandardized = "ANDREAS",
@@ -136,7 +138,9 @@ class VaccinationContainerTest : BaseTest() {
             totalSeriesOfDoses shouldBe 2
             certificateIssuer shouldBe "Bundesministerium für Gesundheit - Test01"
             certificateCountry shouldBe "Deutschland"
-            certificateId shouldBe testData.personAVac1Container.vaccinationQrCode.toSHA256()
+            qrcodeHash shouldBe testData.personAVac1Container.vaccinationQrCode.toSHA256()
+            uniqueCertificateIdentifier shouldBe
+                testData.personAVac1Container.vaccination.uniqueCertificateIdentifier
             personIdentifier shouldBe CertificatePersonIdentifier(
                 dateOfBirthFormatted = "1966-11-11",
                 firstNameStandardized = "ANDREAS",

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/storage/VaccinationContainerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/storage/VaccinationContainerTest.kt
@@ -54,7 +54,7 @@ class VaccinationContainerTest : BaseTest() {
     fun `full property decoding - 1 of 2`() {
         testData.personAVac1Container.apply {
             certificate shouldBe testData.personAVac1Certificate
-            qrcodeHash shouldBe testData.personAVac1Container.vaccinationQrCode.toSHA256()
+            qrCodeHash shouldBe testData.personAVac1Container.vaccinationQrCode.toSHA256()
         }
     }
 
@@ -62,7 +62,7 @@ class VaccinationContainerTest : BaseTest() {
     fun `full property decoding - 2 of 2`() {
         testData.personAVac2Container.apply {
             certificate shouldBe testData.personAVac2Certificate
-            qrcodeHash shouldBe testData.personAVac2Container.vaccinationQrCode.toSHA256()
+            qrCodeHash shouldBe testData.personAVac2Container.vaccinationQrCode.toSHA256()
         }
     }
 
@@ -85,7 +85,7 @@ class VaccinationContainerTest : BaseTest() {
             totalSeriesOfDoses shouldBe 2
             certificateIssuer shouldBe "Bundesministerium für Gesundheit - Test01"
             certificateCountry shouldBe "Deutschland"
-            qrcodeHash shouldBe testData.personAVac1Container.vaccinationQrCode.toSHA256()
+            qrCodeHash shouldBe testData.personAVac1Container.vaccinationQrCode.toSHA256()
             uniqueCertificateIdentifier shouldBe
                 testData.personAVac1Container.certificate.vaccination.uniqueCertificateIdentifier
             personIdentifier shouldBe CertificatePersonIdentifier(
@@ -138,7 +138,7 @@ class VaccinationContainerTest : BaseTest() {
             totalSeriesOfDoses shouldBe 2
             certificateIssuer shouldBe "Bundesministerium für Gesundheit - Test01"
             certificateCountry shouldBe "Deutschland"
-            qrcodeHash shouldBe testData.personAVac1Container.vaccinationQrCode.toSHA256()
+            qrCodeHash shouldBe testData.personAVac1Container.vaccinationQrCode.toSHA256()
             uniqueCertificateIdentifier shouldBe
                 testData.personAVac1Container.vaccination.uniqueCertificateIdentifier
             personIdentifier shouldBe CertificatePersonIdentifier(

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/qrcode/scanner/QrCodeValidatorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/qrcode/scanner/QrCodeValidatorTest.kt
@@ -37,7 +37,7 @@ class QrCodeValidatorTest : BaseTest() {
     fun `validator uses recognises DccQrCode`() = runBlockingTest {
         qrCodeValidator.validate(testData.personAVac1QRCodeString).apply {
             this as DccQrCode
-            hash shouldBe testData.personAVac1Container.qrcodeHash
+            hash shouldBe testData.personAVac1Container.qrCodeHash
         }
     }
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/qrcode/scanner/QrCodeValidatorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/qrcode/scanner/QrCodeValidatorTest.kt
@@ -37,7 +37,7 @@ class QrCodeValidatorTest : BaseTest() {
     fun `validator uses recognises DccQrCode`() = runBlockingTest {
         qrCodeValidator.validate(testData.personAVac1QRCodeString).apply {
             this as DccQrCode
-            uniqueCertificateIdentifier shouldBe testData.personAVac1Container.certificateId
+            hash shouldBe testData.personAVac1Container.qrcodeHash
         }
     }
 


### PR DESCRIPTION
### Issue 
Because of the changes made by #4560 to rely on the qrcode hash to identify the certificate , hash is displayed instead of `ci` in :
- Certificates details screen 
- Exported PDF
- Validation results 

### Fix
- Renamed certificareId (legacy field) to `qrcodeHash` to avoid misusing it in the future
- Expose `uniqueCertificateIdentifier` and display where it is needed 
 
###  Background on the `why`
- These kind of certificates that have same `ci` are possible in Testing tools we have got some issues regarding it 
- It was possible to import two vaccination certificates with the same `ci` as long as they belong to two different persons
- Sine in recycle bin we rely on QrCode Hash to restore the certificate and not `ci`, it was also possible to use it as a workaround to scan many certificates of the same `ci` 
- with the changes made by #4560  QrCode hash is used to identify the certificate

## Testing
- Make sure that `ci` is displayed right in the required places 
- Certificates with same `ci` can be deleted / restored / recycled properly which was the initial cause of such a change  

## Ticket
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-11108