### PR TITLE
Test certificate refresh error dialog (EXPOSUREAPP-10327)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/exception/TestCertificateException.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/exception/TestCertificateException.kt
@@ -19,7 +19,9 @@ class TestCertificateException(
     )
 
     private val errorMessage: LazyString = CachedString { context ->
-        context.getString(errorCode.stringRes) + " ($errorCode)\n\n" + context.getString(R.string.test_certificate_error_faq)
+        context.getString(errorCode.stringRes) +
+            " ($errorCode)\n\n" +
+            context.getString(R.string.test_certificate_error_faq)
     }
 
     enum class ErrorCode(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/exception/TestCertificateException.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/exception/TestCertificateException.kt
@@ -19,7 +19,7 @@ class TestCertificateException(
     )
 
     private val errorMessage: LazyString = CachedString { context ->
-        context.getString(errorCode.stringRes)
+        context.getString(errorCode.stringRes) + " ($errorCode)\n\n" + context.getString(R.string.test_certificate_error_faq)
     }
 
     enum class ErrorCode(
@@ -99,7 +99,7 @@ class TestCertificateException(
             "Private key request failed due to no network connection.",
             ERROR_MESSAGE_NO_NETWORK
         ),
-        BUG_3638_KEYPAIR_LOST(
+        KEYPAIR_LOST(
             "Registered RSA key-pair was lost (GitHub #3638). Test certificate can't be obtained.",
             ERROR_MESSAGE_CERTIFICATE_LOST_SORRY
         )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragment.kt
@@ -79,7 +79,7 @@ class PersonOverviewFragment : Fragment(R.layout.person_overview_fragment), Auto
             is ShowRefreshErrorDialog -> event.error.toErrorDialogBuilder(requireContext()).apply {
                 setTitle(R.string.test_certificate_refresh_dialog_title)
                 setCancelable(false)
-                if (event.isLabError) setNeutralButton(R.string.test_certificate_error_invalid_labid_faq) { _, _ ->
+                if (event.showTestCertificateFaq) setNeutralButton(R.string.test_certificate_error_invalid_labid_faq) { _, _ ->
                     openUrl(getString(R.string.test_certificate_error_invalid_labid_faq_link))
                 }
             }.show()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragment.kt
@@ -79,9 +79,10 @@ class PersonOverviewFragment : Fragment(R.layout.person_overview_fragment), Auto
             is ShowRefreshErrorDialog -> event.error.toErrorDialogBuilder(requireContext()).apply {
                 setTitle(R.string.test_certificate_refresh_dialog_title)
                 setCancelable(false)
-                if (event.showTestCertificateFaq) setNeutralButton(R.string.test_certificate_error_invalid_labid_faq) { _, _ ->
-                    openUrl(getString(R.string.test_certificate_error_invalid_labid_faq_link))
-                }
+                if (event.showTestCertificateFaq)
+                    setNeutralButton(R.string.test_certificate_error_invalid_labid_faq) { _, _ ->
+                        openUrl(getString(R.string.test_certificate_error_invalid_labid_faq_link))
+                    }
             }.show()
 
             OpenCovPassInfo -> doNavigate(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragmentEvents.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragmentEvents.kt
@@ -7,9 +7,8 @@ import de.rki.coronawarnapp.covidcertificate.common.repository.TestCertificateCo
 sealed class PersonOverviewFragmentEvents
 
 data class ShowRefreshErrorDialog(val error: Throwable) : PersonOverviewFragmentEvents() {
-    val isLabError
-        get() = error is TestCertificateException &&
-            error.errorCode == TestCertificateException.ErrorCode.DCC_NOT_SUPPORTED_BY_LAB
+    val showTestCertificateFaq
+        get() = error is TestCertificateException
 }
 
 data class ShowDeleteDialog(val containerId: TestCertificateContainerId) : PersonOverviewFragmentEvents()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateProcessor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateProcessor.kt
@@ -110,7 +110,7 @@ class TestCertificateProcessor @Inject constructor(
             when {
                 e.errorCode == ErrorCode.PKR_409 && isMissingKeyPairEdgeCase -> {
                     // User was affected by bug #3638
-                    throw TestCertificateException(ErrorCode.BUG_3638_KEYPAIR_LOST)
+                    throw TestCertificateException(ErrorCode.KEYPAIR_LOST)
                 }
                 e.errorCode == ErrorCode.PKR_409 && !isMissingKeyPairEdgeCase -> {
                     Timber.tag(TAG).w("PublicKey already registered, assuming we can go ahead.")

--- a/Corona-Warn-App/src/main/res/values-de/green_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/green_certificate_strings.xml
@@ -88,4 +88,6 @@
     <string name="test_certificate_error_refreshing_status">"Ihr Zertifikat wird gerade angefragt, dies kann einige Minuten dauern…"</string>
     <!-- XBUT: Text for invalid test certificate error button, linking to FAQ-->
     <string name="test_certificate_error_invalid_labid_faq">"FAQ zu Testzertifikaten"</string>
+    <!-- XTXT: Text for invalid test certificate error text -->
+    <string name="test_certificate_error_faq">Weitere Informationen zum Erhalt Ihres Testzertifikats finden Sie in den FAQ.</string>
 </resources>

--- a/Corona-Warn-App/src/main/res/values/green_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/green_certificate_strings.xml
@@ -87,5 +87,7 @@
     <string name="test_certificate_error_refreshing_status">"Your certificate is being requested. This may take a few minutes..."</string>
     <!-- XBUT: Text for invalid test certificate error button, linking to FAQ-->
     <string name="test_certificate_error_invalid_labid_faq">"FAQ for Test Certificates"</string>
+    <!-- XTXT: Text for invalid test certificate error text -->
+    <string name="test_certificate_error_faq">Weitere Informationen zum Erhalt Ihres Testzertifikats finden Sie in den FAQ.</string>
 
 </resources>

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateProcessorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateProcessorTest.kt
@@ -215,7 +215,7 @@ class TestCertificateProcessorTest : BaseTest() {
 
         shouldThrow<TestCertificateException> {
             instance.registerPublicKey(edgeCaseData)
-        }.errorCode shouldBe TestCertificateException.ErrorCode.BUG_3638_KEYPAIR_LOST
+        }.errorCode shouldBe TestCertificateException.ErrorCode.KEYPAIR_LOST
 
         coVerify(exactly = 1) {
             certificateServer.registerPublicKeyForTest(edgeCaseData.registrationToken, any())


### PR DESCRIPTION
error dialog for failed refresh of test certificates 

https://www.figma.com/file/KuDEcMSREg3VhZRhC3FXTY/COVID19_Master_2.14?node-id=27904%3A32514
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10327
![device-2021-12-22-165938](https://user-images.githubusercontent.com/49635654/147120524-704d5a82-0fe9-49c8-83a3-b0cfea3bbb95.png)
