### PR TITLE
 Test result when tracing declined (EXPOSUREAPP-13127)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/data/tekhistory/TEKHistoryUpdater.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/data/tekhistory/TEKHistoryUpdater.kt
@@ -37,6 +37,7 @@ class TEKHistoryUpdater @AssistedInject constructor(
                         updateTEKHistoryOrRequestPermission()
                     } else {
                         Timber.tag(TAG).w("Can't start TEK update, tracing permission was declined.")
+                        callback.onTEKPermissionDeclined()
                     }
                 }
 


### PR DESCRIPTION
How to test:

- turn off exposure logging
- scan a positive test result
- deny turning on exposure logging on result available screen -> should be forwarded to result (before it was stuck here)