### PR TITLE
Remove fake exposure window without scanInstances (EXPOSUREAPP-12169)

### DIFF
--- a/Corona-Warn-App/src/deviceForTesters/assets/exposure-windows-increased-risk-random.json
+++ b/Corona-Warn-App/src/deviceForTesters/assets/exposure-windows-increased-risk-random.json
@@ -643,13 +643,6 @@
     "ageInDays": 1,
     "calibrationConfidence": 0,
     "infectiousness": 2,
-    "reportType": 2,
-    "scanInstances": []
-  },
-  {
-    "ageInDays": 1,
-    "calibrationConfidence": 0,
-    "infectiousness": 2,
     "reportType": 3,
     "scanInstances": [
       {


### PR DESCRIPTION
When ExposureWindows without scanInstances are sent, server can't handle and reacts with a 500 server error. 
Maybe thats the issue why ExposureWindows are not inserted into testdata