### PR TITLE
Check newer sonar version (DEV)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   android: circleci/android@0.2.1
-  sonarcloud: sonarsource/sonarcloud@1.0.2
+  sonarcloud: sonarsource/sonarcloud@1.0.3
 
 #######################
 # Commands section


### PR DESCRIPTION
Check if this false check is gone https://sonarcloud.io/project/issues?id=corona-warn-app_cwa-app-android&pullRequest=4590&resolved=false&types=CODE_SMELL