### PR TITLE
Faq links in dark mode (EXPOSUREAPP-12577)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/TravelNoticeView.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/TravelNoticeView.kt
@@ -1,10 +1,10 @@
 package de.rki.coronawarnapp.covidcertificate.common.certificate
 
-import android.widget.LinearLayout
 import android.content.Context
 import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.LayoutInflater
+import android.widget.LinearLayout
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.IncludeTravelNoticeCardBinding
 import setTextWithUrl
@@ -34,6 +34,7 @@ class TravelNoticeView @JvmOverloads constructor(
                     R.string.green_certificate_travel_notice_link_de,
                     R.string.green_certificate_travel_notice_link_de
                 )
+                travelNoticeGerman.setLinkTextColor(resources.getColor(R.color.colorTextTint, null))
             }
 
             if (travelNoticeEnglish.text ==
@@ -44,6 +45,7 @@ class TravelNoticeView @JvmOverloads constructor(
                     R.string.green_certificate_travel_notice_link_en,
                     R.string.green_certificate_travel_notice_link_en
                 )
+                travelNoticeEnglish.setLinkTextColor(resources.getColor(R.color.colorTextTint, null))
             }
         }
     }

--- a/Corona-Warn-App/src/main/res/layout/confirmed_status_card.xml
+++ b/Corona-Warn-App/src/main/res/layout/confirmed_status_card.xml
@@ -77,6 +77,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
         android:text="@string/confirmed_status_faq_text"
+        android:textColorLink="@color/colorTextTint"
         android:textSize="14sp"
         app:layout_constraintStart_toStartOf="@id/body"
         app:layout_constraintTop_toBottomOf="@id/body" />


### PR DESCRIPTION
[Ticket](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12577)
Also changed the link color for the certificate details screens as I've noticed it had the same issue.

![Screen Shot 2022-05-16 at 07 19 15](https://user-images.githubusercontent.com/19816790/168519125-59b83baf-8631-4671-bee7-f88825fa49ae.png)

