### PR TITLE
[FEATURE] ENF delta (EXPOSURAPP-12210)

### DIFF
--- a/Corona-Warn-App/schemas/de.rki.coronawarnapp.diagnosiskeys.storage.KeyCacheDatabase/2.json
+++ b/Corona-Warn-App/schemas/de.rki.coronawarnapp.diagnosiskeys.storage.KeyCacheDatabase/2.json
@@ -1,0 +1,82 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "a696d867fb1d3921b8485c6bd1ce2274",
+    "entities": [
+      {
+        "tableName": "keyfiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `type` TEXT NOT NULL, `location` TEXT NOT NULL, `day` TEXT NOT NULL, `hour` TEXT, `createdAt` TEXT NOT NULL, `checksumMD5` TEXT, `completed` INTEGER NOT NULL, `checkedForExposures` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "location",
+            "columnName": "location",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "day",
+            "columnName": "day",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hour",
+            "columnName": "hour",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "etag",
+            "columnName": "checksumMD5",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isDownloadComplete",
+            "columnName": "completed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checkedForExposures",
+            "columnName": "checkedForExposures",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a696d867fb1d3921b8485c6bd1ce2274')"
+    ]
+  }
+}

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/diagnosiskeys/storage/KeyCacheDatabaseMigrationTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/diagnosiskeys/storage/KeyCacheDatabaseMigrationTest.kt
@@ -1,0 +1,81 @@
+package de.rki.coronawarnapp.diagnosiskeys.storage
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import de.rki.coronawarnapp.diagnosiskeys.server.LocationCode
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.joda.time.Instant
+import org.joda.time.LocalDate
+import org.joda.time.LocalTime
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import testhelpers.BaseTestInstrumentation
+
+@RunWith(AndroidJUnit4::class)
+class KeyCacheDatabaseMigrationTest : BaseTestInstrumentation() {
+
+    @get:Rule
+    val helper: MigrationTestHelper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        KeyCacheDatabase::class.java.canonicalName,
+        FrameworkSQLiteOpenHelperFactory()
+    )
+
+    /**
+     * Test migration to add new optional attributes
+     */
+    @Test
+    fun migrate1To2() {
+        val keyHour = CachedKeyInfo(
+            type = CachedKeyInfo.Type.LOCATION_DAY,
+            location = LocationCode("DE"),
+            day = LocalDate.parse("2020-08-23"),
+            hour = LocalTime.parse("12:00:00"),
+            createdAt = Instant.parse("2020-08-23T12:46:39.999Z"),
+        )
+        helper.createDatabase(KeyCacheDatabase.DATABASE_NAME, 1).apply {
+            execSQL(
+                """
+                    INSERT INTO "keyfiles" (
+                        "id",
+                        "type",
+                        "location",
+                        "day",
+                        "hour",
+                        "createdAt",
+                        "completed"
+                    ) VALUES (
+                        '0f3e9205ba2c753afc5772e9d40b10dded89666d',
+                        'country_day',
+                        'DE',
+                        '2020-08-23',
+                        '12:00:00',
+                        '2020-08-23T12:46:39.999Z',
+                        '0'
+                    );
+                """.trimIndent()
+            )
+            close()
+        }
+
+        // Run migration
+        helper.runMigrationsAndValidate(
+            KeyCacheDatabase.DATABASE_NAME,
+            2,
+            true,
+            KeyCacheDatabaseMigration1To2
+        )
+
+        val daoDb = KeyCacheDatabase.Factory(
+            context = ApplicationProvider.getApplicationContext()
+        ).create()
+
+        runBlocking { daoDb.cachedKeyFiles().allEntries().first() }.single() shouldBe keyHour
+    }
+}

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/diagnosiskeys/storage/KeyCacheDatabaseTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/diagnosiskeys/storage/KeyCacheDatabaseTest.kt
@@ -65,11 +65,25 @@ class KeyCacheDatabaseTest {
                 etag shouldBe "with milk"
             }
 
+            dao.setChecked(keyDay.id)
+            dao.getEntriesForType(CachedKeyInfo.Type.LOCATION_DAY.typeValue).single().apply {
+                checkedForExposures shouldBe true
+            }
+            dao.getEntriesForType(CachedKeyInfo.Type.LOCATION_HOUR.typeValue).single().apply {
+                checkedForExposures shouldBe false
+            }
+
+            dao.setChecked(keyHour.id)
+            dao.getEntriesForType(CachedKeyInfo.Type.LOCATION_HOUR.typeValue).single().apply {
+                checkedForExposures shouldBe true
+            }
+
             dao.deleteEntry(keyDay)
             dao.allEntries().first() shouldBe listOf(
                 keyHour.copy(
                     isDownloadComplete = true,
-                    etag = "with milk"
+                    etag = "with milk",
+                    checkedForExposures = true,
                 )
             )
 

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/keydownload/ui/KeyDownloadTestFragmentViewModel.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/keydownload/ui/KeyDownloadTestFragmentViewModel.kt
@@ -73,7 +73,7 @@ class KeyDownloadTestFragmentViewModel @AssistedInject constructor(
     }
 
     fun deleteKeyFile(it: CachedKeyListItem) = launchWithSyncProgress {
-        keyCacheRepository.delete(listOf(it.info))
+        keyCacheRepository.deleteInfoAndFile(listOf(it.info))
     }
 
     @AssistedFactory

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/BaseKeyPackageSyncTool.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/BaseKeyPackageSyncTool.kt
@@ -33,7 +33,7 @@ open class BaseKeyPackageSyncTool(
             false
         } else {
             Timber.tag(tag).w("Deleting revoked cached keys: %s", toDelete.joinToString("\n"))
-            keyCache.delete(toDelete.map { it.info })
+            keyCache.deleteInfoAndFile(toDelete.map { it.info })
             true
         }
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/BaseKeyPackageSyncTool.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/BaseKeyPackageSyncTool.kt
@@ -87,7 +87,7 @@ open class BaseKeyPackageSyncTool(
         return@filter true
     }
 
-    internal suspend fun getDownloadedCachedKeys(
+    internal suspend fun getCachedKeys(
         location: LocationCode,
         type: CachedKeyInfo.Type
     ): List<CachedKey> = keyCache.getEntriesForType(type)
@@ -95,11 +95,13 @@ open class BaseKeyPackageSyncTool(
         .filter { key ->
             val complete = key.info.isDownloadComplete
             val exists = key.path.exists()
-            if (complete && !exists) {
-                Timber.tag(tag).v("Incomplete download, will overwrite: %s", key)
+            val checked = key.info.checkedForExposures
+            if (complete && !exists && !checked) {
+                // marked complete, but does not exist nor has been checked for exposures -> counts as missing
+                Timber.tag(tag).v("Missing file has not been checked, will be overwritten: %s", key)
             }
-            // We overwrite not completed ones
-            complete && exists
+            // files that have been downloaded already
+            complete && (exists || checked)
         }
 
     data class SyncResult(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/DayPackageSyncTool.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/DayPackageSyncTool.kt
@@ -92,25 +92,25 @@ class DayPackageSyncTool @Inject constructor(
         location: LocationCode,
         forceIndexLookup: Boolean
     ): LocationDays? {
-        val cachedDays = getDownloadedCachedKeys(location, Type.LOCATION_DAY)
+        // existing or checked files -> no download needed
+        val cachedKeys = getCachedKeys(location, Type.LOCATION_DAY)
 
-        if (!forceIndexLookup && !expectNewDayPackages(cachedDays)) {
+        if (!forceIndexLookup && !expectNewDayPackages(cachedKeys)) {
             Timber.tag(TAG).d("We don't expect new day packages.")
             return null
         }
 
         val availableDays = LocationDays(location, keyServer.getDayIndex(location))
 
-        val staleDays = cachedDays.findStaleData(listOf(availableDays))
-
-        if (staleDays.isNotEmpty()) {
-            Timber.tag(TAG).d("Deleting stale days (loation=%s): %s", location, staleDays)
-            keyCache.delete(staleDays.map { it.info })
+        // remove files that are no longer available on the server
+        val staleKeys = cachedKeys.findStaleData(listOf(availableDays))
+        if (staleKeys.isNotEmpty()) {
+            Timber.tag(TAG).d("Deleting stale days (loation=%s): %s", location, staleKeys)
+            keyCache.delete(staleKeys.map { it.info })
         }
+        val nonStaleCachedKeys = cachedKeys.minus(staleKeys)
 
-        val nonStaleDays = cachedDays.minus(staleDays)
-
-        return availableDays.toMissingDays(nonStaleDays) // The missing days
+        return availableDays.toMissingDays(nonStaleCachedKeys) // The missing days
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/DayPackageSyncTool.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/DayPackageSyncTool.kt
@@ -106,7 +106,7 @@ class DayPackageSyncTool @Inject constructor(
         val staleKeys = cachedKeys.findStaleData(listOf(availableDays))
         if (staleKeys.isNotEmpty()) {
             Timber.tag(TAG).d("Deleting stale days (loation=%s): %s", location, staleKeys)
-            keyCache.delete(staleKeys.map { it.info })
+            keyCache.deleteInfoAndFile(staleKeys.map { it.info })
         }
         val nonStaleCachedKeys = cachedKeys.minus(staleKeys)
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/DownloadDiagnosisKeysTask.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/DownloadDiagnosisKeysTask.kt
@@ -5,6 +5,7 @@ import de.rki.coronawarnapp.appconfig.ConfigData
 import de.rki.coronawarnapp.appconfig.ExposureDetectionConfig
 import de.rki.coronawarnapp.coronatest.CoronaTestRepository
 import de.rki.coronawarnapp.diagnosiskeys.server.LocationCode
+import de.rki.coronawarnapp.diagnosiskeys.storage.KeyCacheRepository
 import de.rki.coronawarnapp.environment.EnvironmentSetup
 import de.rki.coronawarnapp.nearby.ENFClient
 import de.rki.coronawarnapp.nearby.modules.detectiontracker.TrackedExposureDetection
@@ -35,6 +36,7 @@ class DownloadDiagnosisKeysTask @Inject constructor(
     private val timeStamper: TimeStamper,
     private val settings: DownloadDiagnosisKeysSettings,
     private val coronaTestRepository: CoronaTestRepository,
+    private val keyCacheRepository: KeyCacheRepository,
 ) : Task<DownloadDiagnosisKeysTask.Progress, DownloadDiagnosisKeysTask.Result> {
 
     private val internalProgress = MutableStateFlow<Progress>(Progress.Started)
@@ -101,10 +103,10 @@ class DownloadDiagnosisKeysTask @Inject constructor(
                 return Result()
             }
 
-            val availableKeyFiles = keySyncResult.availableKeys.map { it.path }
-            val totalFileSize = availableKeyFiles.fold(0L, { acc, file -> file.length() + acc })
+            val deltaKeyFiles = keySyncResult.deltaKeys.map { it.path }
+            val totalFileSize = deltaKeyFiles.fold(0L, { acc, file -> file.length() + acc })
 
-            internalProgress.value = Progress.KeyFilesDownloadFinished(availableKeyFiles.size, totalFileSize)
+            internalProgress.value = Progress.KeyFilesDownloadFinished(deltaKeyFiles.size, totalFileSize)
 
             // remember version code of this execution for next time
             settings.updateLastVersionCodeToCurrent()
@@ -117,10 +119,15 @@ class DownloadDiagnosisKeysTask @Inject constructor(
 
             Timber.tag(TAG).d("Attempting submission to ENF")
             val isSubmissionSuccessful = enfClient.provideDiagnosisKeys(
-                availableKeyFiles,
+                deltaKeyFiles,
                 exposureConfig.diagnosisKeysDataMapping
             )
             Timber.tag(TAG).d("Diagnosis Keys provided (success=%s)", isSubmissionSuccessful)
+
+            if (isSubmissionSuccessful) {
+                // mark key files as checked
+                keyCacheRepository.markKeyChecked(keySyncResult.deltaKeys.map { it.info }.toList())
+            }
 
             internalProgress.value = Progress.ApiSubmissionFinished
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/HourPackageSyncTool.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/HourPackageSyncTool.kt
@@ -172,7 +172,7 @@ class HourPackageSyncTool @Inject constructor(
         val staleHours = cachedHours.findStaleData(listOf(cachedDays, availableHours))
         if (staleHours.isNotEmpty()) {
             Timber.tag(TAG).v("Deleting stale hours: %s", staleHours)
-            keyCache.delete(staleHours.map { it.info })
+            keyCache.deleteInfoAndFile(staleHours.map { it.info })
         }
 
         // subtract key files that are not on the server any more

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/HourPackageSyncTool.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/HourPackageSyncTool.kt
@@ -137,7 +137,8 @@ class HourPackageSyncTool @Inject constructor(
         location: LocationCode,
         forceIndexLookup: Boolean
     ): LocationHours? {
-        val cachedHours = getDownloadedCachedKeys(location, Type.LOCATION_HOUR)
+        // existing or checked files -> no download needed
+        val cachedHours = getCachedKeys(location, Type.LOCATION_HOUR)
 
         val now = timeStamper.nowUTC
 
@@ -164,18 +165,17 @@ class HourPackageSyncTool @Inject constructor(
             LocationHours(location, mapOf(today to hoursToday))
         }
 
-        // If we have hours in covered by a day, delete the hours
-        val cachedDays = getDownloadedCachedKeys(location, Type.LOCATION_DAY).map {
+        // If we have hours that are covered by a day, delete the hours
+        val cachedDays = getCachedKeys(location, Type.LOCATION_DAY).map {
             it.info.day
         }.let { LocationDays(location, it) }
-
         val staleHours = cachedHours.findStaleData(listOf(cachedDays, availableHours))
-
         if (staleHours.isNotEmpty()) {
             Timber.tag(TAG).v("Deleting stale hours: %s", staleHours)
             keyCache.delete(staleHours.map { it.info })
         }
 
+        // subtract key files that are not on the server any more
         val nonStaleHours = cachedHours.minus(staleHours)
 
         return availableHours.toMissingHours(nonStaleHours) // The missing hours

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/KeyDownloadTool.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/KeyDownloadTool.kt
@@ -43,7 +43,7 @@ class KeyDownloadTool @Inject constructor(
         cachedKey
     } catch (e: Exception) {
         Timber.tag(TAG).e(e, "Download failed: %s", cachedKey)
-        keyCache.delete(listOf(cachedKey.info))
+        keyCache.deleteInfoAndFile(listOf(cachedKey.info))
         throw e
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/KeyPackageSyncTool.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/KeyPackageSyncTool.kt
@@ -68,7 +68,7 @@ class KeyPackageSyncTool @Inject constructor(
             .filter { !acceptedLocations.contains(it.location) }
         if (staleLocationData.isNotEmpty()) {
             Timber.tag(TAG).i("Deleting stale location data: %s", staleLocationData.joinToString("\n"))
-            keyCache.delete(staleLocationData)
+            keyCache.deleteInfoAndFile(staleLocationData)
         } else {
             Timber.tag(TAG).d("No stale location data exists.")
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/KeyPackageSyncTool.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/download/KeyPackageSyncTool.kt
@@ -37,7 +37,9 @@ class KeyPackageSyncTool @Inject constructor(
             null
         }
 
-        val availableKeys = keyCache.getAllCachedKeys()
+        val deltaKeys = keyCache.getAllCachedKeys()
+            // exclude files that have been checked
+            .filter { !it.info.checkedForExposures }
             .filter { it.info.isDownloadComplete }
             .filter { (keyInfo, path) ->
                 path.exists().also {
@@ -52,7 +54,7 @@ class KeyPackageSyncTool @Inject constructor(
         hourSyncResult?.let { newKeys.addAll(it.newPackages) }
 
         return Result(
-            availableKeys = availableKeys,
+            deltaKeys = deltaKeys,
             newKeys = newKeys,
             wasDaySyncSucccessful = daySyncResult.successful
         )
@@ -129,7 +131,7 @@ class KeyPackageSyncTool @Inject constructor(
     }
 
     data class Result(
-        val availableKeys: Collection<CachedKey>,
+        val deltaKeys: Collection<CachedKey>,
         val newKeys: Collection<CachedKey>,
         val wasDaySyncSucccessful: Boolean
     )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/storage/CachedKeyInfo.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/storage/CachedKeyInfo.kt
@@ -30,7 +30,7 @@ data class CachedKeyInfo(
         location: LocationCode,
         day: LocalDate,
         hour: LocalTime?,
-        createdAt: Instant
+        createdAt: Instant,
     ) : this(
         id = calcluateId(location, day, hour, type),
         location = location,

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/storage/CachedKeyInfo.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/storage/CachedKeyInfo.kt
@@ -21,7 +21,8 @@ data class CachedKeyInfo(
     @ColumnInfo(name = "hour") val hour: LocalTime?, // i.e. 23
     @ColumnInfo(name = "createdAt") val createdAt: Instant,
     @ColumnInfo(name = "checksumMD5") val etag: String?, // ETag
-    @ColumnInfo(name = "completed") val isDownloadComplete: Boolean
+    @ColumnInfo(name = "completed") val isDownloadComplete: Boolean,
+    @ColumnInfo(name = "checkedForExposures") val checkedForExposures: Boolean = false
 ) {
 
     constructor(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/storage/KeyCacheDatabase.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/storage/KeyCacheDatabase.kt
@@ -45,6 +45,9 @@ abstract class KeyCacheDatabase : RoomDatabase() {
 
         @Update(entity = CachedKeyInfo::class)
         suspend fun updateDownloadState(update: CachedKeyInfo.DownloadUpdate)
+
+        @Query("UPDATE keyfiles SET checkedForExposures = 1 WHERE id = :id")
+        suspend fun setChecked(id: String)
     }
 
     class Factory @Inject constructor(@AppContext private val context: Context) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/storage/KeyCacheDatabase.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/storage/KeyCacheDatabase.kt
@@ -18,7 +18,7 @@ import javax.inject.Inject
 
 @Database(
     entities = [CachedKeyInfo::class],
-    version = 1,
+    version = 2,
     exportSchema = true
 )
 @TypeConverters(CommonConverters::class, CachedKeyInfo.Type.Converter::class)
@@ -54,11 +54,11 @@ abstract class KeyCacheDatabase : RoomDatabase() {
          */
         fun create(): KeyCacheDatabase = Room
             .databaseBuilder(context, KeyCacheDatabase::class.java, DATABASE_NAME)
-            .fallbackToDestructiveMigrationFrom()
+            .addMigrations(KeyCacheDatabaseMigration1To2)
             .build()
     }
 
     companion object {
-        private const val DATABASE_NAME = "keycache.db"
+        const val DATABASE_NAME = "keycache.db"
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/storage/KeyCacheDatabaseMigration1To2.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/storage/KeyCacheDatabaseMigration1To2.kt
@@ -1,0 +1,27 @@
+package de.rki.coronawarnapp.diagnosiskeys.storage
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+import de.rki.coronawarnapp.exception.ExceptionCategory
+import de.rki.coronawarnapp.exception.reporting.report
+import timber.log.Timber
+
+object KeyCacheDatabaseMigration1To2 : Migration(1, 2) {
+
+    override fun migrate(database: SupportSQLiteDatabase) {
+        try {
+            performMigration(database)
+        } catch (e: Exception) {
+            Timber.e(e, "Migration 1->2 failed")
+            e.report(ExceptionCategory.INTERNAL, "KeyCacheDatabase migration 1 to 2 failed.")
+            throw e
+        }
+    }
+
+    private fun performMigration(database: SupportSQLiteDatabase) = with(database) {
+        execSQL(
+            "ALTER TABLE `keyfiles` " +
+                "ADD COLUMN `checkedForExposures` INTEGER NOT NULL DEFAULT 0" // false
+        )
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/storage/KeyCacheRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/diagnosiskeys/storage/KeyCacheRepository.kt
@@ -130,6 +130,14 @@ class KeyCacheRepository @Inject constructor(
         getDao().updateDownloadState(update)
     }
 
+    suspend fun markKeyChecked(cachedKeyInfos: List<CachedKeyInfo>) {
+        with(getDao()) {
+            cachedKeyInfos.forEach {
+                setChecked(it.id)
+            }
+        }
+    }
+
     suspend fun delete(keyInfos: Collection<CachedKeyInfo>) {
         Timber.d("delete(keyFiles=%s)", keyInfos)
         keyInfos.forEach { key ->

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/diagnosiskeyprovider/DefaultDiagnosisKeyProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/nearby/modules/diagnosiskeyprovider/DefaultDiagnosisKeyProvider.kt
@@ -1,8 +1,8 @@
 package de.rki.coronawarnapp.nearby.modules.diagnosiskeyprovider
 
 import com.google.android.gms.common.api.ApiException
-import com.google.android.gms.nearby.exposurenotification.DiagnosisKeysDataMapping
 import com.google.android.gms.nearby.exposurenotification.DiagnosisKeyFileProvider
+import com.google.android.gms.nearby.exposurenotification.DiagnosisKeysDataMapping
 import com.google.android.gms.nearby.exposurenotification.ExposureNotificationClient
 import de.rki.coronawarnapp.exception.reporting.ReportingConstants
 import de.rki.coronawarnapp.nearby.modules.diagnosiskeysdatamapper.DiagnosisKeysDataMapper
@@ -57,7 +57,9 @@ class DefaultDiagnosisKeyProvider @Inject constructor(
         return suspendCoroutine { cont ->
             Timber.d("Performing key submission.")
             provideDiagnosisKeysTask
-                .addOnSuccessListener { cont.resume(true) }
+                .addOnSuccessListener {
+                    cont.resume(true)
+                }
                 .addOnFailureListener {
                     Timber.w("Key submission failed because ${it.message}")
                     val wrappedException =

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/BaseKeyPackageSyncToolTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/BaseKeyPackageSyncToolTest.kt
@@ -271,31 +271,41 @@ class BaseKeyPackageSyncToolTest : BaseIOTest() {
     }
 
     @Test
-    fun `getting completed keys`() = runBlockingTest {
+    fun `getting completed or checked keys`() = runBlockingTest {
+        // incomplete -> no delta
         val key1 = mockk<CachedKey>().apply {
             every { info } returns mockk<CachedKeyInfo>().apply {
                 every { isDownloadComplete } returns false
+                every { checkedForExposures } returns false
                 every { location } returns LocationCode("EUR")
             }
             every { path } returns mockk<File>().apply { every { exists() } returns true }
         }
+        // delta
         val key2 = mockk<CachedKey>().apply {
             every { info } returns mockk<CachedKeyInfo>().apply {
                 every { isDownloadComplete } returns true
+                every { checkedForExposures } returns true
                 every { location } returns LocationCode("EUR")
             }
             every { path } returns mockk<File>().apply { every { exists() } returns false }
         }
+
+        // delta -> not checked but existing
         val key3 = mockk<CachedKey>().apply {
             every { info } returns mockk<CachedKeyInfo>().apply {
                 every { isDownloadComplete } returns true
+                every { checkedForExposures } returns false
                 every { location } returns LocationCode("EUR")
             }
             every { path } returns mockk<File>().apply { every { exists() } returns true }
         }
+
+        //  DE location
         val key4 = mockk<CachedKey>().apply {
             every { info } returns mockk<CachedKeyInfo>().apply {
                 every { isDownloadComplete } returns true
+                every { checkedForExposures } returns true
                 every { location } returns LocationCode("DE")
             }
             every { path } returns mockk<File>().apply { every { exists() } returns true }
@@ -303,16 +313,22 @@ class BaseKeyPackageSyncToolTest : BaseIOTest() {
         coEvery { keyCache.getEntriesForType(any()) } returns listOf(key1, key2, key3, key4)
 
         val instance = createInstance()
-        instance.getDownloadedCachedKeys(
+        instance.getCachedKeys(
             LocationCode("EUR"),
             CachedKeyInfo.Type.LOCATION_DAY
-        ) shouldBe listOf(key3)
+        ) shouldBe listOf(key2, key3)
         coVerify { keyCache.getEntriesForType(CachedKeyInfo.Type.LOCATION_DAY) }
 
-        instance.getDownloadedCachedKeys(
+        instance.getCachedKeys(
             LocationCode("EUR"),
             CachedKeyInfo.Type.LOCATION_HOUR
-        ) shouldBe listOf(key3)
+        ) shouldBe listOf(key2, key3)
+        coVerify { keyCache.getEntriesForType(CachedKeyInfo.Type.LOCATION_HOUR) }
+
+        instance.getCachedKeys(
+            LocationCode("DE"),
+            CachedKeyInfo.Type.LOCATION_HOUR
+        ) shouldBe listOf(key4)
         coVerify { keyCache.getEntriesForType(CachedKeyInfo.Type.LOCATION_HOUR) }
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/BaseKeyPackageSyncToolTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/BaseKeyPackageSyncToolTest.kt
@@ -43,7 +43,7 @@ class BaseKeyPackageSyncToolTest : BaseIOTest() {
         testDir.exists() shouldBe true
 
         coEvery { deviceStorage.requireSpacePrivateStorage(any()) } returns mockk()
-        coEvery { keyCache.delete(any()) } just Runs
+        coEvery { keyCache.deleteInfoAndFile(any()) } just Runs
     }
 
     @AfterEach
@@ -111,7 +111,7 @@ class BaseKeyPackageSyncToolTest : BaseIOTest() {
 
         instance.revokeCachedKeys(emptyList()) shouldBe false
 
-        coVerify { keyCache.delete(listOf(badDayInfo, badHourInfo)) }
+        coVerify { keyCache.deleteInfoAndFile(listOf(badDayInfo, badHourInfo)) }
     }
 
     @Test

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/CommonSyncToolTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/CommonSyncToolTest.kt
@@ -80,7 +80,7 @@ abstract class CommonSyncToolTest : BaseIOTest() {
             mockCachedHour(arg(1), arg(2), arg(3))
         }
         coEvery { keyCache.getAllCachedKeys() } answers { keyRepoData.values.toList() }
-        coEvery { keyCache.delete(any()) } answers {
+        coEvery { keyCache.deleteInfoAndFile(any()) } answers {
             val toDelete: List<CachedKeyInfo> = arg(0)
             toDelete.forEach {
                 keyRepoData.remove(it.id)

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/DayPackageSyncToolTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/DayPackageSyncToolTest.kt
@@ -159,7 +159,7 @@ class DayPackageSyncToolTest : CommonSyncToolTest() {
             configProvider.getAppConfig()
 
             keyCache.getAllCachedKeys()
-            keyCache.delete(listOf(invalidDay.info))
+            keyCache.deleteInfoAndFile(listOf(invalidDay.info))
 
             keyCache.getEntriesForType(Type.LOCATION_DAY)
             keyServer.getDayIndex("EUR".loc)

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/DownloadDiagnosisKeysTaskTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/DownloadDiagnosisKeysTaskTest.kt
@@ -6,6 +6,8 @@ import de.rki.coronawarnapp.appconfig.ConfigData
 import de.rki.coronawarnapp.coronatest.CoronaTestRepository
 import de.rki.coronawarnapp.coronatest.type.CoronaTest
 import de.rki.coronawarnapp.diagnosiskeys.storage.CachedKey
+import de.rki.coronawarnapp.diagnosiskeys.storage.CachedKeyInfo
+import de.rki.coronawarnapp.diagnosiskeys.storage.KeyCacheRepository
 import de.rki.coronawarnapp.environment.BuildConfigWrap
 import de.rki.coronawarnapp.environment.EnvironmentSetup
 import de.rki.coronawarnapp.nearby.ENFClient
@@ -45,11 +47,14 @@ class DownloadDiagnosisKeysTaskTest : BaseTest() {
     @MockK lateinit var syncResult: KeyPackageSyncTool.Result
     @MockK lateinit var diagnosisKeyDataMapping: DiagnosisKeysDataMapping
 
-    @MockK lateinit var availableKey1: CachedKey
+    @MockK lateinit var deltaKey1: CachedKey
     @MockK lateinit var newKey1: CachedKey
+    @MockK lateinit var cachedKeyInfo: CachedKeyInfo
 
     @MockK lateinit var latestTrackedDetection: TrackedExposureDetection
     @MockK lateinit var coronaTestRepository: CoronaTestRepository
+
+    @MockK lateinit var keyCacheRepository: KeyCacheRepository
 
     private val coronaTests: MutableStateFlow<Set<CoronaTest>> = MutableStateFlow(
         setOf(
@@ -66,11 +71,13 @@ class DownloadDiagnosisKeysTaskTest : BaseTest() {
 
         every { coronaTestRepository.coronaTests } returns coronaTests
 
-        availableKey1.apply {
+        deltaKey1.apply {
             every { path } returns File("availableKey1")
+            every { info } returns cachedKeyInfo
         }
         newKey1.apply {
             every { path } returns File("newKey1")
+            every { info } returns cachedKeyInfo
         }
 
         appConfig.apply {
@@ -91,7 +98,7 @@ class DownloadDiagnosisKeysTaskTest : BaseTest() {
         every { environmentSetup.useEuropeKeyPackageFiles } returns true
 
         coEvery { keyPackageSyncTool.syncKeyFiles(any()) } returns syncResult.apply {
-            every { availableKeys } returns listOf(availableKey1)
+            every { deltaKeys } returns listOf(deltaKey1)
             every { newKeys } returns listOf(newKey1)
         }
 
@@ -103,6 +110,8 @@ class DownloadDiagnosisKeysTaskTest : BaseTest() {
             coEvery { latestTrackedExposureDetection() } returns flowOf(listOf(latestTrackedDetection))
             coEvery { provideDiagnosisKeys(any(), any()) } returns true
         }
+
+        coEvery { keyCacheRepository.markKeyChecked(any()) } just Runs
     }
 
     fun createInstance() = DownloadDiagnosisKeysTask(
@@ -113,6 +122,7 @@ class DownloadDiagnosisKeysTaskTest : BaseTest() {
         timeStamper = timeStamper,
         settings = downloadSettings,
         coronaTestRepository = coronaTestRepository,
+        keyCacheRepository = keyCacheRepository,
     )
 
     @Test
@@ -136,15 +146,27 @@ class DownloadDiagnosisKeysTaskTest : BaseTest() {
 
     @Test
     fun `normal execution on first run`() = runBlockingTest {
-        val task = createInstance()
+        createInstance().run(DownloadDiagnosisKeysTask.Arguments())
 
-        task.run(DownloadDiagnosisKeysTask.Arguments())
+        coVerifySequence {
+            enfClient.isTracingEnabled
+            enfClient.latestTrackedExposureDetection()
+            enfClient.provideDiagnosisKeys(any(), any())
+            keyCacheRepository.markKeyChecked(listOf(cachedKeyInfo))
+        }
+    }
+
+    @Test
+    fun `not marked as checked if submission fails`() = runBlockingTest {
+        coEvery { enfClient.provideDiagnosisKeys(any(), any()) } returns false
+        createInstance().run(DownloadDiagnosisKeysTask.Arguments())
 
         coVerifySequence {
             enfClient.isTracingEnabled
             enfClient.latestTrackedExposureDetection()
             enfClient.provideDiagnosisKeys(any(), any())
         }
+        coVerify(exactly = 0) { keyCacheRepository.markKeyChecked(any()) }
     }
 
     @Test

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/HourPackageSyncToolTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/HourPackageSyncToolTest.kt
@@ -67,7 +67,7 @@ class HourPackageSyncToolTest : CommonSyncToolTest() {
 
             keyCache.getEntriesForType(Type.LOCATION_DAY) // Which hours are covered by days already
 
-            keyCache.delete(listOf(staleHour.info))
+            keyCache.deleteInfoAndFile(listOf(staleHour.info))
 
             keyCache.createCacheEntry(Type.LOCATION_HOUR, "EUR".loc, "2020-01-04".day, "00:00".hour)
             downloadTool.downloadKeyFile(any(), downloadConfig)
@@ -108,7 +108,7 @@ class HourPackageSyncToolTest : CommonSyncToolTest() {
             configProvider.getAppConfig()
 
             keyCache.getAllCachedKeys()
-            keyCache.delete(listOf(invalidHour.info))
+            keyCache.deleteInfoAndFile(listOf(invalidHour.info))
 
             keyCache.getEntriesForType(Type.LOCATION_HOUR) // Get all cached hours
             timeStamper.nowUTC // Timestamp for `expectNewHourPackages` and server index
@@ -264,6 +264,6 @@ class HourPackageSyncToolTest : CommonSyncToolTest() {
         )
 
         coVerify(exactly = 1) { keyServer.getHourIndex("EUR".loc, "2020-01-04".day) }
-        coVerify(exactly = 0) { keyCache.delete(any()) }
+        coVerify(exactly = 0) { keyCache.deleteInfoAndFile(any()) }
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/KeyDownloadToolTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/KeyDownloadToolTest.kt
@@ -67,7 +67,7 @@ class KeyDownloadToolTest : BaseIOTest() {
         every { downloadConfig.individualDownloadTimeout } returns Duration.millis(9000L)
 
         coEvery { keyCache.markKeyComplete(any(), any()) } just Runs
-        coEvery { keyCache.delete(any()) } just Runs
+        coEvery { keyCache.deleteInfoAndFile(any()) } just Runs
     }
 
     @AfterEach
@@ -132,6 +132,6 @@ class KeyDownloadToolTest : BaseIOTest() {
             instance.downloadKeyFile(cachedKey, downloadConfig)
         }
 
-        coVerify { keyCache.delete(listOf(cachedKeyInfo)) }
+        coVerify { keyCache.deleteInfoAndFile(listOf(cachedKeyInfo)) }
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/KeyPackageSyncToolTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/KeyPackageSyncToolTest.kt
@@ -107,7 +107,7 @@ class KeyPackageSyncToolTest : BaseIOTest() {
         val instance = createInstance()
 
         instance.syncKeyFiles() shouldBe KeyPackageSyncTool.Result(
-            availableKeys = emptyList(),
+            deltaKeys = emptyList(),
             newKeys = listOf(cachedDayKey, cachedHourKey),
             wasDaySyncSucccessful = true
         )
@@ -139,7 +139,7 @@ class KeyPackageSyncToolTest : BaseIOTest() {
         val instance = createInstance()
 
         instance.syncKeyFiles() shouldBe KeyPackageSyncTool.Result(
-            availableKeys = emptyList(),
+            deltaKeys = emptyList(),
             newKeys = listOf(cachedDayKey, cachedHourKey),
             wasDaySyncSucccessful = false
         )
@@ -170,7 +170,7 @@ class KeyPackageSyncToolTest : BaseIOTest() {
         val instance = createInstance()
 
         instance.syncKeyFiles() shouldBe KeyPackageSyncTool.Result(
-            availableKeys = emptyList(),
+            deltaKeys = emptyList(),
             newKeys = listOf(cachedDayKey, cachedHourKey),
             wasDaySyncSucccessful = true
         )
@@ -216,7 +216,7 @@ class KeyPackageSyncToolTest : BaseIOTest() {
         val instance = createInstance()
 
         instance.syncKeyFiles() shouldBe KeyPackageSyncTool.Result(
-            availableKeys = emptyList(),
+            deltaKeys = emptyList(),
             newKeys = listOf(cachedDayKey, cachedHourKey),
             wasDaySyncSucccessful = true
         )
@@ -249,7 +249,7 @@ class KeyPackageSyncToolTest : BaseIOTest() {
         val instance = createInstance()
 
         instance.syncKeyFiles() shouldBe KeyPackageSyncTool.Result(
-            availableKeys = emptyList(),
+            deltaKeys = emptyList(),
             newKeys = listOf(cachedDayKey),
             wasDaySyncSucccessful = true
         )
@@ -274,6 +274,7 @@ class KeyPackageSyncToolTest : BaseIOTest() {
             info = mockk<CachedKeyInfo>().apply {
                 every { location } returns LocationCode("NOT-EUR")
                 every { isDownloadComplete } returns true
+                every { checkedForExposures } returns true
             },
             path = mockk<File>().apply {
                 every { exists() } returns true
@@ -283,6 +284,7 @@ class KeyPackageSyncToolTest : BaseIOTest() {
             info = mockk<CachedKeyInfo>().apply {
                 every { location } returns LocationCode("EUR")
                 every { isDownloadComplete } returns true
+                every { checkedForExposures } returns false
             },
             path = mockk<File>().apply {
                 every { exists() } returns true

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/KeyPackageSyncToolTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/diagnosiskeys/download/KeyPackageSyncToolTest.kt
@@ -69,7 +69,7 @@ class KeyPackageSyncToolTest : BaseIOTest() {
         testDir.exists() shouldBe true
 
         coEvery { keyCache.getAllCachedKeys() } returns listOf()
-        coEvery { keyCache.delete(any()) } just Runs
+        coEvery { keyCache.deleteInfoAndFile(any()) } just Runs
         coEvery { syncSettings.lastDownloadDays } returns lastDownloadDays
         coEvery { syncSettings.lastDownloadHours } returns lastDownloadHours
 
@@ -297,7 +297,7 @@ class KeyPackageSyncToolTest : BaseIOTest() {
 
         coVerifySequence {
             keyCache.getAllCachedKeys() // To clean up stale locations
-            keyCache.delete(listOf(badLocation.info))
+            keyCache.deleteInfoAndFile(listOf(badLocation.info))
 
             lastDownloadDays.value
             lastDownloadDays.update(any())


### PR DESCRIPTION
How to test:
- check database 'keyfiles' and storage data -> data -> de.coronawarnapp.test -> cache -> diagnosis-keys
- entries marked as checked should disappear on the next app start
- triggering key download should not result in download of files that are marked as checked
- only unmarked files are provided to ENF, marked after successful submission

currently targeting 2.19