### PR TITLE
Fix: New line separators are not working as expected (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ccl/ui/text/CclTextFormatter.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ccl/ui/text/CclTextFormatter.kt
@@ -72,9 +72,7 @@ class CclTextFormatter @Inject constructor(
             ?: localizedText[EN] // Default for other languages
             ?: localizedText[DE] // Default for EN
 
-        return text
-            ?.replace("%@", "%s")
-            ?.format(*parameters.convertValues(locale))
+        return text?.cleanText()?.format(*parameters.convertValues(locale))
     }
 
     private fun PluralText.formatPlural(
@@ -88,10 +86,12 @@ class CclTextFormatter @Inject constructor(
             ?: return null
 
         val text = pluralText(quantity, quantityText, locale)
-        return text
-            .replace("%@", "%s")
-            .format(*parameters.convertValues(locale))
+        return text.cleanText().format(*parameters.convertValues(locale))
     }
+
+    private fun String.cleanText() = this
+        .replace("%@", "%s")
+        .replace("\\n", "\n")
 
     private fun PluralText.quantity(): Int = quantity ?: quantityFromIndex()
 


### PR DESCRIPTION
@LukasLechnerDev  found out that `\n` is not recognised in `TextView`. `\n` should be escaped to work properly

| Before        | After           |
| ------------- |:-------------:|
| <img src="https://user-images.githubusercontent.com/25054729/156195551-235b374f-533a-46d8-9ec7-b6b2bd08abdd.png" width="350"/> | <img src="https://user-images.githubusercontent.com/25054729/156195539-aa85eca6-4c73-4929-aa1a-56e9290ce0aa.png" width="350"/> |


 