### PR TITLE
Changes for Schnelltest-Profil

### DIFF
--- a/Corona-Warn-App/src/main/res/values-de/antigen_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/antigen_strings.xml
@@ -167,7 +167,7 @@
     <!-- XTXT: Create RAT profile email error message -->
     <string name="rat_profile_create_email_error">"Ungültige E-Mail-Adresse"</string>
     <!-- XTXT: Profile fab text -->
-    <string name="profile_fab_text">"Schnelltest Profil"</string>
+    <string name="profile_fab_text">"Schnelltest-Profil"</string>
     <!-- XTXT: RAT profile list no profiles title -->
     <string name="rat_profile_list_no_profiles_title">"Noch kein Schnelltest-Profil erstellt"</string>
     <!-- XTXT: RAT profile list no profiles subtitle -->
@@ -188,7 +188,7 @@
     <!-- XTXT: Create RAT Qr code profile birth date-->
     <string name="rat_qr_code_profile_birth_date">Geboren %1$s</string>
     <!-- XBUT: Create RAT Qr code profile next button-->
-    <string name="rat_qr_code_profile_next_button">Weiter</string>
+    <string name="rat_qr_code_profile_next_button">Test scannen</string>
     <!-- XTXT: Create RAT Qr code profile delete item-->
     <string name="rat_qr_code_profile_delete_item">Schnelltest-Profil löschen</string>
     <!-- XTXT: Create RAT Qr code profile edit item-->


### PR DESCRIPTION
Button text changed from „Weiter“ to “Test scannen”.
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12885

Consistent spelling of “Schnelltest-Profil”
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12923
