### PR TITLE
Fix back navigation when coming from validity check (EXPOSUREAPP-13428)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/failed/DccValidationFailedFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/failed/DccValidationFailedFragment.kt
@@ -2,6 +2,7 @@ package de.rki.coronawarnapp.covidcertificate.validation.ui.validationresult.fai
 
 import android.os.Bundle
 import android.view.View
+import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import de.rki.coronawarnapp.R
@@ -51,11 +52,15 @@ class DccValidationFailedFragment : Fragment(R.layout.covid_certificate_validati
                 )
             }
 
-            toolbar.setNavigationOnClickListener { popBackStack() }
+            toolbar.setNavigationOnClickListener { popBackStackTwice() }
 
             appBarLayout.onOffsetChange { _, subtitleAlpha ->
                 headerImage.alpha = subtitleAlpha
             }
+        }
+
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+            popBackStackTwice()
         }
 
         viewModel.listItems.observe2(this) {
@@ -63,5 +68,10 @@ class DccValidationFailedFragment : Fragment(R.layout.covid_certificate_validati
         }
 
         super.onViewCreated(view, savedInstanceState)
+    }
+
+    private fun popBackStackTwice() {
+        popBackStack()
+        popBackStack()
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/open/DccValidationOpenFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/open/DccValidationOpenFragment.kt
@@ -2,6 +2,7 @@ package de.rki.coronawarnapp.covidcertificate.validation.ui.validationresult.ope
 
 import android.os.Bundle
 import android.view.View
+import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import de.rki.coronawarnapp.R
@@ -53,15 +54,24 @@ class DccValidationOpenFragment : Fragment(R.layout.covid_certificate_validation
                 )
             }
 
-            toolbar.setNavigationOnClickListener { popBackStack() }
+            toolbar.setNavigationOnClickListener { popBackStackTwice() }
 
             appBarLayout.onOffsetChange { _, subtitleAlpha ->
                 headerImage.alpha = subtitleAlpha
             }
         }
 
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+            popBackStackTwice()
+        }
+
         viewModel.listItems.observe2(this) {
             validationResultAdapter.update(it)
         }
+    }
+
+    private fun popBackStackTwice() {
+        popBackStack()
+        popBackStack()
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/passed/DccValidationPassedFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/passed/DccValidationPassedFragment.kt
@@ -2,6 +2,7 @@ package de.rki.coronawarnapp.covidcertificate.validation.ui.validationresult.pas
 
 import android.os.Bundle
 import android.view.View
+import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import de.rki.coronawarnapp.R
@@ -51,28 +52,30 @@ class DccValidationPassedFragment : Fragment(R.layout.covid_certificate_validati
                     )
                 }
 
-                toolbar.setNavigationOnClickListener { viewModel.onCloseClicked() }
+                toolbar.setNavigationOnClickListener {
+                    popBackStackTwice()
+                }
 
                 appBarLayout.onOffsetChange { _, subtitleAlpha ->
                     headerImage.alpha = subtitleAlpha
                 }
             }
 
-            checkAnotherCountryButton.setOnClickListener { viewModel.onCheckAnotherCountryClicked() }
+
+            checkAnotherCountryButton.setOnClickListener { popBackStack() }
+        }
+
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+            popBackStackTwice()
         }
 
         viewModel.items.observe2(this) {
             validationResultAdapter.update(it)
         }
-
-        viewModel.navigation.observe2(this) {
-            handleNavigation(it)
-        }
     }
 
-    private fun handleNavigation(navigation: DccValidationPassedNavigation) {
-        when (navigation) {
-            DccValidationPassedNavigation.Back -> popBackStack()
-        }
+    private fun popBackStackTwice() {
+        popBackStack()
+        popBackStack()
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/passed/DccValidationPassedFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/passed/DccValidationPassedFragment.kt
@@ -61,7 +61,6 @@ class DccValidationPassedFragment : Fragment(R.layout.covid_certificate_validati
                 }
             }
 
-
             checkAnotherCountryButton.setOnClickListener { popBackStack() }
         }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/passed/DccValidationPassedViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/passed/DccValidationPassedViewModel.kt
@@ -8,7 +8,6 @@ import de.rki.coronawarnapp.covidcertificate.validation.core.DccValidation
 import de.rki.coronawarnapp.covidcertificate.validation.ui.validationresult.common.ValidationResultItemCreator
 import de.rki.coronawarnapp.covidcertificate.validation.ui.validationresult.common.listitem.ValidationResultItem
 import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
-import de.rki.coronawarnapp.util.ui.SingleLiveEvent
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactory
 import kotlinx.coroutines.flow.flow
@@ -19,8 +18,6 @@ class DccValidationPassedViewModel @AssistedInject constructor(
     val itemCreator: ValidationResultItemCreator,
     dispatcherProvider: DispatcherProvider
 ) : CWAViewModel(dispatcherProvider = dispatcherProvider) {
-
-    val navigation = SingleLiveEvent<DccValidationPassedNavigation>()
 
     val items: LiveData<List<ValidationResultItem>> = flow {
         emit(generateItems())
@@ -49,16 +46,6 @@ class DccValidationPassedViewModel @AssistedInject constructor(
                 validationPassedHintVHItem()
             )
         }
-    }
-
-    fun onCheckAnotherCountryClicked() {
-        Timber.d("onCheckAnotherCountryClicked()")
-        navigation.postValue(DccValidationPassedNavigation.Back)
-    }
-
-    fun onCloseClicked() {
-        Timber.d("onCloseClicked()")
-        navigation.postValue(DccValidationPassedNavigation.Back)
     }
 
     @AssistedFactory


### PR DESCRIPTION
[Ticket](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13428)

When checking the validity we are either coming from the person details screen or the certificate details screen. When we go back from the result screen of the validity check, we need to skip over the validity check screen and land where we started from, hence the double popBackStack(). I've tried multiple methods but simply calling this function twice seems to work best, althogh I know it's not ideal.