### PR TITLE
Recovery Cert Change - meaningful information (EXPOSUREAPP-12063)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsFragmentTest.kt
@@ -408,7 +408,7 @@ class PersonDetailsFragmentTest : BaseUITest() {
             every { fullName } returns "Andrea Schneider"
             every { uniqueCertificateIdentifier } returns "RN:UVCI:01:AT:858CC18CFCF5965EF82F60E493349AA5#K"
             every { dateOfBirthFormatted } returns "1981-03-20"
-            every { validUntil } returns Instant.parse("2021-03-31T11:35:00.000Z").toLocalDateUserTz()
+            every { testedPositiveOn } returns Instant.parse("2021-05-23T11:35:00.000Z").toLocalDateUserTz()
             every { personIdentifier } returns certificatePersonIdentifier
             every { qrCodeToDisplay } returns CoilQrCode(ScreenshotCertificateTestData.recoveryCertificate)
             every { containerId } returns rcContainerId

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/RecoveryCertificateDetailFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/RecoveryCertificateDetailFragmentTest.kt
@@ -125,8 +125,6 @@ class RecoveryCertificateDetailFragmentTest : BaseUITest() {
         every { testedPositiveOnFormatted } returns "2021-05-24"
         every { certificateCountry } returns "Deutschland"
         every { certificateIssuer } returns "Robert Koch-Institut"
-        every { validFromFormatted } returns "2021-06-07"
-        every { validUntilFormatted } returns "2021-11-10"
         every { hasNotificationBadge } returns false
         every { uniqueCertificateIdentifier } returns "URN:UVCI:01:AT:858CC18CFCF5965EF82F60E493349AA5#K"
         every { qrCodeToDisplay } returns CoilQrCode(ScreenshotCertificateTestData.recoveryCertificate)

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/reyclebin/ui/RecyclerBinOverviewFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/reyclebin/ui/RecyclerBinOverviewFragmentTest.kt
@@ -2,9 +2,13 @@ package de.rki.coronawarnapp.reyclebin.ui
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import dagger.Module
 import dagger.android.ContributesAndroidInjector
+import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.coronatest.type.CoronaTest
 import de.rki.coronawarnapp.coronatest.type.pcr.PCRCoronaTest
 import de.rki.coronawarnapp.coronatest.type.rapidantigen.RACoronaTest
@@ -67,6 +71,8 @@ class RecyclerBinOverviewFragmentTest : BaseUITest() {
 
         launchFragmentInContainer2<RecyclerBinOverviewFragment>()
         takeScreenshot<RecyclerBinOverviewFragment>("full")
+        Espresso.onView(ViewMatchers.withId(R.id.recycler_bin_list)).perform(ViewActions.swipeUp())
+        takeScreenshot<RecyclerBinOverviewFragment>("full_2")
     }
 
     private fun recyclerBinItems(): LiveData<List<RecyclerBinItem>> {
@@ -139,7 +145,7 @@ class RecyclerBinOverviewFragmentTest : BaseUITest() {
         mockk<RecoveryCertificate>().apply {
             every { containerId } returns RecoveryCertificateContainerId("3")
             every { fullName } returns "Thomas Schneider"
-            every { validUntil } returns Instant.parse("2021-11-23T11:35:00.000Z").toLocalDateUserTz()
+            every { testedPositiveOn } returns Instant.parse("2021-11-23T11:35:00.000Z").toLocalDateUserTz()
             every { recycledAt } returns Instant.parse("2021-11-12T15:21:00.000Z")
         }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensions.kt
@@ -12,7 +12,7 @@ import de.rki.coronawarnapp.util.TimeAndDateExtensions.toLocalDateUserTz
     The list items shall be sorted descending by the following date attributes depending on the type of the DGC:
     for Vaccination Certificates (i.e. DGC with v[0]): the date of the vaccination v[0].dt and issuedAt date
     for Test Certificates (i.e. DGC with t[0]): the date of the sample collection t[0].sc
-    for Recovery Certificates (i.e. DGC with r[0]): the date of begin of the validity r[0].df
+    for Recovery Certificates (i.e. DGC with r[0]): the date of the sample collection r[0].fr
  */
 fun Collection<CwaCovidCertificate>.toCertificateSortOrder(): List<CwaCovidCertificate> {
     return this.sortedWith(
@@ -21,7 +21,7 @@ fun Collection<CwaCovidCertificate>.toCertificateSortOrder(): List<CwaCovidCerti
                 when (it) {
                     is VaccinationCertificate -> it.vaccinatedOn
                     is TestCertificate -> it.sampleCollectedAt?.toLocalDateUserTz()
-                    is RecoveryCertificate -> it.validFrom
+                    is RecoveryCertificate -> it.testedPositiveOn
                     else -> throw IllegalStateException("Can't sort $it")
                 }
             },
@@ -29,7 +29,7 @@ fun Collection<CwaCovidCertificate>.toCertificateSortOrder(): List<CwaCovidCerti
                 when (it) {
                     is VaccinationCertificate -> it.headerIssuedAt.toLocalDateUserTz()
                     is TestCertificate -> it.sampleCollectedAt?.toLocalDateUserTz()
-                    is RecoveryCertificate -> it.validFrom
+                    is RecoveryCertificate -> it.testedPositiveOn
                     else -> throw IllegalStateException("Can't sort $it")
                 }
             }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/items/RecoveryCertificateCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/items/RecoveryCertificateCard.kt
@@ -1,82 +1,71 @@
-package de.rki.coronawarnapp.covidcertificate.person.ui.details.items
+package de.rki.coronawarnapp.reyclebin.ui.adapter
 
 import android.view.ViewGroup
-import androidx.core.view.isVisible
+import androidx.core.view.isGone
+import androidx.recyclerview.widget.RecyclerView
 import de.rki.coronawarnapp.R
-import de.rki.coronawarnapp.covidcertificate.common.repository.CertificateContainerId
-import de.rki.coronawarnapp.covidcertificate.person.ui.details.PersonDetailsAdapter
-import de.rki.coronawarnapp.covidcertificate.person.ui.overview.PersonColorShade
 import de.rki.coronawarnapp.covidcertificate.recovery.core.RecoveryCertificate
-import de.rki.coronawarnapp.databinding.RecoveryCertificateCardBinding
+import de.rki.coronawarnapp.databinding.RecyclerBinCertificateItemBinding
+import de.rki.coronawarnapp.reyclebin.ui.common.addDeletionInfoIfExists
+import de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.items.BaseCheckInVH.Companion.setupMenu
 import de.rki.coronawarnapp.util.TimeAndDateExtensions.toShortDayFormat
-import de.rki.coronawarnapp.util.displayExpirationState
+import de.rki.coronawarnapp.util.list.Swipeable
 import de.rki.coronawarnapp.util.lists.diffutil.HasPayloadDiffer
 
 class RecoveryCertificateCard(parent: ViewGroup) :
-    PersonDetailsAdapter.PersonDetailsItemVH<RecoveryCertificateCard.Item, RecoveryCertificateCardBinding>(
-        layoutRes = R.layout.recovery_certificate_card,
+    RecyclerBinAdapter.ItemVH<RecoveryCertificateCard.Item, RecyclerBinCertificateItemBinding>(
+        layoutRes = R.layout.recycler_bin_certificate_item,
         parent = parent
-    ) {
+    ),
+    Swipeable {
 
-    override val viewBinding: Lazy<RecoveryCertificateCardBinding> = lazy {
-        RecoveryCertificateCardBinding.bind(itemView)
+    private var latestItem: Item? = null
+
+    override val viewBinding: Lazy<RecyclerBinCertificateItemBinding> = lazy {
+        RecyclerBinCertificateItemBinding.bind(itemView)
     }
-    override val onBindData: RecoveryCertificateCardBinding.(
+    override val onBindData: RecyclerBinCertificateItemBinding.(
         item: Item,
         payloads: List<Any>
     ) -> Unit = { item, payloads ->
 
-        val curItem = payloads.filterIsInstance<Item>().lastOrNull() ?: item
-        val certificate = curItem.certificate
-        root.setOnClickListener { curItem.onClick() }
+        latestItem = payloads.filterIsInstance<Item>().lastOrNull() ?: item
+        val certificate = latestItem!!.certificate
 
-        certificateDate.text = context.getString(
-            R.string.recovery_certificate_valid_until,
-            certificate.validUntil?.toShortDayFormat() ?: certificate.rawCertificate.recovery.du
+        certificateIcon.setImageResource(R.drawable.ic_certificates_filled_white)
+        certificatePersonName.isGone = false
+        certificateInfoLine1.isGone = true
+        certificateInfoLine2.text = context.getString(
+            R.string.recovery_certificate_sample_collection,
+            certificate.testedPositiveOn?.toShortDayFormat() ?: certificate.rawCertificate.recovery.fr
         )
+        certificatePersonName.text = certificate.fullName
+        certificateType.setText(R.string.recovery_certificate_name)
 
-        val bookmarkIcon =
-            if (curItem.certificate.isDisplayValid) curItem.colorShade.bookmarkIcon else R.drawable.ic_bookmark
-        currentCertificateGroup.isVisible = curItem.isCurrentCertificate
-        bookmark.setImageResource(bookmarkIcon)
+        addDeletionInfoIfExists(item = certificate)
 
-        val color = when {
-            curItem.certificate.isDisplayValid -> curItem.colorShade
-            else -> PersonColorShade.COLOR_INVALID
-        }
+        root.setOnClickListener { item.onRestore(item.certificate) }
 
-        when {
-            curItem.certificate.isDisplayValid -> R.drawable.ic_recovery_certificate
-            else -> R.drawable.ic_certificate_invalid
-        }.also { certificateIcon.setImageResource(it) }
-
-        when {
-            curItem.isCurrentCertificate -> color.currentCertificateBg
-            else -> color.defaultCertificateBg
-        }.also { certificateBg.setImageResource(it) }
-
-        notificationBadge.isVisible = curItem.certificate.hasNotificationBadge
-
-        certificateExpiration.displayExpirationState(curItem.certificate)
-
-        startValidationCheckButton.apply {
-            defaultButton.isEnabled = certificate.isNotBlocked
-            isEnabled = certificate.isNotBlocked
-            isLoading = curItem.isLoading
-            defaultButton.setOnClickListener {
-                curItem.validateCertificate(certificate.containerId)
+        menuAction.setupMenu(R.menu.menu_recycler_bin_list_item) {
+            when (it.itemId) {
+                R.id.menu_remove_permanently -> item.onRemove(item.certificate, null).let { true }
+                R.id.menu_restore -> item.onRestore(item.certificate).let { true }
+                else -> false
             }
         }
     }
 
     data class Item(
         val certificate: RecoveryCertificate,
-        val isCurrentCertificate: Boolean,
-        val colorShade: PersonColorShade,
-        val isLoading: Boolean = false,
-        val onClick: () -> Unit,
-        val validateCertificate: (CertificateContainerId) -> Unit,
-    ) : CertificateItem, HasPayloadDiffer {
+        val onRemove: (RecoveryCertificate, Int?) -> Unit,
+        val onRestore: (RecoveryCertificate) -> Unit
+    ) : RecyclerBinItem, HasPayloadDiffer {
         override val stableId: Long = certificate.containerId.hashCode().toLong()
+    }
+
+    override fun onSwipe(holder: RecyclerView.ViewHolder, direction: Int) {
+        latestItem?.let {
+            it.onRemove(it.certificate, holder.absoluteAdapterPosition)
+        }
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/details/RecoveryCertificateDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/details/RecoveryCertificateDetailsFragment.kt
@@ -113,8 +113,6 @@ class RecoveryCertificateDetailsFragment : Fragment(R.layout.fragment_recovery_c
         dateOfFirstPositiveTestResult.text = certificate.testedPositiveOnFormatted
         certificateCountry.text = certificate.certificateCountry
         certificateIssuer.text = certificate.certificateIssuer
-        certificationPeriodStart.text = certificate.validFromFormatted
-        certificationPeriodEnd.text = certificate.validUntilFormatted
         certificateId.text = certificate.uniqueCertificateIdentifier
         expirationNotice.expirationDate.text = getString(
             R.string.expiration_date,

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccreissuance/ui/consent/DccReissuanceCertificateCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccreissuance/ui/consent/DccReissuanceCertificateCard.kt
@@ -47,8 +47,8 @@ class DccReissuanceCertificateCard @JvmOverloads constructor(
                 }
                 is RecoveryDccV1 -> {
                     val info = context.getString(
-                        R.string.recovery_certificate_valid_until,
-                        value.recovery.validUntil?.toShortDayFormat() ?: value.recovery.du
+                        R.string.recovery_certificate_sample_collection,
+                        value.recovery.testedPositiveOn?.toShortDayFormat() ?: value.recovery.fr
                     )
                     setRecovery("$fullName\n$info")
                 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/ui/certificateselection/cards/DccTicketingRecoveryCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccticketing/ui/certificateselection/cards/DccTicketingRecoveryCard.kt
@@ -30,8 +30,8 @@ class DccTicketingRecoveryCard(parent: ViewGroup) :
             root.setOnClickListener { curItem.onClick() }
 
             certificateDate.text = context.getString(
-                R.string.recovery_certificate_valid_until,
-                certificate.validUntil?.toShortDayFormat() ?: certificate.rawCertificate.recovery.du
+                R.string.recovery_certificate_sample_collection,
+                certificate.testedPositiveOn?.toShortDayFormat() ?: certificate.rawCertificate.recovery.fr
             )
 
             arrow.isVisible = item.showArrow

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/reyclebin/ui/adapter/RecoveryCertificateCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/reyclebin/ui/adapter/RecoveryCertificateCard.kt
@@ -36,8 +36,8 @@ class RecoveryCertificateCard(parent: ViewGroup) :
         certificatePersonName.isGone = false
         certificateInfoLine1.isGone = true
         certificateInfoLine2.text = context.getString(
-            R.string.recovery_certificate_valid_until,
-            certificate.validUntil?.toShortDayFormat() ?: certificate.rawCertificate.recovery.du
+            R.string.recovery_certificate_sample_collection,
+            certificate.testedPositiveOn?.toShortDayFormat() ?: certificate.rawCertificate.recovery.fr
         )
         certificatePersonName.text = certificate.fullName
         certificateType.setText(R.string.recovery_certificate_name)

--- a/Corona-Warn-App/src/main/res/layout/dcc_ticketing_recovery_card.xml
+++ b/Corona-Warn-App/src/main/res/layout/dcc_ticketing_recovery_card.xml
@@ -71,7 +71,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/certificate_bg"
         app:layout_constraintTop_toBottomOf="@id/recovery_certificate_name"
-        tools:text="gültig bis 23.11.21" />
+        tools:text="Positiver Test vom 23.11.21" />
 
     <androidx.constraintlayout.widget.Barrier
         android:id="@+id/bottom_barrier"

--- a/Corona-Warn-App/src/main/res/layout/fragment_recovery_certificate_details.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_recovery_certificate_details.xml
@@ -241,37 +241,6 @@
                         android:layout_marginTop="2dp"
                         tools:text="G05930482748454836478695764787840" />
 
-
-                    <TextView
-                        style="@style/body1Medium"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="16dp"
-                        android:text="@string/recovery_certificate_attribute_certificate_certification_period_start" />
-
-                    <TextView
-                        android:id="@+id/certification_period_start"
-                        style="@style/body1"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="2dp"
-                        tools:text="2021-05-23" />
-
-                    <TextView
-                        style="@style/body1Medium"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="16dp"
-                        android:text="@string/recovery_certificate_attribute_certificate_certification_period_end" />
-
-                    <TextView
-                        android:id="@+id/certification_period_end"
-                        style="@style/body1"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="2dp"
-                        tools:text="2021-11-23" />
-
                     <TextView
                         style="@style/body1Medium"
                         android:layout_width="match_parent"

--- a/Corona-Warn-App/src/main/res/layout/recovery_certificate_card.xml
+++ b/Corona-Warn-App/src/main/res/layout/recovery_certificate_card.xml
@@ -81,7 +81,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@id/certificate_bg"
         app:layout_constraintTop_toBottomOf="@id/recovery_certificate_name"
-        tools:text="gültig bis 23.11.21" />
+        tools:text="Positiver Test vom 23.11.21" />
 
     <TextView
         android:id="@+id/certificate_expiration"

--- a/Corona-Warn-App/src/main/res/values-bg/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-bg/covid_certificate_strings.xml
@@ -90,8 +90,8 @@
     <string name="recovery_certificate_details_subtitle">"Цифров сертификат за тест за COVID на ЕС"</string>
     <!-- XTXT: Recovery certificate card name  -->
     <string name="recovery_certificate_name">"Сертификат за възстановяване"</string>
-    <!-- XTXT: Recovery certificate valid until -->
-    <string name="recovery_certificate_valid_until">"валиден до %s"</string>
+    <!-- XTXT: Recovery certificate the date of the sample collection -->
+    <string name="recovery_certificate_sample_collection">"Positiver Test vom %s"</string>
     <!-- #####################################################
          TEST CERTIFICATE STRINGS BELOW
          ##################################################### -->

--- a/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
@@ -91,8 +91,8 @@
     <string name="recovery_certificate_details_subtitle">"Digitales COVID-Zertifikat der EU"</string>
     <!-- XTXT: Recovery certificate card name  -->
     <string name="recovery_certificate_name">Genesenenzertifikat</string>
-    <!-- XTXT: Recovery certificate valid until -->
-    <string name="recovery_certificate_valid_until">"gültig bis %s"</string>
+    <!-- XTXT: Recovery certificate the date of the sample collection -->
+    <string name="recovery_certificate_sample_collection">"Positiver Test vom %s"</string>
     <!-- #####################################################
          TEST CERTIFICATE STRINGS BELOW
          ##################################################### -->

--- a/Corona-Warn-App/src/main/res/values-pl/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-pl/covid_certificate_strings.xml
@@ -90,8 +90,8 @@
     <string name="recovery_certificate_details_subtitle">"Unijny cyfrowy certyfikat COVID"</string>
     <!-- XTXT: Recovery certificate card name  -->
     <string name="recovery_certificate_name">"Certyfikat statusu ozdrowieńca"</string>
-    <!-- XTXT: Recovery certificate valid until -->
-    <string name="recovery_certificate_valid_until">"ważne do %s"</string>
+    <!-- XTXT: Recovery certificate the date of the sample collection -->
+    <string name="recovery_certificate_sample_collection">"Positiver Test vom %s"</string>
     <!-- #####################################################
          TEST CERTIFICATE STRINGS BELOW
          ##################################################### -->

--- a/Corona-Warn-App/src/main/res/values-ro/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-ro/covid_certificate_strings.xml
@@ -90,8 +90,8 @@
     <string name="recovery_certificate_details_subtitle">"Certificat COVID digital UE"</string>
     <!-- XTXT: Recovery certificate card name  -->
     <string name="recovery_certificate_name">"Certificat de recuperare"</string>
-    <!-- XTXT: Recovery certificate valid until -->
-    <string name="recovery_certificate_valid_until">"valabil până la %s"</string>
+    <!-- XTXT: Recovery certificate the date of the sample collection -->
+    <string name="recovery_certificate_sample_collection">"Positiver Test vom %s"</string>
     <!-- #####################################################
          TEST CERTIFICATE STRINGS BELOW
          ##################################################### -->

--- a/Corona-Warn-App/src/main/res/values-tr/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-tr/covid_certificate_strings.xml
@@ -90,8 +90,8 @@
     <string name="recovery_certificate_details_subtitle">"AB Dijital COVID Sertifikası"</string>
     <!-- XTXT: Recovery certificate card name  -->
     <string name="recovery_certificate_name">"İyileşme Sertifikası"</string>
-    <!-- XTXT: Recovery certificate valid until -->
-    <string name="recovery_certificate_valid_until">"geçerlilik sonu: %s"</string>
+    <!-- XTXT: Recovery certificate the date of the sample collection -->
+    <string name="recovery_certificate_sample_collection">"Positiver Test vom %s"</string>
     <!-- #####################################################
          TEST CERTIFICATE STRINGS BELOW
          ##################################################### -->

--- a/Corona-Warn-App/src/main/res/values/covid_certificate_attribute_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/covid_certificate_attribute_strings.xml
@@ -57,10 +57,6 @@
     <string name="recovery_certificate_attribute_recovered_from" translatable="false">"Genesen von / Recovered from"</string>
     <!-- XTXT: Recovery Certificate Detail Screen Attribute: First Positive Test Result -->
     <string name="recovery_certificate_attribute_first_positive_test_result" translatable="false">"Datum des ersten positiven Testergebnisses / Date of first positive test result (YYYY-MM-DD)"</string>
-    <!-- XTXT: Recovery Certificate Detail Screen Attribute: Start of Certification Period -->
-    <string name="recovery_certificate_attribute_certificate_certification_period_start" translatable="false">"Zertifikat gültig ab / Certificate valid from (YYYY-MM-DD)"</string>
-    <!-- XTXT: Recovery Certificate Detail Screen Attribute: End of Certification Period -->
-    <string name="recovery_certificate_attribute_certificate_certification_period_end" translatable="false">"Zertifikat gültig bis / Certificate valid until (YYYY-MM-DD)"</string>
 
 
     <!-- #####################################################

--- a/Corona-Warn-App/src/main/res/values/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/covid_certificate_strings.xml
@@ -90,8 +90,8 @@
     <string name="recovery_certificate_details_subtitle">"EU Digital COVID Certificate"</string>
     <!-- XTXT: Recovery certificate card name  -->
     <string name="recovery_certificate_name">"Certificate of Recovery"</string>
-    <!-- XTXT: Recovery certificate valid until -->
-    <string name="recovery_certificate_valid_until">"valid to %s"</string>
+    <!-- XTXT: Recovery certificate the date of the sample collection -->
+    <string name="recovery_certificate_sample_collection">"Positiver Test vom %s"</string>
     <!-- #####################################################
          TEST CERTIFICATE STRINGS BELOW
          ##################################################### -->

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensionsTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesExtensionsTest.kt
@@ -37,7 +37,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
         }
 
         val certificateThird = mockk<RecoveryCertificate>().apply {
-            every { validFrom } returns time.minus(oneDayDuration).toLocalDateUtc()
+            every { testedPositiveOn } returns time.minus(oneDayDuration).toLocalDateUtc()
         }
 
         val certificateWithoutDate = mockk<TestCertificate>().apply {
@@ -66,7 +66,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
     }
 
     @Test
-    fun `certificate sort order -  crash EXPOSUREAPP-9880`() {
+    fun `certificate sort order - crash EXPOSUREAPP-9880`() {
         val vc1 = mockk<VaccinationCertificate>().apply {
             every { headerIssuedAt } returns Instant.parse("2021-09-20T10:00:00.000Z")
             every { vaccinatedOn } returns Instant.parse("2021-06-24T14:00:00.000Z").toLocalDateUtc()
@@ -78,7 +78,7 @@ class PersonCertificatesExtensionsTest : BaseTest() {
         }
 
         val rc1 = mockk<RecoveryCertificate>().apply {
-            every { validFrom } returns Instant.parse("2021-04-25T14:00:00.000Z").toLocalDateUtc()
+            every { testedPositiveOn } returns Instant.parse("2021-04-25T14:00:00.000Z").toLocalDateUtc()
         }
 
         val tc2 = mockk<TestCertificate>().apply {

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsViewModelTest.kt
@@ -217,13 +217,12 @@ class PersonDetailsViewModelTest : BaseTest() {
     private fun mockRecoveryCertificate(): RecoveryCertificate =
         mockk<RecoveryCertificate>().apply {
             every { uniqueCertificateIdentifier } returns "RN:UVCI:01:AT:858CC18CFCF5965EF82F60E493349AA5#K"
-            every { validUntil } returns Instant.parse("2021-05-31T11:35:00.000Z").toLocalDateUserTz()
             every { personIdentifier } returns certificatePersonIdentifier
             every { qrCodeToDisplay } returns CoilQrCode("qrCode")
             every { containerId } returns rcContainerId
             every { fullName } returns "Andrea Schneider"
             every { isDisplayValid } returns true
-            every { validFrom } returns LocalDate.now()
+            every { testedPositiveOn } returns LocalDate.now()
             every { rawCertificate } returns mockk<RecoveryDccV1>().apply {
                 every { recovery } returns mockk<DccV1.RecoveryCertificateData>().apply {
                     every { validFrom } returns LocalDate.now()


### PR DESCRIPTION
This PR addresses Exposureapp-[12063](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12063).
Contains more "meaningful informations" for the recovery certificates (e.g. date of the first positive test).

How to test:
- scan a recovery certificate (cli)
- check the changes ui component  (card is displayed together with "positive test..")
- affected cards: Dcc PersonView (Overview), Recycle Bin, Reissuance Consent View, Dcc Validation Service

Screenshot:
![image](https://user-images.githubusercontent.com/46747780/158166788-0808ea93-81da-4776-9a2c-fe41f527969c.png)

