### PR TITLE
Reject redeemed test while registering (EXPOSUREAPP-13676)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/familytest/core/repository/FamilyTestRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/familytest/core/repository/FamilyTestRepository.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.familytest.core.repository
 
 import androidx.annotation.VisibleForTesting
+import de.rki.coronawarnapp.coronatest.errors.AlreadyRedeemedException
 import de.rki.coronawarnapp.coronatest.qrcode.CoronaTestQRCode
 import de.rki.coronawarnapp.coronatest.server.CoronaTestResult
 import de.rki.coronawarnapp.coronatest.type.TestIdentifier
@@ -55,9 +56,11 @@ class FamilyTestRepository @Inject constructor(
         qrCode: CoronaTestQRCode,
         personName: String
     ): FamilyCoronaTest {
+        val coronaTest = processor.register(qrCode)
+        if (coronaTest.isRedeemed) throw AlreadyRedeemedException(coronaTest)
         return FamilyCoronaTest(
             personName = personName,
-            coronaTest = processor.register(qrCode)
+            coronaTest = coronaTest
         ).also { test ->
             storage.save(test)
         }


### PR DESCRIPTION
# Testing 
- There is a link in the ticket comments where you can find redeemed tests. 
- Redeemed tests should not pass registration instead it should show the redeemed error message 
[Ticket](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13676)