### PR TITLE
Include an extra check before sending the booster notification (EXPOSUREAPP-13503)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ccl/dccwalletinfo/calculation/DccWalletInfoCalculationManager.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ccl/dccwalletinfo/calculation/DccWalletInfoCalculationManager.kt
@@ -92,7 +92,10 @@ class DccWalletInfoCalculationManager @Inject constructor(
                 oldWalletInfo = person.dccWalletInfo,
                 newWalletInfo = newWalletInfo
             )
-            Timber.d("The old dccWalletInfo was ${person.dccWalletInfo} and the booster id was ${person.dccWalletInfo?.boosterNotification?.identifier}")
+            Timber.d(
+                "The old dccWalletInfo was ${person.dccWalletInfo} and the booster id was " +
+                    "${person.dccWalletInfo?.boosterNotification?.identifier}"
+            )
         }
 
         dccWalletInfoRepository.save(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ccl/dccwalletinfo/calculation/DccWalletInfoCalculationManager.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ccl/dccwalletinfo/calculation/DccWalletInfoCalculationManager.kt
@@ -92,6 +92,7 @@ class DccWalletInfoCalculationManager @Inject constructor(
                 oldWalletInfo = person.dccWalletInfo,
                 newWalletInfo = newWalletInfo
             )
+            Timber.d("The old dccWalletInfo was ${person.dccWalletInfo} and the booster id was ${person.dccWalletInfo?.boosterNotification?.identifier}")
         }
 
         dccWalletInfoRepository.save(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/core/PersonCertificatesProvider.kt
@@ -108,10 +108,10 @@ class PersonCertificatesProvider @Inject constructor(
 
     private fun PersonSettings?.hasBoosterBadge(boosterNotification: BoosterNotification?): Boolean {
         if (boosterNotification == null || !boosterNotification.visible) return false
-        return hasBoosterRuleNotYetSeen(this, boosterNotification)
+        return hasNotSeenBoosterRuleYet(this, boosterNotification)
     }
 
-    private fun hasBoosterRuleNotYetSeen(
+    fun hasNotSeenBoosterRuleYet(
         personSettings: PersonSettings?,
         boosterNotification: BoosterNotification
     ) = personSettings?.lastSeenBoosterRuleIdentifier != boosterNotification.identifier


### PR DESCRIPTION
Should prevent notification spam in case the old dccWalletInfo is null.