### PR TITLE
Fix Rapid antigen test timestamp (EXPOSUREAPP-7528)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RapidAntigenCoronaTestExtensions.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RapidAntigenCoronaTestExtensions.kt
@@ -28,7 +28,7 @@ fun RACoronaTest?.toSubmissionState(
     if (this == null) return NoTest
     val state = getState(nowUTC, coronaTestConfig)
     return when {
-        isSubmitted && isViewed -> SubmissionDone(testRegisteredAt = registeredAt)
+        isSubmitted && isViewed -> SubmissionDone(testRegisteredAt = testTakenAt)
         isProcessing && state == PENDING -> FetchingResult
         lastError is BadRequestException -> TestInvalid
         else -> when (state) {

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RapidAntigenCoronaTestExtensionsTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/coronatest/type/rapidantigen/RapidAntigenCoronaTestExtensionsTest.kt
@@ -52,7 +52,7 @@ class RapidAntigenCoronaTestExtensionsTest : BaseTest() {
             lastUpdatedAt = Instant.EPOCH,
         )
         test.toSubmissionState(timeStamper.nowUTC, coronaTestConfig) shouldBe SubmissionStateRAT.SubmissionDone(
-            testRegisteredAt = Instant.ofEpochMilli(123)
+            testRegisteredAt = Instant.EPOCH
         )
     }
 


### PR DESCRIPTION
## Test
- Use CLI to generate positive RAT test in today's time
- Set device time into the future just to make time of registration different 
- Time shown in the test should be time when test taken , this can be found in the CLI tool output 
## Ticket
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-7528