### PR TITLE
FIX: No red badge at ‘Hinweis zur Auffrischimpfung’ (EXPOSUREAPP-12966)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/items/BoosterCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/items/BoosterCard.kt
@@ -1,9 +1,7 @@
 package de.rki.coronawarnapp.covidcertificate.person.ui.details.items
 
-import android.text.SpannableString
-import android.text.Spanned
-import android.text.style.ImageSpan
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.covidcertificate.person.ui.details.PersonDetailsAdapter
 import de.rki.coronawarnapp.databinding.PersonDetailsBoosterCardBinding
@@ -26,25 +24,7 @@ class BoosterCard(parent: ViewGroup) :
         root.setOnClickListener { curItem.onClick() }
 
         title.text = curItem.title
-        if (curItem.badgeVisible) {
-            val boosterBadgeDrawable = ImageSpan(context, R.drawable.ic_badge_with_space, 2)
-            title.post {
-                val textOnFirstLine = curItem.title.subSequence(
-                    title.layout.getLineStart(0), title.layout.getLineEnd(0)
-                )
-                val restOfText = curItem.title.subSequence(title.layout.getLineEnd(0), curItem.title.length)
-                val spannableString = SpannableString("$textOnFirstLine*$restOfText")
-                spannableString.setSpan(
-                    boosterBadgeDrawable,
-                    textOnFirstLine.length,
-                    textOnFirstLine.length + 1,
-                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
-                )
-                title.text = spannableString
-            }
-        } else {
-            title.text = curItem.title
-        }
+        boosterBadge.isVisible = curItem.badgeVisible
         subtitle.text = curItem.subtitle
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/items/BoosterCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/items/BoosterCard.kt
@@ -28,22 +28,22 @@ class BoosterCard(parent: ViewGroup) :
         title.text = curItem.title
         if (curItem.badgeVisible) {
             val boosterBadgeDrawable = ImageSpan(context, R.drawable.ic_badge_with_space, 2)
-            if (title.text.isNotEmpty() && title.layout != null) {
-                title.post {
-                    val textOnFirstLine = title.text.subSequence(
-                        title.layout.getLineStart(0), title.layout.getLineEnd(0)
-                    )
-                    val restOfText = title.text.subSequence(title.layout.getLineEnd(0), title.text.length)
-                    val spannableString = SpannableString("$textOnFirstLine*$restOfText")
-                    spannableString.setSpan(
-                        boosterBadgeDrawable,
-                        textOnFirstLine.length,
-                        textOnFirstLine.length + 1,
-                        Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
-                    )
-                    title.text = spannableString
-                }
+            title.post {
+                val textOnFirstLine = curItem.title.subSequence(
+                    title.layout.getLineStart(0), title.layout.getLineEnd(0)
+                )
+                val restOfText = curItem.title.subSequence(title.layout.getLineEnd(0), curItem.title.length)
+                val spannableString = SpannableString("$textOnFirstLine*$restOfText")
+                spannableString.setSpan(
+                    boosterBadgeDrawable,
+                    textOnFirstLine.length,
+                    textOnFirstLine.length + 1,
+                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                )
+                title.text = spannableString
             }
+        } else {
+            title.text = curItem.title
         }
         subtitle.text = curItem.subtitle
     }

--- a/Corona-Warn-App/src/main/res/drawable/ic_badge_with_space.xml
+++ b/Corona-Warn-App/src/main/res/drawable/ic_badge_with_space.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="13dp"
-    android:height="10dp"
-    android:viewportWidth="13"
-    android:viewportHeight="10">
-    <path
-        android:pathData="M13,5C13,2.2386 10.7614,0 8,0C5.2386,0 3,2.2386 3,5C3,7.7614 5.2386,10 8,10C10.7614,10 13,7.7614 13,5Z"
-        android:fillColor="#ED382F" />
-</vector>

--- a/Corona-Warn-App/src/main/res/layout/person_details_booster_card.xml
+++ b/Corona-Warn-App/src/main/res/layout/person_details_booster_card.xml
@@ -16,9 +16,27 @@
         android:layout_height="wrap_content"
         android:textSize="16sp"
         android:textStyle="bold"
+        app:layout_constrainedWidth="true"
+        app:layout_constraintEnd_toStartOf="@id/arrow"
+        app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:text="Booster" />
+        tools:text="Not on Booster Vaccination" />
+
+    <ImageView
+        android:id="@+id/booster_badge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginStart="5dp"
+        android:layout_marginTop="6dp"
+        android:importantForAccessibility="no"
+        app:layout_constraintEnd_toEndOf="@id/arrow"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toEndOf="@id/title"
+        app:layout_constraintTop_toTopOf="@id/title"
+        app:srcCompat="@drawable/ic_badge"
+        tools:visibility="visible" />
 
     <ImageView
         android:id="@+id/arrow"
@@ -26,6 +44,8 @@
         android:layout_height="wrap_content"
         android:alpha="0.6"
         android:hyphenationFrequency="normal"
+        android:paddingStart="@dimen/spacing_normal"
+        android:paddingEnd="0dp"
         android:src="@drawable/ic_contact_diary_right_arrow"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"

--- a/Corona-Warn-App/src/main/res/layout/person_details_booster_card.xml
+++ b/Corona-Warn-App/src/main/res/layout/person_details_booster_card.xml
@@ -46,6 +46,7 @@
         android:hyphenationFrequency="normal"
         android:paddingStart="@dimen/spacing_normal"
         android:paddingEnd="0dp"
+        android:layout_marginTop="3dp"
         android:src="@drawable/ic_contact_diary_right_arrow"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
- ~~reverting changes in [BoosterCard.kt](https://github.com/corona-warn-app/cwa-app-android/pull/5103/files#diff-d12468d067582c46f2f3e9056fff7d48593e107c438f25f4628380546ccc53f9) as it seems this causes another issue and doesn't influence the app crash~~
- The UI & the implementation has been updated, preview:
 
![out](https://user-images.githubusercontent.com/2919625/166214298-5f4397f5-d1ad-410d-8752-cecc8ae51986.png)


### Testing
- scan certificate from the Jira tickets [EXPOSUREAPP-12966](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12966), [EXPOSUREAPP-12777](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12777)
- check if the booster vaccination badge is visible on the user details screen
- delete/restore the certificate to check that the app doesn't crash
- delete certificate > restore certificate > don't click on the notification > delete certificate > click on the notification > app shouldn't crash
- open and close certificate details couple of times, app shouldn't crash

### Jira Ticket
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12966
