### PR TITLE
without header it's not working correctly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,6 +340,7 @@ jobs:
           command: |
             curl -u $CIRCLE_API_ADMIN_TOKEN: \
             -d '{"branch":"main","parameters":{"mobile-os":"android"}}' \
+            -H 'content-type: application/json' \
             https://circleci.com/api/v2/project/github/corona-warn-app/cwa-app-automation/pipeline
 
   instrumentation_tests_device:


### PR DESCRIPTION
## Description
without header it's not working correctly - circleci API requires correct content-type

same as https://github.com/corona-warn-app/cwa-app-ios/pull/4404

in addition to https://github.com/corona-warn-app/cwa-app-android/pull/5010