### PR TITLE
Fix badge ID (EXPOSUREAPP-13464)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainActivity.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/MainActivity.kt
@@ -159,7 +159,7 @@ class MainActivity : AppCompatActivity(), HasAndroidInjector {
 
         viewModel.mainBadgeCount.observe(this) { count ->
             Timber.tag(TAG).d("mainBadgeCount=$count")
-            binding.mainBottomNavigation.updateCountBadge(R.id.mainFragment, count)
+            binding.mainBottomNavigation.updateCountBadge(R.id.status_nav_graph, count)
         }
 
         viewModel.event.observe(this) { event ->


### PR DESCRIPTION
- To facilitate testing , you can rely on test menu  "ENF V2 Calculation" item and change risk level 
- Make sure to navigate to another tab of your choice other than "Status"  after risk level change ,otherwise the badge is dismissed right away once "status" is selected
[Ticket](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13464)