### PR TITLE
Change reissuance success message

### DIFF
--- a/Corona-Warn-App/src/main/res/values-de/dcc_reissuance_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/dcc_reissuance_strings.xml
@@ -2,11 +2,11 @@
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <!-- DCC Reissuance: Success Screen -->
     <!-- XHED: DCC reissuance success screen title -->
-    <string name="dcc_reissuance_success_screen_title">Zertifikat aktualisiert</string>
+    <string name="dcc_reissuance_success_screen_title">Zertifikate erneuert</string>
     <!-- YTXT: Headline for DCC reissuance success screen -->
-    <string name="dcc_reissuance_success_screen_headline">Ihr Zertifikat wurde erfolgreich aktualisiert</string>
+    <string name="dcc_reissuance_success_screen_headline">Ihre Zertifikate wurden erfolgreich erneuert</string>
     <!-- YTXT: Body for DCC reissuance success screen -->
-    <string name="dcc_reissuance_success_screen_body">Sie finden das aktualisierte Zertifikat nun in der Zertifikate-Registerkarte.</string>
+    <string name="dcc_reissuance_success_screen_body">Sie finden die erneuerten Zertifikate nun in der Zertifikate-Registerkarte.</string>
     <!-- XBUT: DCC reissuance button complete -->
     <string name="dcc_reissuance_success_screen_complete_button">Fertig</string>
 


### PR DESCRIPTION
Changed from singular to plural, and changed "aktualisiert" to "erneuert" to comply with wording in Figma.
