### PR TITLE
FIX: NoSuchElementException in PersonDetailsViewModel (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsViewModel.kt
@@ -36,7 +36,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.mapNotNull
 import timber.log.Timber
 
@@ -107,19 +107,23 @@ class PersonDetailsViewModel @AssistedInject constructor(
             personCertificates.certificates.find { it is VaccinationCertificate }?.let { certificate ->
                 val vaccinatedPerson = vaccinatedPerson(certificate)
                 if (vaccinatedPerson != null) {
-                    val daysUntilImmunity = vaccinatedPerson.getDaysUntilImmunity()
-                    val vaccinationStatus = vaccinatedPerson.getVaccinationStatus()
-                    val daysSinceLastVaccination = vaccinatedPerson.getDaysSinceLastVaccination()
-                    val boosterRule = vaccinatedPerson.boosterRule
-                    add(
-                        VaccinationInfoCard.Item(
-                            vaccinationStatus = vaccinationStatus,
-                            daysUntilImmunity = daysUntilImmunity,
-                            boosterRule = boosterRule,
-                            daysSinceLastVaccination = daysSinceLastVaccination,
-                            hasBoosterNotification = vaccinatedPerson.hasBoosterNotification
+                    try {
+                        val daysUntilImmunity = vaccinatedPerson.getDaysUntilImmunity()
+                        val vaccinationStatus = vaccinatedPerson.getVaccinationStatus()
+                        val daysSinceLastVaccination = vaccinatedPerson.getDaysSinceLastVaccination()
+                        val boosterRule = vaccinatedPerson.boosterRule
+                        add(
+                            VaccinationInfoCard.Item(
+                                vaccinationStatus = vaccinationStatus,
+                                daysUntilImmunity = daysUntilImmunity,
+                                boosterRule = boosterRule,
+                                daysSinceLastVaccination = daysSinceLastVaccination,
+                                hasBoosterNotification = vaccinatedPerson.hasBoosterNotification
+                            )
                         )
-                    )
+                    } catch (e: Exception) {
+                        Timber.e(e, "creating VaccinationInfoCard.Item failed")
+                    }
                 }
             }
 
@@ -208,7 +212,7 @@ class PersonDetailsViewModel @AssistedInject constructor(
     }
 
     private suspend fun vaccinatedPerson(certificate: CwaCovidCertificate): VaccinatedPerson? =
-        vaccinationRepository.vaccinationInfos.first().find { it.identifier == certificate.personIdentifier }
+        vaccinationRepository.vaccinationInfos.firstOrNull()?.find { it.identifier == certificate.personIdentifier }
 
     fun refreshBoosterRuleState() = launch(scope = appScope) {
         Timber.v("refreshBoosterRuleState personIdentifierCode=$personIdentifierCode")

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsViewModel.kt
@@ -71,6 +71,7 @@ class PersonDetailsViewModel @AssistedInject constructor(
         createUiState(personSpecificCertificates, isLoading)
     }.asLiveData2()
 
+    @Suppress("NestedBlockDepth")
     private suspend fun createUiState(personCertificates: PersonCertificates, isLoading: Boolean): UiState {
         val priorityCertificate = personCertificates.highestPriorityCertificate
         if (priorityCertificate == null) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/VaccinatedPerson.kt
@@ -55,6 +55,7 @@ data class VaccinatedPerson(
     val hasBoosterNotification: Boolean
         get() = data.boosterRule?.identifier != data.lastSeenBoosterRuleIdentifier
 
+    @Throws(NoSuchElementException::class)
     fun getDaysSinceLastVaccination(): Int {
         val today = Instant.now().toLocalDateUserTz()
         return Days.daysBetween(getNewestDoseVaccinatedOn(), today).days
@@ -67,8 +68,8 @@ data class VaccinatedPerson(
         it.containerId == containerId
     }
 
-    val fullName: String
-        get() = allVaccinationCertificates.first().fullName
+    val fullName: String?
+        get() = allVaccinationCertificates.firstOrNull()?.fullName
 
     fun getVaccinationStatus(nowUTC: Instant = Instant.now()): Status {
         if (boosterRule != null) return Status.BOOSTER_ELIGIBLE
@@ -89,6 +90,7 @@ data class VaccinatedPerson(
         else IMMUNITY_WAITING_DAYS - Days.daysBetween(newestFullDose.vaccinatedOn, today).days
     }
 
+    @Throws(NoSuchElementException::class)
     private fun getNewestDoseVaccinatedOn(): LocalDate =
         vaccinationCertificates.maxOf { it.vaccinatedOn }
 


### PR DESCRIPTION
I have only this stack trace from the google play console

```
java.util.NoSuchElementException: 
  at de.rki.coronawarnapp.covidcertificate.person.ui.details.PersonDetailsViewModel.access$createUiState (PersonDetailsViewModel.kt:39)
  at de.rki.coronawarnapp.covidcertificate.person.ui.details.PersonDetailsViewModel$uiState$1.invokeSuspend (PersonDetailsViewModel.kt:4)
  at de.rki.coronawarnapp.covidcertificate.person.ui.details.PersonDetailsViewModel$uiState$1.invoke (PersonDetailsViewModel.kt:1)
  at kotlinx.coroutines.flow.FlowKt__ZipKt$combine$1$1.invokeSuspend (Zip.kt:1)
  at kotlinx.coroutines.flow.FlowKt__ZipKt$combine$1$1.invoke (Zip.kt:1)
  at kotlinx.coroutines.flow.internal.CombineKt$combineInternal$2.invokeSuspend (Combine.kt:29)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:3)
  at kotlinx.coroutines.DispatchedTask.run (DispatchedTask.kt:18)
  at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely (CoroutineScheduler.kt:1)
  at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run (CoroutineScheduler.kt:10)
```

According to the mapping, it looks like the crash happened in `getNewestDoseVaccinatedOn()` but I wasn't able to reproduce it. A similar crash https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10153 has been fixed before, even though nobody was able to reproduce it. Here is a short test scenario:

- 2 Personal wallets, each has 4 different types of certificates
- delete from each personal wallet one certificate
- repeat 3
- --> target: have a recycle bin with 4 deleted certificates of person 1/2/1/2
- I did this on 4 devices in parallel - 2 iPhones, 2 Androids
- one Android crashed during 4.)
- after reopening the app: the deletion has happened and everything is fine again

 