### PR TITLE
Align reissuance consent screen text formatting (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/fragment_dcc_reissuance_consent.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_dcc_reissuance_consent.xml
@@ -55,7 +55,7 @@
 
             <TextView
                 android:id="@+id/dcc_reissuance_subtitle"
-                style="@style/body1Medium"
+                style="@style/subtitleMedium"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="@dimen/spacing_normal"
@@ -66,7 +66,7 @@
 
             <TextView
                 android:id="@+id/dcc_reissuance_content"
-                style="@style/body1"
+                style="@style/subtitle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="@dimen/spacing_normal"
@@ -94,7 +94,7 @@
 
             <TextView
                 android:id="@+id/dcc_reissuance_deletion_hint"
-                style="@style/body1"
+                style="@style/subtitle"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/spacing_small"
@@ -119,7 +119,7 @@
 
             <TextView
                 android:id="@+id/dcc_reissuance_update_hint"
-                style="@style/body1"
+                style="@style/subtitle"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/spacing_small"


### PR DESCRIPTION
I got some feedback from Anja to adjust the text formatting in the certificate reissuance a bit. 

[before](https://user-images.githubusercontent.com/10398034/156373563-b5c57613-4296-479b-98f8-6448cb976995.png)
[after](https://user-images.githubusercontent.com/10398034/156373481-3ae52b65-ecbd-4df4-8f41-1d2b25583efe.png)

