### PR TITLE
Fix booster card subtitle style (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/person_details_booster_card.xml
+++ b/Corona-Warn-App/src/main/res/layout/person_details_booster_card.xml
@@ -45,11 +45,8 @@
 
     <TextView
         android:id="@+id/subtitle"
-        style="@style/subtitle"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/spacing_tiny"
-        android:textSize="14sp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="@id/title"
         app:layout_constraintTop_toBottomOf="@id/title"


### PR DESCRIPTION
Anja noticed during the demo that the subtitle style of the booster card is not correct. This PR fixes this:

![grafik](https://user-images.githubusercontent.com/10398034/153211859-2e128611-1f3c-437a-b351-8c2b4ba8fc9c.png)
