### PR TITLE
 Expired Certificates - only yyyy.mm.dd considered - hh:mm ignored (EXPOSUREAPP-13146)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/expiration/DccExpirationChecker.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/expiration/DccExpirationChecker.kt
@@ -3,8 +3,6 @@ package de.rki.coronawarnapp.covidcertificate.expiration
 import dagger.Reusable
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate
 import de.rki.coronawarnapp.covidcertificate.common.certificate.DccData
-import de.rki.coronawarnapp.util.TimeAndDateExtensions.daysUntil
-import org.joda.time.DateTimeZone
 import org.joda.time.Duration
 import org.joda.time.Instant
 import javax.inject.Inject
@@ -15,24 +13,15 @@ class DccExpirationChecker @Inject constructor() {
     fun getExpirationState(
         dccData: DccData<*>,
         expirationThreshold: Duration,
-        now: Instant,
-        timeZone: DateTimeZone = DateTimeZone.getDefault()
+        now: Instant
     ): CwaCovidCertificate.State = with(dccData) {
         val expiresAt = header.expiresAt
-        val daysUntilExpiration = now.daysUntil(expiresAt, timeZone)
+        val timeDiffUntilExpiration = Duration(now, expiresAt)
 
         return when {
-            daysUntilExpiration < 0 -> CwaCovidCertificate.State.Expired(expiresAt)
-            daysUntilExpiration == 0 -> {
-                if (now.isAfter(expiresAt)) {
-                    CwaCovidCertificate.State.Expired(expiresAt)
-                } else {
-                    CwaCovidCertificate.State.ExpiringSoon(expiresAt)
-                }
-            }
-            daysUntilExpiration <= expirationThreshold.standardDays -> CwaCovidCertificate.State.ExpiringSoon(expiresAt)
-            daysUntilExpiration > expirationThreshold.standardDays -> CwaCovidCertificate.State.Valid(expiresAt)
-            else -> throw IllegalArgumentException() // impossible!
+            expiresAt <= now -> CwaCovidCertificate.State.Expired(expiresAt)
+            timeDiffUntilExpiration <= expirationThreshold -> CwaCovidCertificate.State.ExpiringSoon(expiresAt)
+            else -> CwaCovidCertificate.State.Valid(expiresAt)
         }
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/expiration/DccExpirationCheckerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/expiration/DccExpirationCheckerTest.kt
@@ -6,7 +6,6 @@ import de.rki.coronawarnapp.covidcertificate.common.certificate.DccQrCodeExtract
 import de.rki.coronawarnapp.covidcertificate.test.TestData
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
-import org.joda.time.DateTimeZone
 import org.joda.time.Duration
 import org.joda.time.Instant
 import org.junit.jupiter.api.BeforeEach
@@ -34,36 +33,37 @@ class DccExpirationCheckerTest : BaseTest() {
         instance.getExpirationState(
             dccData = dccData,
             expirationThreshold = Duration.standardDays(10),
+            now = Instant.parse("2021-05-24T10:12:47.000Z"),
+        ) shouldBe CwaCovidCertificate.State.Valid(exp)
+
+        instance.getExpirationState(
+            dccData = dccData,
+            expirationThreshold = Duration.standardDays(10),
             now = Instant.parse("2021-06-03T10:12:48.000+02:00"),
-            timeZone = DateTimeZone.forOffsetHours(2)
         ) shouldBe CwaCovidCertificate.State.ExpiringSoon(exp)
 
         instance.getExpirationState(
             dccData = dccData,
             expirationThreshold = Duration.standardDays(10),
             now = Instant.parse("2021-06-04T00:12:48.000+02:00"),
-            timeZone = DateTimeZone.forOffsetHours(2)
         ) shouldBe CwaCovidCertificate.State.Expired(exp)
 
         instance.getExpirationState(
             dccData = dccData,
             expirationThreshold = Duration.standardDays(10),
             now = Instant.parse("2021-05-24T10:12:48.000Z"),
-            timeZone = DateTimeZone.forOffsetHours(2)
         ) shouldBe CwaCovidCertificate.State.ExpiringSoon(exp)
 
         instance.getExpirationState(
             dccData = dccData,
             expirationThreshold = Duration.standardDays(10),
             now = Instant.parse("2021-05-23T23:59:59.000+02:00"),
-            timeZone = DateTimeZone.forOffsetHours(2)
         ) shouldBe CwaCovidCertificate.State.Valid(exp)
 
         instance.getExpirationState(
             dccData = dccData,
             expirationThreshold = Duration.standardDays(10),
             now = Instant.parse("2021-05-03T10:12:48.000Z"),
-            timeZone = DateTimeZone.forOffsetHours(2)
         ) shouldBe CwaCovidCertificate.State.Valid(exp)
     }
 }


### PR DESCRIPTION
Change the way how to calculate expired certificates. 

### Testing
generate certificate expiring a few minutes before the expiration threshold and a few minutes after the expiration threshold. And check if the behavior is the same as it should be according to the Jira ticket.

### Jira Ticket
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13146