### PR TITLE
Add back missing title and badge in certificate details (EXPOSUREAPP-13108)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragment.kt
@@ -193,9 +193,7 @@ class VaccinationDetailsFragment : Fragment(R.layout.fragment_vaccination_detail
         }
     }
 
-    private fun FragmentVaccinationDetailsBinding.bindCertificateViews(
-        certificate: VaccinationCertificate
-    ) {
+    private fun FragmentVaccinationDetailsBinding.bindCertificateViews(certificate: VaccinationCertificate) {
         startValidationCheck.apply {
             isEnabled = certificate.isNotScreened
             defaultButton.isEnabled = certificate.isNotScreened

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CertificateStateHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CertificateStateHelper.kt
@@ -21,7 +21,9 @@ import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertific
 import de.rki.coronawarnapp.covidcertificate.common.certificate.getValidQrCode
 import de.rki.coronawarnapp.covidcertificate.person.ui.overview.PersonColorShade
 import de.rki.coronawarnapp.covidcertificate.person.ui.overview.items.PersonCertificateCard
+import de.rki.coronawarnapp.covidcertificate.recovery.core.RecoveryCertificate
 import de.rki.coronawarnapp.covidcertificate.test.core.TestCertificate
+import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinationCertificate
 import de.rki.coronawarnapp.databinding.IncludeCertificateOverviewQrCardBinding
 import de.rki.coronawarnapp.databinding.IncludeCertificateQrcodeCardBinding
 import de.rki.coronawarnapp.databinding.PersonOverviewItemBinding
@@ -50,6 +52,8 @@ fun IncludeCertificateQrcodeCardBinding.bindValidityViews(
 
     when (certificate.displayedState()) {
         is ExpiringSoon -> {
+            setQrTitle(certificate, qrTitle, context)
+            notificationBadge.isVisible = certificate.hasNotificationBadge
             statusIcon.constraintLayoutParams.verticalBias = 0f
             statusIcon.setImageDrawable(context.getDrawableCompat(R.drawable.ic_av_timer))
             statusTitle.text = context.getString(
@@ -61,6 +65,8 @@ fun IncludeCertificateQrcodeCardBinding.bindValidityViews(
         }
 
         is Expired -> {
+            setQrTitle(certificate, qrTitle, context)
+            notificationBadge.isVisible = certificate.hasNotificationBadge
             statusIcon.constraintLayoutParams.verticalBias = 1.0f
             statusIcon.setImageDrawable(context.getDrawableCompat(R.drawable.ic_error_outline))
             statusTitle.text = context.getText(R.string.certificate_qr_expired)
@@ -68,6 +74,8 @@ fun IncludeCertificateQrcodeCardBinding.bindValidityViews(
         }
 
         is Invalid -> {
+            setQrTitle(certificate, qrTitle, context)
+            notificationBadge.isVisible = certificate.hasNotificationBadge
             statusIcon.constraintLayoutParams.verticalBias = 0f
             statusIcon.setImageDrawable(context.getDrawableCompat(R.drawable.ic_error_outline))
             statusTitle.text = context.getText(R.string.certificate_qr_invalid_signature)
@@ -84,6 +92,15 @@ fun IncludeCertificateQrcodeCardBinding.bindValidityViews(
         }
         is Valid,
         CwaCovidCertificate.State.Recycled -> Unit
+    }
+}
+
+private fun setQrTitle(certificate: CwaCovidCertificate, qrTitle: TextView, context: Context) {
+    qrTitle.isVisible = true
+    when (certificate) {
+        is TestCertificate -> qrTitle.text = context.getString(R.string.test_certificate_name)
+        is VaccinationCertificate -> qrTitle.text = context.getString(R.string.vaccination_certificate_name)
+        is RecoveryCertificate -> qrTitle.text = context.getString(R.string.recovery_certificate_name)
     }
 }
 

--- a/Corona-Warn-App/src/main/res/layout/include_certificate_qrcode_card.xml
+++ b/Corona-Warn-App/src/main/res/layout/include_certificate_qrcode_card.xml
@@ -2,10 +2,10 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:background="@drawable/ic_certificate_background_border"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginHorizontal="@dimen/spacing_normal"
+    android:background="@drawable/ic_certificate_background_border"
     android:paddingBottom="@dimen/spacing_small">
 
     <androidx.constraintlayout.widget.Guideline
@@ -102,6 +102,32 @@
         app:layout_constraintStart_toStartOf="@id/image"
         app:layout_constraintTop_toTopOf="@id/image" />
 
+    <TextView
+        android:id="@+id/qr_title"
+        style="@style/subtitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_tiny"
+        android:textStyle="bold"
+        android:visibility="gone"
+        app:layout_constraintStart_toStartOf="@id/image"
+        app:layout_constraintTop_toBottomOf="@id/image"
+        tools:text="@string/test_certificate_name"
+        tools:visibility="visible" />
+
+    <ImageView
+        android:id="@+id/notification_badge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginStart="8dp"
+        android:src="@drawable/ic_badge"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@id/qr_title"
+        app:layout_constraintStart_toEndOf="@id/qr_title"
+        app:layout_constraintTop_toTopOf="@id/qr_title"
+        tools:visibility="visible" />
+
     <ImageView
         android:id="@+id/status_icon"
         android:layout_width="wrap_content"
@@ -123,7 +149,7 @@
         android:layout_marginTop="10dp"
         app:layout_constraintEnd_toEndOf="@id/image"
         app:layout_constraintStart_toEndOf="@id/status_icon"
-        app:layout_constraintTop_toBottomOf="@+id/image"
+        app:layout_constraintTop_toBottomOf="@+id/qr_title"
         tools:text="Zertifikat läuft am 21.08.21 um 14:12 Uhr ab"
         tools:visibility="visible" />
 


### PR DESCRIPTION
[TIcket](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13108)

To test, scan an invalid or soon expiring certificate. The title and a badge should be visible on the certificate details screen.
A valid certificate will not display these two views.