### PR TITLE
Fix delete family test (EXPOSUREAPP-13053)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/familytest/ui/testlist/FamilyTestListEvent.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/familytest/ui/testlist/FamilyTestListEvent.kt
@@ -8,6 +8,8 @@ sealed class FamilyTestListEvent {
 
     data class ConfirmRemoveTest(val familyCoronaTest: FamilyCoronaTest) : FamilyTestListEvent()
 
+    data class DeleteTest(val familyCoronaTest: FamilyCoronaTest) : FamilyTestListEvent()
+
     object ConfirmRemoveAllTests : FamilyTestListEvent()
 
     data class ConfirmSwipeTest(val familyCoronaTest: FamilyCoronaTest, val position: Int) : FamilyTestListEvent()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/familytest/ui/testlist/FamilyTestListFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/familytest/ui/testlist/FamilyTestListFragment.kt
@@ -54,6 +54,7 @@ class FamilyTestListFragment : Fragment(R.layout.fragment_family_test_list), Aut
             is FamilyTestListEvent.NavigateBack -> popBackStack()
             is FamilyTestListEvent.ConfirmSwipeTest -> showRemovalConfirmation(event.familyCoronaTest, event.position)
             is FamilyTestListEvent.ConfirmRemoveTest -> showRemovalConfirmation(event.familyCoronaTest, null)
+            is FamilyTestListEvent.DeleteTest -> viewModel.deleteTest(event.familyCoronaTest)
             is FamilyTestListEvent.ConfirmRemoveAllTests -> showRemovalConfirmation(null, null)
             is FamilyTestListEvent.NavigateToDetails -> openDetailsScreen(event.familyCoronaTest)
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/familytest/ui/testlist/FamilyTestListViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/familytest/ui/testlist/FamilyTestListViewModel.kt
@@ -80,6 +80,12 @@ class FamilyTestListViewModel @AssistedInject constructor(
         }
     }
 
+    fun deleteTest(test: FamilyCoronaTest) {
+        launch(appScope) {
+            familyTestRepository.deleteTest(test.identifier)
+        }
+    }
+
     fun onRefreshTests() {
         launch(appScope) {
             val result = familyTestRepository.refresh().also {
@@ -215,7 +221,7 @@ class FamilyTestListViewModel @AssistedInject constructor(
                 onSwipeItem = { familyCoronaTest, position ->
                     events.postValue(FamilyTestListEvent.ConfirmSwipeTest(familyCoronaTest, position))
                 },
-                onDeleteTest = { events.postValue(FamilyTestListEvent.ConfirmRemoveTest(this)) }
+                onDeleteTest = { events.postValue(FamilyTestListEvent.DeleteTest(this)) }
             )
             // Should not be possible
             State.RECYCLED -> FamilyRapidTestInvalidCard.Item(

--- a/Corona-Warn-App/src/main/res/layout/family_rapid_test_card_outdated.xml
+++ b/Corona-Warn-App/src/main/res/layout/family_rapid_test_card_outdated.xml
@@ -90,7 +90,7 @@
         android:layout_marginTop="24dp"
         android:layout_marginEnd="@dimen/card_padding"
         android:layout_marginBottom="@dimen/card_padding"
-        android:text="@string/submission_status_card_button_failed"
+        android:text="@string/ag_homescreen_card_rapidtest_dont_show_anymore_button"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/familytest/ui/testlist/FamilyTestListViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/familytest/ui/testlist/FamilyTestListViewModelTest.kt
@@ -1,0 +1,110 @@
+package de.rki.coronawarnapp.familytest.ui.testlist
+
+import de.rki.coronawarnapp.appconfig.AppConfigProvider
+import de.rki.coronawarnapp.appconfig.ConfigData
+import de.rki.coronawarnapp.coronatest.type.TestIdentifier
+import de.rki.coronawarnapp.familytest.core.model.FamilyCoronaTest
+import de.rki.coronawarnapp.familytest.core.repository.FamilyTestRepository
+import de.rki.coronawarnapp.util.TimeStamper
+import io.kotest.matchers.shouldBe
+import io.mockk.MockKAnnotations
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.TestScope
+import org.joda.time.Instant
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import testhelpers.BaseTest
+import testhelpers.TestDispatcherProvider
+import testhelpers.extensions.InstantExecutorExtension
+
+@ExtendWith(InstantExecutorExtension::class)
+class FamilyTestListViewModelTest : BaseTest() {
+    @MockK lateinit var appConfigProvider: AppConfigProvider
+    @MockK lateinit var familyTestRepository: FamilyTestRepository
+    @MockK lateinit var timeStamper: TimeStamper
+    @MockK lateinit var configData: ConfigData
+
+    private lateinit var viewModel: FamilyTestListViewModel
+
+    private val ti = TestIdentifier()
+
+    private val fct1 = mockk<FamilyCoronaTest>().apply {
+        every { identifier } returns ti
+        every { hasBadge } returns true
+    }
+    private val fct2 = mockk<FamilyCoronaTest>().apply {
+        every { identifier } returns ti
+        every { hasBadge } returns true
+    }
+
+    @BeforeEach
+    fun setUp() {
+        MockKAnnotations.init(this)
+        every { familyTestRepository.familyTests } returns flowOf(setOf(fct1, fct2))
+        every { timeStamper.nowUTC } returns Instant.parse("2020-11-03T05:35:16.000Z")
+        every { appConfigProvider.currentConfig } returns flowOf(configData)
+
+        viewModel = FamilyTestListViewModel(
+            dispatcherProvider = TestDispatcherProvider(),
+            appConfigProvider = appConfigProvider,
+            familyTestRepository = familyTestRepository,
+            timeStamper = timeStamper,
+            appScope = TestScope()
+        )
+    }
+
+    @Test
+    fun testOnRemoveAllTests() {
+        viewModel.onRemoveAllTests()
+        viewModel.events.value shouldBe FamilyTestListEvent.ConfirmRemoveAllTests
+    }
+
+    @Test
+    fun testOnBackPressed() {
+        viewModel.onBackPressed()
+        viewModel.events.value shouldBe FamilyTestListEvent.NavigateBack
+    }
+
+    @Test
+    fun testMarkAllTestAsViewed() {
+
+        every { familyTestRepository.familyTests } returns flowOf(setOf(fct1, fct2))
+        viewModel.markAllTestAsViewed()
+
+        coVerify {
+            familyTestRepository.markAllBadgesAsViewed(listOf(ti, ti))
+        }
+    }
+
+    @Test
+    fun testDeleteTest() {
+        viewModel.deleteTest(fct1)
+
+        coVerify {
+            familyTestRepository.deleteTest(fct1.identifier)
+        }
+    }
+
+    @Test
+    fun `onRemoveTestConfirmed deletes test with identifier`() {
+        viewModel.onRemoveTestConfirmed(fct1)
+
+        coVerify {
+            familyTestRepository.moveTestToRecycleBin(fct1.identifier)
+        }
+    }
+
+    @Test
+    fun `onRemoveTestConfirmed deletes all tests`() {
+        viewModel.onRemoveTestConfirmed(null)
+
+        coVerify {
+            familyTestRepository.moveAllTestsToRecycleBin(listOf(ti, ti))
+        }
+    }
+}


### PR DESCRIPTION
How to test:
- Scan RAT Test(s)
- Register Test for family member
- Set your phone date min 2 days in the future
- Go to homescreen
- Tap tile "Tests von Familienmitgliedern"
- The registered test(s) is/are displayed as outdated
- The delete button shows text "Nicht mehr anzeigen"
- Tapping delete button completely deletes test (without recycling it)