### PR TITLE
Fix notification spam (EXPOSUREAPP-13503)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ccl/dccwalletinfo/calculation/DccWalletInfoCalculationManager.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ccl/dccwalletinfo/calculation/DccWalletInfoCalculationManager.kt
@@ -92,10 +92,6 @@ class DccWalletInfoCalculationManager @Inject constructor(
                 oldWalletInfo = person.dccWalletInfo,
                 newWalletInfo = newWalletInfo
             )
-            Timber.d(
-                "The old dccWalletInfo was ${person.dccWalletInfo} and the booster id was " +
-                    "${person.dccWalletInfo?.boosterNotification?.identifier}"
-            )
         }
 
         dccWalletInfoRepository.save(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ccl/dccwalletinfo/update/DccWalletInfoUpdateTrigger.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ccl/dccwalletinfo/update/DccWalletInfoUpdateTrigger.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChangedBy
-import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -35,7 +34,6 @@ class DccWalletInfoUpdateTrigger @Inject constructor(
     init {
         appScope.launch {
             personCertificateProvider.personCertificates
-                .drop(1)
                 /*
                  Compare persons emissions certificates by using its hash. Changes in certificates set such as
                  registering, recycling, restoring, retrieving and, re-issuing a DCC will lead to a difference in the

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/booster/BoosterNotificationService.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/booster/BoosterNotificationService.kt
@@ -4,11 +4,9 @@ import de.rki.coronawarnapp.ccl.dccwalletinfo.model.DccWalletInfo
 import de.rki.coronawarnapp.ccl.dccwalletinfo.notification.DccWalletInfoNotificationService
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CertificatePersonIdentifier
 import de.rki.coronawarnapp.covidcertificate.notification.PersonNotificationSender
-import de.rki.coronawarnapp.covidcertificate.person.core.PersonCertificatesProvider
 import de.rki.coronawarnapp.covidcertificate.person.core.PersonCertificatesSettings
 import de.rki.coronawarnapp.tag
 import de.rki.coronawarnapp.util.TimeStamper
-import kotlinx.coroutines.flow.first
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -16,7 +14,6 @@ import javax.inject.Singleton
 @Singleton
 class BoosterNotificationService @Inject constructor(
     private val personNotificationSender: PersonNotificationSender,
-    private val personCertificatesProvider: PersonCertificatesProvider,
     private val timeStamper: TimeStamper,
     private val personCertificatesSettings: PersonCertificatesSettings,
 ) : DccWalletInfoNotificationService {
@@ -49,24 +46,14 @@ class BoosterNotificationService @Inject constructor(
 
         if (newRuleId != oldRuleId) {
             Timber.tag(TAG).d("Notifying person=%s about rule=%s", codeSHA256, newRuleId)
-            val personSettings = personCertificatesSettings.personsSettings.first()
-            val settingsForPerson = personSettings[personIdentifier]
-            if (personCertificatesProvider.hasNotSeenBoosterRuleYet(
-                    settingsForPerson,
-                    newWalletInfo.boosterNotification
-                )
-            ) {
-                personNotificationSender.showNotification(
-                    personIdentifier = personIdentifier,
-                    type = notificationSenderType
-                )
-                // Clears booster rule last seen badge, to be shown in conjunction with notification
-                personCertificatesSettings.clearBoosterRuleInfo(personIdentifier)
-                personCertificatesSettings.setBoosterNotifiedAt(personIdentifier, timeStamper.nowUTC)
-                Timber.tag(TAG).d("Person %s notified about booster rule change", codeSHA256)
-            } else {
-                Timber.tag(TAG).d("Person %s shouldn't be notified about booster rule=%s", codeSHA256, newRuleId)
-            }
+            personNotificationSender.showNotification(
+                personIdentifier = personIdentifier,
+                type = notificationSenderType
+            )
+            // Clears booster rule last seen badge, to be shown in conjunction with notification
+            personCertificatesSettings.clearBoosterRuleInfo(personIdentifier)
+            personCertificatesSettings.setBoosterNotifiedAt(personIdentifier, timeStamper.nowUTC)
+            Timber.tag(TAG).d("Person %s notified about booster rule change", codeSHA256)
         } else {
             Timber.tag(TAG).d("Person %s shouldn't be notified about booster rule=%s", codeSHA256, newRuleId)
         }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ccl/dccwalletinfo/calculation/DccWalletInfoCalculationManagerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ccl/dccwalletinfo/calculation/DccWalletInfoCalculationManagerTest.kt
@@ -112,8 +112,6 @@ class DccWalletInfoCalculationManagerTest : BaseTest() {
 
     @Test
     fun `calculation runs for each person after certificate change`() = runTest {
-        every { dccWalletInfo1.boosterNotification.identifier } returns "1"
-        every { dccWalletInfo2.boosterNotification.identifier } returns "2"
         every { certificatesPersonA.dccWalletInfo } returns dccWalletInfo1
         every { certificatesPersonB.dccWalletInfo } returns dccWalletInfo2
 
@@ -132,8 +130,6 @@ class DccWalletInfoCalculationManagerTest : BaseTest() {
 
     @Test
     fun `calculation runs for each person after config change`() = runTest {
-        every { dccWalletInfo1.boosterNotification.identifier } returns "1"
-        every { dccWalletInfo2.boosterNotification.identifier } returns "2"
         every { certificatesPersonA.dccWalletInfo } returns dccWalletInfo1
         every { certificatesPersonB.dccWalletInfo } returns dccWalletInfo2
         instance.triggerAfterConfigChange("")
@@ -179,8 +175,6 @@ class DccWalletInfoCalculationManagerTest : BaseTest() {
 
     @Test
     fun `calculation runs for each person with invalid walletInfo`() = runTest {
-        every { dccWalletInfo1.boosterNotification.identifier } returns "1"
-        every { dccWalletInfo2.boosterNotification.identifier } returns "2"
         every { certificatesPersonA.dccWalletInfo } returns dccWalletInfo1
         every { certificatesPersonB.dccWalletInfo } returns dccWalletInfo2
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ccl/dccwalletinfo/update/DccWalletInfoUpdateTriggerTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ccl/dccwalletinfo/update/DccWalletInfoUpdateTriggerTest.kt
@@ -114,7 +114,7 @@ internal class DccWalletInfoUpdateTriggerTest : BaseTest() {
 
         delay(1_100L)
 
-        coVerify(exactly = 0) {
+        coVerify(exactly = 1) {
             dccWalletInfoCalculationManager.triggerNow(any())
             dccWalletInfoCleaner.clean()
         }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/booster/BoosterNotificationServiceTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/booster/BoosterNotificationServiceTest.kt
@@ -5,9 +5,7 @@ import de.rki.coronawarnapp.ccl.dccwalletinfo.model.BoosterNotification
 import de.rki.coronawarnapp.ccl.dccwalletinfo.model.DccWalletInfo
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CertificatePersonIdentifier
 import de.rki.coronawarnapp.covidcertificate.notification.PersonNotificationSender
-import de.rki.coronawarnapp.covidcertificate.person.core.PersonCertificatesProvider
 import de.rki.coronawarnapp.covidcertificate.person.core.PersonCertificatesSettings
-import de.rki.coronawarnapp.covidcertificate.person.model.PersonSettings
 import de.rki.coronawarnapp.util.TimeStamper
 import io.mockk.Called
 import io.mockk.MockKAnnotations
@@ -18,7 +16,6 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.just
 import io.mockk.verify
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.joda.time.Instant
 import org.junit.jupiter.api.BeforeEach
@@ -31,8 +28,6 @@ class BoosterNotificationServiceTest : BaseTest() {
     @MockK lateinit var personNotificationSender: PersonNotificationSender
     @MockK lateinit var timeStamper: TimeStamper
     @MockK lateinit var personCertificatesSettings: PersonCertificatesSettings
-    @MockK lateinit var personCertificatesProvider: PersonCertificatesProvider
-    @MockK lateinit var personSettings: PersonSettings
 
     @MockK lateinit var oldWalletInfo: DccWalletInfo
     @MockK lateinit var newWalletInfo: DccWalletInfo
@@ -48,8 +43,6 @@ class BoosterNotificationServiceTest : BaseTest() {
 
         coEvery { personCertificatesSettings.setBoosterNotifiedAt(any(), any()) } just Runs
         coEvery { personCertificatesSettings.clearBoosterRuleInfo(any()) } just Runs
-        coEvery { personCertificatesSettings.personsSettings } returns flowOf(emptyMap())
-        coEvery { personCertificatesProvider.hasNotSeenBoosterRuleYet(any(), any()) } returns true
 
         every { oldWalletInfo.boosterNotification } returns oldBoosterNotification
         every { newWalletInfo.boosterNotification } returns newBoosterNotification
@@ -59,7 +52,6 @@ class BoosterNotificationServiceTest : BaseTest() {
         personNotificationSender = personNotificationSender,
         personCertificatesSettings = personCertificatesSettings,
         timeStamper = timeStamper,
-        personCertificatesProvider = personCertificatesProvider
     )
 
     @Test


### PR DESCRIPTION
Spam was caused by wrong grouping of certificates where some users had slight name variations and had certificates that were eligible for booster. The previous grouping caused the `dccWalletInfo` to always be null, triggering a recalculation of the wallet each time the app started or the background worker was performing it's task, subsequently triggering the booster notification over and over again.