### PR TITLE
All certificates PDF export info screen (EXPOSUREAPP-13261)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/ui/ExportAllCertsPdfInfoFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/ui/ExportAllCertsPdfInfoFragment.kt
@@ -1,0 +1,36 @@
+package de.rki.coronawarnapp.covidcertificate.pdf.ui
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import com.google.android.material.transition.MaterialSharedAxis
+import de.rki.coronawarnapp.R
+import de.rki.coronawarnapp.databinding.ExportAllCertsPdfInfoFragmentBinding
+import de.rki.coronawarnapp.ui.view.onOffsetChange
+import de.rki.coronawarnapp.util.ui.popBackStack
+import de.rki.coronawarnapp.util.ui.viewBinding
+
+class ExportAllCertsPdfInfoFragment : Fragment(R.layout.export_all_certs_pdf_info_fragment) {
+
+    private val binding: ExportAllCertsPdfInfoFragmentBinding by viewBinding()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        enterTransition = MaterialSharedAxis(MaterialSharedAxis.Z, true)
+        returnTransition = MaterialSharedAxis(MaterialSharedAxis.Z, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.apply {
+            toolbar.setNavigationOnClickListener { popBackStack() }
+            nextButton.setOnClickListener {
+                // navigate to all certificates preview screen
+            }
+            appBarLayout.onOffsetChange { _, subtitleAlpha ->
+                headerImage.alpha = subtitleAlpha
+            }
+        }
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragment.kt
@@ -151,7 +151,7 @@ class PersonOverviewFragment : Fragment(R.layout.person_overview_fragment), Auto
                     setupAxisTransition()
                     doNavigate(
                         PersonOverviewFragmentDirections
-                            .actionPersonOverviewFragmentToCertificatesPdfExportInfoFragment()
+                            .actionPersonOverviewFragmentToExportAllCertsPdfInfoFragment()
                     )
                     true
                 }

--- a/Corona-Warn-App/src/main/res/layout/export_all_certs_pdf_info_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/export_all_certs_pdf_info_fragment.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/colorSurface"
+    android:contentDescription="@string/pdf_export_info_title"
+    tools:context="de.rki.coronawarnapp.covidcertificate.pdf.ui.CertificatePdfExportInfoFragment">
+
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:id="@+id/coordinator_layout"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@id/next_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/app_bar_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:contentScrim="@drawable/top_app_bar_shape">
+
+            <com.google.android.material.appbar.CollapsingToolbarLayout
+                android:id="@+id/collapsing_toolbar_layout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@drawable/covid_certificate_validation_gradient"
+                android:nestedScrollingEnabled="true"
+                app:contentScrim="@drawable/top_app_bar_shape"
+                app:layout_scrollFlags="scroll|exitUntilCollapsed|snap"
+                app:titleEnabled="false">
+
+                <ImageView
+                    android:id="@+id/header_image"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:importantForAccessibility="no"
+                    android:scaleType="centerCrop"
+                    app:layout_collapseMode="parallax"
+                    app:srcCompat="@drawable/ic_pdf_info_illustration" />
+
+                <com.google.android.material.appbar.MaterialToolbar
+                    android:id="@+id/toolbar"
+                    style="@style/CWAMaterialToolbar.Close.Transparent"
+                    android:layout_width="match_parent"
+                    android:layout_height="?attr/actionBarSize"
+                    app:expandedTitleGravity="top"
+                    app:layout_collapseMode="pin"
+                    app:title="@string/all_certs_pdf_export_info_title" />
+
+            </com.google.android.material.appbar.CollapsingToolbarLayout>
+
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <androidx.core.widget.NestedScrollView
+            android:id="@+id/scroll_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <ImageView
+                    android:id="@+id/pdf_export_info_pdf_icon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/spacing_normal"
+                    android:layout_marginTop="34dp"
+                    android:importantForAccessibility="no"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:srcCompat="@drawable/ic_pdf_icon" />
+
+                <TextView
+                    android:id="@+id/pdf_export_info_pdf_text"
+                    style="@style/subtitle"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginEnd="26dp"
+                    android:text="@string/pdf_export_info_point_pdf"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/pdf_export_info_pdf_icon"
+                    app:layout_constraintTop_toTopOf="@id/pdf_export_info_pdf_icon" />
+
+                <ImageView
+                    android:id="@+id/pdf_export_info_lock_icon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="27dp"
+                    android:importantForAccessibility="no"
+                    app:layout_constraintStart_toStartOf="@id/pdf_export_info_pdf_icon"
+                    app:layout_constraintTop_toBottomOf="@id/pdf_export_info_pdf_text"
+                    app:srcCompat="@drawable/ic_pdf_lock" />
+
+                <TextView
+                    android:id="@+id/pdf_export_info_sensitive_text"
+                    style="@style/subtitle"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginEnd="26dp"
+                    android:text="@string/pdf_export_info_point_sensitive"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/pdf_export_info_lock_icon"
+                    app:layout_constraintTop_toTopOf="@id/pdf_export_info_lock_icon" />
+
+                <ImageView
+                    android:id="@+id/pdf_export_info_phone_icon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="27dp"
+                    android:importantForAccessibility="no"
+                    app:layout_constraintStart_toStartOf="@id/pdf_export_info_pdf_icon"
+                    app:layout_constraintTop_toBottomOf="@id/pdf_export_info_sensitive_text"
+                    app:srcCompat="@drawable/ic_pdf_phone" />
+
+                <TextView
+                    android:id="@+id/pdf_export_info_recommendations_text"
+                    style="@style/subtitle"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginEnd="26dp"
+                    android:layout_marginBottom="39dp"
+                    android:text="@string/pdf_export_info_point_recommendations"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/pdf_export_info_phone_icon"
+                    app:layout_constraintTop_toTopOf="@id/pdf_export_info_phone_icon" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.core.widget.NestedScrollView>
+
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+
+    <Button
+        android:id="@+id/next_button"
+        style="@style/buttonPrimary"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/spacing_normal"
+        android:layout_marginTop="@dimen/spacing_small"
+        android:layout_marginEnd="@dimen/spacing_normal"
+        android:layout_marginBottom="@dimen/spacing_small"
+        android:text="@string/acknowledge_button"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/coordinator_layout"
+        tools:text="@string/acknowledge_button" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Corona-Warn-App/src/main/res/layout/export_all_certs_pdf_info_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/export_all_certs_pdf_info_fragment.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/colorSurface"
-    android:contentDescription="@string/pdf_export_info_title"
+    android:contentDescription="@string/all_certs_pdf_export_info_title"
     tools:context="de.rki.coronawarnapp.covidcertificate.pdf.ui.CertificatePdfExportInfoFragment">
 
     <androidx.coordinatorlayout.widget.CoordinatorLayout
@@ -83,7 +83,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginStart="16dp"
                     android:layout_marginEnd="26dp"
-                    android:text="@string/pdf_export_info_point_pdf"
+                    android:text="@string/all_certs_pdf_export_info_point_pdf"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toEndOf="@id/pdf_export_info_pdf_icon"
                     app:layout_constraintTop_toTopOf="@id/pdf_export_info_pdf_icon" />
@@ -105,7 +105,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginStart="16dp"
                     android:layout_marginEnd="26dp"
-                    android:text="@string/pdf_export_info_point_sensitive"
+                    android:text="@string/all_certs_pdf_export_info_point_sensitive"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toEndOf="@id/pdf_export_info_lock_icon"
                     app:layout_constraintTop_toTopOf="@id/pdf_export_info_lock_icon" />
@@ -128,7 +128,7 @@
                     android:layout_marginStart="16dp"
                     android:layout_marginEnd="26dp"
                     android:layout_marginBottom="39dp"
-                    android:text="@string/pdf_export_info_point_recommendations"
+                    android:text="@string/all_certs_pdf_export_info_point_recommendations"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toEndOf="@id/pdf_export_info_phone_icon"

--- a/Corona-Warn-App/src/main/res/navigation/covid_certificates_graph.xml
+++ b/Corona-Warn-App/src/main/res/navigation/covid_certificates_graph.xml
@@ -22,8 +22,8 @@
             android:id="@+id/action_personOverviewFragment_to_admissionScenariosFragment"
             app:destination="@id/admissionScenariosFragment" />
         <action
-            android:id="@+id/action_personOverviewFragment_to_certificatesPdfExportInfoFragment"
-            app:destination="@id/certificatesPdfExportInfoFragment" />
+            android:id="@+id/action_personOverviewFragment_to_exportAllCertsPdfInfoFragment"
+            app:destination="@id/exportAllCertsPdfInfoFragment" />
     </fragment>
 
     <fragment
@@ -381,5 +381,11 @@
         android:name="de.rki.coronawarnapp.covidcertificate.pdf.ui.CertificatePdfExportInfoFragment"
         android:label="certificate_pdf_export_info_fragment"
         tools:layout="@layout/certificate_pdf_export_info_fragment" />
+
+    <fragment
+        android:id="@+id/exportAllCertsPdfInfoFragment"
+        android:name="de.rki.coronawarnapp.covidcertificate.pdf.ui.ExportAllCertsPdfInfoFragment"
+        android:label="export_all_certs_pdf_info_fragment"
+        tools:layout="@layout/export_all_certs_pdf_info_fragment" />
 
 </navigation>

--- a/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
@@ -310,6 +310,16 @@
     <!-- XTXT: PDF Export: Info screen point with recommendations -->
     <string name="pdf_export_info_point_recommendations">Wir empfehlen, das PDF-Dokument nicht zu veröffentlichen und nicht per E-Mail zu versenden oder über andere Apps zu teilen.</string>
 
+    <!-- PDF Export: All Certificates Info Screen -->
+    <!-- XHED: PDF Export: All Certificates Info screen title -->
+    <string name="all_certs_pdf_export_info_title">Zertifikate exportieren</string>
+    <!-- XTXT: PDF Export: All Certificates Info screen point regarding PDF storage -->
+    <string name="all_certs_pdf_export_info_point_pdf">Sie können in einem Schritt alle in Ihrer App gehaltenen Zertifikate in einem gemeinsamen PDF-Dokument speichern. Auf das PDF-Dokument haben zunächst nur Sie Zugriff. Sie können im Anschluss entscheiden, ob Sie es auf Ihrem Smartphone speichern oder in andere Apps importieren möchten.</string>
+    <!-- XTXT: PDF Export: All Certificates Info screen point regarding sensitive information in PDF file -->
+    <string name="all_certs_pdf_export_info_point_sensitive">Beachten Sie, dass das PDF-Dokument sensible Informationen enthält. Wir empfehlen Ihnen, hiermit sorgsam umzugehen und es nur Personen vorzuzeigen, denen Sie vertrauen und die zur Prüfung des Nachweises berechtigt sind.</string>
+    <!-- XTXT: PDF Export: All Certificates Info screen point with recommendations -->
+    <string name="all_certs_pdf_export_info_point_recommendations">Wir empfehlen, das PDF-Dokument nicht zu veröffentlichen und nicht per E-Mail zu versenden oder über andere Apps zu teilen.</string>
+
     <!-- PDF Export: Error message -->
     <!-- XHED: PDF Export: Error message title -->
     <string name="pdf_export_error_title">Druckversion anzeigen nicht möglich</string>

--- a/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/covid_certificate_strings.xml
@@ -314,7 +314,7 @@
     <!-- XHED: PDF Export: All Certificates Info screen title -->
     <string name="all_certs_pdf_export_info_title">Zertifikate exportieren</string>
     <!-- XTXT: PDF Export: All Certificates Info screen point regarding PDF storage -->
-    <string name="all_certs_pdf_export_info_point_pdf">Sie können in einem Schritt alle in Ihrer App gehaltenen Zertifikate in einem gemeinsamen PDF-Dokument speichern. Auf das PDF-Dokument haben zunächst nur Sie Zugriff. Sie können im Anschluss entscheiden, ob Sie es auf Ihrem Smartphone speichern oder in andere Apps importieren möchten.</string>
+    <string name="all_certs_pdf_export_info_point_pdf">Sie können in einem Schritt alle in Ihrer App vorhandenen Zertifikate in einem gemeinsamen PDF-Dokument speichern. Auf das PDF-Dokument haben zunächst nur Sie Zugriff. Sie können im Anschluss entscheiden, ob Sie es auf Ihrem Smartphone speichern oder in andere Apps importieren möchten.</string>
     <!-- XTXT: PDF Export: All Certificates Info screen point regarding sensitive information in PDF file -->
     <string name="all_certs_pdf_export_info_point_sensitive">Beachten Sie, dass das PDF-Dokument sensible Informationen enthält. Wir empfehlen Ihnen, hiermit sorgsam umzugehen und es nur Personen vorzuzeigen, denen Sie vertrauen und die zur Prüfung des Nachweises berechtigt sind.</string>
     <!-- XTXT: PDF Export: All Certificates Info screen point with recommendations -->

--- a/Corona-Warn-App/src/main/res/values/covid_certificate_strings.xml
+++ b/Corona-Warn-App/src/main/res/values/covid_certificate_strings.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
 
     <!-- ####################################
        Special string files for the strings
@@ -308,6 +309,16 @@
     <string name="pdf_export_info_point_sensitive">"Please note that the PDF document contains sensitive information. We recommend handling it carefully and only showing it to people who you trust and who are authorized to check the certificate."</string>
     <!-- XTXT: PDF Export: Info screen point with recommendations -->
     <string name="pdf_export_info_point_recommendations">"We recommend that you not publish the PDF document, send it via e-mail, or share it through other apps."</string>
+
+    <!-- PDF Export: All Certificates Info Screen -->
+    <!-- XHED: PDF Export: All Certificates Info screen title -->
+    <string name="all_certs_pdf_export_info_title">Zertifikate exportieren</string>
+    <!-- XTXT: PDF Export: All Certificates Info screen point regarding PDF storage -->
+    <string name="all_certs_pdf_export_info_point_pdf">Sie können in einem Schritt alle in Ihrer App gehaltenen Zertifikate in einem gemeinsamen PDF-Dokument speichern. Auf das PDF-Dokument haben zunächst nur Sie Zugriff. Sie können im Anschluss entscheiden, ob Sie es auf Ihrem Smartphone speichern oder in andere Apps importieren möchten.</string>
+    <!-- XTXT: PDF Export: All Certificates Info screen point regarding sensitive information in PDF file -->
+    <string name="all_certs_pdf_export_info_point_sensitive">Beachten Sie, dass das PDF-Dokument sensible Informationen enthält. Wir empfehlen Ihnen, hiermit sorgsam umzugehen und es nur Personen vorzuzeigen, denen Sie vertrauen und die zur Prüfung des Nachweises berechtigt sind.</string>
+    <!-- XTXT: PDF Export: All Certificates Info screen point with recommendations -->
+    <string name="all_certs_pdf_export_info_point_recommendations">Wir empfehlen, das PDF-Dokument nicht zu veröffentlichen und nicht per E-Mail zu versenden oder über andere Apps zu teilen.</string>
 
     <!-- PDF Export: Error message -->
     <!-- XHED: PDF Export: Error message title -->


### PR DESCRIPTION
Created a new info screen for exporting all certificates as pdf. 
To test, scan at least one certificate -> press the export button on the overview screen -> voila