### PR TITLE
Change term

### DIFF
--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -1571,7 +1571,7 @@ Sollten Sie den Test in der App gelöscht haben, können Sie ihn aus dem Papierk
 
     <!-- Persons Vaccinated Completely Statistics Card -->
     <!-- XHED: Title for vaccinated completely statistics card -->
-    <string name="statistics_vaccinated_completely_card_title">"Vollständig geimpfte Personen"</string>
+    <string name="statistics_vaccinated_completely_card_title">"Grundimmunisiert"</string>
 
     <!-- Persons Vaccinated With Booster Card -->
     <!-- XHED: Title for vaccinated with booster statistics card -->
@@ -1589,7 +1589,7 @@ Sollten Sie den Test in der App gelöscht haben, können Sie ihn aus dem Papierk
     <!-- XTXT: Statistics number of vaccine doses text -->
     <string name="statistics_number_of_vaccine_doses_text">"Anzahl der Impfdosen, die bisher bundesweit verabreicht wurden."</string>
     <!-- XTXT: Statistics number of fully vaccinated people title -->
-    <string name="statistics_fully_vaccinated_people_title">"Vollständig geimpfte Personen"</string>
+    <string name="statistics_fully_vaccinated_people_title">"Grundimmunisiert"</string>
     <!-- XTXT: Statistics number of fully vaccinated people text -->
     <string name="statistics_fully_vaccinated_people_text">"Anzahl der an das RKI übermittelten Personen, die alle notwendigen Impfdosen der Grundimmunisierung erhalten haben."</string>
     <!-- XTXT: Statistics number of people with booster title -->


### PR DESCRIPTION
RKI has changed the term they use on the page Digitales Impfquotenmonitoring zur COVID-19-Impfung. Now they are using the term "Grundimmunisiert" where a couple of days ago the graph was labelled "vollständig geimpft".

--> https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-11520