### PR TITLE
Revert navigation changes from (EXPOSUREAPP-12901)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/familytest/ui/selection/TestRegistrationSelectionFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/familytest/ui/selection/TestRegistrationSelectionFragment.kt
@@ -3,6 +3,7 @@ package de.rki.coronawarnapp.familytest.ui.selection
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
+import androidx.navigation.NavOptions
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import de.rki.coronawarnapp.R
@@ -27,6 +28,7 @@ class TestRegistrationSelectionFragment : Fragment(R.layout.fragment_test_regist
         }
     )
     private val binding: FragmentTestRegistrationSelectionBinding by viewBinding()
+    private val navOptions = NavOptions.Builder().setPopUpTo(R.id.testRegistrationSelectionFragment, true).build()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -41,7 +43,8 @@ class TestRegistrationSelectionFragment : Fragment(R.layout.fragment_test_regist
                         TestRegistrationSelectionFragmentDirections
                             .actionTestRegistrationSelectionFragmentToSubmissionConsentFragment(
                                 coronaTestQrCode = it.coronaTestQRCode
-                            )
+                            ),
+                        navOptions
                     )
                 }
                 is TestRegistrationSelectionNavigationEvents.NavigateToDeletionWarning -> {
@@ -58,7 +61,8 @@ class TestRegistrationSelectionFragment : Fragment(R.layout.fragment_test_regist
                         TestRegistrationSelectionFragmentDirections
                             .actionTestRegistrationSelectionFragmentToFamilyTestConsentFragment(
                                 coronaTestQrCode = it.coronaTestQRCode
-                            )
+                            ),
+                        navOptions
                     )
                 }
             }

--- a/Corona-Warn-App/src/main/res/layout/fragment_family_test_consent.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_family_test_consent.xml
@@ -9,7 +9,7 @@
 
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar"
-        style="@style/CWAMaterialToolbar.BackArrow.Transparent"
+        style="@style/CWAMaterialToolbar.Close.Transparent"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_consent.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_consent.xml
@@ -21,7 +21,7 @@
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/submission_consent_header"
-            style="@style/CWAMaterialToolbar.BackArrow"
+            style="@style/CWAMaterialToolbar.Close"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
Requested changes from [Ticket](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12901) merged in [PR](https://github.com/corona-warn-app/cwa-app-android/pull/5323) require to have a more complex implementation of the current navigation graph, so current changes are rolled back in this PR.
Requested changes will be implemented in 2.26. release cycle