### PR TITLE
Assume 2G+ if valid certificate is completing shot of a series of 3 (EXPOSUREAPP-11401)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificates.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificates.kt
@@ -25,6 +25,8 @@ data class PersonCertificates(
         data class TwoGPlusRAT(val twoGCertificate: CwaCovidCertificate, val testCertificate: CwaCovidCertificate) :
             AdmissionState(twoGCertificate)
 
+        data class TwoGPlus(val twoGCertificate: CwaCovidCertificate) : AdmissionState(twoGCertificate)
+
         data class TwoG(val twoGCertificate: CwaCovidCertificate) : AdmissionState(twoGCertificate)
 
         data class ThreeGWithPCR(val testCertificate: CwaCovidCertificate) : AdmissionState(testCertificate)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensions.kt
@@ -9,6 +9,7 @@ import de.rki.coronawarnapp.covidcertificate.person.core.PersonCertificates.Admi
 import de.rki.coronawarnapp.covidcertificate.person.core.PersonCertificates.AdmissionState.ThreeGWithPCR
 import de.rki.coronawarnapp.covidcertificate.person.core.PersonCertificates.AdmissionState.ThreeGWithRAT
 import de.rki.coronawarnapp.covidcertificate.person.core.PersonCertificates.AdmissionState.TwoG
+import de.rki.coronawarnapp.covidcertificate.person.core.PersonCertificates.AdmissionState.TwoGPlus
 import de.rki.coronawarnapp.covidcertificate.person.core.PersonCertificates.AdmissionState.TwoGPlusPCR
 import de.rki.coronawarnapp.covidcertificate.person.core.PersonCertificates.AdmissionState.TwoGPlusRAT
 import de.rki.coronawarnapp.covidcertificate.recovery.core.RecoveryCertificate
@@ -354,6 +355,10 @@ fun Collection<CwaCovidCertificate>.determineAdmissionState(nowUtc: Instant = In
         val recentVaccination = validCerts.rule1FindRecentLastShot(nowUtc)
         val recentRecovery = validCerts.rule2findRecentRecovery(nowUtc)
 
+        val has3Shots = recentVaccination is VaccinationCertificate
+            && recentVaccination.totalSeriesOfDoses == 3
+            && recentVaccination.isSeriesCompletingShot
+
         val hasVaccination = recentVaccination != null
         val hasRecentRecovery = recentRecovery != null
 
@@ -378,6 +383,10 @@ fun Collection<CwaCovidCertificate>.determineAdmissionState(nowUtc: Instant = In
                     hasRAT -> {
                         Timber.v("Determined admission state = 2G+ RAT")
                         TwoGPlusRAT(twoGCertificate, recentRAT!!)
+                    }
+                    has3Shots -> {
+                        Timber.v("Determined admission state = 2G+ RAT")
+                        TwoGPlus(twoGCertificate)
                     }
                     else -> {
                         Timber.v("Determined admission state = 2G")

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/items/ConfirmedStatusCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/items/ConfirmedStatusCard.kt
@@ -6,6 +6,7 @@ import de.rki.coronawarnapp.covidcertificate.person.core.PersonCertificates.Admi
 import de.rki.coronawarnapp.covidcertificate.person.core.PersonCertificates.AdmissionState.ThreeGWithPCR
 import de.rki.coronawarnapp.covidcertificate.person.core.PersonCertificates.AdmissionState.ThreeGWithRAT
 import de.rki.coronawarnapp.covidcertificate.person.core.PersonCertificates.AdmissionState.TwoG
+import de.rki.coronawarnapp.covidcertificate.person.core.PersonCertificates.AdmissionState.TwoGPlus
 import de.rki.coronawarnapp.covidcertificate.person.core.PersonCertificates.AdmissionState.TwoGPlusPCR
 import de.rki.coronawarnapp.covidcertificate.person.core.PersonCertificates.AdmissionState.TwoGPlusRAT
 import de.rki.coronawarnapp.covidcertificate.person.ui.details.PersonDetailsAdapter
@@ -35,6 +36,11 @@ class ConfirmedStatusCard(parent: ViewGroup) :
                 subtitle.text = context.resources.getString(R.string.confirmed_status_2g_badge)
                 badge.text = context.resources.getString(R.string.confirmed_status_2g_badge)
                 body.text = context.resources.getString(R.string.confirmed_status_2g_body)
+            }
+            is TwoGPlus -> {
+                subtitle.text = context.resources.getString(R.string.confirmed_status_2g_plus_badge)
+                badge.text = context.resources.getString(R.string.confirmed_status_2g_plus_badge)
+                body.text = context.resources.getString(R.string.confirmed_status_2g_plus_body)
             }
             is TwoGPlusPCR -> {
                 subtitle.text = context.resources.getString(R.string.confirmed_status_2g_pcr_subtitle)

--- a/Corona-Warn-App/src/main/res/values-bg/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-bg/covid_certificate_strings.xml
@@ -404,6 +404,8 @@
 
     <!-- XTXT: Confirmed status card 2G body -->
     <string name="confirmed_status_2g_body">"Вашите сертификати отговарят на 2G правилото. Ако Ви се налага да доказвате своя текущ статус затворете този изглед и покажете QR кода в “Преглед на сертификати”."</string>
+    <!-- XTXT: Confirmed status card 2G+ body -->
+    <string name="confirmed_status_2g_plus_body">"Вашите сертификати отговарят на 2G+ правилото. Ако Ви се налага да доказвате своя текущ статус затворете този изглед и покажете QR кода в “Преглед на сертификати”."</string>
     <!-- XTXT: Confirmed status card 2G+ RAT body -->
     <string name="confirmed_status_2g_plus_rat_body">"Вашите сертификати отговарят на 2G plus правилото, освен ако не Ви се изисква PCR тест. Ако Ви се налага да доказвате своя текущ статус затворете този изглед и покажете QR кода в “Преглед на сертификати”."</string>
     <!-- XTXT: Confirmed status card 2G+ PCR body -->

--- a/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
@@ -405,6 +405,8 @@
 
     <!-- XTXT: Confirmed status card 2G body -->
     <string name="confirmed_status_2g_body">"Ihre Zertifikate erfüllen die 2G-Regel. Wenn Sie Ihren aktuellen Status vorweisen müssen, schließen Sie diese Ansicht und zeigen Sie den QR-Code auf der Zertifikatsübersicht."</string>
+    <!-- XTXT: Confirmed status card 2G+ body -->
+    <string name="confirmed_status_2g_plus_body">"Ihre Zertifikate erfüllen die 2G+-Regel. Wenn Sie Ihren aktuellen Status vorweisen müssen, schließen Sie diese Ansicht und zeigen Sie den QR-Code auf der Zertifikatsübersicht."</string>
     <!-- XTXT: Confirmed status card 2G+ RAT body -->
     <string name="confirmed_status_2g_plus_rat_body">"Ihre Zertifikate erfüllen die 2G-Plus-Regel, es sei denn, es wird ein PCR-Test benötigt. Wenn Sie Ihren aktuellen Status vorweisen müssen, schließen Sie diese Ansicht und zeigen Sie den QR-Code auf der Zertifikatsübersicht."</string>
     <!-- XTXT: Confirmed status card 2G+ PCR body -->

--- a/Corona-Warn-App/src/main/res/values-pl/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-pl/covid_certificate_strings.xml
@@ -404,6 +404,8 @@
 
     <!-- XTXT: Confirmed status card 2G body -->
     <string name="confirmed_status_2g_body">"Twoje certyfikaty są zgodne z zasadą 2G. Jeśli musisz udowodnić swój aktualny status, zamknij ten widok i wyświetl kod QR w przeglądzie certyfikatów."</string>
+    <!-- XTXT: Confirmed status card 2G+ body -->
+    <string name="confirmed_status_2g_plus_body">"Twoje certyfikaty są zgodne z zasadą 2G+. Jeśli musisz udowodnić swój aktualny status, zamknij ten widok i wyświetl kod QR w przeglądzie certyfikatów."</string>
     <!-- XTXT: Confirmed status card 2G+ RAT body -->
     <string name="confirmed_status_2g_plus_rat_body">"Twoje certyfikaty są zgodne z zasadą 2G plus, o ile nie jest wymagany test PCR. Jeśli musisz udowodnić swój aktualny status, zamknij ten widok i wyświetl kod QR w przeglądzie certyfikatów."</string>
     <!-- XTXT: Confirmed status card 2G+ PCR body -->

--- a/Corona-Warn-App/src/main/res/values-ro/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-ro/covid_certificate_strings.xml
@@ -404,6 +404,8 @@
 
     <!-- XTXT: Confirmed status card 2G body -->
     <string name="confirmed_status_2g_body">"Certificatele dvs. respectă regula 2G. Dacă trebuie să dovediți starea dvs. curentă, închideți această vizualizare și afișați codul QR în sumarul certificatului."</string>
+    <!-- XTXT: Confirmed status card 2G+ body -->
+    <string name="confirmed_status_2g_plus_body">"Certificatele dvs. respectă regula 2G+. Dacă trebuie să dovediți starea dvs. curentă, închideți această vizualizare și afișați codul QR în sumarul certificatului."</string>
     <!-- XTXT: Confirmed status card 2G+ RAT body -->
     <string name="confirmed_status_2g_plus_rat_body">"Certificatele dvs. respectă regula 2G plus, cu excepția cazului în care este necesar un test PCR. Dacă trebuie să dovediți starea dvs. curentă, închideți această vizualizare și afișați codul QR în sumarul certificatului."</string>
     <!-- XTXT: Confirmed status card 2G+ PCR body -->

--- a/Corona-Warn-App/src/main/res/values-tr/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-tr/covid_certificate_strings.xml
@@ -404,6 +404,8 @@
 
     <!-- XTXT: Confirmed status card 2G body -->
     <string name="confirmed_status_2g_body">"Sertifikalarınız 2G kuralına uygun. Güncel durumunuzu kanıtlamanız gerekiyorsa bu görünümünü kapatın ve sertifikaya genel bakış bölümündeki QR kodu gösterin."</string>
+    <!-- XTXT: Confirmed status card 2G+ body -->
+    <string name="confirmed_status_2g_plus_body">"Sertifikalarınız 2G+ kuralına uygun. Güncel durumunuzu kanıtlamanız gerekiyorsa bu görünümünü kapatın ve sertifikaya genel bakış bölümündeki QR kodu gösterin."</string>
     <!-- XTXT: Confirmed status card 2G+ RAT body -->
     <string name="confirmed_status_2g_plus_rat_body">"PCR testi gerekmiyorsa sertifikalarınız 2G plus kuralına uygun. Güncel durumunuzu kanıtlamanız gerekiyorsa bu görünümünü kapatın ve sertifikaya genel bakış bölümündeki QR kodu gösterin."</string>
     <!-- XTXT: Confirmed status card 2G+ PCR body -->

--- a/Corona-Warn-App/src/main/res/values/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/covid_certificate_strings.xml
@@ -404,6 +404,8 @@
 
     <!-- XTXT: Confirmed status card 2G body -->
     <string name="confirmed_status_2g_body">"Your certificates satisfy the 2G rule. If you need to prove your current status, close this view and show the QR code in the certificate overview."</string>
+    <!-- XTXT: Confirmed status card 2G+ body -->
+    <string name="confirmed_status_2g_plus_body">"Your certificates satisfy the 2G+ rule. If you need to prove your current status, close this view and show the QR code in the certificate overview."</string>
     <!-- XTXT: Confirmed status card 2G+ RAT body -->
     <string name="confirmed_status_2g_plus_rat_body">"Your certificates satisfy the 2G plus rule, unless a PCR test is required. If you need to prove your current status, close this view and show the QR code in the certificate overview."</string>
     <!-- XTXT: Confirmed status card 2G+ PCR body -->


### PR DESCRIPTION
#4707
EXPOSUREAPP-11401

Aufgrund des fehlenden protoc-gen-javalite auf macOS/M1 (protoc-gen-javalite-3.0.0-osx-aarch_64.exe) konnte ich das leider nicht testen, und ich erwarte auch nicht, dass das so ohne weiteres gemerged wird. Aber vielleicht ist es ja trotzdem eine Hilfe für das Team.

Ich würde mir den Code jedenfalls so vorstellen, wenn 2G+ für derzeit "ordentliche" Boosterungen angezeigt werden soll.