### PR TITLE
[Dcc Validation] Save user selection(EXPOSUREAPP-8469)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/core/DccValidation.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/core/DccValidation.kt
@@ -6,8 +6,8 @@ import de.rki.coronawarnapp.covidcertificate.validation.core.rule.DccValidationR
 import de.rki.coronawarnapp.covidcertificate.validation.core.rule.EvaluatedDccRule
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
-import org.joda.time.Instant
-import org.joda.time.LocalDateTime
+import java.time.Instant
+import java.time.LocalDateTime
 
 @Parcelize
 data class DccValidation(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/core/DccValidationRepository.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/core/DccValidationRepository.kt
@@ -19,8 +19,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.plus
-import org.joda.time.Duration
 import timber.log.Timber
+import java.time.Duration
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -46,7 +46,7 @@ class DccValidationRepository @Inject constructor(
         loggingTag = TAG,
         scope = appScope + dispatcherProvider.Default,
         sharingBehavior = SharingStarted.WhileSubscribed(
-            stopTimeoutMillis = Duration.standardSeconds(5).millis,
+            stopTimeoutMillis = Duration.ofSeconds(5).toMillis(),
             replayExpirationMillis = 0
         ),
     ) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/core/business/BusinessValidator.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/core/business/BusinessValidator.kt
@@ -9,9 +9,10 @@ import de.rki.coronawarnapp.covidcertificate.validation.core.business.wrapper.fi
 import de.rki.coronawarnapp.covidcertificate.validation.core.business.wrapper.typeString
 import de.rki.coronawarnapp.covidcertificate.validation.core.country.DccCountry
 import kotlinx.coroutines.flow.first
-import org.joda.time.DateTimeZone
-import org.joda.time.LocalDateTime
 import timber.log.Timber
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
 import javax.inject.Inject
 
 @Reusable
@@ -24,14 +25,14 @@ class BusinessValidator @Inject constructor(
         localValidationDateTime: LocalDateTime,
         certificate: DccData<out DccV1.MetaData>,
         // best guess for tz of validation date and time, needs to be selected by the user for correct results
-        timeZone: DateTimeZone = DateTimeZone.getDefault(),
+        timeZone: ZoneId = ZoneOffset.systemDefault(),
     ): BusinessValidation {
 
         Timber.i("Start CertLogic validation for arrival in ${arrivalCountry.countryCode} on $localValidationDateTime.")
         Timber.i("${certificate.typeString} certificate of ${certificate.certificate.nameData.fullName}.")
         Timber.i("Certificate was issued by ${certificate.header.issuer} at ${certificate.header.issuedAt}.")
 
-        val validationDateTime = localValidationDateTime.toDateTime(timeZone)
+        val validationDateTime = localValidationDateTime.atZone(timeZone)
 
         // accepted by arrival country
         Timber.i("Validating acceptance rules of ${arrivalCountry.countryCode} at $validationDateTime.")

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/core/business/wrapper/CertLogicEngineWrapper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/core/business/wrapper/CertLogicEngineWrapper.kt
@@ -8,8 +8,8 @@ import de.rki.coronawarnapp.covidcertificate.validation.core.rule.DccValidationR
 import de.rki.coronawarnapp.covidcertificate.validation.core.rule.EvaluatedDccRule
 import dgca.verifier.app.engine.DefaultCertLogicEngine
 import kotlinx.coroutines.flow.first
-import org.joda.time.DateTime
 import timber.log.Timber
+import java.time.ZonedDateTime
 import javax.inject.Inject
 
 @Reusable
@@ -20,7 +20,7 @@ class CertLogicEngineWrapper @Inject constructor(
 
     suspend fun process(
         rules: List<DccValidationRule>,
-        validationDateTime: DateTime,
+        validationDateTime: ZonedDateTime,
         certificate: DccData<out DccV1.MetaData>,
         countryCode: String,
     ): Set<EvaluatedDccRule> {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/core/business/wrapper/Mappings.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/core/business/wrapper/Mappings.kt
@@ -9,6 +9,7 @@ import de.rki.coronawarnapp.covidcertificate.common.certificate.VaccinationDccV1
 import de.rki.coronawarnapp.covidcertificate.validation.core.country.DccCountry
 import de.rki.coronawarnapp.covidcertificate.validation.core.rule.DccValidationRule
 import de.rki.coronawarnapp.covidcertificate.validation.core.rule.EvaluatedDccRule
+import de.rki.coronawarnapp.util.toJavaInstant
 import dgca.verifier.app.engine.Result
 import dgca.verifier.app.engine.UTC_ZONE_ID
 import dgca.verifier.app.engine.data.CertificateType
@@ -16,31 +17,24 @@ import dgca.verifier.app.engine.data.ExternalParameter
 import dgca.verifier.app.engine.data.Rule
 import dgca.verifier.app.engine.data.RuleCertificateType
 import dgca.verifier.app.engine.data.Type
-import org.joda.time.DateTime
-import org.joda.time.DateTimeZone
-import org.joda.time.Instant
-import java.time.ZoneId
 import java.time.ZonedDateTime
 
 internal fun assembleExternalParameter(
     certificate: DccData<*>,
-    validationDateTime: DateTime,
+    validationDateTime: ZonedDateTime,
     countryCode: String,
     valueSets: Map<String, List<String>>,
 ): ExternalParameter {
     // convert to utc - engine does not like other tz
-    val validationClock = validationDateTime
-        .toDateTime(DateTimeZone.UTC)
-        .asZonedDateTime(UTC_ZONE_ID)
-
+    val validationClock = validationDateTime.withZoneSameInstant(UTC_ZONE_ID)
     return ExternalParameter(
         kid = certificate.kid,
         validationClock = validationClock,
         valueSets = valueSets,
         countryCode = countryCode,
         issuerCountryCode = certificate.header.issuer,
-        exp = certificate.header.expiresAt.toZonedDateTime(UTC_ZONE_ID),
-        iat = certificate.header.issuedAt.toZonedDateTime(UTC_ZONE_ID)
+        exp = certificate.header.expiresAt.toJavaInstant().atZone(UTC_ZONE_ID),
+        iat = certificate.header.issuedAt.toJavaInstant().atZone(UTC_ZONE_ID)
     )
 }
 
@@ -59,7 +53,7 @@ internal val DccValidationRule.asExternalRule: Rule
         engine = engine,
         engineVersion = engineVersion,
         ruleCertificateType = certificateType.asExternalCertificateType,
-        descriptions = description.map { it.languageCode to it.description }.toMap(),
+        descriptions = description.associate { it.languageCode to it.description },
         validFrom = validFrom.toZonedDateTime(),
         validTo = validTo.toZonedDateTime(),
         affectedString = affectedFields,
@@ -121,10 +115,6 @@ private val String.asExternalCertificateType: RuleCertificateType
         else -> throw IllegalArgumentException()
     }
 
-fun Instant.toZonedDateTime(zoneId: ZoneId): ZonedDateTime {
-    return ZonedDateTime.ofInstant(java.time.Instant.ofEpochMilli(this.millis), zoneId)
-}
-
 @VisibleForTesting
 internal fun String.toZonedDateTime(): ZonedDateTime {
     return ZonedDateTime.parse(this)
@@ -151,7 +141,7 @@ internal val DccData<out DccV1.MetaData>.typeString: String
     }
 
 internal fun List<DccValidationRule>.filterRelevantRules(
-    validationDateTime: DateTime,
+    validationDateTime: ZonedDateTime,
     certificateType: String,
     country: DccCountry,
 ): List<DccValidationRule> = this
@@ -169,17 +159,6 @@ internal fun List<DccValidationRule>.filterRelevantRules(
         entry.value.maxByOrNull { it.versionSemVer }
     }
     .toList()
-
-fun DateTime.asZonedDateTime(zoneId: ZoneId): ZonedDateTime = ZonedDateTime.of(
-    year,
-    monthOfYear,
-    dayOfMonth,
-    hourOfDay,
-    minuteOfHour,
-    secondOfMinute,
-    0,
-    zoneId
-)
 
 internal const val GENERAL = "General"
 internal const val TEST = "Test"

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/core/business/wrapper/ValueSetWrapper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/core/business/wrapper/ValueSetWrapper.kt
@@ -12,8 +12,8 @@ class ValueSetWrapper @Inject constructor(
     dccValidationRepository: DccValidationRepository
 ) {
 
-    private val countryCodes = dccValidationRepository.dccCountries.map {
-        it.map { it.countryCode }
+    private val countryCodes = dccValidationRepository.dccCountries.map { countries ->
+        countries.map { country -> country.countryCode }
     }
 
     val valueMap: Flow<Map<String, List<String>>> = combine(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/core/common/exception/DccValidationException.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/core/common/exception/DccValidationException.kt
@@ -17,7 +17,6 @@ open class DccValidationException(
     enum class ErrorCode(
         val message: String
     ) {
-        ACCEPTANCE_RULE_CLIENT_ERROR("Update of acceptance rules failed with client error."),
         ACCEPTANCE_RULE_JSON_ARCHIVE_FILE_MISSING("Acceptance rules archive is missing files."),
         ACCEPTANCE_RULE_JSON_ARCHIVE_SIGNATURE_INVALID("Acceptance rules archive has an invalid signature."),
         ACCEPTANCE_RULE_JSON_EXTRACTION_FAILED("Acceptance rules could not be extracted from archive."),
@@ -27,20 +26,17 @@ open class DccValidationException(
         BOOSTER_NOTIFICATION_RULE_JSON_ARCHIVE_SIGNATURE_INVALID("Booster notification rules archive has an invalid signature."),
         BOOSTER_NOTIFICATION_RULE_JSON_EXTRACTION_FAILED("Booster notification rules could not be extracted from archive."),
         BOOSTER_NOTIFICATION_RULE_SERVER_ERROR("Update of Booster notification rules failed with server error."),
-        INVALIDATION_RULE_CLIENT_ERROR("Update of invalidation rules failed with client error."),
         INVALIDATION_RULE_JSON_ARCHIVE_FILE_MISSING("Invalidation rules archive is missing files."),
         INVALIDATION_RULE_JSON_ARCHIVE_SIGNATURE_INVALID("Invalidation rules archive has an invalid signature."),
         INVALIDATION_RULE_JSON_EXTRACTION_FAILED("Invalidation rules could not be extracted from archive."),
         INVALIDATION_RULE_SERVER_ERROR("Update of invalidation rules failed with server error."),
         INVALIDATION_RULE_JSON_DECODING_FAILED("Decoding invalidation rules failed."),
-        ONBOARDED_COUNTRIES_CLIENT_ERROR("Update of onboarded countries failed with client error."),
         ONBOARDED_COUNTRIES_JSON_ARCHIVE_FILE_MISSING("Onboarded countries archive is missing files."),
         ONBOARDED_COUNTRIES_JSON_ARCHIVE_SIGNATURE_INVALID("Onboarded countries archive has invalid signature."),
         ONBOARDED_COUNTRIES_JSON_EXTRACTION_FAILED("Onboarded countries could not be extracted from archive."),
         ONBOARDED_COUNTRIES_SERVER_ERROR("Update of onboarded countries failed with server error."),
         ONBOARDED_COUNTRIES_JSON_DECODING_FAILED("Decoding onboarded dcc countries failed."),
         NO_NETWORK("No or poor network when downloading value sets, acceptance rules, or invalidation rules."),
-        VALUE_SET_SERVER_ERROR("Update of value sets failed with server error."),
     }
 
     open val errorMessage: LazyString

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/core/rule/DccValidationRule.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/core/rule/DccValidationRule.kt
@@ -10,8 +10,8 @@ import kotlinx.parcelize.Parceler
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.TypeParceler
 import net.swiftzer.semver.SemVer
-import org.joda.time.DateTime
 import timber.log.Timber
+import java.time.ZonedDateTime
 
 @Parcelize
 @TypeParceler<JsonNode, LogicParceler>()
@@ -59,11 +59,11 @@ data class DccValidationRule(
     @SerializedName("Logic") val logic: JsonNode
 ) : Parcelable {
 
-    val validFromDateTime: DateTime
-        get() = DateTime.parse(validFrom)
+    val validFromDateTime: ZonedDateTime
+        get() = ZonedDateTime.parse(validFrom)
 
-    val validToDateTime: DateTime
-        get() = DateTime.parse(validTo)
+    val validToDateTime: ZonedDateTime
+        get() = ZonedDateTime.parse(validTo)
 
     val versionSemVer: SemVer
         get() = try {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/core/settings/DccValidationSettings.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/core/settings/DccValidationSettings.kt
@@ -1,0 +1,55 @@
+package de.rki.coronawarnapp.covidcertificate.validation.core.settings
+
+import androidx.annotation.VisibleForTesting
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import de.rki.coronawarnapp.covidcertificate.validation.core.CertificateValidationDataStore
+import de.rki.coronawarnapp.covidcertificate.validation.core.country.DccCountry
+import de.rki.coronawarnapp.util.datastore.clear
+import de.rki.coronawarnapp.util.datastore.dataRecovering
+import de.rki.coronawarnapp.util.datastore.trySetValue
+import de.rki.coronawarnapp.util.reset.Resettable
+import kotlinx.coroutines.flow.map
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class DccValidationSettings @Inject constructor(
+    @CertificateValidationDataStore private val dataStore: DataStore<Preferences>
+) : Resettable {
+
+    val settings = dataStore.dataRecovering.map { prefs ->
+        Pair(
+            prefs[DCC_VALIDATION_ARRIVAL_COUNTRY] ?: DccCountry.DE,
+            prefs[DCC_VALIDATION_ARRIVAL_TIME] ?: System.currentTimeMillis()
+        )
+    }
+
+    suspend fun updateDccValidationCountry(
+        arrivalCountry: String
+    ) = with(dataStore) {
+        trySetValue(DCC_VALIDATION_ARRIVAL_COUNTRY, arrivalCountry)
+    }
+
+    suspend fun updateDccValidationTime(
+        arrivalTime: Long
+    ) = with(dataStore) {
+        trySetValue(DCC_VALIDATION_ARRIVAL_TIME, arrivalTime)
+    }
+
+    override suspend fun reset() {
+        Timber.d("reset()")
+        dataStore.clear()
+    }
+
+    companion object {
+        @VisibleForTesting
+        val DCC_VALIDATION_ARRIVAL_TIME = longPreferencesKey("DccValidationSettings.arrival.timestamp")
+
+        @VisibleForTesting
+        val DCC_VALIDATION_ARRIVAL_COUNTRY = stringPreferencesKey("DccValidationSettings.arrival.country")
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/core/settings/DccValidationSettings.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/core/settings/DccValidationSettings.kt
@@ -7,6 +7,7 @@ import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import de.rki.coronawarnapp.covidcertificate.validation.core.CertificateValidationDataStore
 import de.rki.coronawarnapp.covidcertificate.validation.core.country.DccCountry
+import de.rki.coronawarnapp.util.TimeStamper
 import de.rki.coronawarnapp.util.datastore.clear
 import de.rki.coronawarnapp.util.datastore.dataRecovering
 import de.rki.coronawarnapp.util.datastore.trySetValue
@@ -18,13 +19,14 @@ import javax.inject.Singleton
 
 @Singleton
 class DccValidationSettings @Inject constructor(
-    @CertificateValidationDataStore private val dataStore: DataStore<Preferences>
+    @CertificateValidationDataStore private val dataStore: DataStore<Preferences>,
+    private val timeStamper: TimeStamper,
 ) : Resettable {
 
     val settings = dataStore.dataRecovering.map { prefs ->
         Pair(
             prefs[DCC_VALIDATION_ARRIVAL_COUNTRY] ?: DccCountry.DE,
-            prefs[DCC_VALIDATION_ARRIVAL_TIME] ?: System.currentTimeMillis()
+            prefs[DCC_VALIDATION_ARRIVAL_TIME] ?: timeStamper.nowJavaUTC.toEpochMilli()
         )
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/ValidationResultItemCreator.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/ValidationResultItemCreator.kt
@@ -22,7 +22,6 @@ import de.rki.coronawarnapp.util.ui.toResolvingString
 import java.time.Instant
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
-import java.util.Locale
 import javax.inject.Inject
 
 @Reusable

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/ValidationResultItemCreator.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/ValidationResultItemCreator.kt
@@ -16,6 +16,8 @@ import de.rki.coronawarnapp.covidcertificate.validation.ui.validationresult.comm
 import de.rki.coronawarnapp.covidcertificate.validation.ui.validationresult.common.listitem.businessrule.BusinessRuleVH
 import de.rki.coronawarnapp.covidcertificate.validation.ui.validationresult.common.listitem.mapAffectedFields
 import de.rki.coronawarnapp.util.TimeAndDateExtensions.toLocalDateTimeUserTz
+import de.rki.coronawarnapp.util.toJavaInstant
+import de.rki.coronawarnapp.util.toLocaleDateTimeUtc
 import de.rki.coronawarnapp.util.toUserTimeZone
 import de.rki.coronawarnapp.util.ui.LazyString
 import de.rki.coronawarnapp.util.ui.toLazyString
@@ -102,7 +104,7 @@ class ValidationResultItemCreator @Inject constructor() {
     ): TechnicalValidationFailedVH.Item =
         TechnicalValidationFailedVH.Item(
             validation = validation,
-            certificateExpiresAt = certificate.headerExpiresAt.toLocalDateTimeUserTz()
+            certificateExpiresAt = certificate.headerExpiresAt.toJavaInstant().toUserTimeZone()
         )
 
     fun validationFaqVHItem(): ValidationFaqVH.Item = ValidationFaqVH.Item

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/ValidationResultItemCreator.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/ValidationResultItemCreator.kt
@@ -109,8 +109,11 @@ class ValidationResultItemCreator @Inject constructor() {
             userInput.arrivalDateTime.toLocalTime().format(DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT))
         return ValidationInputVH.Item(
             dateDetails = R.string.validation_rules_result_valid_result_country_and_time.toResolvingString(
-                userInput.arrivalCountry, "$dateFormat $timeFormat",
-                validatedAt.toUserTimeZone().format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT))
+                userInput.arrivalCountry,
+                "$dateFormat $timeFormat",
+                validatedAt.toUserTimeZone().format(
+                    DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT)
+                )
             )
         )
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/ValidationResultItemCreator.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/ValidationResultItemCreator.kt
@@ -15,9 +15,7 @@ import de.rki.coronawarnapp.covidcertificate.validation.ui.validationresult.comm
 import de.rki.coronawarnapp.covidcertificate.validation.ui.validationresult.common.listitem.ValidationPassedHintVH
 import de.rki.coronawarnapp.covidcertificate.validation.ui.validationresult.common.listitem.businessrule.BusinessRuleVH
 import de.rki.coronawarnapp.covidcertificate.validation.ui.validationresult.common.listitem.mapAffectedFields
-import de.rki.coronawarnapp.util.TimeAndDateExtensions.toLocalDateTimeUserTz
 import de.rki.coronawarnapp.util.toJavaInstant
-import de.rki.coronawarnapp.util.toLocaleDateTimeUtc
 import de.rki.coronawarnapp.util.toUserTimeZone
 import de.rki.coronawarnapp.util.ui.LazyString
 import de.rki.coronawarnapp.util.ui.toLazyString

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/ValidationResultItemCreator.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/ValidationResultItemCreator.kt
@@ -16,14 +16,13 @@ import de.rki.coronawarnapp.covidcertificate.validation.ui.validationresult.comm
 import de.rki.coronawarnapp.covidcertificate.validation.ui.validationresult.common.listitem.businessrule.BusinessRuleVH
 import de.rki.coronawarnapp.covidcertificate.validation.ui.validationresult.common.listitem.mapAffectedFields
 import de.rki.coronawarnapp.util.TimeAndDateExtensions.toLocalDateTimeUserTz
-import de.rki.coronawarnapp.util.TimeAndDateExtensions.toShortDateTimeFormat
-import de.rki.coronawarnapp.util.TimeAndDateExtensions.toShortDayFormat
-import de.rki.coronawarnapp.util.TimeAndDateExtensions.toShortTimeFormat
-import de.rki.coronawarnapp.util.TimeAndDateExtensions.toUserTimeZone
+import de.rki.coronawarnapp.util.toUserTimeZone
 import de.rki.coronawarnapp.util.ui.LazyString
 import de.rki.coronawarnapp.util.ui.toLazyString
 import de.rki.coronawarnapp.util.ui.toResolvingString
-import org.joda.time.Instant
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 import java.util.Locale
 import javax.inject.Inject
 
@@ -108,15 +107,18 @@ class ValidationResultItemCreator @Inject constructor() {
 
     fun validationFaqVHItem(): ValidationFaqVH.Item = ValidationFaqVH.Item
 
-    fun validationInputVHItem(userInput: ValidationUserInput, validatedAt: Instant): ValidationInputVH.Item =
-        ValidationInputVH.Item(
+    fun validationInputVHItem(userInput: ValidationUserInput, validatedAt: Instant): ValidationInputVH.Item {
+        val dateFormat =
+            userInput.arrivalDateTime.toLocalDate().format(DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT))
+        val timeFormat =
+            userInput.arrivalDateTime.toLocalTime().format(DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT))
+        return ValidationInputVH.Item(
             dateDetails = R.string.validation_rules_result_valid_result_country_and_time.toResolvingString(
-                userInput.arrivalCountry,
-                "${userInput.arrivalDateTime.toLocalDate().toShortDayFormat()} " +
-                    userInput.arrivalDateTime.toLocalTime().toShortTimeFormat(),
-                validatedAt.toUserTimeZone().toShortDateTimeFormat()
+                userInput.arrivalCountry, "$dateFormat $timeFormat",
+                validatedAt.toUserTimeZone().format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT))
             )
         )
+    }
 
     fun validationOverallResultVHItem(state: DccValidation.State, ruleCount: Int = 0): ValidationOverallResultVH.Item =
         ValidationOverallResultVH.Item(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/listitem/TechnicalValidationFailedVH.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/listitem/TechnicalValidationFailedVH.kt
@@ -6,10 +6,10 @@ import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.covidcertificate.validation.core.DccValidation
 import de.rki.coronawarnapp.covidcertificate.validation.ui.validationresult.common.listitem.TechnicalValidationFailedVH.Item
 import de.rki.coronawarnapp.databinding.CovidCertificateValidationResultTechnicalFailedItemBinding
-import de.rki.coronawarnapp.util.TimeAndDateExtensions.toShortDayFormat
-import de.rki.coronawarnapp.util.TimeAndDateExtensions.toShortTimeFormat
 import de.rki.coronawarnapp.util.lists.diffutil.HasPayloadDiffer
-import org.joda.time.LocalDateTime
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 
 class TechnicalValidationFailedVH(
     parent: ViewGroup
@@ -40,8 +40,8 @@ class TechnicalValidationFailedVH(
 
             textExpiredDate.text = context.getString(
                 R.string.validation_rule_technical_error_date_expired_format,
-                curItem.certificateExpiresAt.toShortDayFormat(),
-                curItem.certificateExpiresAt.toShortTimeFormat(),
+                curItem.certificateExpiresAt.format(DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT)),
+                curItem.certificateExpiresAt.format(DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)),
             )
         }
     }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationstart/ValidationStartFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationstart/ValidationStartFragment.kt
@@ -87,11 +87,6 @@ class ValidationStartFragment : Fragment(R.layout.validation_start_fragment), Au
             viewModel.events.observe(viewLifecycleOwner) { onNavEvent(it) }
         }
 
-    override fun onResume() {
-        super.onResume()
-        viewModel.refreshTimeCheck()
-    }
-
     private fun ValidationStartFragmentBinding.onNavEvent(event: StartValidationNavEvent?) {
         when (event) {
             NavigateToValidationInfoFragment -> findNavController().navigate(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationstart/ValidationStartViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationstart/ValidationStartViewModel.kt
@@ -1,6 +1,5 @@
 package de.rki.coronawarnapp.covidcertificate.validation.ui.validationstart
 
-import androidx.lifecycle.LiveData
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -11,19 +10,22 @@ import de.rki.coronawarnapp.covidcertificate.validation.core.DccValidator
 import de.rki.coronawarnapp.covidcertificate.validation.core.ValidationUserInput
 import de.rki.coronawarnapp.covidcertificate.validation.core.country.DccCountry
 import de.rki.coronawarnapp.covidcertificate.validation.core.country.DccCountry.Companion.DE
+import de.rki.coronawarnapp.covidcertificate.validation.core.settings.DccValidationSettings
 import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
 import de.rki.coronawarnapp.util.network.NetworkStateProvider
+import de.rki.coronawarnapp.util.toUserTimeZone
 import de.rki.coronawarnapp.util.ui.SingleLiveEvent
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactory
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import timber.log.Timber
 import java.text.Collator
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import java.time.temporal.ChronoUnit
@@ -35,6 +37,7 @@ class ValidationStartViewModel @AssistedInject constructor(
     private val certificateProvider: CertificateProvider,
     @Assisted private val containerId: CertificateContainerId,
     private val networkStateProvider: NetworkStateProvider,
+    private val dccValidationSettings: DccValidationSettings,
 ) : CWAViewModel(dispatcherProvider = dispatcherProvider) {
 
     @AssistedFactory
@@ -43,11 +46,19 @@ class ValidationStartViewModel @AssistedInject constructor(
     }
 
     private val collator = Collator.getInstance()
-    private val uiState = MutableStateFlow(UIState())
-    val state: LiveData<UIState> = uiState.asLiveData2()
-    val selectedDate: LocalDate get() = uiState.value.localDate
-    val selectedTime: LocalTime get() = uiState.value.localTime
-    val selectedCountryCode: String get() = uiState.value.dccCountry.countryCode
+    val state = dccValidationSettings.settings.map { (country, timestamp) ->
+        val localDateTime = Instant.ofEpochMilli(timestamp).toUserTimeZone()
+        UIState(
+            DccCountry(country),
+            localDateTime.toLocalDate(),
+            localDateTime.toLocalTime()
+        )
+    }.asLiveData2()
+
+    val selectedDate: LocalDate get() = state.value?.localDate ?: LocalDate.now()
+    val selectedTime: LocalTime get() = state.value?.localTime ?: LocalTime.now()
+    val selectedCountryCode: String get() = state.value?.dccCountry?.countryCode ?: DccCountry.DE
+
     val events = SingleLiveEvent<StartValidationNavEvent>()
     val countryList = dccValidationRepository.dccCountries.map { countryList ->
         val countries = countryList.ifEmpty { listOf(DccCountry(DE)) }
@@ -58,14 +69,14 @@ class ValidationStartViewModel @AssistedInject constructor(
 
     fun onPrivacyClick() = events.postValue(NavigateToPrivacyFragment)
 
-    fun countryChanged(country: DccCountry) = uiState.apply { value = value.copy(dccCountry = country) }
-
-    fun refreshTimeCheck() = dateChanged(selectedDate, selectedTime)
+    fun countryChanged(country: DccCountry) = launch {
+        dccValidationSettings.updateDccValidationCountry(country.countryCode)
+    }
 
     fun onCheckClick() = launch {
         val event = if (networkStateProvider.networkState.first().isInternetAvailable) {
             try {
-                val state = uiState.value
+                val state = state.value!!
                 val country = state.dccCountry
                 val certificateData = certificateProvider.findCertificate(containerId).dccData
                 val validationResult = dccValidator.validateDcc(
@@ -86,12 +97,16 @@ class ValidationStartViewModel @AssistedInject constructor(
         events.postValue(event)
     }
 
-    fun dateChanged(localDate: LocalDate, localTime: LocalTime) {
-        val invalidTime = localDate.atTime(localTime).isBefore(
+    fun dateChanged(localDate: LocalDate, localTime: LocalTime) = launch {
+        val localDateTime = localDate.atTime(localTime)
+        val invalidTime = localDateTime.isBefore(
             LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS)
         )
+
+        dccValidationSettings.updateDccValidationTime(
+            localDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        )
         events.postValue(ShowTimeMessage(invalidTime))
-        uiState.apply { value = value.copy(localDate = localDate, localTime = localTime) }
     }
 
     data class UIState(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/JavaTimeAndDateExtenstions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/JavaTimeAndDateExtenstions.kt
@@ -8,6 +8,7 @@ import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 
 fun Instant.toUserTimeZone(): LocalDateTime = LocalDateTime.ofInstant(this, ZoneId.systemDefault())
+fun Instant.toLocaleDateTimeUtc(): LocalDateTime = LocalDateTime.ofInstant(this, ZoneOffset.UTC)
 fun Instant.toLocalDateUtc(): LocalDate = atZone(ZoneOffset.UTC).toLocalDate()
 fun LocalDate.ageInDays(now: LocalDate) = ChronoUnit.DAYS.between(this, now).toInt()
 fun Instant.toLocalDateUserTimeZone(): LocalDate = atZone(ZoneId.systemDefault()).toLocalDate()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/TimeAndDateExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/TimeAndDateExtensions.kt
@@ -82,7 +82,7 @@ object TimeAndDateExtensions {
      */
     fun Instant.toDayFormat(): String = toString(dayFormatter)
 
-    fun LocalDate.toInstantMidnightUtc() =
+    fun LocalDate.toInstantMidnightUtc(): Instant =
         this.toLocalDateTime(LocalTime.MIDNIGHT).toDateTime(DateTimeZone.UTC).toInstant()
 
     /**

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/validation/core/DccValidationTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/validation/core/DccValidationTest.kt
@@ -4,13 +4,12 @@ import de.rki.coronawarnapp.covidcertificate.validation.core.business.wrapper.cr
 import de.rki.coronawarnapp.covidcertificate.validation.core.country.DccCountry
 import de.rki.coronawarnapp.covidcertificate.validation.core.rule.DccValidationRule
 import de.rki.coronawarnapp.covidcertificate.validation.core.rule.EvaluatedDccRule
-import de.rki.coronawarnapp.util.TimeAndDateExtensions.toLocalDateTime
+import de.rki.coronawarnapp.util.toLocaleDateTimeUtc
 import dgca.verifier.app.engine.data.RuleCertificateType
 import io.kotest.matchers.shouldBe
-import org.joda.time.DateTimeZone
-import org.joda.time.Instant
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import java.time.Instant
 
 class DccValidationTest : BaseTest() {
 
@@ -18,7 +17,7 @@ class DccValidationTest : BaseTest() {
 
     private val userInput = ValidationUserInput(
         DccCountry("PT"),
-        nowUTC.toLocalDateTime(DateTimeZone.UTC),
+        nowUTC.toLocaleDateTimeUtc(),
     )
 
     @Test

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/validation/core/DccValidatorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/validation/core/DccValidatorTest.kt
@@ -19,11 +19,11 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.just
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import org.joda.time.Instant
-import org.joda.time.LocalDateTime
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import java.time.Instant
+import java.time.LocalDateTime
 import javax.inject.Inject
 
 @ExperimentalCoroutinesApi
@@ -45,7 +45,7 @@ class DccValidatorTest : BaseTest() {
         every { dccJsonSchemaValidator.isValid(any()) } returns JsonSchemaValidator.Result(emptySet())
         coEvery { businessValidator.validate(any(), any(), any()) } returns
             BusinessValidation(emptySet(), emptySet())
-        every { timeStamper.nowUTC } returns Instant.ofEpochSecond(1625827095)
+        every { timeStamper.nowJavaUTC } returns Instant.ofEpochSecond(1625827095)
         coEvery { dscSignatureValidator.validateSignature(any()) } just Runs
         dccValidator = DccValidator(
             businessValidator = businessValidator,

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/validation/core/business/wrapper/MappingsTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/validation/core/business/wrapper/MappingsTest.kt
@@ -4,18 +4,18 @@ import de.rki.coronawarnapp.covidcertificate.validation.core.country.DccCountry
 import dgca.verifier.app.engine.UTC_ZONE_ID
 import dgca.verifier.app.engine.data.RuleCertificateType
 import io.kotest.matchers.shouldBe
-import org.joda.time.DateTimeZone
-import org.joda.time.Instant
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import java.time.Instant
 import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
 
 class MappingsTest : BaseTest() {
 
     @Test
     fun `Instant toZonedDateTime works`() {
         val original = Instant.parse("2021-05-27T07:46:40.000Z")
-        val zoned = original.toZonedDateTime(UTC_ZONE_ID)
+        val zoned = original.atZone(UTC_ZONE_ID)
         zoned shouldBe ZonedDateTime.of(
             2021,
             5,
@@ -26,7 +26,7 @@ class MappingsTest : BaseTest() {
             0,
             UTC_ZONE_ID
         )
-        zoned.toInstant().toEpochMilli() shouldBe original.millis
+        zoned.toInstant().toEpochMilli() shouldBe original.toEpochMilli()
     }
 
     @Test
@@ -49,64 +49,64 @@ class MappingsTest : BaseTest() {
     @Test
     fun `filter rules works`() {
         val validationClock = Instant.parse("2021-05-27T07:46:40Z")
-        val validationDate = validationClock.toDateTime(DateTimeZone.UTC)
+        val validationDate = validationClock.atZone(UTC_ZONE_ID)
 
         val vacA1 = createDccRule(
             certificateType = RuleCertificateType.VACCINATION,
             identifier = "VR-DE-1",
             version = "1.0.0",
-            validFrom = validationClock.minus(100).toString(),
-            validTo = validationClock.plus(100).toString(),
+            validFrom = validationClock.minus(100, ChronoUnit.DAYS).toString(),
+            validTo = validationClock.plus(100, ChronoUnit.DAYS).toString(),
         ) // Has newer version
         val vacA2 = createDccRule(
             certificateType = RuleCertificateType.VACCINATION,
             identifier = "VR-DE-1",
             version = "1.0.1",
-            validFrom = validationClock.minus(100).toString(),
-            validTo = validationClock.plus(100).toString(),
+            validFrom = validationClock.minus(100, ChronoUnit.DAYS).toString(),
+            validTo = validationClock.plus(100, ChronoUnit.DAYS).toString(),
         ) // :)
         val vacA3 = createDccRule(
             certificateType = RuleCertificateType.VACCINATION,
             identifier = "VR-DE-1",
             version = "1.0.2",
-            validFrom = validationClock.minus(100).toString(),
-            validTo = validationClock.plus(100).toString(),
+            validFrom = validationClock.minus(100, ChronoUnit.DAYS).toString(),
+            validTo = validationClock.plus(100, ChronoUnit.DAYS).toString(),
             country = "NL"
         ) // Wrong arrival country
         val vacB1 = createDccRule(
             certificateType = RuleCertificateType.TEST,
             identifier = "TR-DE-2",
             version = "1.0.0",
-            validFrom = validationClock.minus(100).toString(),
-            validTo = validationClock.plus(100).toString(),
+            validFrom = validationClock.minus(100, ChronoUnit.DAYS).toString(),
+            validTo = validationClock.plus(100, ChronoUnit.DAYS).toString(),
         ) // Wrong type
         val genA1 = createDccRule(
             certificateType = RuleCertificateType.GENERAL,
             identifier = "GR-DE-1",
             version = "1.0.0",
-            validFrom = validationClock.minus(100).toString(),
-            validTo = validationClock.plus(100).toString(),
+            validFrom = validationClock.minus(100, ChronoUnit.DAYS).toString(),
+            validTo = validationClock.plus(100, ChronoUnit.DAYS).toString(),
         ) // Has newer version
         val genA2 = createDccRule(
             certificateType = RuleCertificateType.GENERAL,
             identifier = "GR-DE-1",
             version = "1.0.1",
-            validFrom = validationClock.minus(100).toString(),
-            validTo = validationClock.plus(100).toString(),
+            validFrom = validationClock.minus(100, ChronoUnit.DAYS).toString(),
+            validTo = validationClock.plus(100, ChronoUnit.DAYS).toString(),
         ) // :)
         val genA3 = createDccRule(
             certificateType = RuleCertificateType.GENERAL,
             identifier = "GR-DE-1",
             version = "2.0.1",
-            validFrom = validationClock.plus(1).toString(),
-            validTo = validationClock.plus(100).toString(),
+            validFrom = validationClock.plus(1, ChronoUnit.DAYS).toString(),
+            validTo = validationClock.plus(100, ChronoUnit.DAYS).toString(),
         ) // validFrom is in the future
         val genA4 = createDccRule(
             certificateType = RuleCertificateType.GENERAL,
             identifier = "GR-DE-1",
             version = "2.0.1",
-            validFrom = validationClock.plus(1).toString(),
-            validTo = validationClock.minus(1).toString(),
+            validFrom = validationClock.plus(1, ChronoUnit.DAYS).toString(),
+            validTo = validationClock.minus(1, ChronoUnit.DAYS).toString(),
         ) // validTo is in the past
 
         val genA5 = createDccRule(

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/validation/core/business/wrapper/MappingsTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/validation/core/business/wrapper/MappingsTest.kt
@@ -55,58 +55,58 @@ class MappingsTest : BaseTest() {
             certificateType = RuleCertificateType.VACCINATION,
             identifier = "VR-DE-1",
             version = "1.0.0",
-            validFrom = validationClock.minus(100, ChronoUnit.DAYS).toString(),
-            validTo = validationClock.plus(100, ChronoUnit.DAYS).toString(),
+            validFrom = validationClock.minus(100, ChronoUnit.MILLIS).toString(),
+            validTo = validationClock.plus(100, ChronoUnit.MILLIS).toString(),
         ) // Has newer version
         val vacA2 = createDccRule(
             certificateType = RuleCertificateType.VACCINATION,
             identifier = "VR-DE-1",
             version = "1.0.1",
-            validFrom = validationClock.minus(100, ChronoUnit.DAYS).toString(),
-            validTo = validationClock.plus(100, ChronoUnit.DAYS).toString(),
+            validFrom = validationClock.minus(100, ChronoUnit.MILLIS).toString(),
+            validTo = validationClock.plus(100, ChronoUnit.MILLIS).toString(),
         ) // :)
         val vacA3 = createDccRule(
             certificateType = RuleCertificateType.VACCINATION,
             identifier = "VR-DE-1",
             version = "1.0.2",
-            validFrom = validationClock.minus(100, ChronoUnit.DAYS).toString(),
-            validTo = validationClock.plus(100, ChronoUnit.DAYS).toString(),
+            validFrom = validationClock.minus(100, ChronoUnit.MILLIS).toString(),
+            validTo = validationClock.plus(100, ChronoUnit.MILLIS).toString(),
             country = "NL"
         ) // Wrong arrival country
         val vacB1 = createDccRule(
             certificateType = RuleCertificateType.TEST,
             identifier = "TR-DE-2",
             version = "1.0.0",
-            validFrom = validationClock.minus(100, ChronoUnit.DAYS).toString(),
-            validTo = validationClock.plus(100, ChronoUnit.DAYS).toString(),
+            validFrom = validationClock.minus(100, ChronoUnit.MILLIS).toString(),
+            validTo = validationClock.plus(100, ChronoUnit.MILLIS).toString(),
         ) // Wrong type
         val genA1 = createDccRule(
             certificateType = RuleCertificateType.GENERAL,
             identifier = "GR-DE-1",
             version = "1.0.0",
-            validFrom = validationClock.minus(100, ChronoUnit.DAYS).toString(),
-            validTo = validationClock.plus(100, ChronoUnit.DAYS).toString(),
+            validFrom = validationClock.minus(100, ChronoUnit.MILLIS).toString(),
+            validTo = validationClock.plus(100, ChronoUnit.MILLIS).toString(),
         ) // Has newer version
         val genA2 = createDccRule(
             certificateType = RuleCertificateType.GENERAL,
             identifier = "GR-DE-1",
             version = "1.0.1",
-            validFrom = validationClock.minus(100, ChronoUnit.DAYS).toString(),
-            validTo = validationClock.plus(100, ChronoUnit.DAYS).toString(),
+            validFrom = validationClock.minus(100, ChronoUnit.MILLIS).toString(),
+            validTo = validationClock.plus(100, ChronoUnit.MILLIS).toString(),
         ) // :)
         val genA3 = createDccRule(
             certificateType = RuleCertificateType.GENERAL,
             identifier = "GR-DE-1",
             version = "2.0.1",
-            validFrom = validationClock.plus(1, ChronoUnit.DAYS).toString(),
-            validTo = validationClock.plus(100, ChronoUnit.DAYS).toString(),
+            validFrom = validationClock.plus(1, ChronoUnit.MILLIS).toString(),
+            validTo = validationClock.plus(100, ChronoUnit.MILLIS).toString(),
         ) // validFrom is in the future
         val genA4 = createDccRule(
             certificateType = RuleCertificateType.GENERAL,
             identifier = "GR-DE-1",
             version = "2.0.1",
-            validFrom = validationClock.plus(1, ChronoUnit.DAYS).toString(),
-            validTo = validationClock.minus(1, ChronoUnit.DAYS).toString(),
+            validFrom = validationClock.plus(1, ChronoUnit.MILLIS).toString(),
+            validTo = validationClock.minus(1, ChronoUnit.MILLIS).toString(),
         ) // validTo is in the past
 
         val genA5 = createDccRule(

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/validation/core/settings/DccValidationSettingsTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/validation/core/settings/DccValidationSettingsTest.kt
@@ -1,0 +1,63 @@
+package de.rki.coronawarnapp.covidcertificate.validation.core.settings
+
+import de.rki.coronawarnapp.util.TimeStamper
+import io.kotest.matchers.shouldBe
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.preferences.FakeDataStore
+import java.time.Instant
+
+internal class DccValidationSettingsTest : BaseTest() {
+
+    @MockK lateinit var timeStamper: TimeStamper
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this)
+        every { timeStamper.nowJavaUTC } returns Instant.ofEpochMilli(2000L)
+    }
+
+    @Test
+    fun getSettings() = runTest {
+        instance().settings.first() shouldBe ("DE" to 2000L)
+    }
+
+    @Test
+    fun updateDccValidationCountry() = runTest {
+        instance().apply {
+            settings.first() shouldBe ("DE" to 2000L)
+            updateDccValidationCountry("AT")
+            settings.first() shouldBe ("AT" to 2000L)
+        }
+    }
+
+    @Test
+    fun updateDccValidationTime() = runTest {
+        instance().apply {
+            settings.first() shouldBe ("DE" to 2000L)
+            updateDccValidationTime(3000L)
+            settings.first() shouldBe ("DE" to 3000L)
+        }
+    }
+
+    @Test
+    fun reset() = runTest {
+        instance().apply {
+            updateDccValidationTime(0L)
+            settings.first() shouldBe ("DE" to 0L)
+            reset()
+            settings.first() shouldBe ("DE" to 2000L)
+        }
+    }
+
+    fun instance() = DccValidationSettings(
+        FakeDataStore(),
+        timeStamper
+    )
+}

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/reset/ResetTestComponent.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/util/reset/ResetTestComponent.kt
@@ -30,6 +30,7 @@ import de.rki.coronawarnapp.covidcertificate.vaccination.core.repository.Vaccina
 import de.rki.coronawarnapp.covidcertificate.validation.core.DccValidationCache
 import de.rki.coronawarnapp.covidcertificate.validation.core.DccValidationModule
 import de.rki.coronawarnapp.covidcertificate.validation.core.server.DccValidationServer
+import de.rki.coronawarnapp.covidcertificate.validation.core.settings.DccValidationSettings
 import de.rki.coronawarnapp.covidcertificate.valueset.CertificateValueSetModule
 import de.rki.coronawarnapp.covidcertificate.valueset.ValueSetsRepository
 import de.rki.coronawarnapp.covidcertificate.valueset.server.CertificateValueSetServer
@@ -274,4 +275,7 @@ object MockProvider {
 
     @Provides
     fun provideDefaultExposureDetectionTracker(): DefaultExposureDetectionTracker = mockk(relaxed = true)
+
+    @Provides
+    fun provideDccValidationSettings(): DccValidationSettings = mockk(relaxed = true)
 }


### PR DESCRIPTION
## Changes
- [x] As part of migration to Java time, Dcc Validation package has been updated to use Java Time APIs 
- [x] Save user selection for subsequent use
- DCC Validation Screen should now persist user selection between subsequent validations
<img width="400" alt="Screenshot 2022-08-18 at 16 59 58" src="https://user-images.githubusercontent.com/25054729/185428410-cc4bd97f-7253-4ade-bf1b-f2260f7c4dc3.png">


## Ticket
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8469