### PR TITLE
Fix server time parser on newer Android versions (EXPOSUREAPP-9077)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/appconfig/sources/remote/AppConfigServer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/appconfig/sources/remote/AppConfigServer.kt
@@ -107,7 +107,7 @@ class AppConfigServer @Inject constructor(
         )
         DATE_FORMAT.parse(rawDate, Instant::from)
     } catch (e: Exception) {
-        Timber.e("Failed to get server time.")
+        Timber.e(e, "Failed to get server time.")
         null
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/appconfig/sources/remote/AppConfigServer.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/appconfig/sources/remote/AppConfigServer.kt
@@ -116,7 +116,7 @@ class AppConfigServer @Inject constructor(
         private const val EXPORT_SIGNATURE_FILE_NAME = "export.sig"
         private val DATE_FORMAT = DateTimeFormatter
             .ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz")
-            .withLocale(Locale.ROOT)
+            .withLocale(Locale.ENGLISH)
         private val TAG = AppConfigServer::class.java.simpleName
     }
 }


### PR DESCRIPTION
- Root cause: Wrong time detection on newer Android versions was broken which led that calculation happens even though time on device is wrong  

## To verify the fix in here:

- Set device time into the future (2 days)
- Install CWA 
- Make sure that wrong time warning shows up 
- Risk calculation is not checked while device is being set on wrong time 
## Ticket
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-9077