### PR TITLE
Update expiry notice (EXPOSUREAPP-13111)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/include_expiration_notice_card.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_expiration_notice_card.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    style="@style/Card.GreenCertificate"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    style="@style/Card.GreenCertificate"
     android:layout_marginHorizontal="24dp"
     android:layout_marginTop="8dp"
     android:orientation="vertical"
@@ -14,7 +14,7 @@
         style="@style/subtitleBoldSixteen"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/expiration_date_title"/>
+        android:text="@string/expiration_date_title" />
 
     <TextView
         android:id="@+id/expiration_date"
@@ -30,6 +30,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
-        android:text="@string/expiration_info" />
+        android:text="@string/expiration_technical_info" />
 
 </LinearLayout>

--- a/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
@@ -264,7 +264,9 @@
     <!-- XHED: Vaccination Detail expiration Date -->
     <string name="expiration_date">Gültig bis %s, %s Uhr</string>
     <!-- XHED: Vaccination Detail expiration info -->
-    <string name="expiration_info">Bitte bemühen Sie sich rechtzeitig darum, einen neuen digitalen Nachweis ausstellen zu lassen.</string>
+    <string name="expiration_info">Wenn dies Ihr aktuell verwendetes Zertifikat ist, bemühen Sie sich bitte rechtzeitig darum, es zu erneuern. Ab 28 Tage vor Ablauf können Sie solche Zertifikate direkt über die App erneuern lassen. Sie finden die Option "Zertifikate erneuern" dann in Ihrer Zertifikatsübersicht unter der Kachel "Status-Nachweis".</string>
+    <!-- XTXT: Vaccination Detail Techincal expiration info -->
+    <string name="expiration_technical_info">Bitte bemühen Sie sich rechtzeitig darum, einen neuen digitalen Nachweis ausstellen zu lassen.</string>
     <!-- XTXT: Expired certificate info -->
     <string name="expired_certificate_info">"Das Ablaufdatum wurde überschritten. Bitte erneuern Sie das Zertifikat. Sie können die Erneuerung bis maximal 90 Tage nach Ablauf über den Hinweis in Ihrer Zertifikatsübersicht anfordern. "</string>
     <!-- XTXT: Invalid certificate signature info -->

--- a/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
@@ -264,7 +264,7 @@
     <!-- XHED: Vaccination Detail expiration Date -->
     <string name="expiration_date">Gültig bis %s, %s Uhr</string>
     <!-- XHED: Vaccination Detail expiration info -->
-    <string name="expiration_info">Wenn dies Ihr aktuell verwendetes Zertifikat ist, bemühen Sie sich bitte rechtzeitig darum, es zu erneuern. Ab 28 Tage vor Ablauf können Sie solche Zertifikate direkt über die App erneuern lassen. Sie finden die Option "Zertifikate erneuern" dann in Ihrer Zertifikatsübersicht unter der Kachel "Status-Nachweis".</string>
+    <string name="expiration_info">Bitte bemühen Sie sich rechtzeitig darum, einen neuen digitalen Nachweis ausstellen zu lassen.</string>
     <!-- XTXT: Expired certificate info -->
     <string name="expired_certificate_info">"Das Ablaufdatum wurde überschritten. Bitte erneuern Sie das Zertifikat. Sie können die Erneuerung bis maximal 90 Tage nach Ablauf über den Hinweis in Ihrer Zertifikatsübersicht anfordern. "</string>
     <!-- XTXT: Invalid certificate signature info -->

--- a/Corona-Warn-App/src/main/res/values/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/covid_certificate_strings.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
 
     <!-- ####################################
        Special string files for the strings
@@ -264,6 +265,8 @@
     <string name="expiration_date">"Valid until %s, %s"</string>
     <!-- XHED: Vaccination Detail expiration info -->
     <string name="expiration_info">"If this is the certificate you currently use, please be sure to renew it on time. You can renew such certificates directly in the app if they will expire within the next 28 days. In this case, the “Renew Certificates” option appears in your certificate overview, below the “Proof of Status” tile."</string>
+    <!-- XTXT: Vaccination Detail Techincal expiration info -->
+    <string name="expiration_technical_info">Bitte bemühen Sie sich rechtzeitig darum, einen neuen digitalen Nachweis ausstellen zu lassen.</string>
     <!-- XTXT: Expired certificate info -->
     <string name="expired_certificate_info">"The expiration date has passed. Please renew the certificate. You can request a renewal up to 90 days after a certificate expires, by clicking the note in your certificate overview."</string>
     <!-- XTXT: Invalid certificate signature info -->


### PR DESCRIPTION
According to [Figma](https://www.figma.com/file/KuDEcMSREg3VhZRhC3FXTY/COVID19_Master_2.20?node-id=27939%3A22789) the expiry notice was outdated, it is not really related to reissuance.

while expiring soon should have still the old text see [Figma](https://www.figma.com/file/KuDEcMSREg3VhZRhC3FXTY/COVID19_Master_2.20?node-id=33889%3A26132)

## Ticket
- https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13111
- https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13113