### PR TITLE
Register test back navigation (EXPOSUREAPP-12901)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/familytest/ui/consent/FamilyTestConsentFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/familytest/ui/consent/FamilyTestConsentFragment.kt
@@ -3,6 +3,7 @@ package de.rki.coronawarnapp.familytest.ui.consent
 import android.os.Bundle
 import android.view.View
 import android.view.inputmethod.EditorInfo
+import androidx.activity.OnBackPressedCallback
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavOptions
@@ -42,9 +43,23 @@ class FamilyTestConsentFragment : Fragment(R.layout.fragment_family_test_consent
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                viewModel.onNavigateBack()
+            }
+        })
+
         viewModel.routeToScreen.observe2(this) {
             when (it) {
                 is FamilyTestConsentNavigationEvents.NavigateBack -> {
+                    binding.root.hideKeyboard()
+                    doNavigate(
+                        FamilyTestConsentFragmentDirections.actionFamilyTestConsentFragmentToTestRegistrationSelectionFragment(
+                            navArgs.coronaTestQrCode
+                        )
+                    )
+                }
+                is FamilyTestConsentNavigationEvents.NavigateClose -> {
                     binding.root.hideKeyboard()
                     popBackStack()
                 }
@@ -110,7 +125,7 @@ class FamilyTestConsentFragment : Fragment(R.layout.fragment_family_test_consent
             }
             nameInputEdit.setText(qrcodeSharedViewModel.familyTestPersonName)
             toolbar.setNavigationOnClickListener {
-                viewModel.onNavigateBack()
+                viewModel.onNavigateClose()
             }
             dataPrivacy.setOnClickListener {
                 viewModel.onDataPrivacyClick()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/familytest/ui/consent/FamilyTestConsentFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/familytest/ui/consent/FamilyTestConsentFragment.kt
@@ -43,20 +43,24 @@ class FamilyTestConsentFragment : Fragment(R.layout.fragment_family_test_consent
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, object : OnBackPressedCallback(true) {
-            override fun handleOnBackPressed() {
-                viewModel.onNavigateBack()
+        requireActivity().onBackPressedDispatcher.addCallback(
+            viewLifecycleOwner,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    viewModel.onNavigateBack()
+                }
             }
-        })
+        )
 
         viewModel.routeToScreen.observe2(this) {
             when (it) {
                 is FamilyTestConsentNavigationEvents.NavigateBack -> {
                     binding.root.hideKeyboard()
                     doNavigate(
-                        FamilyTestConsentFragmentDirections.actionFamilyTestConsentFragmentToTestRegistrationSelectionFragment(
-                            navArgs.coronaTestQrCode
-                        )
+                        FamilyTestConsentFragmentDirections
+                            .actionFamilyTestConsentFragmentToTestRegistrationSelectionFragment(
+                                navArgs.coronaTestQrCode
+                            )
                     )
                 }
                 is FamilyTestConsentNavigationEvents.NavigateClose -> {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/familytest/ui/consent/FamilyTestConsentNavigationEvents.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/familytest/ui/consent/FamilyTestConsentNavigationEvents.kt
@@ -14,4 +14,6 @@ sealed class FamilyTestConsentNavigationEvents {
     object NavigateToDataPrivacy : FamilyTestConsentNavigationEvents()
 
     object NavigateBack : FamilyTestConsentNavigationEvents()
+
+    object NavigateClose : FamilyTestConsentNavigationEvents()
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/familytest/ui/consent/FamilyTestConsentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/familytest/ui/consent/FamilyTestConsentViewModel.kt
@@ -42,6 +42,10 @@ class FamilyTestConsentViewModel @AssistedInject constructor(
         routeToScreen.postValue(FamilyTestConsentNavigationEvents.NavigateBack)
     }
 
+    fun onNavigateClose() {
+        routeToScreen.postValue(FamilyTestConsentNavigationEvents.NavigateClose)
+    }
+
     fun onConsentButtonClick() = launch {
         val personName = personName.first()
         familyTestCensor.addName(personName)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/familytest/ui/selection/TestRegistrationSelectionFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/familytest/ui/selection/TestRegistrationSelectionFragment.kt
@@ -8,6 +8,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.FragmentTestRegistrationSelectionBinding
+import de.rki.coronawarnapp.ui.submission.qrcode.consent.SubmissionConsentBackNavArg.BackToTestRegistrationSelection
 import de.rki.coronawarnapp.util.di.AutoInject
 import de.rki.coronawarnapp.util.ui.observe2
 import de.rki.coronawarnapp.util.ui.popBackStack
@@ -42,7 +43,8 @@ class TestRegistrationSelectionFragment : Fragment(R.layout.fragment_test_regist
                     findNavController().navigate(
                         TestRegistrationSelectionFragmentDirections
                             .actionTestRegistrationSelectionFragmentToSubmissionConsentFragment(
-                                coronaTestQrCode = it.coronaTestQRCode
+                                coronaTestQrCode = it.coronaTestQRCode,
+                                navigateBackTo = BackToTestRegistrationSelection
                             ),
                         navOptions
                     )

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/consent/SubmissionConsentBackNavArg.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/consent/SubmissionConsentBackNavArg.kt
@@ -1,0 +1,9 @@
+package de.rki.coronawarnapp.ui.submission.qrcode.consent
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+sealed class SubmissionConsentBackNavArg : Parcelable {
+    object BackToTestRegistrationSelection : SubmissionConsentBackNavArg()
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/consent/SubmissionConsentBackNavArg.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/consent/SubmissionConsentBackNavArg.kt
@@ -1,9 +1,11 @@
 package de.rki.coronawarnapp.ui.submission.qrcode.consent
 
+import android.annotation.SuppressLint
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
+@SuppressLint("ParcelCreator")
 sealed class SubmissionConsentBackNavArg : Parcelable {
     object BackToTestRegistrationSelection : SubmissionConsentBackNavArg()
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/consent/SubmissionConsentFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/consent/SubmissionConsentFragment.kt
@@ -5,6 +5,8 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.view.accessibility.AccessibilityEvent
+import androidx.activity.OnBackPressedCallback
+import de.rki.coronawarnapp.ui.submission.qrcode.consent.SubmissionConsentBackNavArg.BackToTestRegistrationSelection
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.findNavController
@@ -41,7 +43,20 @@ class SubmissionConsentFragment : Fragment(R.layout.fragment_submission_consent)
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.viewModel = viewModel
-        binding.submissionConsentHeader.setNavigationOnClickListener { popBackStack() }
+        binding.submissionConsentHeader.setNavigationOnClickListener { viewModel.onNavigateClose() }
+
+        requireActivity().onBackPressedDispatcher.addCallback(
+            viewLifecycleOwner,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    when (navArgs.navigateBackTo) {
+                        is BackToTestRegistrationSelection -> viewModel.navigateBackToTestRegistration()
+                        else -> viewModel.onNavigateClose()
+                    }
+                }
+            }
+        )
+
         viewModel.routeToScreen.observe2(this) {
             when (it) {
                 is SubmissionNavigationEvents.NavigateToDataPrivacy -> doNavigate(
@@ -60,6 +75,13 @@ class SubmissionConsentFragment : Fragment(R.layout.fragment_submission_consent)
                         allowTestReplacement = it.allowReplacement
                     ),
                     navOptions
+                )
+                is SubmissionNavigationEvents.NavigateClose -> popBackStack()
+                is SubmissionNavigationEvents.NavigateBackToTestRegistration -> doNavigate(
+                    SubmissionConsentFragmentDirections
+                        .actionSubmissionConsentFragmentToTestRegistrationSelectionFragment(
+                            navArgs.coronaTestQrCode
+                        )
                 )
                 else -> Unit
             }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/consent/SubmissionConsentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/qrcode/consent/SubmissionConsentViewModel.kt
@@ -71,6 +71,14 @@ class SubmissionConsentViewModel @AssistedInject constructor(
         routeToScreen.postValue(SubmissionNavigationEvents.NavigateToDataPrivacy)
     }
 
+    fun navigateBackToTestRegistration() {
+        routeToScreen.postValue(SubmissionNavigationEvents.NavigateBackToTestRegistration)
+    }
+
+    fun onNavigateClose() {
+        routeToScreen.postValue(SubmissionNavigationEvents.NavigateClose)
+    }
+
     fun giveGoogleConsentResult(accepted: Boolean) = launch {
         Timber.i("User allowed Google consent:$accepted")
         // Navigate regardless of consent result

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/viewmodel/SubmissionNavigationEvents.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/viewmodel/SubmissionNavigationEvents.kt
@@ -36,4 +36,8 @@ sealed class SubmissionNavigationEvents {
     data class ResolvePlayServicesException(val exception: ApiException) : SubmissionNavigationEvents()
 
     object OpenTestCenterUrl : SubmissionNavigationEvents()
+
+    object NavigateBackToTestRegistration : SubmissionNavigationEvents()
+
+    object NavigateClose : SubmissionNavigationEvents()
 }

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_consent.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_consent.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
@@ -17,7 +18,8 @@
         android:id="@+id/content_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/colorSurface">
+        android:background="@color/colorSurface"
+        tools:context="ui.submission.qrcode.consent.SubmissionConsentFragment">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/submission_consent_header"

--- a/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
+++ b/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
@@ -369,6 +369,13 @@
         <action
             android:id="@+id/action_submissionConsentFragment_to_informationPrivacyFragment"
             app:destination="@id/informationPrivacyFragment" />
+
+        <action
+            android:id="@+id/action_submissionConsentFragment_to_testRegistrationSelectionFragment"
+            app:destination="@id/testRegistrationSelectionFragment"
+            app:popUpTo="@id/mainFragment"
+            app:popUpToInclusive="false" />
+
         <argument
             android:name="coronaTestQrCode"
             app:argType="de.rki.coronawarnapp.coronatest.qrcode.CoronaTestQRCode" />
@@ -506,6 +513,12 @@
         <action
             android:id="@+id/action_familyTestConsentFragment_to_informationPrivacyFragment"
             app:destination="@id/informationPrivacyFragment" />
+
+        <action
+            android:id="@+id/action_familyTestConsentFragment_to_testRegistrationSelectionFragment"
+            app:destination="@id/testRegistrationSelectionFragment"
+            app:popUpTo="@id/mainFragment"
+            app:popUpToInclusive="false" />
 
     </fragment>
 

--- a/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
+++ b/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
@@ -71,7 +71,8 @@
         android:id="@+id/action_submissionConsentFragment"
         app:destination="@id/submissionConsentFragment"
         app:popUpTo="@id/mainFragment"
-        app:popUpToInclusive="false" />
+        app:popUpToInclusive="false"
+        />
     <action
         android:id="@+id/action_to_universal_scanner"
         app:destination="@id/universalScanner" />
@@ -379,6 +380,12 @@
         <argument
             android:name="coronaTestQrCode"
             app:argType="de.rki.coronawarnapp.coronatest.qrcode.CoronaTestQRCode" />
+
+        <argument
+            android:name="navigateBackTo"
+            app:argType="de.rki.coronawarnapp.ui.submission.qrcode.consent.SubmissionConsentBackNavArg"
+            android:defaultValue="@null"
+            app:nullable="true"/>
 
         <argument
             android:name="allowTestReplacement"

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/familytest/ui/consent/FamilyTestConsentViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/familytest/ui/consent/FamilyTestConsentViewModelTest.kt
@@ -3,6 +3,7 @@ package de.rki.coronawarnapp.familytest.ui.consent
 import de.rki.coronawarnapp.bugreporting.censors.family.FamilyTestCensor
 import de.rki.coronawarnapp.coronatest.qrcode.CoronaTestQRCode
 import de.rki.coronawarnapp.familytest.ui.consent.FamilyTestConsentNavigationEvents.NavigateBack
+import de.rki.coronawarnapp.familytest.ui.consent.FamilyTestConsentNavigationEvents.NavigateClose
 import de.rki.coronawarnapp.familytest.ui.consent.FamilyTestConsentNavigationEvents.NavigateToCertificateRequest
 import de.rki.coronawarnapp.familytest.ui.consent.FamilyTestConsentNavigationEvents.NavigateToDataPrivacy
 import de.rki.coronawarnapp.submission.TestRegistrationStateProcessor
@@ -109,5 +110,11 @@ class FamilyTestConsentViewModelTest : BaseTest() {
     fun testOnNavigateBack() {
         viewModelDcc.onNavigateBack()
         viewModelDcc.routeToScreen.getOrAwaitValue() shouldBe NavigateBack
+    }
+
+    @Test
+    fun testOnNavigateClose() {
+        viewModelDcc.onNavigateClose()
+        viewModelDcc.routeToScreen.getOrAwaitValue() shouldBe NavigateClose
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/qrcode/consent/SubmissionConsentViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/submission/qrcode/consent/SubmissionConsentViewModelTest.kt
@@ -7,7 +7,10 @@ import de.rki.coronawarnapp.storage.interoperability.InteroperabilityRepository
 import de.rki.coronawarnapp.submission.SubmissionRepository
 import de.rki.coronawarnapp.submission.TestRegistrationStateProcessor
 import de.rki.coronawarnapp.ui.Country
-import de.rki.coronawarnapp.ui.submission.viewmodel.SubmissionNavigationEvents
+import de.rki.coronawarnapp.ui.submission.viewmodel.SubmissionNavigationEvents.NavigateToDataPrivacy
+import de.rki.coronawarnapp.ui.submission.viewmodel.SubmissionNavigationEvents.NavigateClose
+import de.rki.coronawarnapp.ui.submission.viewmodel.SubmissionNavigationEvents.NavigateBackToTestRegistration
+import de.rki.coronawarnapp.ui.submission.viewmodel.SubmissionNavigationEvents.ResolvePlayServicesException
 import io.kotest.matchers.shouldBe
 import io.mockk.MockKAnnotations
 import io.mockk.Runs
@@ -61,7 +64,19 @@ class SubmissionConsentViewModelTest {
     @Test
     fun testOnDataPrivacyClick() {
         viewModel.onDataPrivacyClick()
-        viewModel.routeToScreen.value shouldBe SubmissionNavigationEvents.NavigateToDataPrivacy
+        viewModel.routeToScreen.value shouldBe NavigateToDataPrivacy
+    }
+
+    @Test
+    fun testOnNavigateBackToTestRegistration() {
+        viewModel.navigateBackToTestRegistration()
+        viewModel.routeToScreen.value shouldBe NavigateBackToTestRegistration
+    }
+
+    @Test
+    fun testOnNavigateClose() {
+        viewModel.onNavigateClose()
+        viewModel.routeToScreen.value shouldBe NavigateClose
     }
 
     @Test
@@ -86,6 +101,6 @@ class SubmissionConsentViewModelTest {
 
         viewModel.onConsentButtonClick()
 
-        viewModel.routeToScreen.value shouldBe SubmissionNavigationEvents.ResolvePlayServicesException(apiException)
+        viewModel.routeToScreen.value shouldBe ResolvePlayServicesException(apiException)
     }
 }


### PR DESCRIPTION
[Ticket](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12901)

Add possibility to navigate back from SubmissionConsentFragment and FamilyTestConsentFragment to TestRegistrationSelectionFragment

Testing:
- Scan PCR or RAT Test
- On Register Test Screen, tap "For me" or "For others"
- On Both next Screens there is an option to go back to Register Test Screen
- On Both next Screens there is an option to dismiss registering on top left close button