### PR TITLE
chore: update CCL text descriptor test cases

### DIFF
--- a/Corona-Warn-App/src/androidTest/assets/ccl/ccl-text-descriptor-test-cases.gen.json
+++ b/Corona-Warn-App/src/androidTest/assets/ccl/ccl-text-descriptor-test-cases.gen.json
@@ -1,5 +1,6 @@
 {
-  "$comment": "Generated at Thu Jan 27 2022 18:00:50 GMT+0100 (Central European Standard Time)",
+  "$comment": "Generated at Tue Feb 15 2022 09:52:07 GMT+0000 (Coordinated Universal Time)",
+  "sourceTreeish": "81d9b76",
   "testCases": [
     {
       "description": "simple hello world",
@@ -48,28 +49,7 @@
         "parameters": [
           {
             "type": "number",
-            "value": 3.1415
-          }
-        ]
-      },
-      "assertions": [
-        {
-          "languageCode": "de",
-          "text": "Hallo 3"
-        }
-      ]
-    },
-    {
-      "description": "placeholder %d",
-      "textDescriptor": {
-        "type": "string",
-        "localizedText": {
-          "de": "Hallo %d"
-        },
-        "parameters": [
-          {
-            "type": "number",
-            "value": 3.1415
+            "value": 3
           }
         ]
       },
@@ -181,7 +161,7 @@
       ]
     },
     {
-      "description": "placeholder of type localDate",
+      "description": "placeholder of type localDate (without milliseconds)",
       "textDescriptor": {
         "type": "string",
         "localizedText": {
@@ -190,7 +170,28 @@
         "parameters": [
           {
             "type": "localDate",
-            "value": "2022-01-01T23:30:00.000Z"
+            "value": "2022-01-02T00:30:00+01:00"
+          }
+        ]
+      },
+      "assertions": [
+        {
+          "languageCode": "de",
+          "text": "Gültig ab 02.01.22"
+        }
+      ]
+    },
+    {
+      "description": "placeholder of type localDate (with milliseconds)",
+      "textDescriptor": {
+        "type": "string",
+        "localizedText": {
+          "de": "Gültig ab %s"
+        },
+        "parameters": [
+          {
+            "type": "localDate",
+            "value": "2022-01-02T00:30:00.000+01:00"
           }
         ]
       },
@@ -211,7 +212,7 @@
         "parameters": [
           {
             "type": "localDateTime",
-            "value": "2022-01-01T23:30:00.000Z"
+            "value": "2022-01-02T00:30:00+01:00"
           }
         ]
       },
@@ -232,7 +233,7 @@
         "parameters": [
           {
             "type": "utcDate",
-            "value": "2022-01-01T23:30:00.000Z"
+            "value": "2022-01-02T00:30:00+01:00"
           }
         ]
       },
@@ -253,7 +254,7 @@
         "parameters": [
           {
             "type": "utcDateTime",
-            "value": "2022-01-01T23:30:00.000Z"
+            "value": "2022-01-02T00:30:00+01:00"
           }
         ]
       },
@@ -531,6 +532,39 @@
         {
           "languageCode": "de",
           "text": "vor 2 Minuten"
+        }
+      ]
+    },
+    {
+      "description": "fallback - EN is used as fallback if there is no text for the given languageCode",
+      "textDescriptor": {
+        "type": "string",
+        "localizedText": {
+          "de": "Hallo Welt",
+          "en": "Hello World"
+        },
+        "parameters": []
+      },
+      "assertions": [
+        {
+          "languageCode": "tr",
+          "text": "Hello World"
+        }
+      ]
+    },
+    {
+      "description": "fallback - DE is used as fallback if there is no text for the given languageCode and for EN",
+      "textDescriptor": {
+        "type": "string",
+        "localizedText": {
+          "de": "Hallo Welt"
+        },
+        "parameters": []
+      },
+      "assertions": [
+        {
+          "languageCode": "tr",
+          "text": "Hallo Welt"
         }
       ]
     }

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ccl/ui/text/CCLTextFormatterTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ccl/ui/text/CCLTextFormatterTest.kt
@@ -57,7 +57,7 @@ class CCLTextFormatterTest : BaseTestInstrumentation() {
         testCases.testCases.forEach { testCase ->
             format(
                 testCase.textDescriptor,
-                "de",
+                testCase.assertions[0].languageCode,
                 Locale.GERMAN
             ) shouldBe testCase.assertions[0].text
         }


### PR DESCRIPTION
PR updates the CCL text descriptor test cases as of https://github.com/corona-warn-app/cwa-app-ccl/tree/81d9b7604f64de1d24dcb348b4c822ceda8c9a92. Should not contain any breaking changes, but let's see...

Related to https://github.com/corona-warn-app/cwa-app-ccl/pull/18