### PR TITLE
RAT test result texts (EXPOSUREAPP-12978)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/testresult/negative/SubmissionTestResultNegativeFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/testresult/negative/SubmissionTestResultNegativeFragment.kt
@@ -95,11 +95,26 @@ class SubmissionTestResultNegativeFragment : Fragment(R.layout.fragment_submissi
                         )
                     }
                     BaseCoronaTest.Type.RAPID_ANTIGEN -> {
-                        testResultStepsTestAdded.setEntryTitle(
-                            getText(
-                                R.string.submission_family_test_result_steps_added_rat_heading
+
+                        when (coronaTest) {
+                            is FamilyCoronaTest -> testResultStepsTestAdded.setEntryTitle(
+                                getText(
+                                    R.string.submission_family_test_result_steps_added_rat_heading
+                                )
                             )
-                        )
+                            is PersonalCoronaTest -> {
+                                testResultStepsTestAdded.setEntryTitle(
+                                    getText(
+                                        R.string.submission_test_result_steps_added_rat_heading
+                                    )
+                                )
+                                testResultStepsTestAdded.setEntryText(
+                                    getText(
+                                        R.string.submission_test_result_steps_added_body_rat
+                                    )
+                                )
+                            }
+                        }
 
                         testResultStepsNegativeResult.setEntryText(
                             getText(

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_test_result_negative.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_test_result_negative.xml
@@ -197,7 +197,7 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/submission_test_result_subtitle"
-                    app:simple_step_entry_text="@string/submission_test_result_steps_added_body"
+                    app:simple_step_entry_text="@string/submission_test_result_steps_added_body_pcr"
                     app:simple_step_entry_title="@string/submission_test_result_steps_added_heading"
                     app:step_entry_final="false"
                     app:step_entry_icon="@drawable/ic_test_result_step_done" />

--- a/Corona-Warn-App/src/main/res/values-bg/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-bg/strings.xml
@@ -1034,8 +1034,10 @@
     <string name="submission_test_result_subtitle">"Как работи:"</string>
     <!-- XHED: Page headline for results next steps  -->
     <string name="submission_test_result_steps_added_heading">"Вашият PCR тест е добавен"</string>
-    <!-- YTXT: Body text for for results next steps  -->
-    <string name="submission_test_result_steps_added_body">"Вашият тест е запазен в приложението Corona-Warn-App."</string>
+    <!-- YTXT: Body text for for results next steps pcr -->
+    <string name="submission_test_result_steps_added_body_pcr">"Вашият тест е запазен в приложението Corona-Warn-App."</string>
+    <!-- YTXT: Body text for for results next steps rat -->
+    <string name="submission_test_result_steps_added_body_rat"></string>
     <!-- XHED: Page headline for family results next steps PCR -->
     <string name="submission_family_test_result_steps_added_pcr_heading">"PCR тестът е добавен"</string>
     <!-- XHED: Page headline for family results next steps RAT -->

--- a/Corona-Warn-App/src/main/res/values-de/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-de/strings.xml
@@ -1039,8 +1039,10 @@ Sollten Sie den Test in der App gelöscht haben, können Sie ihn aus dem Papierk
     <string name="submission_test_result_subtitle">"Info zum Ablauf:"</string>
     <!-- XHED: Page headline for results next steps  -->
     <string name="submission_test_result_steps_added_heading">"Ihr PCR-Test wurde hinzugefügt"</string>
-    <!-- YTXT: Body text for for results next steps  -->
-    <string name="submission_test_result_steps_added_body">"Ihr Test wurde in der Corona-Warn-App registriert."</string>
+    <!-- YTXT: Body text for for results next steps pcr -->
+    <string name="submission_test_result_steps_added_body_pcr">"Ihr Test wurde in der Corona-Warn-App registriert."</string>
+    <!-- YTXT: Body text for for results next steps rat -->
+    <string name="submission_test_result_steps_added_body_rat">"Das Test-Ergebnis wird 48 Stunden hier angezeigt. Zusätzlich legt die App einen Eintrag in Ihrem Kontakt-Tagebuch an."</string>
     <!-- XHED: Page headline for family results next steps PCR -->
     <string name="submission_family_test_result_steps_added_pcr_heading">"Der PCR-Test wurde hinzugefügt"</string>
     <!-- XHED: Page headline for family results next steps RAT -->

--- a/Corona-Warn-App/src/main/res/values-pl/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-pl/strings.xml
@@ -1034,8 +1034,10 @@
     <string name="submission_test_result_subtitle">"Jak to działa:"</string>
     <!-- XHED: Page headline for results next steps  -->
     <string name="submission_test_result_steps_added_heading">"Test PCR został dodany"</string>
-    <!-- YTXT: Body text for for results next steps  -->
-    <string name="submission_test_result_steps_added_body">"Twój test został zapisany w Corona-Warn-App."</string>
+    <!-- YTXT: Body text for for results next steps pcr -->
+    <string name="submission_test_result_steps_added_body_pcr">"Twój test został zapisany w Corona-Warn-App."</string>
+    <!-- YTXT: Body text for for results next steps rat -->
+    <string name="submission_test_result_steps_added_body_rat"></string>
     <!-- XHED: Page headline for family results next steps PCR -->
     <string name="submission_family_test_result_steps_added_pcr_heading">"Test PCR został dodany"</string>
     <!-- XHED: Page headline for family results next steps RAT -->

--- a/Corona-Warn-App/src/main/res/values-ro/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-ro/strings.xml
@@ -1034,8 +1034,10 @@
     <string name="submission_test_result_subtitle">"Cum funcționează:"</string>
     <!-- XHED: Page headline for results next steps  -->
     <string name="submission_test_result_steps_added_heading">"Testul dvs. PCR a fost adăugat"</string>
-    <!-- YTXT: Body text for for results next steps  -->
-    <string name="submission_test_result_steps_added_body">"Testul dvs. a fost stocat în Corona-Warn-App."</string>
+    <!-- YTXT: Body text for for results next steps pcr -->
+    <string name="submission_test_result_steps_added_body_pcr">"Testul dvs. a fost stocat în Corona-Warn-App."</string>
+    <!-- YTXT: Body text for for results next steps rat -->
+    <string name="submission_test_result_steps_added_body_rat"></string>
     <!-- XHED: Page headline for family results next steps PCR -->
     <string name="submission_family_test_result_steps_added_pcr_heading">"Testul PCR a fost adăugat"</string>
     <!-- XHED: Page headline for family results next steps RAT -->

--- a/Corona-Warn-App/src/main/res/values-tr/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-tr/strings.xml
@@ -1034,8 +1034,10 @@
     <string name="submission_test_result_subtitle">"Nasıl çalışır?"</string>
     <!-- XHED: Page headline for results next steps  -->
     <string name="submission_test_result_steps_added_heading">"PCR Testiniz Eklendi"</string>
-    <!-- YTXT: Body text for for results next steps  -->
-    <string name="submission_test_result_steps_added_body">"Testiniz Corona-Warn-App\'e kaydedildi."</string>
+    <!-- YTXT: Body text for for results next steps pcr -->
+    <string name="submission_test_result_steps_added_body_pcr">"Testiniz Corona-Warn-App\'e kaydedildi."</string>
+    <!-- YTXT: Body text for for results next steps rat -->
+    <string name="submission_test_result_steps_added_body_rat"></string>
     <!-- XHED: Page headline for family results next steps PCR -->
     <string name="submission_family_test_result_steps_added_pcr_heading">"PCR testi eklendi"</string>
     <!-- XHED: Page headline for family results next steps RAT -->

--- a/Corona-Warn-App/src/main/res/values-uk/strings.xml
+++ b/Corona-Warn-App/src/main/res/values-uk/strings.xml
@@ -1034,8 +1034,10 @@
     <string name="submission_test_result_subtitle">"Як це працює:"</string>
     <!-- XHED: Page headline for results next steps  -->
     <string name="submission_test_result_steps_added_heading">"Ваш ПЛР-тест додано"</string>
-    <!-- YTXT: Body text for for results next steps  -->
-    <string name="submission_test_result_steps_added_body">"Ваш тест було збережено в Corona-Warn-App."</string>
+    <!-- YTXT: Body text for for results next steps pcr -->
+    <string name="submission_test_result_steps_added_body_pcr">"Ваш тест було збережено в Corona-Warn-App."</string>
+    <!-- YTXT: Body text for for results next steps rat -->
+    <string name="submission_test_result_steps_added_body_rat"></string>
     <!-- XHED: Page headline for family results next steps PCR -->
     <string name="submission_family_test_result_steps_added_pcr_heading">"ПЛР-тест було додано"</string>
     <!-- XHED: Page headline for family results next steps RAT -->

--- a/Corona-Warn-App/src/main/res/values/strings.xml
+++ b/Corona-Warn-App/src/main/res/values/strings.xml
@@ -1037,8 +1037,10 @@
     <string name="submission_test_result_subtitle">"How this works:"</string>
     <!-- XHED: Page headline for results next steps  -->
     <string name="submission_test_result_steps_added_heading">"Your PCR Test Was Added"</string>
-    <!-- YTXT: Body text for for results next steps  -->
-    <string name="submission_test_result_steps_added_body">"Your test has been stored in the Corona-Warn-App."</string>
+    <!-- YTXT: Body text for for results next steps pcr -->
+    <string name="submission_test_result_steps_added_body_pcr">"Your test has been stored in the Corona-Warn-App."</string>
+    <!-- YTXT: Body text for for results next steps rat -->
+    <string name="submission_test_result_steps_added_body_rat"></string>
     <!-- XHED: Page headline for family results next steps PCR -->
     <string name="submission_family_test_result_steps_added_pcr_heading">"The PCR test was added"</string>
     <!-- XHED: Page headline for family results next steps RAT -->


### PR DESCRIPTION
[Ticket](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-12978)

Change RAT test result texts to match [figma design](https://www.figma.com/file/KuDEcMSREg3VhZRhC3FXTY/COVID19_Master_2.25?node-id=53253%3A38324):


Remarks:

- Text from Ticket "Bitte löschen Sie den Test wieder aus der Corona-Warn-App, damit Sie bei Bedarf einen neuen Test hinterlegen können." was removed from figma design
- PR also addresses "infos zum Ablauf" headline for personal test "Ihr Schnelltest wurde hinzugefügt." which wasn't reflected in the ticket