### PR TITLE
Remove ".de"

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/core/DccTicketingCoreModule.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/core/DccTicketingCoreModule.kt
@@ -84,6 +84,6 @@ class DccTicketingCoreModule {
 }
 
 // Dummy base url to satisfy Retrofit ¯\_(ツ)_/¯
-private const val BASE_URL = "https://localhost.de"
+private const val BASE_URL = "https://localhost"
 
 private const val TAG = "DccTicketingOkHttpClient"


### PR DESCRIPTION
Remove `.de` from the dummy base url based on BSI feedback