### PR TITLE
Fix: Support `UK` 🇺🇦  lang (EXPOSUREAPP-12625)

### DIFF
--- a/Corona-Warn-App/build.gradle
+++ b/Corona-Warn-App/build.gradle
@@ -12,6 +12,8 @@ def environmentExtractor = { File path ->
     return "\"${escapedJson}\""
 }
 
+def supportedLocales = ['de', 'en', 'tr', 'bg', 'pl', 'ro', 'uk']
+
 jacoco {
     toolVersion = "0.8.7"
 }
@@ -43,7 +45,9 @@ android {
         println("Used versionName: $versionName")
 
         testInstrumentationRunner "testhelpers.TestApplicationUIRunner"
-        resConfigs 'de', 'en', 'tr', 'bg', 'pl', 'ro'
+        resConfigs supportedLocales.join(",")
+
+        println("Supported Locales: ${supportedLocales.join(",")}")
 
 
         def prodEnvJson = environmentExtractor(file("../prod_environments.json"))
@@ -157,6 +161,8 @@ android {
                 output.outputFileName = apkName
             }
         }
+
+        buildConfigField("String[]", "SUPPORTED_LOCALES", 'new String[]{' + supportedLocales.collect { "\"${it}\"" }.join(",") + '}')
     }
 
     buildFeatures {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ccl/configuration/model/CclDefaultInputParameters.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ccl/configuration/model/CclDefaultInputParameters.kt
@@ -2,6 +2,7 @@ package de.rki.coronawarnapp.ccl.configuration.model
 
 import android.os.Build
 import android.os.LocaleList
+import de.rki.coronawarnapp.BuildConfig
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
 import org.joda.time.format.ISODateTimeFormat
@@ -34,20 +35,12 @@ data class CclDateTime(
     val utcDateTimeMidnight: String = dateTimeUtc.toLocalDateTimeMidnightString()
 }
 
-private val supportedLanguages = arrayOf(
-    "de",
-    "en",
-    "bg",
-    "pl",
-    "ro",
-    "tr",
-)
-
 val cclLanguage: String by lazy {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-        LocaleList.getDefault().getFirstMatch(supportedLanguages)?.language ?: Locale.getDefault().language.also {
-            Timber.d("No match. Using default language $it")
-        }
+        LocaleList.getDefault().getFirstMatch(BuildConfig.SUPPORTED_LOCALES)?.language
+            ?: Locale.getDefault().language.also {
+                Timber.d("No match. Using default language $it")
+            }
     } else {
         Locale.getDefault().language
     }.also {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/util/CWADateTimeFormatPatternFactory.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/util/CWADateTimeFormatPatternFactory.kt
@@ -5,13 +5,14 @@ import java.util.Locale
 
 object CWADateTimeFormatPatternFactory {
 
-    fun Locale.shortDatePattern() = when {
+    fun Locale.shortDatePattern(): String = when {
         this == Locale.GERMANY -> "dd.MM.yy"
         this == Locale.UK -> "dd/MM/yyyy"
         this == Locale.US -> "M/d/yy"
         this == Locale("bg", "BG") -> "d.MM.yy 'г'."
         this == Locale("ro", "RO") -> "dd.MM.yyyy"
         this == Locale("pl", "PL") -> "dd.MM.yyyy"
+        this == Locale("uk", "UA") -> "dd.MM.yyyy"
         this == Locale("tr", "TR") -> "d.MM.yyyy"
         else -> DateTimeFormat.patternForStyle("S-", this)
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/util/CWADateTimeFormatPatternFactory.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/contactdiary/util/CWADateTimeFormatPatternFactory.kt
@@ -10,9 +10,10 @@ object CWADateTimeFormatPatternFactory {
         this == Locale.UK -> "dd/MM/yyyy"
         this == Locale.US -> "M/d/yy"
         this == Locale("bg", "BG") -> "d.MM.yy 'г'."
-        this == Locale("ro", "RO") -> "dd.MM.yyyy"
-        this == Locale("pl", "PL") -> "dd.MM.yyyy"
-        this == Locale("uk", "UA") -> "dd.MM.yyyy"
+        this == Locale("ro", "RO") ||
+            this == Locale("pl", "PL") ||
+            this == Locale("uk", "UA") -> "dd.MM.yyyy"
+
         this == Locale("tr", "TR") -> "d.MM.yyyy"
         else -> DateTimeFormat.patternForStyle("S-", this)
     }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/SupportedLocalesTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/SupportedLocalesTest.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp
 
 import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import timber.log.Timber
@@ -16,18 +17,29 @@ class SupportedLocalesTest : BaseTest() {
             "bg",
             "pl",
             "ro",
-            "uk"
+            "uk",
         ).sorted()
         BuildConfig.SUPPORTED_LOCALES.toList().sorted() shouldBe expectedSupportedLocales
 
+        val regex = "values-[a-z]{2}$".toRegex()
         val values = File("./src/main/res")
             .listFiles()!!
             .map { it.name.substringAfterLast("/") }
-            .filter { it == "values" || it.matches("values-[a-z]{2}$".toRegex()) }
+            .filter { it == "values" || it.matches(regex) }
             .map { if (it == "values") "en" else it.substringAfterLast("-") }
             .sorted()
 
-        values shouldBe expectedSupportedLocales
+        val message = """
+            New Locale detected in `res` directory!. Make sure to update the following:
+            - `supportedLocales` array in build.gradle file
+            - `CclDefaultInputParameters`
+            - `CWADateTimeFormatPatternFactory` 
+            - `CWADateTimeFormatPatternFactoryTest`
+            - `NewReleaseInfoFragmentTest`
+            - run the App and check newly added localization and ccl localization
+        """.trimIndent()
+
+        Assertions.assertIterableEquals(expectedSupportedLocales, values, message)
 
         Timber.d("Locales in values=$values")
     }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/SupportedLocalesTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/SupportedLocalesTest.kt
@@ -1,0 +1,34 @@
+package de.rki.coronawarnapp
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import timber.log.Timber
+import java.io.File
+
+class SupportedLocalesTest : BaseTest() {
+    @Test
+    fun assertSupportedLocales() {
+        val expectedSupportedLocales = listOf(
+            "de",
+            "en",
+            "tr",
+            "bg",
+            "pl",
+            "ro",
+            "uk"
+        ).sorted()
+        BuildConfig.SUPPORTED_LOCALES.toList().sorted() shouldBe expectedSupportedLocales
+
+        val values = File("./src/main/res")
+            .listFiles()!!
+            .map { it.name.substringAfterLast("/") }
+            .filter { it == "values" || it.matches("values-[a-z]{2}$".toRegex()) }
+            .map { if (it == "values") "en" else it.substringAfterLast("-") }
+            .sorted()
+
+        values shouldBe expectedSupportedLocales
+
+        Timber.d("Locales in values=$values")
+    }
+}

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/SupportedLocalesTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/SupportedLocalesTest.kt
@@ -19,7 +19,10 @@ class SupportedLocalesTest : BaseTest() {
             "ro",
             "uk",
         ).sorted()
-        BuildConfig.SUPPORTED_LOCALES.toList().sorted() shouldBe expectedSupportedLocales
+        BuildConfig.SUPPORTED_LOCALES.toList().sorted().apply {
+            this shouldBe expectedSupportedLocales
+            size shouldBe expectedSupportedLocales.size
+        }
 
         val regex = "values-[a-z]{2}$".toRegex()
         val values = File("./src/main/res")
@@ -38,6 +41,7 @@ class SupportedLocalesTest : BaseTest() {
             - run the App and check newly added localization and ccl localization
         """.trimIndent()
 
+        expectedSupportedLocales.size shouldBe values.size
         Assertions.assertIterableEquals(expectedSupportedLocales, values, message)
 
         Timber.d("Locales in values=$values")

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/SupportedLocalesTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/SupportedLocalesTest.kt
@@ -32,7 +32,6 @@ class SupportedLocalesTest : BaseTest() {
         val message = """
             New Locale detected in `res` directory!. Make sure to update the following:
             - `supportedLocales` array in build.gradle file
-            - `CclDefaultInputParameters`
             - `CWADateTimeFormatPatternFactory` 
             - `CWADateTimeFormatPatternFactoryTest`
             - `NewReleaseInfoFragmentTest`

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/contactdiary/util/CWADateTimeFormatPatternFactoryTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/contactdiary/util/CWADateTimeFormatPatternFactoryTest.kt
@@ -33,6 +33,11 @@ class CWADateTimeFormatPatternFactoryTest {
     }
 
     @Test
+    fun `pattern for ukrainian  date`() {
+        Locale("uk", "UA").shortDatePattern() shouldBe "dd.MM.yyyy"
+    }
+
+    @Test
     fun `pattern for polish date`() {
         Locale("pl", "PL").shortDatePattern() shouldBe "dd.MM.yyyy"
     }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/contactdiary/util/ContactDiaryDateFormatterExtensionTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/contactdiary/util/ContactDiaryDateFormatterExtensionTest.kt
@@ -50,4 +50,11 @@ class ContactDiaryDateFormatterExtensionTest {
             Locale("tr", "TR")
         ) shouldBe "Çarşamba, 6.01.2021"
     }
+
+    @Test
+    fun `format ukrainian date`() {
+        LocalDate("2021-01-06").toFormattedDay(
+            Locale("uk", "UA")
+        ) shouldBe "середа, 06.01.2021"
+    }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/contactdiary/util/ContactDiaryExtensionsTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/contactdiary/util/ContactDiaryExtensionsTest.kt
@@ -3,7 +3,7 @@ package de.rki.coronawarnapp.contactdiary.util
 import de.rki.coronawarnapp.contactdiary.model.DefaultContactDiaryLocation
 import de.rki.coronawarnapp.contactdiary.model.DefaultContactDiaryPerson
 import de.rki.coronawarnapp.contactdiary.model.sortByNameAndIdASC
-import org.junit.Assert
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class ContactDiaryExtensionsTest {
@@ -23,7 +23,7 @@ class ContactDiaryExtensionsTest {
         )
 
         // Test that lowercase "erika musterfrau2" is sorted to the 2nd position instead of the end
-        Assert.assertEquals(expectedResult, testList.sortByNameAndIdASC())
+        Assertions.assertEquals(expectedResult, testList.sortByNameAndIdASC())
     }
 
     @Test
@@ -42,7 +42,7 @@ class ContactDiaryExtensionsTest {
 
         // Test that "Erika Musterfrau" with lower personId comes before the other one, even though it was
         // added as the last entry to the testList
-        Assert.assertEquals(expectedResult, testList.sortByNameAndIdASC())
+        Assertions.assertEquals(expectedResult, testList.sortByNameAndIdASC())
     }
 
     @Test
@@ -60,7 +60,7 @@ class ContactDiaryExtensionsTest {
         )
 
         // Test that lowercase "at home" is sorted to the 2nd position instead of the end
-        Assert.assertEquals(expectedResult, testList.sortByNameAndIdASC())
+        Assertions.assertEquals(expectedResult, testList.sortByNameAndIdASC())
     }
 
     @Test
@@ -79,6 +79,6 @@ class ContactDiaryExtensionsTest {
 
         // Test that "At home" with lower locationId comes before the other one, even though it was
         // added as the last entry to the testList
-        Assert.assertEquals(expectedResult, testList.sortByNameAndIdASC())
+        Assertions.assertEquals(expectedResult, testList.sortByNameAndIdASC())
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/release/NewReleaseInfoFragmentTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/release/NewReleaseInfoFragmentTest.kt
@@ -49,6 +49,10 @@ class NewReleaseInfoFragmentTest : BaseTest() {
     @Test
     fun `ensure ROMANIAN new release info arrays are of equal length`() = loadAndCompareStringArrayResources()
 
+    @Config(qualifiers = "uk")
+    @Test
+    fun `ensure UKRAINIAN new release info arrays are of equal length`() = loadAndCompareStringArrayResources()
+
     @Config(qualifiers = "tr")
     @Test
     fun `ensure TURKISH new release info arrays are of equal length`() = loadAndCompareStringArrayResources()


### PR DESCRIPTION
- Build a `release` APK and check UK locale exists 🛑 
- Check Ccl Text is also provided
- Gradle will assemble an array to be used in the App to have once unified place to update `supportedLocales`
- Added unit test to check resources agains what we support in case a new locale has been added from example `es` an error message should be reported 
```js
New Locale detected in `res` directory!. Make sure to update the following:
- `supportedLocales` array in build.gradle file
- `CclDefaultInputParameters`
- `CWADateTimeFormatPatternFactory` 
- `CWADateTimeFormatPatternFactoryTest`
- `NewReleaseInfoFragmentTest`
- run the App and check newly added localization and ccl localization ==> iterable contents differ at index [3], expected: <pl> but was: <es>
Expected :pl
Actual   :es
```

## Ticket
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12625