### PR TITLE
Only schedule the 'warn others' notification once the user has actually viewed the test (EXPOSUREAPP-10432)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/notification/ShareTestResultNotificationService.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/notification/ShareTestResultNotificationService.kt
@@ -95,7 +95,7 @@ class ShareTestResultNotificationService @Inject constructor(
             .onEach { tests ->
                 // schedule reminder if test wasn't submitted
                 tests.filter { test ->
-                    test.isSubmissionAllowed && !test.isSubmitted
+                    test.isSubmissionAllowed && !test.isSubmitted && test.isViewed
                 }.forEach { test ->
                     maybeScheduleSharePositiveTestResultReminder(test.type, test.identifier)
                 }


### PR DESCRIPTION
[Jira ticket](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10432)

How to test: 
- Generate RAT QR code with `cwa rat -r positive -e wru`
- Scan test
- Leave Screen with title "Ihr Testergebnis liegt vor" and confirm dialog
- Check Logcat and make sure no notification was scheduled (No log statement beginning with "Schedule positive test result notification for RAT test reminders" was printed out.
- Open Test again to see the test result
- Check Logcat again - Notification should be scheduled now.