### PR TITLE
Remove text for expiration date on details screen (EXPOSUREAPP-13343)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsEvents.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsEvents.kt
@@ -11,17 +11,20 @@ sealed class PersonDetailsEvents
 
 data class OpenVaccinationCertificateDetails(
     val containerId: VaccinationCertificateContainerId,
-    val colorShade: PersonColorShade
+    val colorShade: PersonColorShade,
+    val isReissuance: Boolean
 ) : PersonDetailsEvents()
 
 data class OpenTestCertificateDetails(
     val containerId: TestCertificateContainerId,
-    val colorShade: PersonColorShade
+    val colorShade: PersonColorShade,
+    val isReissuance: Boolean
 ) : PersonDetailsEvents()
 
 data class OpenRecoveryCertificateDetails(
     val containerId: RecoveryCertificateContainerId,
-    val colorShade: PersonColorShade
+    val colorShade: PersonColorShade,
+    val isReissuance: Boolean
 ) : PersonDetailsEvents()
 
 data class ValidationStart(val containerId: CertificateContainerId) : PersonDetailsEvents()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsFragment.kt
@@ -111,7 +111,8 @@ class PersonDetailsFragment : Fragment(R.layout.person_details_fragment), AutoIn
                         certIdentifier = event.containerId.qrCodeHash,
                         numberOfCertificates = numberOfCertificates,
                         fromScanner = false,
-                        colorShade = event.colorShade
+                        colorShade = event.colorShade,
+                        isReissuance = event.isReissuance
                     ).also { viewModel.dismissAdmissionStateBadge() }
             )
             is OpenTestCertificateDetails -> doNavigate(
@@ -120,7 +121,8 @@ class PersonDetailsFragment : Fragment(R.layout.person_details_fragment), AutoIn
                         certIdentifier = event.containerId.qrCodeHash,
                         numberOfCertificates = numberOfCertificates,
                         fromScanner = false,
-                        colorShade = event.colorShade
+                        colorShade = event.colorShade,
+                        isReissuance = event.isReissuance
                     ).also { viewModel.dismissAdmissionStateBadge() }
             )
             is OpenVaccinationCertificateDetails -> doNavigate(
@@ -129,7 +131,8 @@ class PersonDetailsFragment : Fragment(R.layout.person_details_fragment), AutoIn
                         certIdentifier = event.containerId.qrCodeHash,
                         numberOfCertificates = numberOfCertificates,
                         fromScanner = false,
-                        colorShade = event.colorShade
+                        colorShade = event.colorShade,
+                        isReissuance = event.isReissuance
                     ).also { viewModel.dismissAdmissionStateBadge() }
             )
             is ValidationStart -> doNavigate(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsViewModel.kt
@@ -81,6 +81,7 @@ class PersonDetailsViewModel @AssistedInject constructor(
             return UiState(name = "", emptyList())
         }
 
+        var hasReissuance = false
         val color = if (priorityCertificate.isDisplayValid) colorShade else PersonColorShade.COLOR_INVALID
         colorShadeData.postValue(color)
 
@@ -92,6 +93,7 @@ class PersonDetailsViewModel @AssistedInject constructor(
             // 2. Dcc reissuance tile
             if (info.hasReissuance) info.certificateReissuance?.reissuanceDivision?.let { division ->
                 certificateItems.add(dccReissuanceItem(division, personCertificates))
+                hasReissuance = true
             }
             // 3. Booster notification tile
             if (info.boosterNotification.visible)
@@ -112,7 +114,8 @@ class PersonDetailsViewModel @AssistedInject constructor(
                 certificateItems.addCardItem(
                     certificate = cwaCert,
                     priorityCertificate = priorityCertificate,
-                    isLoading = isLoading
+                    isLoading = isLoading,
+                    isReissuance = hasReissuance
                 )
             }
 
@@ -126,13 +129,14 @@ class PersonDetailsViewModel @AssistedInject constructor(
     private fun MutableList<CertificateItem>.addCardItem(
         certificate: CwaCovidCertificate,
         priorityCertificate: CwaCovidCertificate,
-        isLoading: Boolean
+        isLoading: Boolean,
+        isReissuance: Boolean
     ) {
         val isCurrentCertificate = certificate.containerId == priorityCertificate.containerId
         when (certificate) {
-            is TestCertificate -> add(tcItem(certificate, isCurrentCertificate, isLoading))
-            is VaccinationCertificate -> add(vcItem(certificate, isCurrentCertificate, isLoading))
-            is RecoveryCertificate -> add(rcItem(certificate, isCurrentCertificate, isLoading))
+            is TestCertificate -> add(tcItem(certificate, isCurrentCertificate, isLoading, isReissuance))
+            is VaccinationCertificate -> add(vcItem(certificate, isCurrentCertificate, isLoading, isReissuance))
+            is RecoveryCertificate -> add(rcItem(certificate, isCurrentCertificate, isLoading, isReissuance))
         }
     }
 
@@ -204,7 +208,8 @@ class PersonDetailsViewModel @AssistedInject constructor(
     private fun rcItem(
         certificate: RecoveryCertificate,
         isCurrentCertificate: Boolean,
-        isLoading: Boolean
+        isLoading: Boolean,
+        isReissuance: Boolean
     ) = RecoveryCertificateCard.Item(
         certificate = certificate,
         isCurrentCertificate = isCurrentCertificate,
@@ -215,7 +220,8 @@ class PersonDetailsViewModel @AssistedInject constructor(
             events.postValue(
                 OpenRecoveryCertificateDetails(
                     containerId = certificate.containerId,
-                    colorShade = getItemColorShade(certificate.isDisplayValid, isCurrentCertificate)
+                    colorShade = getItemColorShade(certificate.isDisplayValid, isCurrentCertificate),
+                    isReissuance = isReissuance
                 )
             )
         },
@@ -231,7 +237,8 @@ class PersonDetailsViewModel @AssistedInject constructor(
     private fun vcItem(
         certificate: VaccinationCertificate,
         isCurrentCertificate: Boolean,
-        isLoading: Boolean
+        isLoading: Boolean,
+        isReissuance: Boolean
     ) = VaccinationCertificateCard.Item(
         certificate = certificate,
         isCurrentCertificate = isCurrentCertificate,
@@ -242,7 +249,8 @@ class PersonDetailsViewModel @AssistedInject constructor(
             events.postValue(
                 OpenVaccinationCertificateDetails(
                     containerId = certificate.containerId,
-                    colorShade = getItemColorShade(certificate.isDisplayValid, isCurrentCertificate)
+                    colorShade = getItemColorShade(certificate.isDisplayValid, isCurrentCertificate),
+                    isReissuance = isReissuance
                 )
             )
         },
@@ -254,7 +262,8 @@ class PersonDetailsViewModel @AssistedInject constructor(
     private fun tcItem(
         certificate: TestCertificate,
         isCurrentCertificate: Boolean,
-        isLoading: Boolean
+        isLoading: Boolean,
+        isReissuance: Boolean
     ) = TestCertificateCard.Item(
         certificate = certificate,
         isCurrentCertificate = isCurrentCertificate,
@@ -265,7 +274,8 @@ class PersonDetailsViewModel @AssistedInject constructor(
             events.postValue(
                 OpenTestCertificateDetails(
                     containerId = certificate.containerId,
-                    colorShade = getItemColorShade(certificate.isDisplayValid, isCurrentCertificate)
+                    colorShade = getItemColorShade(certificate.isDisplayValid, isCurrentCertificate),
+                    isReissuance = isReissuance
                 )
             )
         },

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/details/RecoveryCertificateDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/recovery/ui/details/RecoveryCertificateDetailsFragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.widget.LinearLayout
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.net.toUri
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.navigation.fragment.findNavController
@@ -128,6 +129,7 @@ class RecoveryCertificateDetailsFragment : Fragment(R.layout.fragment_recovery_c
             certificate.headerExpiresAt.toLocalDateTimeUserTz().toShortDayFormat(),
             certificate.headerExpiresAt.toLocalDateTimeUserTz().toShortTimeFormat()
         )
+        expirationNotice.expirationInfoText.isVisible = !args.isReissuance
 
         expandedImage.setImageResource(certificate.expendedImageResource(args.colorShade))
         europaImage.setImageDrawable(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/TestCertificateDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/test/ui/details/TestCertificateDetailsFragment.kt
@@ -8,6 +8,7 @@ import android.widget.LinearLayout
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.net.toUri
 import androidx.core.view.isGone
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.navigation.fragment.findNavController
@@ -128,6 +129,7 @@ class TestCertificateDetailsFragment : Fragment(R.layout.fragment_test_certifica
             certificate.headerExpiresAt.toLocalDateTimeUserTz().toShortDayFormat(),
             certificate.headerExpiresAt.toLocalDateTimeUserTz().toShortTimeFormat()
         )
+        expirationNotice.expirationInfoText.isVisible = !args.isReissuance
 
         expandedImage.setImageResource(certificate.expendedImageResource(args.colorShade))
         europaImage.setImageDrawable(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/vaccination/ui/details/VaccinationDetailsFragment.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.widget.LinearLayout
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.net.toUri
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.navigation.fragment.findNavController
@@ -222,6 +223,7 @@ class VaccinationDetailsFragment : Fragment(R.layout.fragment_vaccination_detail
             certificate.headerExpiresAt.toLocalDateTimeUserTz().toShortDayFormat(),
             certificate.headerExpiresAt.toLocalDateTimeUserTz().toShortTimeFormat()
         )
+        expirationNotice.expirationInfoText.isVisible = !args.isReissuance
     }
 
     private fun setToolbarOverlay() {

--- a/Corona-Warn-App/src/main/res/navigation/covid_certificates_graph.xml
+++ b/Corona-Warn-App/src/main/res/navigation/covid_certificates_graph.xml
@@ -87,6 +87,11 @@
             android:defaultValue="COLOR_UNDEFINED"
             app:argType="de.rki.coronawarnapp.covidcertificate.person.ui.overview.PersonColorShade" />
 
+        <argument
+            android:name="isReissuance"
+            android:defaultValue="false"
+            app:argType="boolean" />
+
         <action
             android:id="@+id/action_testCertificateDetailsFragment_to_validationStartFragment"
             app:destination="@id/validationStartFragment" />
@@ -173,6 +178,11 @@
             android:defaultValue="COLOR_UNDEFINED"
             app:argType="de.rki.coronawarnapp.covidcertificate.person.ui.overview.PersonColorShade" />
 
+        <argument
+            android:name="isReissuance"
+            android:defaultValue="false"
+            app:argType="boolean" />
+
         <action
             android:id="@+id/action_vaccinationDetailsFragment_to_validationStartFragment"
             app:destination="@id/validationStartFragment" />
@@ -214,6 +224,11 @@
             android:name="colorShade"
             android:defaultValue="COLOR_UNDEFINED"
             app:argType="de.rki.coronawarnapp.covidcertificate.person.ui.overview.PersonColorShade" />
+
+        <argument
+            android:name="isReissuance"
+            android:defaultValue="false"
+            app:argType="boolean" />
 
         <action
             android:id="@+id/action_recoveryCertificateDetailsFragment_to_validationStartFragment"

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/details/PersonDetailsViewModelTest.kt
@@ -128,7 +128,8 @@ class PersonDetailsViewModelTest : BaseTest() {
                             onClick()
                             events.getOrAwaitValue() shouldBe OpenRecoveryCertificateDetails(
                                 rcContainerId,
-                                colorShade
+                                colorShade,
+                                false
                             )
                         }
 
@@ -136,7 +137,8 @@ class PersonDetailsViewModelTest : BaseTest() {
                             onClick()
                             events.getOrAwaitValue() shouldBe OpenTestCertificateDetails(
                                 tcsContainerId,
-                                PersonColorShade.COLOR_INVALID
+                                PersonColorShade.COLOR_INVALID,
+                                false
                             )
                         }
 
@@ -144,7 +146,8 @@ class PersonDetailsViewModelTest : BaseTest() {
                             onClick()
                             events.getOrAwaitValue() shouldBe OpenVaccinationCertificateDetails(
                                 vcContainerId,
-                                PersonColorShade.COLOR_INVALID
+                                PersonColorShade.COLOR_INVALID,
+                                false
                             )
                         }
 
@@ -152,7 +155,8 @@ class PersonDetailsViewModelTest : BaseTest() {
                             onClick()
                             events.getOrAwaitValue() shouldBe OpenVaccinationCertificateDetails(
                                 vcContainerId,
-                                PersonColorShade.COLOR_INVALID
+                                PersonColorShade.COLOR_INVALID,
+                                false
                             )
                         }
                     }


### PR DESCRIPTION
Hide expirationNotice for reissuance certificates on detail fragments

[Ticket](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13343)

How to test:
Generate Reissuance Certificates: cwa dcc series -e cf --preset 18 -o
On the certificate details screens there should be no detail text below the date of "Technisches Ablaufdatum"

[See Figma](https://www.figma.com/file/KuDEcMSREg3VhZRhC3FXTY/COVID19_Master_2.20?node-id=49842%3A40263)