### PR TITLE
Information menu not easy to open (EXPOSUREAPP-13721)

### DIFF
--- a/Corona-Warn-App/src/main/res/layout/home_fragment_layout.xml
+++ b/Corona-Warn-App/src/main/res/layout/home_fragment_layout.xml
@@ -5,6 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+
         <variable
             name="tracingHeader"
             type="de.rki.coronawarnapp.tracing.ui.statusbar.TracingHeaderState" />
@@ -21,11 +22,12 @@
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
+            style="@style/CWAMaterialToolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:theme="@style/CWAMaterialToolbar.OverflowMenu"
             android:touchscreenBlocksFocus="false"
             app:menu="@menu/menu_main">
+
             <ImageView
                 android:id="@+id/main_header_logo"
                 android:layout_width="wrap_content"
@@ -65,8 +67,8 @@
                         style="@style/bodyButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:background="@color/colorTransparent"
                         android:layout_marginEnd="72dp"
+                        android:background="@color/colorTransparent"
                         android:contentDescription="@{tracingHeader.getTracingContentDescription(context)}"
                         android:focusable="false"
                         android:gravity="start|center_vertical"

--- a/Corona-Warn-App/src/main/res/layout/person_overview_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/person_overview_fragment.xml
@@ -16,12 +16,12 @@
             android:layout_height="wrap_content"
             android:background="@color/colorSurface"
             app:liftOnScroll="true">
+
             <com.google.android.material.appbar.MaterialToolbar
                 android:id="@+id/toolbar"
                 style="@style/CWAMaterialToolbar"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:theme="@style/CWAMaterialToolbar.OverflowMenu"
                 app:layout_scrollFlags="scroll|enterAlways"
                 app:menu="@menu/menu_person_overview"
                 app:title="@string/certification_screen_title" />

--- a/Corona-Warn-App/src/main/res/layout/person_overview_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/person_overview_fragment.xml
@@ -7,57 +7,6 @@
     android:layout_height="match_parent"
     android:background="@color/colorSurface">
 
-    <androidx.coordinatorlayout.widget.CoordinatorLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
-
-        <com.google.android.material.appbar.AppBarLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@color/colorSurface"
-            app:liftOnScroll="true">
-
-            <com.google.android.material.appbar.MaterialToolbar
-                android:id="@+id/toolbar"
-                style="@style/CWAMaterialToolbar"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:layout_scrollFlags="scroll|enterAlways"
-                app:menu="@menu/menu_person_overview"
-                app:title="@string/certification_screen_title" />
-
-            <include
-                android:id="@+id/admission_container"
-                layout="@layout/admission_scenario_tile"
-                android:visibility="gone" />
-        </com.google.android.material.appbar.AppBarLayout>
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recycler_view"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:clipToPadding="false"
-            android:paddingBottom="@dimen/spacing_fab_padding"
-            android:visibility="gone"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior"
-            tools:itemCount="1"
-            tools:listitem="@layout/person_overview_item"
-            tools:visibility="visible" />
-
-        <include
-            android:id="@+id/export_tooltip"
-            layout="@layout/export_tooltip"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="32dp"
-            android:layout_marginTop="45dp"
-            android:layout_marginEnd="16dp"
-            android:visibility="gone"
-            tools:visibility="visible" />
-
-    </androidx.coordinatorlayout.widget.CoordinatorLayout>
-
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -147,4 +96,56 @@
             app:constraint_referenced_ids="loading_progress_bar,loading_text" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.google.android.material.appbar.AppBarLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/colorSurface"
+            app:liftOnScroll="true">
+
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/toolbar"
+                style="@style/CWAMaterialToolbar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_scrollFlags="scroll|enterAlways"
+                app:menu="@menu/menu_person_overview"
+                app:title="@string/certification_screen_title" />
+
+            <include
+                android:id="@+id/admission_container"
+                layout="@layout/admission_scenario_tile"
+                android:visibility="gone" />
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recycler_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipToPadding="false"
+            android:paddingBottom="@dimen/spacing_fab_padding"
+            android:visibility="gone"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_behavior="@string/appbar_scrolling_view_behavior"
+            tools:itemCount="1"
+            tools:listitem="@layout/person_overview_item"
+            tools:visibility="visible" />
+
+        <include
+            android:id="@+id/export_tooltip"
+            layout="@layout/export_tooltip"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="32dp"
+            android:layout_marginTop="45dp"
+            android:layout_marginEnd="16dp"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+
 </FrameLayout>

--- a/Corona-Warn-App/src/main/res/layout/trace_location_attendee_checkins_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/trace_location_attendee_checkins_fragment.xml
@@ -8,17 +8,6 @@
     android:background="@color/colorSurface"
     tools:context="ui.presencetracing.attendee.checkins.CheckInsFragment">
 
-    <com.google.android.material.appbar.MaterialToolbar
-        android:id="@+id/toolbar"
-        style="@style/CWAMaterialToolbar"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:menu="@menu/menu_trace_location_attendee_checkins"
-        app:title="@string/trace_location_checkins_title" />
-
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/check_ins_list"
         android:layout_width="0dp"
@@ -35,7 +24,7 @@
 
     <ScrollView
         android:id="@+id/empty_list_info_container"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="0dp"
         android:paddingTop="@dimen/spacing_toolbar_padding"
         android:paddingBottom="@dimen/spacing_fab_padding"
@@ -44,12 +33,12 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHeight_default="wrap"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:visibility="gone">
+        app:layout_constraintTop_toTopOf="@id/toolbar"
+        tools:visibility="visible">
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="0dp"
             android:layout_marginHorizontal="@dimen/spacing_small"
             android:gravity="center"
             android:orientation="vertical">
@@ -88,7 +77,18 @@
                 android:text="@string/trace_location_checkins_empty_description_2"
                 app:autoSizeTextType="uniform" />
         </LinearLayout>
-
     </ScrollView>
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        style="@style/CWAMaterialToolbar"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:menu="@menu/menu_trace_location_attendee_checkins"
+        app:title="@string/trace_location_checkins_title" />
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Corona-Warn-App/src/main/res/layout/trace_location_attendee_checkins_fragment.xml
+++ b/Corona-Warn-App/src/main/res/layout/trace_location_attendee_checkins_fragment.xml
@@ -13,7 +13,6 @@
         style="@style/CWAMaterialToolbar"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:theme="@style/CWAMaterialToolbar.OverflowMenu"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
- Align toolbar styles in the screens of bottom Navigation 
- Bring toolbar in Certificates screen and Checkins Screen to front , in smaller devices part of the toolbar was covered by empty layout which was eating the clickable area 
[Ticket](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13721) 