### PR TITLE
Fix expired and expiring soon text  (EXPOSUREAPP-13196, 13182)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CertificateStateHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CertificateStateHelper.kt
@@ -70,7 +70,7 @@ fun IncludeCertificateQrcodeCardBinding.bindValidityViews(
             statusIcon.constraintLayoutParams.verticalBias = 1.0f
             statusIcon.setImageDrawable(context.getDrawableCompat(R.drawable.ic_error_outline))
             statusTitle.text = context.getText(R.string.certificate_qr_expired)
-            statusBody.text = context.getText(R.string.expired_certificate_info)
+            statusBody.text = context.getText(R.string.expiration_info)
         }
 
         is Invalid -> {

--- a/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
@@ -264,7 +264,7 @@
     <!-- XHED: Vaccination Detail expiration Date -->
     <string name="expiration_date">Gültig bis %s, %s Uhr</string>
     <!-- XHED: Vaccination Detail expiration info -->
-    <string name="expiration_info">Wenn dies Ihr aktuell verwendetes Zertifikat ist, bemühen Sie sich bitte rechtzeitig darum, es zu erneuern. Ab 28 Tage vor Ablauf können Sie solche Zertifikate direkt über die App erneuern lassen. Sie finden die Option "Zertifikate erneuern" dann in Ihrer Zertifikatsübersicht unter der Kachel "Status-Nachweis". Sollte dies nicht Ihr aktuell verwendetes Zertifikat sein, muss es nicht verlängert werden und Sie müssen nichts weiter tun.</string>
+    <string name="expiration_info">Wenn dies Ihr aktuell verwendetes Zertifikat ist, bemühen Sie sich bitte rechtzeitig darum, es zu erneuern. Ab 28 Tage vor Ablauf können Sie solche Zertifikate direkt über die App erneuern lassen. Sie finden die Option \"Zertifikate erneuern\" dann in Ihrer Zertifikatsübersicht unter der Kachel \"Status-Nachweis\". Sollte dies nicht Ihr aktuell verwendetes Zertifikat sein, muss es nicht verlängert werden und Sie müssen nichts weiter tun.</string>
     <!-- XTXT: Vaccination Detail Techincal expiration info -->
     <string name="expiration_technical_info">Bitte bemühen Sie sich rechtzeitig darum, einen neuen digitalen Nachweis ausstellen zu lassen.</string>
     <!-- XTXT: Expired certificate info -->


### PR DESCRIPTION
The text for expiring soon adn expired certificates is now the same. 
Escaped the quotes in the text so it actually shows up now.