### PR TITLE
Submission flow symptoms screens (EXPOSUREAPP-13178)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/submission/SubmissionSymptomCalendarFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/submission/SubmissionSymptomCalendarFragmentTest.kt
@@ -20,6 +20,7 @@ import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.spyk
+import kotlinx.coroutines.test.TestScope
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -49,7 +50,8 @@ class SubmissionSymptomCalendarFragmentTest : BaseUITest() {
                 TestDispatcherProvider(),
                 submissionRepository,
                 autoSubmission,
-                analyticsKeySubmissionCollector
+                analyticsKeySubmissionCollector,
+                TestScope()
             )
         )
         with(viewModel) {

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/submission/SubmissionSymptomIntroFragmentTest.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/ui/submission/SubmissionSymptomIntroFragmentTest.kt
@@ -21,6 +21,7 @@ import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.spyk
+import kotlinx.coroutines.test.TestScope
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -50,7 +51,8 @@ class SubmissionSymptomIntroFragmentTest : BaseUITest() {
                 submissionRepository,
                 autoSubmission,
                 analyticsKeySubmissionCollector,
-                BaseCoronaTest.Type.PCR
+                BaseCoronaTest.Type.PCR,
+                TestScope()
             )
         )
         with(viewModel) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/SubmissionRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/submission/SubmissionRepository.kt
@@ -54,7 +54,6 @@ class SubmissionRepository @Inject constructor(
 
     val currentSymptoms = submissionSettings.symptoms
 
-    // to be used by new submission flow screens
     suspend fun giveConsentToSubmission(type: BaseCoronaTest.Type) {
         Timber.tag(TAG).v("giveConsentToSubmission(type=%s)", type)
         withContext(scope.coroutineContext) {
@@ -65,7 +64,6 @@ class SubmissionRepository @Inject constructor(
         }
     }
 
-    // to be used by new submission flow screens
     suspend fun revokeConsentToSubmission(type: BaseCoronaTest.Type) {
         Timber.tag(TAG).v("revokeConsentToSubmission(type=%s)", type)
         withContext(scope.coroutineContext) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/symptoms/calendar/SubmissionSymptomCalendarFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/symptoms/calendar/SubmissionSymptomCalendarFragment.kt
@@ -9,7 +9,6 @@ import androidx.navigation.fragment.navArgs
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.FragmentSubmissionSymptomCalendarBinding
 import de.rki.coronawarnapp.submission.Symptoms
-import de.rki.coronawarnapp.ui.submission.SubmissionBlockingDialog
 import de.rki.coronawarnapp.ui.submission.SubmissionCancelDialog
 import de.rki.coronawarnapp.util.di.AutoInject
 import de.rki.coronawarnapp.util.formatter.formatSymptomBackgroundButtonStyleByState
@@ -37,11 +36,9 @@ class SubmissionSymptomCalendarFragment :
     )
 
     private val binding: FragmentSubmissionSymptomCalendarBinding by viewBinding()
-    private lateinit var uploadDialog: SubmissionBlockingDialog
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        uploadDialog = SubmissionBlockingDialog(requireContext())
 
         binding.symptomCalendarContainer.setDateSelectedListener {
             viewModel.onDateSelected(it)
@@ -52,12 +49,8 @@ class SubmissionSymptomCalendarFragment :
                 viewModel.onCancelConfirmed()
             }
         }
-        viewModel.showUploadDialog.observe2(this) {
-            uploadDialog.setState(show = it)
-        }
 
         viewModel.routeToScreen.observe2(this) {
-            uploadDialog.setState(show = false)
             doNavigate(it)
         }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/symptoms/calendar/SubmissionSymptomCalendarViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/symptoms/calendar/SubmissionSymptomCalendarViewModel.kt
@@ -1,7 +1,5 @@
 package de.rki.coronawarnapp.ui.submission.symptoms.calendar
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.asLiveData
 import androidx.navigation.NavDirections
 import dagger.assisted.Assisted
@@ -14,11 +12,14 @@ import de.rki.coronawarnapp.datadonation.analytics.modules.keysubmission.Screen
 import de.rki.coronawarnapp.submission.SubmissionRepository
 import de.rki.coronawarnapp.submission.Symptoms
 import de.rki.coronawarnapp.submission.auto.AutoSubmission
+import de.rki.coronawarnapp.util.coroutine.AppScope
 import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
 import de.rki.coronawarnapp.util.ui.SingleLiveEvent
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactory
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 import org.joda.time.LocalDate
 import timber.log.Timber
 
@@ -28,7 +29,8 @@ class SubmissionSymptomCalendarViewModel @AssistedInject constructor(
     dispatcherProvider: DispatcherProvider,
     private val submissionRepository: SubmissionRepository,
     private val autoSubmission: AutoSubmission,
-    private val analyticsKeySubmissionCollector: AnalyticsKeySubmissionCollector
+    private val analyticsKeySubmissionCollector: AnalyticsKeySubmissionCollector,
+    @AppScope private val appScope: CoroutineScope,
 ) : CWAViewModel(dispatcherProvider = dispatcherProvider) {
 
     private val symptomStartInternal = MutableStateFlow<Symptoms.StartOf?>(null)
@@ -36,17 +38,6 @@ class SubmissionSymptomCalendarViewModel @AssistedInject constructor(
 
     val routeToScreen = SingleLiveEvent<NavDirections>()
     val showCancelDialog = SingleLiveEvent<Unit>()
-    private val mediatorShowUploadDialog = MediatorLiveData<Boolean>()
-
-    init {
-        mediatorShowUploadDialog.addSource(
-            autoSubmission.isSubmissionRunning.asLiveData(context = dispatcherProvider.Default)
-        ) { show ->
-            mediatorShowUploadDialog.postValue(show)
-        }
-    }
-
-    val showUploadDialog: LiveData<Boolean> = mediatorShowUploadDialog
 
     fun onLastSevenDaysStart() {
         updateSymptomStart(Symptoms.StartOf.LastSevenDays)
@@ -92,6 +83,10 @@ class SubmissionSymptomCalendarViewModel @AssistedInject constructor(
         performSubmission {
             analyticsKeySubmissionCollector.reportSubmittedAfterSymptomFlow(testType)
         }
+        routeToScreen.postValue(
+            SubmissionSymptomCalendarFragmentDirections
+                .actionSubmissionSymptomCalendarFragmentToSubmissionDoneFragment(testType)
+        )
     }
 
     fun onCancelConfirmed() {
@@ -99,22 +94,18 @@ class SubmissionSymptomCalendarViewModel @AssistedInject constructor(
         performSubmission {
             analyticsKeySubmissionCollector.reportSubmittedAfterCancel(testType)
         }
+        routeToScreen.postValue(
+            SubmissionSymptomCalendarFragmentDirections.actionSubmissionSymptomCalendarFragmentToMainFragment()
+        )
     }
 
     private fun performSubmission(onSubmitted: () -> Unit) {
-        launch {
+        appScope.launch {
             try {
                 autoSubmission.runSubmissionNow(testType)
                 onSubmitted()
             } catch (e: Exception) {
                 Timber.tag(TAG).e(e, "performSubmission() failed.")
-            } finally {
-                Timber.i("Hide uploading progress and navigate to HomeFragment")
-                mediatorShowUploadDialog.postValue(false)
-                routeToScreen.postValue(
-                    SubmissionSymptomCalendarFragmentDirections
-                        .actionSubmissionSymptomCalendarFragmentToSubmissionDoneFragment(testType)
-                )
             }
         }
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/symptoms/introduction/SubmissionSymptomIntroductionFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/symptoms/introduction/SubmissionSymptomIntroductionFragment.kt
@@ -10,7 +10,6 @@ import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.FragmentSubmissionSymptomIntroBinding
 import de.rki.coronawarnapp.submission.Symptoms
 import de.rki.coronawarnapp.ui.presencetracing.attendee.checkins.consent.CheckInsConsentFragmentArgs
-import de.rki.coronawarnapp.ui.submission.SubmissionBlockingDialog
 import de.rki.coronawarnapp.ui.submission.SubmissionCancelDialog
 import de.rki.coronawarnapp.util.di.AutoInject
 import de.rki.coronawarnapp.util.formatter.formatSymptomBackgroundButtonStyleByState
@@ -42,14 +41,10 @@ class SubmissionSymptomIntroductionFragment :
     )
     private val binding: FragmentSubmissionSymptomIntroBinding by viewBinding()
 
-    private lateinit var uploadDialog: SubmissionBlockingDialog
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        uploadDialog = SubmissionBlockingDialog(requireContext())
 
         viewModel.navigation.observe2(this) {
-            uploadDialog.setState(show = false)
             doNavigate(it)
         }
 
@@ -57,10 +52,6 @@ class SubmissionSymptomIntroductionFragment :
             SubmissionCancelDialog(requireContext()).show {
                 viewModel.onCancelConfirmed()
             }
-        }
-
-        viewModel.showUploadDialog.observe2(this) {
-            uploadDialog.setState(show = it)
         }
 
         viewModel.symptomIndication.observe2(this) {


### PR DESCRIPTION
What has been changed:
Navigate directly to thank-you or main screen after submission has been triggered
removed loading dialog as it is now obsolete 

https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13178

Background: 
If the submission takes a while or runs into timeout, users are confused. As we trigger autosubmission anyway in case of failure, there is no need to keep the user waiting.

How to test: check out the submission flow with symptoms