### PR TITLE
Drop expiry notification in favor of reissuance notification (EXPOSUREAPP-13143)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/test/ui/TestCertificateDetailsFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/test/ui/TestCertificateDetailsFragmentTest.kt
@@ -181,9 +181,6 @@ class TestCertificateDetailsFragmentTest : BaseUITest() {
         override val dccData: DccData<*>
             get() = mockk()
 
-        override val hasNotificationBadge: Boolean
-            get() = false
-
         override val notifiedInvalidAt: Instant?
             get() = null
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/CwaCovidCertificate.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/CwaCovidCertificate.kt
@@ -8,7 +8,6 @@ import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertific
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate.State.Revoked
 import de.rki.coronawarnapp.covidcertificate.common.repository.CertificateContainerId
 import de.rki.coronawarnapp.covidcertificate.test.core.TestCertificate
-import de.rki.coronawarnapp.covidcertificate.test.core.storage.isScreenedTestCert
 import de.rki.coronawarnapp.reyclebin.common.Recyclable
 import de.rki.coronawarnapp.util.qrcode.coil.CoilQrCode
 import de.rki.coronawarnapp.util.serialization.SerializationModule
@@ -64,7 +63,7 @@ interface CwaCovidCertificate : Recyclable {
      * Expiring_Soon, Expired, Invalid, Blocked, Revoked or certificate is newly registered in the App
      * @see [isNew]
      */
-    val hasNotificationBadge: Boolean
+    val hasNotificationBadge: Boolean get() = (isScreenedCert(state) && state != lastSeenStateChange) || isNew
 
     /**
      * Certificate is newly scanned or retrieved from server in case of TC
@@ -78,7 +77,7 @@ interface CwaCovidCertificate : Recyclable {
 
     val isDisplayValid
         get() = when (this) {
-            is TestCertificate -> !isScreenedTestCert(state)
+            is TestCertificate -> !isScreenedCert(state)
             else -> state is State.Valid || state is ExpiringSoon
         }
 
@@ -137,3 +136,6 @@ interface CwaCovidCertificate : Recyclable {
         }
     }
 }
+
+fun isScreenedCert(state: CwaCovidCertificate.State): Boolean =
+    state is Invalid || state is Blocked || state is Revoked

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/expiration/DccValidityStateChangeObserver.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/expiration/DccValidityStateChangeObserver.kt
@@ -38,7 +38,7 @@ class DccValidityStateChangeObserver @Inject constructor(
             .filter { it.isNotEmpty() }
             .onEach {
                 Timber.tag(TAG).d("Dcc validity states: %s", it)
-                dccValidityStateNotificationService.showNotificationIfStateChanged(ignoreLastCheck = true)
+                dccValidityStateNotificationService.showNotificationIfStateChanged(forceCheck = true)
             }
             .catch { Timber.tag(TAG).e("Failed to observe certs for state changes") }
             .launchIn(scope = appScope)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/RecoveryCertificateRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/RecoveryCertificateRepository.kt
@@ -3,8 +3,6 @@ package de.rki.coronawarnapp.covidcertificate.recovery.core
 import de.rki.coronawarnapp.bugreporting.reportProblem
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate.State.Blocked
-import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate.State.Expired
-import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate.State.ExpiringSoon
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate.State.Invalid
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate.State.Revoked
 import de.rki.coronawarnapp.covidcertificate.common.certificate.DccQrCodeExtractor
@@ -185,8 +183,6 @@ class RecoveryCertificateRepository @Inject constructor(
             }
 
             val newData = when (state) {
-                is Expired -> toUpdate.data.copy(notifiedExpiredAt = time)
-                is ExpiringSoon -> toUpdate.data.copy(notifiedExpiresSoonAt = time)
                 is Invalid -> toUpdate.data.copy(notifiedInvalidAt = time)
                 is Blocked -> toUpdate.data.copy(notifiedBlockedAt = time)
                 is Revoked -> toUpdate.data.copy(notifiedRevokedAt = time)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/storage/RecoveryCertificateContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/storage/RecoveryCertificateContainer.kt
@@ -160,9 +160,6 @@ data class RecoveryCertificateContainer(
             override val dccData: DccData<out DccV1.MetaData>
                 get() = certificateData
 
-            override val hasNotificationBadge: Boolean
-                get() = (state !is Valid && state != lastSeenStateChange) || isNew
-
             override val isNew: Boolean
                 get() = !data.certificateSeenByUser
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/storage/RecoveryCertificateContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/core/storage/RecoveryCertificateContainer.kt
@@ -2,7 +2,6 @@ package de.rki.coronawarnapp.covidcertificate.recovery.core.storage
 
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CertificatePersonIdentifier
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate.State
-import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate.State.Valid
 import de.rki.coronawarnapp.covidcertificate.common.certificate.DccData
 import de.rki.coronawarnapp.covidcertificate.common.certificate.DccQrCodeExtractor
 import de.rki.coronawarnapp.covidcertificate.common.certificate.DccV1

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/TestCertificateRepository.kt
@@ -7,6 +7,7 @@ import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertific
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate.State.Invalid
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate.State.Revoked
 import de.rki.coronawarnapp.covidcertificate.common.certificate.DccQrCodeExtractor
+import de.rki.coronawarnapp.covidcertificate.common.certificate.isScreenedCert
 import de.rki.coronawarnapp.covidcertificate.common.exception.InvalidHealthCertificateException
 import de.rki.coronawarnapp.covidcertificate.common.exception.InvalidTestCertificateException
 import de.rki.coronawarnapp.covidcertificate.common.repository.TestCertificateContainerId
@@ -16,7 +17,6 @@ import de.rki.coronawarnapp.covidcertificate.common.statecheck.DccValidityMeasur
 import de.rki.coronawarnapp.covidcertificate.test.core.qrcode.TestCertificateQRCode
 import de.rki.coronawarnapp.covidcertificate.test.core.storage.TestCertificateContainer
 import de.rki.coronawarnapp.covidcertificate.test.core.storage.TestCertificateStorage
-import de.rki.coronawarnapp.covidcertificate.test.core.storage.isScreenedTestCert
 import de.rki.coronawarnapp.covidcertificate.test.core.storage.types.BaseTestCertificateData
 import de.rki.coronawarnapp.covidcertificate.test.core.storage.types.GenericTestCertificateData
 import de.rki.coronawarnapp.covidcertificate.test.core.storage.types.PCRCertificateData
@@ -445,7 +445,7 @@ class TestCertificateRepository @Inject constructor(
                 dccValidityMeasures = dccValidityMeasuresObserver.dccValidityMeasures()
             )
 
-            if (!isScreenedTestCert(currentState)) {
+            if (!isScreenedCert(currentState)) {
                 Timber.tag(TAG).w("%s is still valid ", containerId)
                 return@updateBlocking this
             }
@@ -484,7 +484,7 @@ class TestCertificateRepository @Inject constructor(
                 return@updateBlocking this
             }
 
-            val isValid = !isScreenedTestCert(state)
+            val isValid = !isScreenedCert(state)
             if (isValid) {
                 Timber.tag(TAG).w("%s is still valid", containerId)
                 return@updateBlocking this

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateContainer.kt
@@ -2,9 +2,6 @@ package de.rki.coronawarnapp.covidcertificate.test.core.storage
 
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CertificatePersonIdentifier
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate.State
-import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate.State.Blocked
-import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate.State.Invalid
-import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate.State.Revoked
 import de.rki.coronawarnapp.covidcertificate.common.certificate.DccData
 import de.rki.coronawarnapp.covidcertificate.common.certificate.DccQrCodeExtractor
 import de.rki.coronawarnapp.covidcertificate.common.certificate.DccV1

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/core/storage/TestCertificateContainer.kt
@@ -184,17 +184,10 @@ data class TestCertificateContainer(
             override val isNew: Boolean
                 get() = !certificateSeenByUser && !isCertificateRetrievalPending
 
-            override val hasNotificationBadge: Boolean
-                get() = (isScreenedTestCert(state) && state != lastSeenStateChange) || isNew
-
             override val recycledAt: Instant?
                 get() = data.recycledAt
 
             override fun toString(): String = "TestCertificate($containerId)"
         }
     }
-}
-
-fun isScreenedTestCert(state: State): Boolean {
-    return state is Invalid || state is Blocked || state is Revoked
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/VaccinationCertificateRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/VaccinationCertificateRepository.kt
@@ -3,8 +3,6 @@ package de.rki.coronawarnapp.covidcertificate.vaccination.core.repository
 import de.rki.coronawarnapp.bugreporting.reportProblem
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate.State.Blocked
-import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate.State.Expired
-import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate.State.ExpiringSoon
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate.State.Invalid
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate.State.Revoked
 import de.rki.coronawarnapp.covidcertificate.common.certificate.DccQrCodeExtractor
@@ -184,8 +182,6 @@ class VaccinationCertificateRepository @Inject constructor(
             }
 
             val newData = when (state) {
-                is Expired -> toUpdate.data.copy(notifiedExpiredAt = time)
-                is ExpiringSoon -> toUpdate.data.copy(notifiedExpiresSoonAt = time)
                 is Invalid -> toUpdate.data.copy(notifiedInvalidAt = time)
                 is Blocked -> toUpdate.data.copy(notifiedBlockedAt = time)
                 is Revoked -> toUpdate.data.copy(notifiedRevokedAt = time)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/storage/VaccinationCertificateContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/storage/VaccinationCertificateContainer.kt
@@ -2,7 +2,6 @@ package de.rki.coronawarnapp.covidcertificate.vaccination.core.repository.storag
 
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CertificatePersonIdentifier
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate.State
-import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate.State.Valid
 import de.rki.coronawarnapp.covidcertificate.common.certificate.DccData
 import de.rki.coronawarnapp.covidcertificate.common.certificate.DccHeader
 import de.rki.coronawarnapp.covidcertificate.common.certificate.DccQrCodeExtractor

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/storage/VaccinationCertificateContainer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/core/repository/storage/VaccinationCertificateContainer.kt
@@ -170,9 +170,6 @@ data class VaccinationCertificateContainer(
         override val dccData: DccData<out DccV1.MetaData>
             get() = certificateData
 
-        override val hasNotificationBadge: Boolean
-            get() = (state !is Valid && state != lastSeenStateChange) || isNew
-
         override val isNew: Boolean get() = !data.certificateSeenByUser
 
         override val recycledAt: Instant?

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/expiration/DccValidityStateChangeObserverTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/expiration/DccValidityStateChangeObserverTest.kt
@@ -59,7 +59,7 @@ class DccValidityStateChangeObserverTest : BaseTest() {
         advanceUntilIdle()
 
         coVerify(exactly = 1) {
-            dccValidityStateNotificationService.showNotificationIfStateChanged(ignoreLastCheck = true)
+            dccValidityStateNotificationService.showNotificationIfStateChanged(forceCheck = true)
         }
     }
 
@@ -95,7 +95,7 @@ class DccValidityStateChangeObserverTest : BaseTest() {
         advanceUntilIdle()
 
         coVerify(exactly = 1) {
-            dccValidityStateNotificationService.showNotificationIfStateChanged(ignoreLastCheck = true)
+            dccValidityStateNotificationService.showNotificationIfStateChanged(forceCheck = true)
         }
     }
 
@@ -107,7 +107,7 @@ class DccValidityStateChangeObserverTest : BaseTest() {
         advanceUntilIdle()
 
         coVerify(exactly = 1) {
-            dccValidityStateNotificationService.showNotificationIfStateChanged(ignoreLastCheck = true)
+            dccValidityStateNotificationService.showNotificationIfStateChanged(forceCheck = true)
         }
     }
 
@@ -119,7 +119,7 @@ class DccValidityStateChangeObserverTest : BaseTest() {
         advanceUntilIdle()
 
         coVerify(exactly = 1) {
-            dccValidityStateNotificationService.showNotificationIfStateChanged(ignoreLastCheck = true)
+            dccValidityStateNotificationService.showNotificationIfStateChanged(forceCheck = true)
         }
     }
 
@@ -131,7 +131,7 @@ class DccValidityStateChangeObserverTest : BaseTest() {
         advanceUntilIdle()
 
         coVerify(exactly = 1) {
-            dccValidityStateNotificationService.showNotificationIfStateChanged(ignoreLastCheck = true)
+            dccValidityStateNotificationService.showNotificationIfStateChanged(forceCheck = true)
         }
     }
 
@@ -143,7 +143,7 @@ class DccValidityStateChangeObserverTest : BaseTest() {
         advanceUntilIdle()
 
         coVerify(exactly = 1) {
-            dccValidityStateNotificationService.showNotificationIfStateChanged(ignoreLastCheck = true)
+            dccValidityStateNotificationService.showNotificationIfStateChanged(forceCheck = true)
         }
     }
 
@@ -155,7 +155,7 @@ class DccValidityStateChangeObserverTest : BaseTest() {
         advanceUntilIdle()
 
         coVerify(exactly = 1) {
-            dccValidityStateNotificationService.showNotificationIfStateChanged(ignoreLastCheck = true)
+            dccValidityStateNotificationService.showNotificationIfStateChanged(forceCheck = true)
         }
     }
 
@@ -173,7 +173,7 @@ class DccValidityStateChangeObserverTest : BaseTest() {
         advanceUntilIdle()
 
         coVerify(exactly = 3) {
-            dccValidityStateNotificationService.showNotificationIfStateChanged(ignoreLastCheck = true)
+            dccValidityStateNotificationService.showNotificationIfStateChanged(forceCheck = true)
         }
     }
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/expiration/DccValidityStateNotificationServiceTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/expiration/DccValidityStateNotificationServiceTest.kt
@@ -141,7 +141,7 @@ class DccValidityStateNotificationServiceTest : BaseTest() {
     fun `check can be enforced`() = runTest {
         lastDccStateBackgroundCheck.update { timeStamper.nowUTC }
         createInstance().run {
-            showNotificationIfStateChanged(ignoreLastCheck = true)
+            showNotificationIfStateChanged(forceCheck = true)
 
             verify {
                 vaccinationCertificateRepository.certificates

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/expiration/DccValidityStateNotificationServiceTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/expiration/DccValidityStateNotificationServiceTest.kt
@@ -183,7 +183,7 @@ class DccValidityStateNotificationServiceTest : BaseTest() {
 
         createInstance().showNotificationIfStateChanged()
 
-        coVerify { dccValidityStateNotification.showNotification(any()) }
+        coVerify(exactly = 0) { dccValidityStateNotification.showNotification(any()) }
     }
 
     @Test
@@ -193,7 +193,7 @@ class DccValidityStateNotificationServiceTest : BaseTest() {
 
         createInstance().showNotificationIfStateChanged()
 
-        coVerify { dccValidityStateNotification.showNotification(any()) }
+        coVerify(exactly = 0) { dccValidityStateNotification.showNotification(any()) }
     }
 
     @Test
@@ -204,9 +204,17 @@ class DccValidityStateNotificationServiceTest : BaseTest() {
 
         createInstance().showNotificationIfStateChanged()
 
-        coVerify(exactly = 3) { dccValidityStateNotification.showNotification(any()) }
+        coVerify(exactly = 1) { dccValidityStateNotification.showNotification(any()) }
 
-        coVerify(exactly = 1) {
+        coVerify {
+            testCertificateRepository.setNotifiedState(
+                containerId = testContainerId,
+                state = State.Blocked,
+                time = nowUtc,
+            )
+        }
+
+        coVerify(exactly = 0) {
             vaccinationCertificateRepository.setNotifiedState(
                 containerId = vaccinationContainerId,
                 state = State.ExpiringSoon(expiresAt = Instant.EPOCH),
@@ -216,12 +224,6 @@ class DccValidityStateNotificationServiceTest : BaseTest() {
             recoveryRepository.setNotifiedState(
                 containerId = recoverContainerId,
                 state = State.Expired(expiredAt = Instant.EPOCH),
-                time = nowUtc,
-            )
-
-            testCertificateRepository.setNotifiedState(
-                containerId = testContainerId,
-                state = State.Blocked,
                 time = nowUtc,
             )
         }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonCertificatesData.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonCertificatesData.kt
@@ -86,8 +86,6 @@ fun testCertificate(
     override val uniqueCertificateIdentifier: String
         get() = "URN:UVCI:01:AT:858CC18CFCF5965EF82F60E493349AA5#K"
 
-    override val hasNotificationBadge: Boolean
-        get() = false
     override val notifiedInvalidAt: Instant?
         get() = null
     override val lastSeenStateChange: CwaCovidCertificate.State?

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/recovery/core/RecoveryCertificateRepositoryTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/recovery/core/RecoveryCertificateRepositoryTest.kt
@@ -203,18 +203,12 @@ class RecoveryCertificateRepositoryTest : BaseTest() {
         coEvery { storage.load() } returns setOf(storedRecoveryCertificate)
         val instance = createInstance(this)
 
-        instance.setNotifiedState(
-            RecoveryCertificateContainerId(containerIdRecoveryQrCode2),
-            CwaCovidCertificate.State.ExpiringSoon(Instant.EPOCH),
-            Instant.EPOCH
-        )
-
-        val firstCert = instance.certificates.first().first()
-        firstCert.recoveryCertificate.apply {
-            notifiedInvalidAt shouldBe null
-            notifiedBlockedAt shouldBe null
-            notifiedExpiredAt shouldBe null
-            notifiedExpiresSoonAt shouldBe Instant.EPOCH
+        shouldThrow<UnsupportedOperationException> {
+            instance.setNotifiedState(
+                RecoveryCertificateContainerId(containerIdRecoveryQrCode2),
+                CwaCovidCertificate.State.ExpiringSoon(Instant.EPOCH),
+                Instant.EPOCH
+            )
         }
     }
 
@@ -224,18 +218,12 @@ class RecoveryCertificateRepositoryTest : BaseTest() {
         coEvery { storage.load() } returns setOf(storedRecoveryCertificate)
         val instance = createInstance(this)
 
-        instance.setNotifiedState(
-            RecoveryCertificateContainerId(containerIdRecoveryQrCode2),
-            CwaCovidCertificate.State.Expired(Instant.EPOCH),
-            Instant.EPOCH
-        )
-
-        val firstCert = instance.certificates.first().first()
-        firstCert.recoveryCertificate.apply {
-            notifiedExpiresSoonAt shouldBe null
-            notifiedInvalidAt shouldBe null
-            notifiedBlockedAt shouldBe null
-            notifiedExpiredAt shouldBe Instant.EPOCH
+        shouldThrow<UnsupportedOperationException> {
+            instance.setNotifiedState(
+                RecoveryCertificateContainerId(containerIdRecoveryQrCode2),
+                CwaCovidCertificate.State.Expired(Instant.EPOCH),
+                Instant.EPOCH
+            )
         }
     }
 


### PR DESCRIPTION
This PR drops expiry notification for states `Expired or Expiring_Soon` in favor of DccReissuance notification
## How to verify?
- In 2.23
- Before this change if you scan expired or expiring soon certificates , you would be able to see two notifications
  - one opens the certificate details screen
  - the other one opens the person details screen
- After this change the DccReissuance notification stays the other is gone 🌬️ 
Note: Badges for these states are also gone, don't confuse the `isNew ` badge with  state change badges (if you scan new certificates)

You can generate expired or expiring certificates by
```js
# absolute timestamp
cwa vc gen --exp 2021-07-22T08:57:25Z
cwa vc gen --cwt-exp 2021-07-22T08:57:25Z

# relative timestamp
cwa vc gen --exp 2days 
cwa vc gen --exp 5minutes 
```
   

[Ticket 🎫 ](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13143) [Ticket 🎟  ](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13132)