### PR TITLE
Fix back navigation for UQS when opened from dispatcher fragment (EXPOSUREAPP-10004)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/fragment/SubmissionDispatcherFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/fragment/SubmissionDispatcherFragment.kt
@@ -5,7 +5,6 @@ import android.view.View
 import android.view.accessibility.AccessibilityEvent
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavGraph
-import androidx.navigation.NavOptions
 import androidx.navigation.fragment.FragmentNavigatorExtras
 import androidx.navigation.fragment.findNavController
 import de.rki.coronawarnapp.R
@@ -70,13 +69,10 @@ class SubmissionDispatcherFragment : Fragment(R.layout.fragment_submission_dispa
         val dispatcherCard = binding.submissionDispatcherQr.dispatcherCard.apply {
             transitionName = "shared_element_container"
         }
-        val navOptions = NavOptions.Builder()
-            .setPopUpTo(R.id.mainFragment, false)
-            .build()
         findNavController().navigate(
             R.id.action_to_universal_scanner,
             null,
-            navOptions,
+            null,
             FragmentNavigatorExtras(dispatcherCard to dispatcherCard.transitionName)
         )
     }


### PR DESCRIPTION
[Ticket](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-10004)

Open the UQS from the dispatccher fragment. Close is or press the OS back button -> you should land on the dispatcher fragment and not the home screen.