### PR TITLE
FIX: 2.17 Hotfix App Crash (EXPOSUREAPP-11675)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/ui/onboarding/CovidCertificateOnboardingViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/ui/onboarding/CovidCertificateOnboardingViewModel.kt
@@ -5,16 +5,12 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import de.rki.coronawarnapp.covidcertificate.common.qrcode.DccQrCode
 import de.rki.coronawarnapp.covidcertificate.common.repository.CertificateContainerId
-import de.rki.coronawarnapp.covidcertificate.signature.core.DscRepository
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.CovidCertificateSettings
 import de.rki.coronawarnapp.qrcode.handler.DccQrCodeHandler
-import de.rki.coronawarnapp.util.TimeStamper
 import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
 import de.rki.coronawarnapp.util.ui.SingleLiveEvent
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactory
-import kotlinx.coroutines.flow.first
-import org.joda.time.Duration
 import timber.log.Timber
 
 class CovidCertificateOnboardingViewModel @AssistedInject constructor(
@@ -22,22 +18,9 @@ class CovidCertificateOnboardingViewModel @AssistedInject constructor(
     @Assisted private val dccQrCode: DccQrCode?,
     private val dccQrCodeHandler: DccQrCodeHandler,
     dispatcherProvider: DispatcherProvider,
-    private val dscRepository: DscRepository,
-    private val timeStamper: TimeStamper,
 ) : CWAViewModel(dispatcherProvider) {
 
     val events = SingleLiveEvent<Event>()
-
-    init {
-        launch {
-            val currentDscData = dscRepository.dscData.first()
-            if (Duration(currentDscData.updatedAt, timeStamper.nowUTC) < Duration.standardHours(12)) {
-                Timber.d("Last DSC data refresh was recent: %s", currentDscData.updatedAt)
-                return@launch
-            }
-            dscRepository.refresh()
-        }
-    }
 
     fun onContinueClick() = launch {
         covidCertificateSettings.isOnboarded.update { true }


### PR DESCRIPTION


### Testing

- Turn off internet connection
- Reset the App
- open certificates tab
- the app crashes

```
de.rki.coronawarnapp.covidcertificate.signature.core.common.exception.DscValidationException: 
 at de.rki.coronawarnapp.covidcertificate.signature.core.server.DscServer.getDscList (DscServer.kt:8)
 at de.rki.coronawarnapp.covidcertificate.signature.core.server.DscServer$getDscList$1.invokeSuspend (Unknown Source:11)
```

### Jira Ticket
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-11675


