### PR TITLE
VC issued by italy can be printed (EXPOSUREAPP-11155)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/ui/CertificateExportHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/ui/CertificateExportHelper.kt
@@ -6,4 +6,4 @@ import de.rki.coronawarnapp.covidcertificate.validation.core.country.DccCountry
 /**
  * Certificate could be exported only if DCC country is Germany (DE)
  */
-fun CwaCovidCertificate.canBeExported() = certificateCountry == DccCountry("DE").displayName()
+fun CwaCovidCertificate.canBeExported() = headerIssuer == DccCountry.DE


### PR DESCRIPTION
- Check based on `iss` not `co` 
## Testing 
- Scan certificate from the ticket and verify that it can not be exported as PDF
- Scan DE issued certificate and verify that it can exported 
## Ticket
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-11155