### PR TITLE
Adapt screenshots to not show unplanned feature (EXPOSUREAPP-12726)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/person_overview_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/person_overview_fragment.xml
@@ -27,6 +27,7 @@
 
             <include
                 android:id="@+id/admission_container"
+                android:visibility="gone"
                 layout="@layout/admission_scenario_tile" />
         </com.google.android.material.appbar.AppBarLayout>
 


### PR DESCRIPTION
The PersonOverviewFragment screenshots also included a card that wasn't planned for release.

[Ticket](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12726)