### PR TITLE
FIX: App crash when marking cert. as personal cert. (EXPOSUREAPP-12116)

### DIFF
--- a/Corona-Warn-App/proguard-rules.pro
+++ b/Corona-Warn-App/proguard-rules.pro
@@ -116,3 +116,4 @@
 -keep class de.rki.coronawarnapp.ccl.configuration.model.** { *; }
 -keep class de.rki.coronawarnapp.ccl.dccwalletinfo.model.** { *; }
 -keep class de.rki.coronawarnapp.ccl.dccadmission.model.** { *; }
+-keep class de.rki.coronawarnapp.covidcertificate.common.certificate.** { *; }


### PR DESCRIPTION
Proguard update to prevent app crash

### Testing
- make release build
- scan any certificate
- mark certificate as personal certificate
- app shouldn't crash

### Jira Ticket
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12116