### PR TITLE
Update Google allowlist information in README (Community)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ The goal of this project is to develop the official Corona-Warn-App for Germany 
 
 ## Known Issues
 
-* The Exposure Notification API is going to block you from successfully testing the Application unless you are whitelisted inside GMS; **Shoutout to @pocmo for working on a demo mode to test unreleased app versions in advance without whitelisting (issue [#321](https://github.com/corona-warn-app/cwa-app-android/issues/321))**, if you want to contribute you can reach out [here](https://github.com/pocmo/cwa-app-android) for the time being - thank you!
+* Activating exposure logging on a test version of the Android app requires a Google account which has been  allowlisted for this purpose by Google (see [Exposure Notifications implementation guide - Prerequisites](https://developers.google.com/android/exposure-notifications/implementation-guide#prereqs)). Google only allowlists official development partners: general CWA community members are not included. If you try to activate exposure logging and your account is not allowlisted then you will see the error message "Cause 3". Other functionality in the app which does not rely on exposure logging can however still be tested.
+
 * The Storage is currently based on Encrypted Shared Preferences and SQL Cipher (SQLite) - this could change in the future
 * Test Coverage is generally low and needs to be improved. We appreciate your help here!
 * In General every TODO comment within the code or the documentation can be regarded as an issue. You are free to tackle the TODOs anytime!


### PR DESCRIPTION
This PR resolves https://github.com/corona-warn-app/cwa-app-android/issues/5481 "Obsolete information regarding "whitelisting" for testers" by updating the [README - Known Issues](https://github.com/corona-warn-app/cwa-app-android/blob/main/README.md#known-issues) section.