### PR TITLE
Broken UI after deleted test (EXPOSUREAPP-12938)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsFragment.kt
@@ -181,8 +181,8 @@ class PersonDetailsFragment : Fragment(R.layout.person_details_fragment), AutoIn
 
                         binding.europaImage.layoutParams.height = binding.collapsingToolbarLayout.height + overlap
                         binding.europaImage.requestLayout()
-                        binding.recyclerViewCertificatesList.viewTreeObserver.removeOnGlobalLayoutListener(this)
                     }
+                    binding.recyclerViewCertificatesList.viewTreeObserver.removeOnGlobalLayoutListener(this)
                 }
             })
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/details/RecoveryCertificateDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/details/RecoveryCertificateDetailsFragment.kt
@@ -24,6 +24,7 @@ import de.rki.coronawarnapp.covidcertificate.validation.ui.common.DccValidationN
 import de.rki.coronawarnapp.databinding.FragmentRecoveryCertificateDetailsBinding
 import de.rki.coronawarnapp.reyclebin.ui.dialog.RecycleBinDialogType
 import de.rki.coronawarnapp.reyclebin.ui.dialog.show
+import de.rki.coronawarnapp.tag
 import de.rki.coronawarnapp.ui.qrcode.fullscreen.QrCodeFullScreenFragmentArgs
 import de.rki.coronawarnapp.ui.view.onOffsetChange
 import de.rki.coronawarnapp.util.ContextExtensions.getColorCompat
@@ -42,6 +43,7 @@ import de.rki.coronawarnapp.util.ui.popBackStack
 import de.rki.coronawarnapp.util.ui.viewBinding
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactoryProvider
 import de.rki.coronawarnapp.util.viewmodel.cwaViewModelsAssisted
+import timber.log.Timber
 import java.net.URLEncoder
 import javax.inject.Inject
 
@@ -79,7 +81,15 @@ class RecoveryCertificateDetailsFragment : Fragment(R.layout.fragment_recovery_c
 
         viewModel.errors.observe(viewLifecycleOwner) { onError(it) }
         viewModel.events.observe(viewLifecycleOwner) { onNavEvent(it) }
-        viewModel.recoveryCertificate.observe(viewLifecycleOwner) { it?.let { onCertificateReady(it) } }
+        viewModel.recoveryCertificate.observe(viewLifecycleOwner) {
+            when(it != null) {
+                true -> onCertificateReady(it)
+                false -> {
+                    Timber.tag(TAG).d("Certificate is null. Closing %s", TAG)
+                    goBack()
+                }
+            }
+        }
 
         viewModel.exportError.observe(viewLifecycleOwner) {
             CertificateExportErrorDialog.showDialog(
@@ -148,7 +158,7 @@ class RecoveryCertificateDetailsFragment : Fragment(R.layout.fragment_recovery_c
 
     private fun FragmentRecoveryCertificateDetailsBinding.onNavEvent(event: RecoveryCertificateDetailsNavigation) {
         when (event) {
-            RecoveryCertificateDetailsNavigation.Back -> popBackStack()
+            RecoveryCertificateDetailsNavigation.Back -> goBack()
             is RecoveryCertificateDetailsNavigation.FullQrCode -> findNavController().navigate(
                 R.id.action_global_qrCodeFullScreenFragment,
                 QrCodeFullScreenFragmentArgs(event.qrCode).toBundle(),
@@ -175,6 +185,8 @@ class RecoveryCertificateDetailsFragment : Fragment(R.layout.fragment_recovery_c
                 )
         }
     }
+
+    private fun goBack() = popBackStack()
 
     private fun FragmentRecoveryCertificateDetailsBinding.bindToolbar() = toolbar.apply {
         toolbar.navigationIcon = resources.mutateDrawable(R.drawable.ic_back, Color.WHITE)
@@ -214,6 +226,8 @@ class RecoveryCertificateDetailsFragment : Fragment(R.layout.fragment_recovery_c
     }
 
     companion object {
+        private val TAG = tag<RecoveryCertificateDetailsFragment>()
+
         fun uri(certIdentifier: String): Uri {
             val encodedId = URLEncoder.encode(certIdentifier, "UTF-8")
             return "cwa://recovery-certificate/?fromScanner=true&certIdentifier=$encodedId".toUri()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/details/RecoveryCertificateDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/details/RecoveryCertificateDetailsFragment.kt
@@ -82,7 +82,7 @@ class RecoveryCertificateDetailsFragment : Fragment(R.layout.fragment_recovery_c
         viewModel.errors.observe(viewLifecycleOwner) { onError(it) }
         viewModel.events.observe(viewLifecycleOwner) { onNavEvent(it) }
         viewModel.recoveryCertificate.observe(viewLifecycleOwner) {
-            when(it != null) {
+            when (it != null) {
                 true -> onCertificateReady(it)
                 false -> {
                     Timber.tag(TAG).d("Certificate is null. Closing %s", TAG)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/TestCertificateDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/TestCertificateDetailsFragment.kt
@@ -83,7 +83,7 @@ class TestCertificateDetailsFragment : Fragment(R.layout.fragment_test_certifica
         viewModel.errors.observe(viewLifecycleOwner) { onError(it) }
         viewModel.events.observe(viewLifecycleOwner) { onNavEvent(it) }
         viewModel.covidCertificate.observe(viewLifecycleOwner) {
-            when(it != null) {
+            when (it != null) {
                 true -> onCertificateReady(it)
                 false -> {
                     Timber.tag(TAG).d("Certificate is null. Closing %s", TAG)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/TestCertificateDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/TestCertificateDetailsFragment.kt
@@ -25,6 +25,7 @@ import de.rki.coronawarnapp.covidcertificate.validation.ui.common.DccValidationN
 import de.rki.coronawarnapp.databinding.FragmentTestCertificateDetailsBinding
 import de.rki.coronawarnapp.reyclebin.ui.dialog.RecycleBinDialogType
 import de.rki.coronawarnapp.reyclebin.ui.dialog.show
+import de.rki.coronawarnapp.tag
 import de.rki.coronawarnapp.ui.qrcode.fullscreen.QrCodeFullScreenFragmentArgs
 import de.rki.coronawarnapp.ui.view.onOffsetChange
 import de.rki.coronawarnapp.util.ContextExtensions.getColorCompat
@@ -43,6 +44,7 @@ import de.rki.coronawarnapp.util.ui.popBackStack
 import de.rki.coronawarnapp.util.ui.viewBinding
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactoryProvider
 import de.rki.coronawarnapp.util.viewmodel.cwaViewModelsAssisted
+import timber.log.Timber
 import java.net.URLEncoder
 import javax.inject.Inject
 
@@ -80,7 +82,15 @@ class TestCertificateDetailsFragment : Fragment(R.layout.fragment_test_certifica
 
         viewModel.errors.observe(viewLifecycleOwner) { onError(it) }
         viewModel.events.observe(viewLifecycleOwner) { onNavEvent(it) }
-        viewModel.covidCertificate.observe(viewLifecycleOwner) { it?.let { onCertificateReady(it) } }
+        viewModel.covidCertificate.observe(viewLifecycleOwner) {
+            when(it != null) {
+                true -> onCertificateReady(it)
+                false -> {
+                    Timber.tag(TAG).d("Certificate is null. Closing %s", TAG)
+                    goBack()
+                }
+            }
+        }
 
         viewModel.exportError.observe(viewLifecycleOwner) {
             CertificateExportErrorDialog.showDialog(
@@ -180,7 +190,7 @@ class TestCertificateDetailsFragment : Fragment(R.layout.fragment_test_certifica
 
     private fun FragmentTestCertificateDetailsBinding.onNavEvent(event: TestCertificateDetailsNavigation) {
         when (event) {
-            TestCertificateDetailsNavigation.Back -> popBackStack()
+            TestCertificateDetailsNavigation.Back -> goBack()
             is TestCertificateDetailsNavigation.FullQrCode -> findNavController().navigate(
                 R.id.action_global_qrCodeFullScreenFragment,
                 QrCodeFullScreenFragmentArgs(event.qrCode).toBundle(),
@@ -207,6 +217,8 @@ class TestCertificateDetailsFragment : Fragment(R.layout.fragment_test_certifica
                 )
         }
     }
+
+    private fun goBack() = popBackStack()
 
     private fun FragmentTestCertificateDetailsBinding.bindToolbar() = toolbar.apply {
         toolbar.navigationIcon = resources.mutateDrawable(R.drawable.ic_back, Color.WHITE)
@@ -246,6 +258,8 @@ class TestCertificateDetailsFragment : Fragment(R.layout.fragment_test_certifica
     }
 
     companion object {
+        private val TAG = tag<TestCertificateDetailsFragment>()
+
         fun uri(certIdentifier: String): Uri {
             val encodedId = URLEncoder.encode(certIdentifier, "UTF-8")
             return "cwa://test-certificate/?fromScanner=true&certIdentifier=$encodedId".toUri()


### PR DESCRIPTION
This PR addresses Exposureapp-12938.
Bugfix for Notification-Destination after a test has been deleted.

**How to test:**
- scan in a VC or RC
- trigger the revocation of certs (cli tool) (also possible with revocation via invalidation rules)
- delete the test
- follow the notification which should be still there
(steps/details also in the ticket)