### PR TITLE
"2G+"-function shows vaccination certificate although "Test Certificate" is highlighted (EXPOSUREAPP-12158)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragmentTest.kt
@@ -2,6 +2,7 @@ package de.rki.coronawarnapp.covidcertificate.person.ui.overview
 
 import androidx.annotation.IdRes
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModelStore
 import androidx.navigation.testing.TestNavHostController
 import androidx.test.core.app.ApplicationProvider
@@ -85,7 +86,10 @@ class PersonOverviewFragmentTest : BaseUITest() {
         )
         setupMockViewModel(
             object : PersonOverviewViewModel.Factory {
-                override fun create(admissionScenariosSharedViewModel: AdmissionScenariosSharedViewModel): PersonOverviewViewModel {
+                override fun create(
+                    admissionScenariosSharedViewModel: AdmissionScenariosSharedViewModel,
+                    savedStateHandle: SavedStateHandle
+                ): PersonOverviewViewModel {
                     return viewModel
                 }
             }
@@ -253,7 +257,8 @@ class PersonOverviewFragmentTest : BaseUITest() {
                     colorShade = PersonColorShade.COLOR_1,
                     badgeCount = 0,
                     onClickAction = { _, _ -> },
-                    onCovPassInfoAction = {}
+                    onCovPassInfoAction = {},
+                    onCertificateSelected = {},
                 )
             )
         }
@@ -283,7 +288,8 @@ class PersonOverviewFragmentTest : BaseUITest() {
                     colorShade = PersonColorShade.COLOR_1,
                     badgeCount = 0,
                     onClickAction = { _, _ -> },
-                    onCovPassInfoAction = {}
+                    onCovPassInfoAction = {},
+                    onCertificateSelected = {},
                 )
             )
         }
@@ -305,7 +311,8 @@ class PersonOverviewFragmentTest : BaseUITest() {
                     colorShade = PersonColorShade.COLOR_1,
                     badgeCount = 5,
                     onClickAction = { _, _ -> },
-                    onCovPassInfoAction = {}
+                    onCovPassInfoAction = {},
+                    onCertificateSelected = {},
                 )
             )
 
@@ -324,7 +331,8 @@ class PersonOverviewFragmentTest : BaseUITest() {
                     colorShade = PersonColorShade.COLOR_2,
                     badgeCount = 3,
                     onClickAction = { _, _ -> },
-                    onCovPassInfoAction = {}
+                    onCovPassInfoAction = {},
+                    onCertificateSelected = {},
                 )
             )
 
@@ -343,7 +351,8 @@ class PersonOverviewFragmentTest : BaseUITest() {
                     colorShade = PersonColorShade.COLOR_3,
                     badgeCount = 0,
                     onClickAction = { _, _ -> },
-                    onCovPassInfoAction = {}
+                    onCovPassInfoAction = {},
+                    onCertificateSelected = {},
                 )
             )
         }
@@ -365,7 +374,8 @@ class PersonOverviewFragmentTest : BaseUITest() {
                     colorShade = PersonColorShade.COLOR_1,
                     badgeCount = 0,
                     onClickAction = { _, _ -> },
-                    onCovPassInfoAction = {}
+                    onCovPassInfoAction = {},
+                    onCertificateSelected = {},
                 )
             )
         }
@@ -387,7 +397,8 @@ class PersonOverviewFragmentTest : BaseUITest() {
                     colorShade = PersonColorShade.COLOR_1,
                     badgeCount = 1,
                     onClickAction = { _, _ -> },
-                    onCovPassInfoAction = {}
+                    onCovPassInfoAction = {},
+                    onCertificateSelected = {},
                 )
             )
         }
@@ -416,7 +427,8 @@ class PersonOverviewFragmentTest : BaseUITest() {
                     colorShade = PersonColorShade.COLOR_1,
                     badgeCount = 0,
                     onClickAction = { _, _ -> },
-                    onCovPassInfoAction = {}
+                    onCovPassInfoAction = {},
+                    onCertificateSelected = {},
                 )
             )
         }
@@ -452,7 +464,8 @@ class PersonOverviewFragmentTest : BaseUITest() {
                     colorShade = PersonColorShade.COLOR_1,
                     badgeCount = 0,
                     onClickAction = { _, _ -> },
-                    onCovPassInfoAction = {}
+                    onCovPassInfoAction = {},
+                    onCertificateSelected = {},
                 )
             )
         }
@@ -481,7 +494,8 @@ class PersonOverviewFragmentTest : BaseUITest() {
                     colorShade = PersonColorShade.COLOR_1,
                     badgeCount = 1,
                     onClickAction = { _, _ -> },
-                    onCovPassInfoAction = {}
+                    onCovPassInfoAction = {},
+                    onCertificateSelected = {},
                 )
             )
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragment.kt
@@ -30,7 +30,6 @@ import de.rki.coronawarnapp.util.viewmodel.cwaViewModelsAssisted
 import timber.log.Timber
 import javax.inject.Inject
 
-// Shows a list of multiple persons
 class PersonOverviewFragment : Fragment(R.layout.person_overview_fragment), AutoInject {
     @Inject lateinit var viewModelFactory: CWAViewModelFactoryProvider.Factory
     private val admissionViewModel by navGraphViewModels<AdmissionScenariosSharedViewModel>(
@@ -38,10 +37,11 @@ class PersonOverviewFragment : Fragment(R.layout.person_overview_fragment), Auto
     )
     private val viewModel: PersonOverviewViewModel by cwaViewModelsAssisted(
         factoryProducer = { viewModelFactory },
-        constructorCall = { factory, _ ->
+        constructorCall = { factory, savedState ->
             factory as PersonOverviewViewModel.Factory
             factory.create(
-                admissionScenariosSharedViewModel = admissionViewModel
+                admissionScenariosSharedViewModel = admissionViewModel,
+                savedState = savedState
             )
         }
     )
@@ -78,6 +78,7 @@ class PersonOverviewFragment : Fragment(R.layout.person_overview_fragment), Auto
                     navigatorExtras
                 )
             }
+
             is ShowDeleteDialog -> MaterialAlertDialogBuilder(requireContext())
                 .setTitle(R.string.test_certificate_delete_dialog_title)
                 .setMessage(R.string.test_certificate_delete_dialog_body)
@@ -170,6 +171,7 @@ class PersonOverviewFragment : Fragment(R.layout.person_overview_fragment), Auto
                 personOverviewAdapter.update(uiState.personCertificates)
                 loadingLayoutGroup.isVisible = false
             }
+
             PersonOverviewViewModel.UiState.Loading -> {
                 recyclerView.isGone = true
                 emptyLayout.isGone = true

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewViewModel.kt
@@ -121,7 +121,6 @@ class PersonOverviewViewModel @AssistedInject constructor(
                     selectedCertificates.update { it.mutate { put(person.personIdentifier, selection) } }
                 }
             )
-
         }
 
     private fun MutableList<PersonCertificatesItem>.addPendingCards(tcWrappers: Set<TestCertificateWrapper>) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewViewModel.kt
@@ -118,9 +118,7 @@ class PersonOverviewViewModel @AssistedInject constructor(
                 },
                 onCovPassInfoAction = { events.postValue(OpenCovPassInfo) },
                 onCertificateSelected = { selection ->
-                    selectedCertificates.update { map ->
-                        map.mutate { put(person.personIdentifier, selection) }
-                    }
+                    selectedCertificates.update { it.mutate { put(person.personIdentifier, selection) } }
                 }
             )
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/items/PersonCertificateCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/items/PersonCertificateCard.kt
@@ -26,14 +26,7 @@ class PersonCertificateCard(parent: ViewGroup) :
         val curItem = payloads.filterIsInstance<Item>().lastOrNull() ?: item
 
         val firstCertificate = curItem.overviewCertificates[0]
-
-        setUIState(
-            certificateItems = curItem.overviewCertificates.take(3),
-            colorShade = curItem.colorShade,
-            statusBadgeText = curItem.admissionBadgeText,
-            badgeCount = curItem.badgeCount,
-            onCovPassInfoAction = curItem.onCovPassInfoAction,
-        )
+        setUIState(curItem)
 
         itemView.apply {
             setOnClickListener { curItem.onClickAction(curItem, bindingAdapterPosition) }
@@ -46,10 +39,12 @@ class PersonCertificateCard(parent: ViewGroup) :
         val primaryCertificateText: String = "",
         val secondaryCertificateText: String = "",
         val admissionBadgeText: String = "",
+        val certificateSelection: CertificateSelection = CertificateSelection.FIRST,
         val colorShade: PersonColorShade,
         val badgeCount: Int,
         val onClickAction: (Item, Int) -> Unit,
-        val onCovPassInfoAction: () -> Unit
+        val onCovPassInfoAction: () -> Unit,
+        val onCertificateSelected: (certificateSelection: CertificateSelection) -> Unit,
     ) : PersonCertificatesItem, HasPayloadDiffer {
         override val stableId: Long =
             overviewCertificates[0].cwaCertificate.personIdentifier.hashCode().toLong()
@@ -58,5 +53,11 @@ class PersonCertificateCard(parent: ViewGroup) :
             val cwaCertificate: CwaCovidCertificate,
             val buttonText: String = ""
         )
+
+        enum class CertificateSelection {
+            FIRST,
+            SECOND,
+            THIRD
+        }
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CertificateStateHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CertificateStateHelper.kt
@@ -22,6 +22,7 @@ import de.rki.coronawarnapp.covidcertificate.common.certificate.getValidQrCode
 import de.rki.coronawarnapp.covidcertificate.person.ui.overview.PersonColorShade
 import de.rki.coronawarnapp.covidcertificate.person.ui.overview.items.PersonCertificateCard
 import de.rki.coronawarnapp.covidcertificate.person.ui.overview.items.PersonCertificateCard.Item.CertificateSelection
+import de.rki.coronawarnapp.covidcertificate.person.ui.overview.items.PersonCertificateCard.Item.OverviewCertificate
 import de.rki.coronawarnapp.covidcertificate.recovery.core.RecoveryCertificate
 import de.rki.coronawarnapp.covidcertificate.test.core.TestCertificate
 import de.rki.coronawarnapp.covidcertificate.vaccination.core.VaccinationCertificate
@@ -175,9 +176,9 @@ fun PersonOverviewItemBinding.setUIState(
 }
 
 private fun IncludeCertificateOverviewQrCardBinding.bindButtonToggleGroup(
-    secondCertificate: PersonCertificateCard.Item.OverviewCertificate?,
-    thirdCertificate: PersonCertificateCard.Item.OverviewCertificate?,
-    firstCertificate: PersonCertificateCard.Item.OverviewCertificate,
+    secondCertificate: OverviewCertificate?,
+    thirdCertificate: OverviewCertificate?,
+    firstCertificate: OverviewCertificate,
     item: PersonCertificateCard.Item
 ) {
     certificateToggleGroup.isVisible = secondCertificate != null || thirdCertificate != null
@@ -237,7 +238,7 @@ private fun IncludeCertificateOverviewQrCardBinding.loadQrImage(certificate: Cwa
 
 private fun setButton(
     button: MaterialButton,
-    certificate: PersonCertificateCard.Item.OverviewCertificate?,
+    certificate: OverviewCertificate?,
     typeface: Typeface = Typeface.DEFAULT,
 ) {
     if (certificate?.buttonText == null) {

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewViewModelTest.kt
@@ -1,5 +1,6 @@
 package de.rki.coronawarnapp.covidcertificate.person.ui.overview
 
+import androidx.lifecycle.SavedStateHandle
 import de.rki.coronawarnapp.ccl.dccadmission.calculation.DccAdmissionCheckScenariosCalculation
 import de.rki.coronawarnapp.ccl.dccwalletinfo.calculation.CclJsonFunctions
 import de.rki.coronawarnapp.ccl.ui.text.CclTextFormatter
@@ -296,6 +297,7 @@ class PersonOverviewViewModelTest : BaseTest() {
             admissionCheckScenariosCalculation = admissionCheckScenariosCalculation,
             dccAdmissionTileProvider = admissionTileProvider,
             migrationCheck = migrationCheck,
-            onboardingSettings = onboardingSettings
+            onboardingSettings = onboardingSettings,
+            savedState = SavedStateHandle()
         )
 }


### PR DESCRIPTION
This PR moved certificates toggle selection logic to view model to preserve the state when view is destroyed and then restored.

## How to test?
1- Scan some certificates where many persons should have certificates toggle (VC + TC)
2- From `Developer options` , switch on `Don't keep activities`
3- Keep CWA open on the certificates tab and put in the background 
4- Open many other Apps 
5- Return back to CWA 
6- Certificates Toggle selection should stay as is in step 3  and right certificate should be synced with the checked button

[Ticket](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12158)