### PR TITLE
Fix blocked certificate accepted (EXPOSUREAPP-12707)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/statecheck/DccStateChecker.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/statecheck/DccStateChecker.kt
@@ -7,6 +7,7 @@ import de.rki.coronawarnapp.covidcertificate.common.certificate.DccData
 import de.rki.coronawarnapp.covidcertificate.expiration.DccExpirationChecker
 import de.rki.coronawarnapp.covidcertificate.signature.core.DscRepository
 import de.rki.coronawarnapp.covidcertificate.signature.core.DscSignatureValidator
+import de.rki.coronawarnapp.covidcertificate.validation.core.DccBlocklistValidator
 import de.rki.coronawarnapp.util.TimeStamper
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -19,7 +20,8 @@ class DccStateChecker @Inject constructor(
     private val appConfigProvider: AppConfigProvider,
     private val dscRepository: DscRepository,
     private val dscSignatureValidator: DscSignatureValidator,
-    private val expirationChecker: DccExpirationChecker,
+    private val dccExpirationChecker: DccExpirationChecker,
+    private val dccBlocklistValidator: DccBlocklistValidator,
 ) {
 
     suspend fun checkState(
@@ -36,6 +38,16 @@ class DccStateChecker @Inject constructor(
         }
 
         try {
+            dccBlocklistValidator.validate(
+                dccData = dccData,
+                blocklist = appConfig.covidCertificateParameters.blockListParameters
+            )
+        } catch (e: Exception) {
+            Timber.tag(TAG).w("Certificate is in the blocklist %s", e.message)
+            return@combine CwaCovidCertificate.State.Blocked
+        }
+
+        try {
             dscSignatureValidator.validateSignature(dccData = dccData, preFetchedDscData = dscData)
         } catch (e: Exception) {
             Timber.tag(TAG).w("Certificate had invalid signature %s", e.message)
@@ -44,7 +56,7 @@ class DccStateChecker @Inject constructor(
 
         val nowUtc = timeStamper.nowUTC
 
-        return@combine expirationChecker.getExpirationState(
+        return@combine dccExpirationChecker.getExpirationState(
             dccData = dccData,
             expirationThreshold = appConfig.covidCertificateParameters.expirationThreshold,
             now = nowUtc

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/statecheck/DccStateChecker.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/statecheck/DccStateChecker.kt
@@ -33,10 +33,12 @@ class DccStateChecker @Inject constructor(
         dscRepository.dscData
     ) { appConfig, dscData ->
 
+        //Check for newly scanned certificates
         if (qrCodeHash in blockedCertificateQrCodeHashes) {
             return@combine CwaCovidCertificate.State.Blocked
         }
 
+        //Check for imported certificates from older app versions < 2.21
         try {
             dccBlocklistValidator.validate(
                 dccData = dccData,

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/statecheck/DccStateChecker.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/statecheck/DccStateChecker.kt
@@ -33,12 +33,12 @@ class DccStateChecker @Inject constructor(
         dscRepository.dscData
     ) { appConfig, dscData ->
 
-        //Check for newly scanned certificates
+        // Check for newly scanned certificates
         if (qrCodeHash in blockedCertificateQrCodeHashes) {
             return@combine CwaCovidCertificate.State.Blocked
         }
 
-        //Check for imported certificates from older app versions < 2.21
+        // Check for imported certificates from older app versions < 2.21
         try {
             dccBlocklistValidator.validate(
                 dccData = dccData,

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/core/DccBlocklistValidator.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/core/DccBlocklistValidator.kt
@@ -1,0 +1,36 @@
+package de.rki.coronawarnapp.covidcertificate.validation.core
+
+import androidx.annotation.VisibleForTesting
+import de.rki.coronawarnapp.appconfig.CovidCertificateConfig
+import de.rki.coronawarnapp.covidcertificate.common.certificate.DccData
+import de.rki.coronawarnapp.covidcertificate.common.exception.InvalidHealthCertificateException
+import de.rki.coronawarnapp.util.HashExtensions.toSHA256
+import de.rki.coronawarnapp.covidcertificate.common.exception.InvalidHealthCertificateException.ErrorCode.HC_DCC_BLOCKED
+import javax.inject.Inject
+
+class DccBlocklistValidator @Inject constructor() {
+
+    fun validate(dccData: DccData<*>, blocklist: List<CovidCertificateConfig.BlockedChunk>) {
+        val chunks = parseIdentifierToChunks(dccData.certificate.payload.uniqueCertificateIdentifier)
+        blocklist.forEach {
+            val hash = it.indices.mapNotNull { index ->
+                if (index >= 0 && index < chunks.size)
+                    chunks[index]
+                else
+                    null
+            }
+                .joinToString("/")
+                .toSHA256()
+            if (hash == it.hash.hex()) throw InvalidHealthCertificateException(HC_DCC_BLOCKED)
+        }
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    fun parseIdentifierToChunks(uvci: String): List<String> {
+        return uvci.removePrefix(UVCI_PREFIX).split('/', '#', ':')
+    }
+
+    companion object {
+        const val UVCI_PREFIX = "URN:UVCI:"
+    }
+}

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/common/statecheck/DccStateCheckerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/common/statecheck/DccStateCheckerTest.kt
@@ -9,6 +9,7 @@ import de.rki.coronawarnapp.covidcertificate.expiration.DccExpirationChecker
 import de.rki.coronawarnapp.covidcertificate.signature.core.DscData
 import de.rki.coronawarnapp.covidcertificate.signature.core.DscRepository
 import de.rki.coronawarnapp.covidcertificate.signature.core.DscSignatureValidator
+import de.rki.coronawarnapp.covidcertificate.validation.core.DccBlocklistValidator
 import de.rki.coronawarnapp.util.TimeStamper
 import io.kotest.matchers.shouldBe
 import io.mockk.Called
@@ -37,6 +38,7 @@ class DccStateCheckerTest : BaseTest() {
     @MockK lateinit var mockDscData: DscData
     @MockK lateinit var dscSignatureValidator: DscSignatureValidator
     @MockK lateinit var expirationChecker: DccExpirationChecker
+    @MockK lateinit var dccBlocklistValidator: DccBlocklistValidator
     @MockK lateinit var mockData: DccData<*>
 
     @BeforeEach
@@ -46,6 +48,7 @@ class DccStateCheckerTest : BaseTest() {
         every { configData.covidCertificateParameters } returns covidCertificateConfig
         every { covidCertificateConfig.expirationThreshold } returns Duration.standardDays(10)
         every { covidCertificateConfig.blockListParameters } returns emptyList()
+        every { dccBlocklistValidator.validate(any(), any()) } just Runs
         coEvery { appConfigProvider.currentConfig } returns flowOf(configData)
 
         every { dscRepository.dscData } returns flowOf(mockDscData)
@@ -60,7 +63,8 @@ class DccStateCheckerTest : BaseTest() {
         appConfigProvider = appConfigProvider,
         dscRepository = dscRepository,
         dscSignatureValidator = dscSignatureValidator,
-        expirationChecker = expirationChecker,
+        dccExpirationChecker = expirationChecker,
+        dccBlocklistValidator = dccBlocklistValidator
     )
 
     @Test

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/validation/core/DccBlocklistValidationTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/validation/core/DccBlocklistValidationTest.kt
@@ -1,0 +1,104 @@
+package de.rki.coronawarnapp.covidcertificate.validation.core
+
+import de.rki.coronawarnapp.appconfig.mapping.CovidCertificateConfigMapper
+import de.rki.coronawarnapp.covidcertificate.common.certificate.DccData
+import de.rki.coronawarnapp.covidcertificate.common.certificate.DccV1
+import de.rki.coronawarnapp.covidcertificate.common.exception.InvalidHealthCertificateException
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import okio.ByteString.Companion.decodeHex
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class DccBlocklistValidationTest : BaseTest() {
+
+    @MockK lateinit var dccData: DccData<DccV1.MetaData>
+
+    @BeforeEach
+    fun setUp() {
+        MockKAnnotations.init(this)
+    }
+
+    @Test
+    fun `Test chunks validation`() {
+        every { dccData.certificate.payload.uniqueCertificateIdentifier } returns "foo/bar::baz#999lizards"
+        shouldThrow<InvalidHealthCertificateException> {
+            createInstance().validate(
+                dccData,
+                listOf(
+                    CovidCertificateConfigMapper.BlockedUvciChunk(
+                        listOf(1),
+                        "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9".decodeHex()
+                    )
+                )
+            )
+        }.errorCode shouldBe InvalidHealthCertificateException.ErrorCode.HC_DCC_BLOCKED
+
+        every { dccData.certificate.payload.uniqueCertificateIdentifier } returns "foo/baz::baz#999lizards"
+        shouldNotThrow<InvalidHealthCertificateException> {
+            createInstance().validate(
+                dccData,
+                listOf(
+                    CovidCertificateConfigMapper.BlockedUvciChunk(
+                        listOf(1),
+                        "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9".decodeHex()
+                    )
+                )
+            )
+        }
+
+        every { dccData.certificate.payload.uniqueCertificateIdentifier } returns "foo/bar::baz#999lizards"
+        shouldThrow<InvalidHealthCertificateException> {
+            createInstance().validate(
+                dccData,
+                listOf(
+                    CovidCertificateConfigMapper.BlockedUvciChunk(
+                        listOf(0, 1),
+                        "cc5d46bdb4991c6eae3eb739c9c8a7a46fe9654fab79c47b4fe48383b5b25e1c".decodeHex()
+                    )
+                )
+            )
+        }.errorCode shouldBe InvalidHealthCertificateException.ErrorCode.HC_DCC_BLOCKED
+
+        every { dccData.certificate.payload.uniqueCertificateIdentifier } returns "foo/baz::baz#999lizards"
+        shouldNotThrow<InvalidHealthCertificateException> {
+            createInstance().validate(
+                dccData,
+                listOf(
+                    CovidCertificateConfigMapper.BlockedUvciChunk(
+                        listOf(0, 1),
+                        "cc5d46bdb4991c6eae3eb739c9c8a7a46fe9654fab79c47b4fe48383b5b25e1c".decodeHex()
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `Test Parsing UVCI to Chunks`() {
+        createInstance().parseIdentifierToChunks("foo/bar::baz#999lizards") shouldBe listOf(
+            "foo",
+            "bar",
+            "",
+            "baz",
+            "999lizards"
+        )
+
+        createInstance().parseIdentifierToChunks("URN:UVCI:foo/bar::baz#999lizards") shouldBe listOf(
+            "foo",
+            "bar",
+            "",
+            "baz",
+            "999lizards"
+        )
+
+        createInstance().parseIdentifierToChunks("a::c/#/f") shouldBe listOf("a", "", "c", "", "", "f")
+    }
+
+    private fun createInstance() = DccBlocklistValidator()
+}


### PR DESCRIPTION
As blocked certificates check changed from uniqueCertificateIdentifier to QR Code Hash validation
old certificates from old versions where accepted as valid.
A re-add of the uniqueCertificateIdentifier check fixes this issue
