### PR TITLE
Catch potential crash (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/qrcode/ui/QrCodeScannerFragment.kt
@@ -148,8 +148,14 @@ class QrCodeScannerFragment : Fragment(R.layout.fragment_qrcode_scanner), AutoIn
         false -> requestCameraPermission()
     }
 
-    private fun startDecode() = binding.scannerPreview.decodeSingle { parseResult ->
-        viewModel.onParseResult(parseResult = parseResult)
+    private fun startDecode() {
+        runCatching {
+            binding.scannerPreview.decodeSingle { parseResult ->
+                viewModel.onParseResult(parseResult = parseResult)
+            }
+        }.onFailure {
+            Timber.tag(TAG).d(it, "startDecode() failed")
+        }
     }
 
     private fun showCameraPermissionDeniedDialog() {


### PR DESCRIPTION
 I'm not able to re-produce, but I see that in Google Play Console for a very few users 
```java
java.lang.NullPointerException: 
  at de.rki.coronawarnapp.qrcode.ui.QrCodeScannerFragment.startDecode (QrCodeScannerFragment.kt:1)
  at de.rki.coronawarnapp.qrcode.ui.QrCodeScannerFragment$$ExternalSyntheticLambda15.onDismiss (R8$$SyntheticClass:2)
  at android.app.Dialog$ListenersHandler.handleMessage (Dialog.java:1405)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loop (Looper.java:236)
  at android.app.ActivityThread.main (ActivityThread.java:8057)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:620)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1011)
```