### PR TITLE
DccValueSets language changes with system language (EXPOSUREAPP-8864)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/ValidationResultItemCreator.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/ValidationResultItemCreator.kt
@@ -41,16 +41,13 @@ class ValidationResultItemCreator @Inject constructor() {
             )
         }
 
-        val countryInformation = rule.getCountryDescription()
-
         val affectedFields = mapAffectedFields(rule.affectedFields, certificate)
 
         val identifier = "${rule.identifier} (${rule.version})"
 
         return BusinessRuleVH.Item(
             ruleIconRes = iconRes,
-            ruleDescriptionText = rule,
-            countryInformationText = countryInformation,
+            dccValidationRule = rule,
             affectedFields = affectedFields,
             identifier = identifier
         )
@@ -132,18 +129,4 @@ class ValidationResultItemCreator @Inject constructor() {
         )
 
     fun validationPassedHintVHItem(): ValidationPassedHintVH.Item = ValidationPassedHintVH.Item
-
-    // Apply rules from tech spec to decide which rule description to display
-    private fun DccValidationRule.getCountryDescription(): Pair<Int, String?> = when (typeDcc) {
-        DccValidationRule.Type.ACCEPTANCE -> Pair(
-            R.string.validation_rules_acceptance_country,
-            country
-        )
-        DccValidationRule.Type.INVALIDATION -> Pair(
-            R.string.validation_rules_invalidation_country,
-            null
-        )
-        DccValidationRule.Type.BOOSTER_NOTIFICATION ->
-            throw IllegalStateException("Booster notification rules are not allowed here!")
-    }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/ValidationResultItemCreator.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/ValidationResultItemCreator.kt
@@ -5,7 +5,6 @@ import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.covidcertificate.common.certificate.CwaCovidCertificate
 import de.rki.coronawarnapp.covidcertificate.validation.core.DccValidation
 import de.rki.coronawarnapp.covidcertificate.validation.core.ValidationUserInput
-import de.rki.coronawarnapp.covidcertificate.validation.core.country.DccCountry
 import de.rki.coronawarnapp.covidcertificate.validation.core.rule.DccValidationRule
 import de.rki.coronawarnapp.covidcertificate.validation.ui.validationresult.common.listitem.RuleHeaderVH
 import de.rki.coronawarnapp.covidcertificate.validation.ui.validationresult.common.listitem.TechnicalValidationFailedVH
@@ -24,7 +23,6 @@ import de.rki.coronawarnapp.util.ui.LazyString
 import de.rki.coronawarnapp.util.ui.toLazyString
 import de.rki.coronawarnapp.util.ui.toResolvingString
 import org.joda.time.Instant
-import java.util.Locale
 import javax.inject.Inject
 
 @Reusable
@@ -43,7 +41,6 @@ class ValidationResultItemCreator @Inject constructor() {
             )
         }
 
-        val ruleDescription = rule.getRuleDescription().toLazyString()
         val countryInformation = rule.getCountryDescription()
 
         val affectedFields = mapAffectedFields(rule.affectedFields, certificate)
@@ -52,7 +49,7 @@ class ValidationResultItemCreator @Inject constructor() {
 
         return BusinessRuleVH.Item(
             ruleIconRes = iconRes,
-            ruleDescriptionText = ruleDescription,
+            ruleDescriptionText = rule,
             countryInformationText = countryInformation,
             affectedFields = affectedFields,
             identifier = identifier
@@ -137,20 +134,16 @@ class ValidationResultItemCreator @Inject constructor() {
     fun validationPassedHintVHItem(): ValidationPassedHintVH.Item = ValidationPassedHintVH.Item
 
     // Apply rules from tech spec to decide which rule description to display
-    private fun DccValidationRule.getCountryDescription(): LazyString = when (typeDcc) {
-        DccValidationRule.Type.ACCEPTANCE -> R.string.validation_rules_acceptance_country.toResolvingString(
-            DccCountry(country).displayName()
+    private fun DccValidationRule.getCountryDescription(): Pair<Int, String?> = when (typeDcc) {
+        DccValidationRule.Type.ACCEPTANCE -> Pair(
+            R.string.validation_rules_acceptance_country,
+            country
         )
-        DccValidationRule.Type.INVALIDATION -> R.string.validation_rules_invalidation_country.toResolvingString()
+        DccValidationRule.Type.INVALIDATION -> Pair(
+            R.string.validation_rules_invalidation_country,
+            null
+        )
         DccValidationRule.Type.BOOSTER_NOTIFICATION ->
             throw IllegalStateException("Booster notification rules are not allowed here!")
     }
-}
-
-// Apply rules from tech spec to decide which rule description to display
-fun DccValidationRule.getRuleDescription(): String {
-    val currentLocaleCode = Locale.getDefault().language
-    val descItem = description.find { it.languageCode == currentLocaleCode }
-        ?: description.find { it.languageCode == "en" } ?: description.firstOrNull()
-    return descItem?.description ?: identifier
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/listitem/businessrule/BusinessRuleVH.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/validation/ui/validationresult/common/listitem/businessrule/BusinessRuleVH.kt
@@ -52,10 +52,8 @@ class BusinessRuleVH(
         }
     }
 
-    private fun countryName(countryCode: String?, userLocale: Locale = Locale.getDefault()): String =
-        if (countryCode != null) {
-            Locale(userLocale.language, countryCode.uppercase()).getDisplayCountry(userLocale)
-        } else ""
+    private fun countryName(countryCode: String, userLocale: Locale = Locale.getDefault()): String =
+        Locale(userLocale.language, countryCode.uppercase()).getDisplayCountry(userLocale)
 
     private fun DccValidationRule.getRuleDescription(): String {
         val currentLocaleCode = Locale.getDefault().language


### PR DESCRIPTION
[Ticket](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-8684)

Some text fields were not changing when switching system language.

To test, check the validity of a certificate and try to land on the "Certificate not valid page". Go to system settings and change the language. All text should be in the system language set, with the exception of the affected fields that can't be transalted and are only available in German/English. 
Also the country name should be displayed in the language you switched to.
