### PR TITLE
Fix: re-grouping schema 1.3.2 (EXPOSUREAPP-13724, 13723)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/CertificatePersonIdentifier.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/CertificatePersonIdentifier.kt
@@ -21,7 +21,7 @@ data class CertificatePersonIdentifier(
     val sanitizedFamilyName: List<String> by lazy { lastNameStandardized?.sanitizeName().orEmpty() }
 
     @get:JsonIgnore
-    private val sanitizedGivenName: List<String> by lazy { firstNameStandardized?.sanitizeName().orEmpty() }
+    val sanitizedGivenName: List<String> by lazy { firstNameStandardized?.sanitizeName().orEmpty() }
 
     /**
      * Method shall decide whether the DGCs belong to the same holder.
@@ -44,8 +44,7 @@ data class CertificatePersonIdentifier(
         val givenNameOverlap = sanitizedGivenName.hasIntersect(other.sanitizedGivenName)
         val bothGivenNamesAreEmpty = sanitizedGivenName.isEmpty() && other.sanitizedGivenName.isEmpty()
         val bothFamilyNamesAreEmpty = sanitizedFamilyName.isEmpty() && other.sanitizedFamilyName.isEmpty()
-        val familyNameAndGivenNameAreSwapped = sanitizedFamilyName.hasIntersect(other.sanitizedGivenName) &&
-            sanitizedGivenName.hasIntersect(other.sanitizedFamilyName)
+        val familyNameAndGivenNameAreSwapped = this.hasSwappedNameWith(other) || other.hasSwappedNameWith(this)
 
         return when {
             familyNameOverlap && (givenNameOverlap || bothGivenNamesAreEmpty) -> true
@@ -130,4 +129,10 @@ private fun String.sanitizeName(): List<String> {
         .split("<")
         .filter { !filteringList.contains(it) }
         .filter { it.isNotBlank() }
+}
+
+private fun CertificatePersonIdentifier.hasSwappedNameWith(other: CertificatePersonIdentifier): Boolean {
+    val hasEmptySwappedName = sanitizedGivenName.isEmpty() && other.sanitizedFamilyName.isEmpty()
+    val hasSwappedIntersect = sanitizedGivenName.hasIntersect(other.sanitizedFamilyName)
+    return sanitizedFamilyName.hasIntersect(other.sanitizedGivenName) && (hasSwappedIntersect || hasEmptySwappedName)
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/CertificatePersonIdentifier.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/CertificatePersonIdentifier.kt
@@ -28,12 +28,12 @@ data class CertificatePersonIdentifier(
      * Two DCCs shall be considered as belonging to the same holder, if:
      * - the sanitized `dob` attributes are the same strings, and
      * - one of:
-     * - the intersection/overlap of the name components of sanitized `a.nam.fnt` and `b.nam.fnt` has at least one
-     * element, and the intersection/overlap of the name components of sanitized `a.nam.gnt` and `b.nam.gnt` has at least
-     * one element or both are empty sets (`gnt` is an optional field)
-     * - the intersection/overlap of the name components of sanitized `a.nam.fnt` and `b.nam.gnt` has at least one
-     * element, and the intersection/overlap of the name components of sanitized `a.nam.gnt` and `b.nam.fnt` has at least
-     * one element
+     *    - the intersection/overlap of the name components of sanitized `a.nam.fnt` and `b.nam.fnt` has at least one
+     *      element, and the intersection/overlap of the name components of sanitized `a.nam.gnt` and `b.nam.gnt` has at least
+     *      one element or both are empty sets (`gnt` is an optional field)
+     *    - the intersection/overlap of the name components of sanitized `a.nam.fnt` and `b.nam.gnt` has at least one
+     *      element, and the intersection/overlap of the name components of sanitized `a.nam.gnt` and `b.nam.fnt` has at least
+     *      one element
      */
     fun belongsToSamePerson(other: CwaCovidCertificate): Boolean = belongsToSamePerson(other.personIdentifier)
     fun belongsToSamePerson(other: CertificatePersonIdentifier?): Boolean {
@@ -43,14 +43,15 @@ data class CertificatePersonIdentifier(
         val familyNameOverlap = sanitizedFamilyName.hasIntersect(other.sanitizedFamilyName)
         val givenNameOverlap = sanitizedGivenName.hasIntersect(other.sanitizedGivenName)
         val bothGivenNamesAreEmpty = sanitizedGivenName.isEmpty() && other.sanitizedGivenName.isEmpty()
+        val bothFamilyNamesAreEmpty = sanitizedFamilyName.isEmpty() && other.sanitizedFamilyName.isEmpty()
         val familyNameAndGivenNameAreSwapped = sanitizedFamilyName.hasIntersect(other.sanitizedGivenName) &&
             sanitizedGivenName.hasIntersect(other.sanitizedFamilyName)
 
-        if (familyNameOverlap && (givenNameOverlap || bothGivenNamesAreEmpty)) {
-            return true
+        return when {
+            familyNameOverlap && (givenNameOverlap || bothGivenNamesAreEmpty) -> true
+            givenNameOverlap && (familyNameOverlap || bothFamilyNamesAreEmpty) -> true
+            else -> familyNameAndGivenNameAreSwapped
         }
-
-        return familyNameAndGivenNameAreSwapped
     }
 
     /**

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/CertificatePersonIdentifier.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/CertificatePersonIdentifier.kt
@@ -48,7 +48,7 @@ data class CertificatePersonIdentifier(
 
         return when {
             familyNameOverlap && (givenNameOverlap || bothGivenNamesAreEmpty) -> true
-            givenNameOverlap && (familyNameOverlap || bothFamilyNamesAreEmpty) -> true
+            givenNameOverlap && bothFamilyNamesAreEmpty -> true
             else -> familyNameAndGivenNameAreSwapped
         }
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/CertificatePersonIdentifier.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/common/certificate/CertificatePersonIdentifier.kt
@@ -25,15 +25,7 @@ data class CertificatePersonIdentifier(
 
     /**
      * Method shall decide whether the DGCs belong to the same holder.
-     * Two DCCs shall be considered as belonging to the same holder, if:
-     * - the sanitized `dob` attributes are the same strings, and
-     * - one of:
-     *    - the intersection/overlap of the name components of sanitized `a.nam.fnt` and `b.nam.fnt` has at least one
-     *      element, and the intersection/overlap of the name components of sanitized `a.nam.gnt` and `b.nam.gnt` has at least
-     *      one element or both are empty sets (`gnt` is an optional field)
-     *    - the intersection/overlap of the name components of sanitized `a.nam.fnt` and `b.nam.gnt` has at least one
-     *      element, and the intersection/overlap of the name components of sanitized `a.nam.gnt` and `b.nam.fnt` has at least
-     *      one element
+     * based on [specs](https://github.com/corona-warn-app/cwa-app-tech-spec/blob/33e97a146240d2f9a015955e9a3937ab9b065789/docs/spec/dgc-overview-client.md#grouping-dgcs-by-person)
      */
     fun belongsToSamePerson(other: CwaCovidCertificate): Boolean = belongsToSamePerson(other.personIdentifier)
     fun belongsToSamePerson(other: CertificatePersonIdentifier?): Boolean {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/list/ListExt.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/list/ListExt.kt
@@ -5,5 +5,5 @@ package de.rki.coronawarnapp.util.list
  * one common element, otherwise it returns False.
  */
 fun <T> Iterable<T>.hasIntersect(other: Iterable<T>): Boolean {
-    return intersect(other).isNotEmpty()
+    return intersect(other.toSet()).isNotEmpty()
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ccl/holder/grouping/DccGroupingExtensionsTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ccl/holder/grouping/DccGroupingExtensionsTest.kt
@@ -66,7 +66,7 @@ class DccGroupingExtensionsTest : testhelpers.BaseTest() {
     }
 
     @Test
-    fun `Schema 1_3_2 certificates should have one group gnt, fnt swapped`() {
+    fun `Schema 1_3_2 certificates should have one group gnt, fnt swapped and are equal`() {
         setOf(
             certSchema132GntA1,
             certSchema132GntA2,
@@ -76,7 +76,7 @@ class DccGroupingExtensionsTest : testhelpers.BaseTest() {
     }
 
     @Test
-    fun `Schema 1_3_2 certificates should have one group gnt (Given name)`() {
+    fun `Schema 1_3_2 certificates should have one group gnt (Given name) is the same`() {
         setOf(
             certSchema132GntA1,
             certSchema132GntA2
@@ -84,7 +84,7 @@ class DccGroupingExtensionsTest : testhelpers.BaseTest() {
     }
 
     @Test
-    fun `Schema 1_3_2 certificates should have one group fnt (Family name)`() {
+    fun `Schema 1_3_2 certificates should have one group fnt (Family name) is the same`() {
         setOf(
             certSchema132FntA1,
             certSchema132FntA2

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ccl/holder/grouping/DccGroupingExtensionsTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ccl/holder/grouping/DccGroupingExtensionsTest.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 class DccGroupingExtensionsTest : testhelpers.BaseTest() {
@@ -66,6 +67,32 @@ class DccGroupingExtensionsTest : testhelpers.BaseTest() {
     }
 
     @Test
+    fun `Schema 1_3_2 certificates should have one group gnt, fnt swapped`() {
+        setOf(
+            certSchema132GntA1,
+            certSchema132GntA2,
+            certSchema132FntA1,
+            certSchema132FntA2
+        ).groupByPerson().count() shouldBe 1
+    }
+
+    @Test
+    fun `Schema 1_3_2 certificates should have one group gnt (Given name)`() {
+        setOf(
+            certSchema132GntA1,
+            certSchema132GntA2
+        ).groupByPerson().count() shouldBe 1
+    }
+
+    @Test
+    fun `Schema 1_3_2 certificates should have one group fnt (Family name)`() {
+        setOf(
+            certSchema132FntA1,
+            certSchema132FntA2
+        ).groupByPerson().count() shouldBe 1
+    }
+
+    @Test
     fun `second grouping check`() {
         val certificates = setOf(
             certD12,
@@ -97,6 +124,40 @@ class DccGroupingExtensionsTest : testhelpers.BaseTest() {
             certD3,
             certD2,
             certD1,
+        )
+    }
+
+    // 1.3.2 given name is the same
+    private val certSchema132GntA1: CwaCovidCertificate = mockk {
+        every { personIdentifier } returns CertificatePersonIdentifier(
+            dateOfBirthFormatted = "1980-02-03",
+            firstNameStandardized = "MARIO",
+            lastNameStandardized = null
+        )
+    }
+
+    private val certSchema132GntA2: CwaCovidCertificate = mockk {
+        every { personIdentifier } returns CertificatePersonIdentifier(
+            dateOfBirthFormatted = "1980-02-03",
+            firstNameStandardized = "MARIO",
+            lastNameStandardized = null
+        )
+    }
+
+    // 1.3.2  family name is the same
+    private val certSchema132FntA1: CwaCovidCertificate = mockk {
+        every { personIdentifier } returns CertificatePersonIdentifier(
+            dateOfBirthFormatted = "1980-02-03",
+            firstNameStandardized = null,
+            lastNameStandardized = "MARIO"
+        )
+    }
+
+    private val certSchema132FntA2: CwaCovidCertificate = mockk {
+        every { personIdentifier } returns CertificatePersonIdentifier(
+            dateOfBirthFormatted = "1980-02-03",
+            firstNameStandardized = null,
+            lastNameStandardized = "MARIO"
         )
     }
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ccl/holder/grouping/DccGroupingExtensionsTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ccl/holder/grouping/DccGroupingExtensionsTest.kt
@@ -7,7 +7,6 @@ import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 class DccGroupingExtensionsTest : testhelpers.BaseTest() {

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ccl/holder/grouping/DccHolderComparisonTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ccl/holder/grouping/DccHolderComparisonTest.kt
@@ -13,7 +13,7 @@ class DccHolderComparisonTest : testhelpers.BaseTest() {
     @ParameterizedTest(name = "{index}: {0}")
     @ArgumentsSource(DccHolderComparisonTestCaseProvider::class)
     fun allTestCases(testCase: TestCase) {
-
+        print(testCase)
         val certA: CwaCovidCertificate = mockk {
             every { personIdentifier } returns CertificatePersonIdentifier(
                 dateOfBirthFormatted = testCase.holderA.dateOfBirth,

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ccl/holder/grouping/DccHolderNameComponentsTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ccl/holder/grouping/DccHolderNameComponentsTest.kt
@@ -11,6 +11,7 @@ class DccHolderNameComponentsTest : testhelpers.BaseTest() {
     @ParameterizedTest(name = "{index}: {0}")
     @ArgumentsSource(DccHolderNameComponentsTestCaseProvider::class)
     fun allTestCases(testCase: TestCaseName) {
+        print(testCase)
         CertificatePersonIdentifier("", testCase.name).sanitizedFamilyName shouldBe testCase.expectedResult
     }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ccl/holder/grouping/TestCases.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ccl/holder/grouping/TestCases.kt
@@ -37,8 +37,8 @@ data class Holder(
 
 data class HolderName(
     @JsonProperty("gnt")
-    val givenName: String,
+    val givenName: String?,
 
     @JsonProperty("fnt")
-    val familyName: String
+    val familyName: String?
 )

--- a/Corona-Warn-App/src/test/resources/dcc-holder-comparison.gen.json
+++ b/Corona-Warn-App/src/test/resources/dcc-holder-comparison.gen.json
@@ -1,6 +1,6 @@
 {
-  "$comment": "Generated at Mon Aug 08 2022 11:26:46 GMT+0200 (Central European Summer Time)",
-  "$sourceHash": "8a3b11dc892d73aa2efc8965df7e7d41a1eb5bb737d4d2df40a1aab1e73116fa",
+  "$comment": "Generated at Mon Aug 08 2022 12:22:20 GMT+0200 (Central European Summer Time)",
+  "$sourceHash": "310d05c317544e54a20b8be2f25c4a26ed57bc57ea4e2c3be72fc70462709fd9",
   "data": [
     {
       "description": "happy path - match",
@@ -641,6 +641,42 @@
         "nam": {
           "gnt": "MUSTERMANN<MARIA",
           "fnt": "ERIKA"
+        },
+        "dob": "1980-02-03"
+      },
+      "expIsSameHolder": true
+    },
+    {
+      "description": "edge case for swapped first/last name with empty name component (1)",
+      "actHolderA": {
+        "nam": {
+          "gnt": "",
+          "fnt": "MUSTERMANN"
+        },
+        "dob": "1980-02-03"
+      },
+      "actHolderB": {
+        "nam": {
+          "gnt": "MUSTERMANN",
+          "fnt": ""
+        },
+        "dob": "1980-02-03"
+      },
+      "expIsSameHolder": true
+    },
+    {
+      "description": "edge case for swapped first/last name with empty name component (2)",
+      "actHolderA": {
+        "nam": {
+          "gnt": "MUSTERMANN",
+          "fnt": ""
+        },
+        "dob": "1980-02-03"
+      },
+      "actHolderB": {
+        "nam": {
+          "gnt": "",
+          "fnt": "MUSTERMANN"
         },
         "dob": "1980-02-03"
       },

--- a/Corona-Warn-App/src/test/resources/dcc-holder-comparison.gen.json
+++ b/Corona-Warn-App/src/test/resources/dcc-holder-comparison.gen.json
@@ -1,6 +1,6 @@
 {
-  "$comment": "Generated at Mon Feb 07 2022 14:33:50 GMT+0100 (Central European Standard Time)",
-  "$sourceHash": "7237e59ac249676777277bdb1573aba3b0eacc16f3f585ff082f3ec2b0fc9492",
+  "$comment": "Generated at Mon Aug 08 2022 11:26:46 GMT+0200 (Central European Summer Time)",
+  "$sourceHash": "8a3b11dc892d73aa2efc8965df7e7d41a1eb5bb737d4d2df40a1aab1e73116fa",
   "data": [
     {
       "description": "happy path - match",
@@ -399,7 +399,7 @@
       "expIsSameHolder": false
     },
     {
-      "description": "match if both first names are empty (gnt is optional)",
+      "description": "match if both first names are empty (only one of fnt/gnt is mandatory)",
       "actHolderA": {
         "nam": {
           "gnt": "",
@@ -411,6 +411,56 @@
         "nam": {
           "gnt": "",
           "fnt": "MUSTERMANN"
+        },
+        "dob": "1980-02-03"
+      },
+      "expIsSameHolder": true
+    },
+    {
+      "description": "match if both first names are absent (only one of fnt/gnt is mandatory)",
+      "actHolderA": {
+        "nam": {
+          "fnt": "MUSTERMANN"
+        },
+        "dob": "1980-02-03"
+      },
+      "actHolderB": {
+        "nam": {
+          "fnt": "MUSTERMANN"
+        },
+        "dob": "1980-02-03"
+      },
+      "expIsSameHolder": true
+    },
+    {
+      "description": "match if both last names are empty (only one of fnt/gnt is mandatory)",
+      "actHolderA": {
+        "nam": {
+          "gnt": "ERIKA",
+          "fnt": ""
+        },
+        "dob": "1980-02-03"
+      },
+      "actHolderB": {
+        "nam": {
+          "gnt": "ERIKA",
+          "fnt": ""
+        },
+        "dob": "1980-02-03"
+      },
+      "expIsSameHolder": true
+    },
+    {
+      "description": "match if both last names are absent (only one of fnt/gnt is mandatory)",
+      "actHolderA": {
+        "nam": {
+          "gnt": "ERIKA"
+        },
+        "dob": "1980-02-03"
+      },
+      "actHolderB": {
+        "nam": {
+          "gnt": "ERIKA"
         },
         "dob": "1980-02-03"
       },
@@ -489,7 +539,7 @@
       "expIsSameHolder": true
     },
     {
-      "description": "german Ä",
+      "description": "match german Ä",
       "actHolderA": {
         "nam": {
           "gnt": "MÄRTHE<täve",
@@ -507,7 +557,7 @@
       "expIsSameHolder": true
     },
     {
-      "description": "german Ö",
+      "description": "match german Ö",
       "actHolderA": {
         "nam": {
           "gnt": "VÖLKER<völker",
@@ -525,7 +575,7 @@
       "expIsSameHolder": true
     },
     {
-      "description": "german Ü",
+      "description": "match german Ü",
       "actHolderA": {
         "nam": {
           "gnt": "GÜNTHER<Jürgen",
@@ -543,7 +593,7 @@
       "expIsSameHolder": true
     },
     {
-      "description": "german ß",
+      "description": "match german ß",
       "actHolderA": {
         "nam": {
           "gnt": "ANGELIKA<MARIA",
@@ -561,25 +611,25 @@
       "expIsSameHolder": true
     },
     {
-      "description": "mars adventurer (unusual name)",
+      "description": "match mars adventurer (unusual name)",
       "actHolderA": {
         "nam": {
           "gnt": "X Æ A-12",
-          "fnt": "ROCKET"
+          "fnt": "MUSK"
         },
-        "dob": "2010-01-01"
+        "dob": "1980-02-03"
       },
       "actHolderB": {
         "nam": {
-          "gnt": "ROCKET",
+          "gnt": "MUSK",
           "fnt": "X Æ A-12"
         },
-        "dob": "2010-01-01"
+        "dob": "1980-02-03"
       },
       "expIsSameHolder": true
     },
     {
-      "description": "match if partly swapped",
+      "description": "edge case for swapped first/last name",
       "actHolderA": {
         "nam": {
           "gnt": "ERIKA<MARIA",
@@ -595,114 +645,6 @@
         "dob": "1980-02-03"
       },
       "expIsSameHolder": true
-    },
-    {
-      "description": "Schema 1.3.2 -> fnt optional",
-      "actHolderA": {
-        "nam": {
-          "gnt": "ERIKA<MARIA",
-          "fnt": null
-        },
-        "dob": "1980-02-03"
-      },
-      "actHolderB": {
-        "nam": {
-          "gnt": "MUSTERMANN<MARIA",
-          "fnt": null
-        },
-        "dob": "1980-02-03"
-      },
-      "expIsSameHolder": true
-    },
-    {
-      "description": "Schema 1.3.2 -> fnt is empty",
-      "actHolderA": {
-        "nam": {
-          "gnt": "ERIKA<MARIA",
-          "fnt": ""
-        },
-        "dob": "1980-02-03"
-      },
-      "actHolderB": {
-        "nam": {
-          "gnt": "MUSTERMANN<MARIA",
-          "fnt": ""
-        },
-        "dob": "1980-02-03"
-      },
-      "expIsSameHolder": true
-    },
-    {
-      "description": "Schema 1.3.2 -> gnt optional",
-      "actHolderA": {
-        "nam": {
-          "gnt": null,
-          "fnt": "ERIKA"
-        },
-        "dob": "1980-02-03"
-      },
-      "actHolderB": {
-        "nam": {
-          "gnt": null,
-          "fnt": "ERIKA"
-        },
-        "dob": "1980-02-03"
-      },
-      "expIsSameHolder": true
-    },
-    {
-      "description": "Schema 1.3.2 -> gnt is empty",
-      "actHolderA": {
-        "nam": {
-          "gnt": "",
-          "fnt": "ERIKA"
-        },
-        "dob": "1980-02-03"
-      },
-      "actHolderB": {
-        "nam": {
-          "gnt": "",
-          "fnt": "ERIKA"
-        },
-        "dob": "1980-02-03"
-      },
-      "expIsSameHolder": true
-    },
-    {
-      "description": "Schema 1.3.2 -> gnt and fnt are swapped and optional",
-      "actHolderA": {
-        "nam": {
-          "gnt": "ERIKA",
-          "fnt": null
-        },
-        "dob": "1980-02-03"
-      },
-      "actHolderB": {
-        "nam": {
-          "gnt": null,
-          "fnt": "ERIKA"
-        },
-        "dob": "1980-02-03"
-      },
-      "expIsSameHolder": true
-    },
-    {
-      "description": "Schema 1.3.2 -> Test 1",
-      "actHolderA": {
-        "nam": {
-          "gnt": "ERIKA",
-          "fnt": "Musterfrau"
-        },
-        "dob": "1980-02-03"
-      },
-      "actHolderB": {
-        "nam": {
-          "gnt": null,
-          "fnt": "ERIKA"
-        },
-        "dob": "1980-02-03"
-      },
-      "expIsSameHolder": false
     }
   ]
 }

--- a/Corona-Warn-App/src/test/resources/dcc-holder-comparison.gen.json
+++ b/Corona-Warn-App/src/test/resources/dcc-holder-comparison.gen.json
@@ -579,7 +579,7 @@
       "expIsSameHolder": true
     },
     {
-      "description": "match if partly swaped",
+      "description": "match if partly swapped",
       "actHolderA": {
         "nam": {
           "gnt": "ERIKA<MARIA",
@@ -595,6 +595,114 @@
         "dob": "1980-02-03"
       },
       "expIsSameHolder": true
+    },
+    {
+      "description": "Schema 1.3.2 -> fnt optional",
+      "actHolderA": {
+        "nam": {
+          "gnt": "ERIKA<MARIA",
+          "fnt": null
+        },
+        "dob": "1980-02-03"
+      },
+      "actHolderB": {
+        "nam": {
+          "gnt": "MUSTERMANN<MARIA",
+          "fnt": null
+        },
+        "dob": "1980-02-03"
+      },
+      "expIsSameHolder": true
+    },
+    {
+      "description": "Schema 1.3.2 -> fnt is empty",
+      "actHolderA": {
+        "nam": {
+          "gnt": "ERIKA<MARIA",
+          "fnt": ""
+        },
+        "dob": "1980-02-03"
+      },
+      "actHolderB": {
+        "nam": {
+          "gnt": "MUSTERMANN<MARIA",
+          "fnt": ""
+        },
+        "dob": "1980-02-03"
+      },
+      "expIsSameHolder": true
+    },
+    {
+      "description": "Schema 1.3.2 -> gnt optional",
+      "actHolderA": {
+        "nam": {
+          "gnt": null,
+          "fnt": "ERIKA"
+        },
+        "dob": "1980-02-03"
+      },
+      "actHolderB": {
+        "nam": {
+          "gnt": null,
+          "fnt": "ERIKA"
+        },
+        "dob": "1980-02-03"
+      },
+      "expIsSameHolder": true
+    },
+    {
+      "description": "Schema 1.3.2 -> gnt is empty",
+      "actHolderA": {
+        "nam": {
+          "gnt": "",
+          "fnt": "ERIKA"
+        },
+        "dob": "1980-02-03"
+      },
+      "actHolderB": {
+        "nam": {
+          "gnt": "",
+          "fnt": "ERIKA"
+        },
+        "dob": "1980-02-03"
+      },
+      "expIsSameHolder": true
+    },
+    {
+      "description": "Schema 1.3.2 -> gnt and fnt are swapped and optional",
+      "actHolderA": {
+        "nam": {
+          "gnt": "ERIKA",
+          "fnt": null
+        },
+        "dob": "1980-02-03"
+      },
+      "actHolderB": {
+        "nam": {
+          "gnt": null,
+          "fnt": "ERIKA"
+        },
+        "dob": "1980-02-03"
+      },
+      "expIsSameHolder": true
+    },
+    {
+      "description": "Schema 1.3.2 -> Test 1",
+      "actHolderA": {
+        "nam": {
+          "gnt": "ERIKA",
+          "fnt": "Musterfrau"
+        },
+        "dob": "1980-02-03"
+      },
+      "actHolderB": {
+        "nam": {
+          "gnt": null,
+          "fnt": "ERIKA"
+        },
+        "dob": "1980-02-03"
+      },
+      "expIsSameHolder": false
     }
   ]
 }


### PR DESCRIPTION
## Test
- Scan the attached certificates group from the ticket
- There should be two groups each and the app should not crash 

[Updated specs
](https://github.com/corona-warn-app/cwa-app-tech-spec/pull/191/commits/33e97a146240d2f9a015955e9a3937ab9b065789)
[Ticket](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13724) , [Ticket2](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13723) 