### PR TITLE
DEV: censoring loop bug

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesSettings.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesSettings.kt
@@ -38,8 +38,6 @@ class PersonCertificatesSettings @Inject constructor(
         .map { prefs ->
             runCatching {
                 mapper.readValue<CertificatePersonIdentifier?>(prefs[CURRENT_PERSON_KEY].orEmpty())
-            }.onFailure {
-                Timber.tag(TAG).d(it, "currentCwaUser failed to parse")
             }.getOrNull()
         }
 


### PR DESCRIPTION
There was unhandled censoring loop:

1) Could not erase  `currentCwaUser`
2) `onFailure{}` logs  an error
3) On log censor tries to get currentCwaUser (CwaUserCensor line 19)
    https://github.com/corona-warn-app/cwa-app-android/blob/e121b268f3e630522444d1582f4346e8fde2f11d/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/bugreporting/censors/dcc/CwaUserCensor.kt#L19
4) go to 1