### PR TITLE
Dismiss dcc reissuance badge automatically (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccreissuance/notification/DccReissuanceNotificationService.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccreissuance/notification/DccReissuanceNotificationService.kt
@@ -33,7 +33,7 @@ class DccReissuanceNotificationService @Inject constructor(
                 )
                 personCertificatesSettings.setDccReissuanceNotifiedAt(personIdentifier)
             }
-            // New calculation says not Dcc Reissuance anymore
+            // New calculation says no Dcc Reissuance anymore
             newCertReissuance == null -> {
                 Timber.tag(TAG).d("Person=%s shouldn't be notified about Dcc reissuance", personIdentifier.codeSHA256)
                 Timber.tag(TAG).d("Dismiss badge of Dcc reissuance for person=%s", personIdentifier.codeSHA256)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccreissuance/notification/DccReissuanceNotificationService.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccreissuance/notification/DccReissuanceNotificationService.kt
@@ -24,15 +24,25 @@ class DccReissuanceNotificationService @Inject constructor(
     ) {
         val oldCertReissuance = oldWalletInfo?.certificateReissuance
         val newCertReissuance = newWalletInfo.certificateReissuance
-        if (newCertReissuance != null && oldCertReissuance == null) {
-            Timber.tag(TAG).d("Notify person=%s about Dcc reissuance", personIdentifier.codeSHA256)
-            personNotificationSender.showNotification(
-                personIdentifier = personIdentifier,
-                messageRes = R.string.notification_body_certificate
-            )
-            personCertificatesSettings.setDccReissuanceNotifiedAt(personIdentifier)
-        } else {
-            Timber.tag(TAG).d("Person=%s shouldn't be notified about Dcc reissuance", personIdentifier.codeSHA256)
+        when {
+            newCertReissuance != null && oldCertReissuance == null -> {
+                Timber.tag(TAG).d("Notify person=%s about Dcc reissuance", personIdentifier.codeSHA256)
+                personNotificationSender.showNotification(
+                    personIdentifier = personIdentifier,
+                    messageRes = R.string.notification_body_certificate
+                )
+                personCertificatesSettings.setDccReissuanceNotifiedAt(personIdentifier)
+            }
+            // New calculation says not Dcc Reissuance anymore
+            newCertReissuance == null -> {
+                Timber.tag(TAG).d("Person=%s shouldn't be notified about Dcc reissuance", personIdentifier.codeSHA256)
+                Timber.tag(TAG).d("Dismiss badge of Dcc reissuance for person=%s", personIdentifier.codeSHA256)
+                personCertificatesSettings.dismissReissuanceBadge(personIdentifier)
+            }
+            // Otherwise nothing
+            else -> {
+                Timber.tag(TAG).d("Person=%s shouldn't be notified about Dcc reissuance", personIdentifier.codeSHA256)
+            }
         }
     }
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/dccreissuance/notification/DccReissuanceNotificationServiceTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/dccreissuance/notification/DccReissuanceNotificationServiceTest.kt
@@ -34,6 +34,7 @@ internal class DccReissuanceNotificationServiceTest : BaseTest() {
     fun setUp() {
         MockKAnnotations.init(this)
         coEvery { personCertificatesSettings.setDccReissuanceNotifiedAt(any(), any()) } just Runs
+        coEvery { personCertificatesSettings.dismissReissuanceBadge(any()) } just Runs
         every { personNotificationSender.showNotification(any(), any()) } just Runs
         every { dccWalletInfo.certificateReissuance } returns mockk()
     }
@@ -65,6 +66,27 @@ internal class DccReissuanceNotificationServiceTest : BaseTest() {
             oldWalletInfo = mockk<DccWalletInfo>().apply { every { certificateReissuance } returns mockk() },
             newWalletInfo = dccWalletInfo
         )
+
+        coVerify(exactly = 0) {
+            personNotificationSender.showNotification(personIdentifier, R.string.notification_body_certificate)
+            personCertificatesSettings.setDccReissuanceNotifiedAt(personIdentifier, any())
+        }
+    }
+
+    @Test
+    fun `dismiss the badge if the new dcc reissuance doesn't exist`() = runBlockingTest {
+        DccReissuanceNotificationService(
+            personCertificatesSettings = personCertificatesSettings,
+            personNotificationSender = personNotificationSender
+        ).notifyIfNecessary(
+            personIdentifier = personIdentifier,
+            oldWalletInfo = dccWalletInfo,
+            newWalletInfo = mockk<DccWalletInfo>().apply { every { certificateReissuance } returns null }
+        )
+
+        coEvery {
+            personCertificatesSettings.dismissReissuanceBadge(personIdentifier)
+        }
 
         coVerify(exactly = 0) {
             personNotificationSender.showNotification(personIdentifier, R.string.notification_body_certificate)


### PR DESCRIPTION
### How to reproduce?

1. Scan one of dcc reissuance presets
2. Request new Dcc
3. Now Delete the `new ` requested Dcc
4. Restore old recycled Dcc
5. The badge should be shown 
6. Restore the new recycled Dcc from step 3
7.  the badge should dismiss (after the fix), (before the fix badge is not dismissible)

