### PR TITLE
FIX: Broken TAN flow (EXPOSUREAPP-12699)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/tan/SubmissionTanFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/tan/SubmissionTanFragment.kt
@@ -11,7 +11,6 @@ import de.rki.coronawarnapp.exception.http.BadRequestException
 import de.rki.coronawarnapp.exception.http.CwaClientError
 import de.rki.coronawarnapp.exception.http.CwaServerError
 import de.rki.coronawarnapp.exception.http.CwaWebException
-import de.rki.coronawarnapp.ui.submission.ApiRequestState
 import de.rki.coronawarnapp.ui.submission.viewmodel.SubmissionNavigationEvents
 import de.rki.coronawarnapp.util.DialogHelper
 import de.rki.coronawarnapp.util.di.AutoInject
@@ -22,6 +21,7 @@ import de.rki.coronawarnapp.util.ui.setGone
 import de.rki.coronawarnapp.util.ui.viewBinding
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactoryProvider
 import de.rki.coronawarnapp.util.viewmodel.cwaViewModels
+import de.rki.coronawarnapp.ui.submission.tan.SubmissionTanViewModel.TanApiRequestState
 import javax.inject.Inject
 
 /**
@@ -79,14 +79,14 @@ class SubmissionTanFragment : Fragment(R.layout.fragment_submission_tan), AutoIn
 
         viewModel.registrationState.observe2(this) {
             binding.submissionTanSpinner.visibility = when (it) {
-                ApiRequestState.STARTED -> View.VISIBLE
+                TanApiRequestState.STARTED -> View.VISIBLE
                 else -> View.GONE
             }
 
-            if (ApiRequestState.SUCCESS == it) {
+            if (it is TanApiRequestState.SUCCESS) {
                 doNavigate(
                     SubmissionTanFragmentDirections.actionSubmissionTanFragmentToSubmissionTestResultNoConsentFragment(
-                        testIdentifier = ""
+                        testIdentifier = it.identifier
                     )
                 )
             }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/tan/SubmissionTanViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/tan/SubmissionTanViewModel.kt
@@ -1,5 +1,6 @@
 package de.rki.coronawarnapp.ui.submission.tan
 
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.asLiveData
 import dagger.assisted.AssistedFactory
@@ -7,11 +8,11 @@ import dagger.assisted.AssistedInject
 import de.rki.coronawarnapp.bugreporting.censors.submission.PcrTeleTanCensor
 import de.rki.coronawarnapp.coronatest.tan.CoronaTestTAN
 import de.rki.coronawarnapp.coronatest.type.BaseCoronaTest
+import de.rki.coronawarnapp.coronatest.type.TestIdentifier
 import de.rki.coronawarnapp.exception.ExceptionCategory
 import de.rki.coronawarnapp.exception.http.CwaWebException
 import de.rki.coronawarnapp.exception.reporting.report
 import de.rki.coronawarnapp.submission.SubmissionRepository
-import de.rki.coronawarnapp.ui.submission.ApiRequestState
 import de.rki.coronawarnapp.ui.submission.viewmodel.SubmissionNavigationEvents
 import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
 import de.rki.coronawarnapp.util.ui.SingleLiveEvent
@@ -29,7 +30,6 @@ class SubmissionTanViewModel @AssistedInject constructor(
 
     private val currentTan = MutableStateFlow(Tan(""))
 
-    val routeToScreen = SingleLiveEvent<SubmissionNavigationEvents>()
     val state = currentTan.map { currentTan ->
         UIState(
             isTanValid = currentTan.isTanValid,
@@ -39,7 +39,9 @@ class SubmissionTanViewModel @AssistedInject constructor(
         )
     }.asLiveData(context = dispatcherProvider.Default)
 
-    val registrationState = MutableLiveData(ApiRequestState.IDLE)
+    val mutableRegistrationState: MutableLiveData<TanApiRequestState> = MutableLiveData(TanApiRequestState.IDLE)
+    val registrationState: LiveData<TanApiRequestState> = mutableRegistrationState
+    val routeToScreen = SingleLiveEvent<SubmissionNavigationEvents>()
     val registrationError = SingleLiveEvent<CwaWebException>()
 
     fun onTanChanged(tan: String) {
@@ -74,15 +76,15 @@ class SubmissionTanViewModel @AssistedInject constructor(
     private suspend fun onTanSubmit(teletan: Tan) {
 
         try {
-            registrationState.postValue(ApiRequestState.STARTED)
+            mutableRegistrationState.postValue(TanApiRequestState.STARTED)
             val request = CoronaTestTAN.PCR(tan = teletan.value)
             submissionRepository.registerTest(request)
-            registrationState.postValue(ApiRequestState.SUCCESS)
+            mutableRegistrationState.postValue(TanApiRequestState.SUCCESS(request.identifier))
         } catch (err: CwaWebException) {
-            registrationState.postValue(ApiRequestState.FAILED)
+            mutableRegistrationState.postValue(TanApiRequestState.FAILED)
             registrationError.postValue(err)
         } catch (err: Exception) {
-            registrationState.postValue(ApiRequestState.FAILED)
+            mutableRegistrationState.postValue(TanApiRequestState.FAILED)
             err.report(ExceptionCategory.INTERNAL)
         }
     }
@@ -96,4 +98,11 @@ class SubmissionTanViewModel @AssistedInject constructor(
 
     @AssistedFactory
     interface Factory : SimpleCWAViewModelFactory<SubmissionTanViewModel>
+
+    sealed class TanApiRequestState {
+        object IDLE : TanApiRequestState()
+        object STARTED : TanApiRequestState()
+        object FAILED : TanApiRequestState()
+        data class SUCCESS(val identifier: TestIdentifier) : TanApiRequestState()
+    }
 }


### PR DESCRIPTION
This PR fixes missing `testIdentifier` in `SubmissionTanFragment`

### Testing
- Sie lassen sich testen? > TAN für PCR-Test eingeben > enter TAN
- You should be able to register test using TAN

You can generate a new TAN on INT env. or use any valid TAN on the local mock server.
If you want to work on a local mock server don't forget to update `.server-config.yml` to look as follows:

```yml
endpoints:
      - name: /version/v1/registrationToken
        responseId: '201'
      - name: /version/v1/tan
        responseId: '201'
      - name: /version/v1/testresult
        responseId: 200+2
```
then start the cwa server and use any valid TAN eg: "9A3B578UMG", "DEU7TKSV3H", "PTPHM35RP4"

### Jira Ticket
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12699