### PR TITLE
Duplicate warning screen back navigation (EXPOSUREAPP-12325)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/familytest/ui/selection/TestRegistrationSelectionFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/familytest/ui/selection/TestRegistrationSelectionFragment.kt
@@ -52,8 +52,7 @@ class TestRegistrationSelectionFragment : Fragment(R.layout.fragment_test_regist
                         TestRegistrationSelectionFragmentDirections
                             .actionTestRegistrationSelectionFragmentToSubmissionDeletionWarningFragment(
                                 testRegistrationRequest = it.testRegistrationRequest
-                            ),
-                        navOptions
+                            )
                     )
                 }
                 is TestRegistrationSelectionNavigationEvents.NavigateToFamily -> {
@@ -61,8 +60,7 @@ class TestRegistrationSelectionFragment : Fragment(R.layout.fragment_test_regist
                         TestRegistrationSelectionFragmentDirections
                             .actionTestRegistrationSelectionFragmentToFamilyTestConsentFragment(
                                 coronaTestQrCode = it.coronaTestQRCode
-                            ),
-                        navOptions
+                            )
                     )
                 }
             }

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_deletion_warning.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_deletion_warning.xml
@@ -11,7 +11,7 @@
 
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar"
-        style="@style/CWAMaterialToolbar.Close"
+        style="@style/CWAMaterialToolbar.BackArrow"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"

--- a/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
+++ b/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
@@ -617,7 +617,6 @@
             app:destination="@id/submissionTestResultNoConsentFragment"
             app:popUpTo="@id/mainFragment"
             app:popUpToInclusive="false" />
-
         <argument
             android:name="testIdentifier"
             app:argType="string" />
@@ -641,9 +640,7 @@
         <argument
             android:name="testIdentifier"
             app:argType="string" />
-
     </fragment>
-
     <fragment
         android:id="@+id/debuglogFragment"
         android:name="de.rki.coronawarnapp.bugreporting.debuglog.ui.DebugLogFragment"

--- a/Corona-Warn-App/src/main/res/values-de/antigen_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/antigen_strings.xml
@@ -76,7 +76,7 @@
     <string name="ag_homescreen_card_pcr_body_result_date">"Test registriert am %1$s"</string>
 
     <!-- XBUT: submission deletion warning button continue -->
-    <string name="submission_deletion_warning_continue_button">"Weiter"</string>
+    <string name="submission_deletion_warning_continue_button">"Test überschreiben"</string>
     <!-- XHED: submission deletion warning title -->
     <string name="submission_deletion_warning_title">"Hinweis"</string>
     <!-- YTXT: Headline for rapid test submission deletion warning -->


### PR DESCRIPTION
When trying to register another personal test, the duplicate warning screen back button will now take you back to the test registration selection screen instead of returning to the home screen. The button text has also changed.