### PR TITLE
Fix: App Crash when rendering Increased Risk card (EXPOSUREAPP-11213)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/view/TracingCardInfoRow.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/view/TracingCardInfoRow.kt
@@ -47,7 +47,8 @@ class TracingCardInfoRow @JvmOverloads constructor(
         }
     }
 
-    fun setText(text: String) {
+    // should expect nullable strings since IncreasedRisk.getRiskContactBody() can return null
+    fun setText(text: String?) {
         this.body.text = text
     }
 }


### PR DESCRIPTION
It looks like we introduced this bug in https://github.com/corona-warn-app/cwa-app-android/pull/4618 since `IncreasedRisk.getRiskContactBody()` can return null but `TracingCardInfoRow.setText()` accept only not null strings.
The crash happens when the user is in a state of Increased risk with daysWithEncounters == 0

### Jira Ticket
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-11213