### PR TITLE
Fix booster notification background trigger (EXPOSUREAPP-11804)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ccl/configuration/update/CCLConfigurationUpdateScheduler.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ccl/configuration/update/CCLConfigurationUpdateScheduler.kt
@@ -1,13 +1,12 @@
 package de.rki.coronawarnapp.ccl.configuration.update
 
-import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
-import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequest
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import de.rki.coronawarnapp.util.coroutine.AppScope
 import de.rki.coronawarnapp.util.device.ForegroundState
+import de.rki.coronawarnapp.worker.BackgroundConstants
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
@@ -48,14 +47,13 @@ class CCLConfigurationUpdateScheduler @Inject constructor(
     }
 
     private fun buildWorkRequest(): PeriodicWorkRequest {
-        val constraints = Constraints.Builder()
-            .setRequiredNetworkType(NetworkType.CONNECTED)
-            .build()
-
         return PeriodicWorkRequestBuilder<CCLConfigurationUpdateWorker>(
             repeatInterval = 24,
             repeatIntervalTimeUnit = TimeUnit.HOURS
-        ).setConstraints(constraints).build()
+        ).setInitialDelay(
+            BackgroundConstants.KIND_DELAY,
+            TimeUnit.MINUTES
+        ).build()
     }
 }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/worker/WorkerBinder.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/worker/WorkerBinder.kt
@@ -141,6 +141,6 @@ abstract class WorkerBinder {
     @IntoMap
     @WorkerKey(CCLConfigurationUpdateWorker::class)
     abstract fun cclConfigurationUpdateWorker(
-        factory: DccStateCheckWorker.Factory
+        factory: CCLConfigurationUpdateWorker.Factory
     ): InjectedWorkerFactory<out ListenableWorker>
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/worker/WorkerBinderTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/worker/WorkerBinderTest.kt
@@ -6,6 +6,7 @@ import com.google.gson.Gson
 import dagger.Component
 import dagger.Module
 import dagger.Provides
+import de.rki.coronawarnapp.ccl.configuration.update.CCLConfigurationUpdater
 import de.rki.coronawarnapp.coronatest.CoronaTestRepository
 import de.rki.coronawarnapp.coronatest.type.pcr.execution.PCRResultScheduler
 import de.rki.coronawarnapp.coronatest.type.pcr.notification.PCRTestResultAvailableNotificationService
@@ -188,4 +189,7 @@ class MockProvider {
 
     @Provides
     fun recoveryCertificateRepository(): RecoveryCertificateRepository = mockk()
+
+    @Provides
+    fun cclConfigurationUpdater(): CCLConfigurationUpdater = mockk()
 }


### PR DESCRIPTION
This PR fixes the issue that the booster notifications are not triggered by our background worker. 

Because of a copy-paste mistake of mine (in `WorkerBinder.kt`), the background worker did actually never run...

How to test: 
- Fresh install
- Start app
- Switch to WRU and set "fake correct device time" in Remote Config Data Test Menu (Not sure if this switch is really necessary to set
- Close app
- Set device time to 2022-02-10 12:30
- Open App
- Force ccl config update (config from WRU and INT are different)
- Scan certificate from the ticket
- See that booster notification shows up
- Close app and click on notification
- Close app
- Set device time 24h into the future (2022-02-11 12:30)
- Without opening the app, the worker should start its work and the booster notificaiton should appear