### PR TITLE
Fix invalid family test status headline (EXPOSUREAPP-13130)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/family_pcr_test_card_redeemed.xml
+++ b/Corona-Warn-App/src/main/res/layout/family_pcr_test_card_redeemed.xml
@@ -43,7 +43,7 @@
         android:layout_marginStart="@dimen/card_padding"
         android:layout_marginEnd="@dimen/spacing_small"
         android:focusable="false"
-        android:text="@string/ag_homescreen_card_status_error"
+        android:text="@string/ag_homescreen_card_status_invalid"
         app:layout_constraintEnd_toStartOf="@+id/icon"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/findings" />

--- a/Corona-Warn-App/src/main/res/layout/family_rapid_test_card_redeemed.xml
+++ b/Corona-Warn-App/src/main/res/layout/family_rapid_test_card_redeemed.xml
@@ -43,7 +43,7 @@
         android:layout_marginStart="@dimen/card_padding"
         android:layout_marginEnd="@dimen/spacing_small"
         android:focusable="false"
-        android:text="@string/ag_homescreen_card_status_error"
+        android:text="@string/ag_homescreen_card_status_invalid"
         app:layout_constraintEnd_toStartOf="@+id/icon"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/findings" />


### PR DESCRIPTION
Test: scan redeemed pcr or rat test for family member, on homescreen title is displayed "Nicht mehr gültig" instead of "Fehlerhafter Test"
