### PR TITLE
Main user switch turns off after renewing a certificate (EXPOSUREAPP-13695) 

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccreissuance/core/reissuer/DccReissuer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/dccreissuance/core/reissuer/DccReissuer.kt
@@ -31,15 +31,15 @@ class DccReissuer @Inject constructor(
         }.orEmpty()
 
         updates.flatMap {
-            it.recycleBin
-        }.toSet().forEach {
-            moveToBin(it)
-        }
-
-        updates.flatMap {
             it.register
         }.toSet().forEach {
             register(it)
+        }
+
+        updates.flatMap {
+            it.recycleBin
+        }.toSet().forEach {
+            moveToBin(it)
         }
     }
 


### PR DESCRIPTION
## Test
- Scan certificate named `vc-ExpCert_Booster_EXPIRED_CERTIFICATES_DOB_1997-07-09_Cert_3v3_DT_2022-04-18_MP_EU_1_20_1528_MA_ORG-100030215_EX_2022-06-30T19_11_20+02_00.png` from ticket ONLY
- Switch CWA user flag on 
- Renew certificate
- Check CWA user flag , it should stay on

## Reason
- Since user has only one certificate in this case , while reissuing the new certificate , old one is recycled and this leads for  short time that user wallet is empty until new certificate is registered. Having an empty wallet of CWA user reset the flag 
## Fix
- Register new certificates first to ensure that user will have always certificates in the wallet 
[Ticket](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13695)