### PR TITLE
Hide empty badges in person overview screen (DEV)

### DIFF
--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragmentTest2.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewFragmentTest2.kt
@@ -125,6 +125,42 @@ class PersonOverviewFragmentTest2 : BaseUITest() {
         takeSelfieWithBottomNavBadge("gStatusIsNullAndMaskIsVisible", R.id.covid_certificates_graph)
     }
 
+    @Test
+    @Screenshot
+    fun gStatusIsVisibleTextEmptyAndMaskIsVisible() {
+        every { viewModel.uiState } returns MutableLiveData(
+            UiState.Done(
+                gStatusIsVisibleTextEmptyAndMaskIsVisibleItem()
+            )
+        )
+        takeSelfieWithBottomNavBadge("gStatusIsVisibleTextEmptyAndMaskIsVisible", R.id.covid_certificates_graph)
+    }
+
+    @Test
+    @Screenshot
+    fun gStatusIsVisibleAndMaskIsVisibleTextEmpty() {
+        every { viewModel.uiState } returns MutableLiveData(
+            UiState.Done(
+                gStatusIsVisibleAndMaskIsVisibleTextEmptyItem()
+            )
+        )
+        takeSelfieWithBottomNavBadge("gStatusIsVisibleAndMaskIsVisibleTextEmpty", R.id.covid_certificates_graph)
+    }
+
+    @Test
+    @Screenshot
+    fun gStatusIsVisibleTextEmptyAndMaskIsVisibleTextEmpty() {
+        every { viewModel.uiState } returns MutableLiveData(
+            UiState.Done(
+                gStatusIsVisibleTextEmptyAndMaskIsVisibleTextEmptyItem()
+            )
+        )
+        takeSelfieWithBottomNavBadge(
+            "gStatusIsVisibleTextEmptyAndMaskIsVisibleTextEmpty",
+            R.id.covid_certificates_graph
+        )
+    }
+
     @After
     fun teardown() {
         clearAllViewModels()

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/TestData.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/TestData.kt
@@ -308,6 +308,96 @@ fun gStatusIsVisibleAndMaskIsVisibleItem() = mutableListOf<PersonCertificatesIte
         )
     }
 
+fun gStatusIsVisibleTextEmptyAndMaskIsVisibleItem() = mutableListOf<PersonCertificatesItem>()
+    .apply {
+        add(
+            PersonCertificateCard.Item(
+                overviewCertificates = listOf(
+                    PersonCertificateCard.Item.OverviewCertificate(
+                        mockVaccinationCertificate("Andrea Schneider"),
+                        buttonText = when (Locale.getDefault()) {
+                            Locale.GERMANY, Locale.GERMAN -> "2G-Zertifikat"
+                            else -> "2G Certificate"
+                        }
+                    )
+                ),
+                admission = PersonCertificateCard.Item.Admission(
+                    state = admissionState,
+                    text = ""
+                ),
+                mask = PersonCertificateCard.Item.Mask(
+                    state = maskState,
+                    text = "Maskenpflicht"
+                ),
+                colorShade = PersonColorShade.COLOR_1,
+                badgeCount = 0,
+                onClickAction = { _, _ -> },
+                onCovPassInfoAction = {},
+                onCertificateSelected = {},
+            )
+        )
+    }
+
+fun gStatusIsVisibleAndMaskIsVisibleTextEmptyItem() = mutableListOf<PersonCertificatesItem>()
+    .apply {
+        add(
+            PersonCertificateCard.Item(
+                overviewCertificates = listOf(
+                    PersonCertificateCard.Item.OverviewCertificate(
+                        mockVaccinationCertificate("Andrea Schneider"),
+                        buttonText = when (Locale.getDefault()) {
+                            Locale.GERMANY, Locale.GERMAN -> "2G-Zertifikat"
+                            else -> "2G Certificate"
+                        }
+                    )
+                ),
+                admission = PersonCertificateCard.Item.Admission(
+                    state = admissionState,
+                    text = "2G"
+                ),
+                mask = PersonCertificateCard.Item.Mask(
+                    state = maskState,
+                    text = ""
+                ),
+                colorShade = PersonColorShade.COLOR_1,
+                badgeCount = 0,
+                onClickAction = { _, _ -> },
+                onCovPassInfoAction = {},
+                onCertificateSelected = {},
+            )
+        )
+    }
+
+fun gStatusIsVisibleTextEmptyAndMaskIsVisibleTextEmptyItem() = mutableListOf<PersonCertificatesItem>()
+    .apply {
+        add(
+            PersonCertificateCard.Item(
+                overviewCertificates = listOf(
+                    PersonCertificateCard.Item.OverviewCertificate(
+                        mockVaccinationCertificate("Andrea Schneider"),
+                        buttonText = when (Locale.getDefault()) {
+                            Locale.GERMANY, Locale.GERMAN -> "2G-Zertifikat"
+                            else -> "2G Certificate"
+                        }
+                    )
+                ),
+                admission = PersonCertificateCard.Item.Admission(
+                    state = admissionState,
+                    text = ""
+                ),
+                mask = PersonCertificateCard.Item.Mask(
+                    state = maskState,
+                    text = ""
+                ),
+                colorShade = PersonColorShade.COLOR_1,
+                badgeCount = 0,
+                onClickAction = { _, _ -> },
+                onCovPassInfoAction = {},
+                onCertificateSelected = {},
+            )
+        )
+    }
+
 fun maskFree() = mutableListOf<PersonCertificatesItem>().apply {
     add(
         PersonCertificateCard.Item(

--- a/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/TestData.kt
+++ b/Corona-Warn-App/src/androidTest/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/TestData.kt
@@ -44,11 +44,11 @@ fun listItemWithPendingItem() = mutableListOf<PersonCertificatesItem>()
                 ),
                 admission = PersonCertificateCard.Item.Admission(
                     state = admissionState,
-                    admissionBadgeText = "2G+"
+                    text = "2G+"
                 ),
                 mask = PersonCertificateCard.Item.Mask(
                     state = maskState,
-                    maskBadgeText = "Maskenpflicht"
+                    text = "Maskenpflicht"
                 ),
                 colorShade = PersonColorShade.COLOR_1,
                 badgeCount = 0,
@@ -82,11 +82,11 @@ fun listItemWithUpdatingItem() = mutableListOf<PersonCertificatesItem>()
                 ),
                 admission = PersonCertificateCard.Item.Admission(
                     state = null,
-                    admissionBadgeText = "2G+"
+                    text = "2G+"
                 ),
                 mask = PersonCertificateCard.Item.Mask(
                     state = maskState.copy(),
-                    maskBadgeText = "Maskenpflicht"
+                    text = "Maskenpflicht"
                 ),
                 colorShade = PersonColorShade.COLOR_1,
                 badgeCount = 0,
@@ -112,11 +112,11 @@ fun gStatusIsNullAndMaskIsVisibleItem() = mutableListOf<PersonCertificatesItem>(
                 ),
                 admission = PersonCertificateCard.Item.Admission(
                     state = null,
-                    admissionBadgeText = ""
+                    text = ""
                 ),
                 mask = PersonCertificateCard.Item.Mask(
                     state = maskState,
-                    maskBadgeText = "Maskenpflicht"
+                    text = "Maskenpflicht"
                 ),
                 colorShade = PersonColorShade.COLOR_1,
                 badgeCount = 0,
@@ -142,11 +142,11 @@ fun gStatusIsNullAndMaskIsNullItem() = mutableListOf<PersonCertificatesItem>()
                 ),
                 admission = PersonCertificateCard.Item.Admission(
                     state = null,
-                    admissionBadgeText = ""
+                    text = ""
                 ),
                 mask = PersonCertificateCard.Item.Mask(
                     state = null,
-                    maskBadgeText = ""
+                    text = ""
                 ),
                 colorShade = PersonColorShade.COLOR_1,
                 badgeCount = 0,
@@ -173,11 +173,11 @@ fun gStatusIsNullAndMaskIsInvisibleItem() = mutableListOf<PersonCertificatesItem
                 ),
                 admission = PersonCertificateCard.Item.Admission(
                     state = null,
-                    admissionBadgeText = ""
+                    text = ""
                 ),
                 mask = PersonCertificateCard.Item.Mask(
                     state = maskState.copy(visible = false),
-                    maskBadgeText = "Maskenpflicht"
+                    text = "Maskenpflicht"
                 ),
                 colorShade = PersonColorShade.COLOR_1,
                 badgeCount = 0,
@@ -203,11 +203,11 @@ fun gStatusIsInvisibleAndMaskIsVisibleItem() = mutableListOf<PersonCertificatesI
                 ),
                 admission = PersonCertificateCard.Item.Admission(
                     state = admissionState.copy(visible = false),
-                    admissionBadgeText = "2G"
+                    text = "2G"
                 ),
                 mask = PersonCertificateCard.Item.Mask(
                     state = maskState,
-                    maskBadgeText = "Maskenpflicht"
+                    text = "Maskenpflicht"
                 ),
                 colorShade = PersonColorShade.COLOR_1,
                 badgeCount = 0,
@@ -233,11 +233,11 @@ fun gStatusIsInvisibleAndMaskIsInvisibleItem() = mutableListOf<PersonCertificate
                 ),
                 admission = PersonCertificateCard.Item.Admission(
                     state = admissionState.copy(visible = false),
-                    admissionBadgeText = "2G"
+                    text = "2G"
                 ),
                 mask = PersonCertificateCard.Item.Mask(
                     state = maskState.copy(visible = false),
-                    maskBadgeText = "Maskenpflicht"
+                    text = "Maskenpflicht"
                 ),
                 colorShade = PersonColorShade.COLOR_1,
                 badgeCount = 0,
@@ -263,11 +263,11 @@ fun gStatusIsVisibleAndMaskIsInvisibleItem() = mutableListOf<PersonCertificatesI
                 ),
                 admission = PersonCertificateCard.Item.Admission(
                     state = admissionState.copy(visible = true),
-                    admissionBadgeText = "2G"
+                    text = "2G"
                 ),
                 mask = PersonCertificateCard.Item.Mask(
                     state = maskState.copy(visible = false),
-                    maskBadgeText = "Maskenpflicht"
+                    text = "Maskenpflicht"
                 ),
                 colorShade = PersonColorShade.COLOR_1,
                 badgeCount = 0,
@@ -293,11 +293,11 @@ fun gStatusIsVisibleAndMaskIsVisibleItem() = mutableListOf<PersonCertificatesIte
                 ),
                 admission = PersonCertificateCard.Item.Admission(
                     state = admissionState,
-                    admissionBadgeText = "2G"
+                    text = "2G"
                 ),
                 mask = PersonCertificateCard.Item.Mask(
                     state = maskState,
-                    maskBadgeText = "Maskenpflicht"
+                    text = "Maskenpflicht"
                 ),
                 colorShade = PersonColorShade.COLOR_1,
                 badgeCount = 0,
@@ -318,11 +318,11 @@ fun maskFree() = mutableListOf<PersonCertificatesItem>().apply {
             ),
             admission = PersonCertificateCard.Item.Admission(
                 state = admissionState,
-                admissionBadgeText = "2G"
+                text = "2G"
             ),
             mask = PersonCertificateCard.Item.Mask(
                 state = maskState.copy(identifier = MaskState.MaskStateIdentifier.OPTIONAL),
-                maskBadgeText = "Keine Maskenpflicht"
+                text = "Keine Maskenpflicht"
             ),
             colorShade = PersonColorShade.GREEN,
             badgeCount = 0,
@@ -343,11 +343,11 @@ fun maskFreeMultiLine() = mutableListOf<PersonCertificatesItem>().apply {
             ),
             admission = PersonCertificateCard.Item.Admission(
                 state = admissionState,
-                admissionBadgeText = "2G"
+                text = "2G"
             ),
             mask = PersonCertificateCard.Item.Mask(
                 state = maskState,
-                maskBadgeText = "Keine Maskenpflicht, Multi Line, aber mindestens zwei"
+                text = "Keine Maskenpflicht, Multi Line, aber mindestens zwei"
             ),
             colorShade = PersonColorShade.GREEN,
             badgeCount = 0,
@@ -368,11 +368,11 @@ fun maskRequiredAndNoStatus() = mutableListOf<PersonCertificatesItem>().apply {
             ),
             admission = PersonCertificateCard.Item.Admission(
                 state = null,
-                admissionBadgeText = "2G+"
+                text = "2G+"
             ),
             mask = PersonCertificateCard.Item.Mask(
                 state = maskState.copy(identifier = MaskState.MaskStateIdentifier.REQUIRED),
-                maskBadgeText = "Maskenpflicht"
+                text = "Maskenpflicht"
             ),
             colorShade = PersonColorShade.COLOR_3,
             badgeCount = 0,
@@ -393,11 +393,11 @@ fun maskInvalidOutdated() = mutableListOf<PersonCertificatesItem>().apply {
             ),
             admission = PersonCertificateCard.Item.Admission(
                 state = null,
-                admissionBadgeText = "2G+"
+                text = "2G+"
             ),
             mask = PersonCertificateCard.Item.Mask(
                 state = maskState.copy(),
-                maskBadgeText = "Maskenpflicht"
+                text = "Maskenpflicht"
             ),
             colorShade = PersonColorShade.COLOR_INVALID,
             badgeCount = 0,
@@ -418,11 +418,11 @@ fun noMaskInfoStatusInfo() = mutableListOf<PersonCertificatesItem>().apply {
             ),
             admission = PersonCertificateCard.Item.Admission(
                 state = admissionState,
-                admissionBadgeText = "2G+"
+                text = "2G+"
             ),
             mask = PersonCertificateCard.Item.Mask(
                 state = maskState.copy(visible = false),
-                maskBadgeText = ""
+                text = ""
             ),
             colorShade = PersonColorShade.COLOR_1,
             badgeCount = 0,
@@ -443,11 +443,11 @@ fun noMaskInfoNoStatusInfo() = mutableListOf<PersonCertificatesItem>().apply {
             ),
             admission = PersonCertificateCard.Item.Admission(
                 state = null,
-                admissionBadgeText = ""
+                text = ""
             ),
             mask = PersonCertificateCard.Item.Mask(
                 state = maskState.copy(visible = false),
-                maskBadgeText = ""
+                text = ""
             ),
             colorShade = PersonColorShade.COLOR_3,
             badgeCount = 0,
@@ -473,11 +473,11 @@ fun personsItems() = mutableListOf<PersonCertificatesItem>()
                 ),
                 admission = PersonCertificateCard.Item.Admission(
                     state = admissionState,
-                    admissionBadgeText = "3G"
+                    text = "3G"
                 ),
                 mask = PersonCertificateCard.Item.Mask(
                     state = maskState.copy(visible = false),
-                    maskBadgeText = ""
+                    text = ""
                 ),
                 colorShade = PersonColorShade.COLOR_1,
                 badgeCount = 5,
@@ -500,11 +500,11 @@ fun personsItems() = mutableListOf<PersonCertificatesItem>()
                 ),
                 admission = PersonCertificateCard.Item.Admission(
                     state = admissionState,
-                    admissionBadgeText = "3G"
+                    text = "3G"
                 ),
                 mask = PersonCertificateCard.Item.Mask(
                     state = maskState.copy(visible = false),
-                    maskBadgeText = ""
+                    text = ""
                 ),
                 colorShade = PersonColorShade.COLOR_2,
                 badgeCount = 3,
@@ -527,11 +527,11 @@ fun personsItems() = mutableListOf<PersonCertificatesItem>()
                 ),
                 admission = PersonCertificateCard.Item.Admission(
                     state = null,
-                    admissionBadgeText = "2G+"
+                    text = "2G+"
                 ),
                 mask = PersonCertificateCard.Item.Mask(
                     state = maskState.copy(),
-                    maskBadgeText = "Maskenpflicht"
+                    text = "Maskenpflicht"
                 ),
                 colorShade = PersonColorShade.COLOR_3,
                 badgeCount = 0,
@@ -557,11 +557,11 @@ fun onePersonItem() = mutableListOf<PersonCertificatesItem>()
                 ),
                 admission = PersonCertificateCard.Item.Admission(
                     state = null,
-                    admissionBadgeText = "2G+"
+                    text = "2G+"
                 ),
                 mask = PersonCertificateCard.Item.Mask(
                     state = maskState.copy(),
-                    maskBadgeText = "Maskenpflicht"
+                    text = "Maskenpflicht"
                 ),
                 colorShade = PersonColorShade.COLOR_1,
                 badgeCount = 0,
@@ -587,11 +587,11 @@ fun onePersonItemWithBadgeCount() = mutableListOf<PersonCertificatesItem>()
                 ),
                 admission = PersonCertificateCard.Item.Admission(
                     state = admissionState,
-                    admissionBadgeText = "2G"
+                    text = "2G"
                 ),
                 mask = PersonCertificateCard.Item.Mask(
                     state = maskState.copy(visible = false),
-                    maskBadgeText = ""
+                    text = ""
                 ),
                 colorShade = PersonColorShade.COLOR_1,
                 badgeCount = 1,
@@ -624,11 +624,11 @@ fun twoGPlusCertificate() = mutableListOf<PersonCertificatesItem>()
                 ),
                 admission = PersonCertificateCard.Item.Admission(
                     state = admissionState,
-                    admissionBadgeText = "2G+"
+                    text = "2G+"
                 ),
                 mask = PersonCertificateCard.Item.Mask(
                     state = maskState.copy(visible = false),
-                    maskBadgeText = ""
+                    text = ""
                 ),
                 colorShade = PersonColorShade.COLOR_1,
                 badgeCount = 0,
@@ -668,11 +668,11 @@ fun threeCertificates() = mutableListOf<PersonCertificatesItem>()
                 ),
                 admission = PersonCertificateCard.Item.Admission(
                     state = admissionState,
-                    admissionBadgeText = "2G+"
+                    text = "2G+"
                 ),
                 mask = PersonCertificateCard.Item.Mask(
                     state = maskState.copy(visible = false),
-                    maskBadgeText = ""
+                    text = ""
                 ),
                 colorShade = PersonColorShade.COLOR_1,
                 badgeCount = 0,
@@ -705,11 +705,11 @@ fun twoGPlusCertificateWithBadge() = mutableListOf<PersonCertificatesItem>()
                 ),
                 admission = PersonCertificateCard.Item.Admission(
                     state = admissionState,
-                    admissionBadgeText = "2G+"
+                    text = "2G+"
                 ),
                 mask = PersonCertificateCard.Item.Mask(
                     state = maskState.copy(visible = false),
-                    maskBadgeText = ""
+                    text = ""
                 ),
                 colorShade = PersonColorShade.COLOR_1,
                 badgeCount = 1,

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/PersonOverviewViewModel.kt
@@ -118,11 +118,11 @@ class PersonOverviewViewModel @AssistedInject constructor(
                 },
                 admission = PersonCertificateCard.Item.Admission(
                     state = admissionState,
-                    admissionBadgeText = format(admissionState?.badgeText)
+                    text = format(admissionState?.badgeText)
                 ),
                 mask = PersonCertificateCard.Item.Mask(
                     state = person.dccWalletInfo?.maskState,
-                    maskBadgeText = format(person.dccWalletInfo?.maskState?.badgeText)
+                    text = format(person.dccWalletInfo?.maskState?.badgeText)
                 ),
                 colorShade = color,
                 badgeCount = person.badgeCount,

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/items/PersonCertificateCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/person/ui/overview/items/PersonCertificateCard.kt
@@ -65,12 +65,12 @@ class PersonCertificateCard(parent: ViewGroup) :
 
         data class Admission(
             val state: AdmissionState?,
-            val admissionBadgeText: String
+            val text: String
         )
 
         data class Mask(
             val state: MaskState?,
-            val maskBadgeText: String
+            val text: String
         )
     }
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CertificateStateHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CertificateStateHelper.kt
@@ -3,6 +3,9 @@ package de.rki.coronawarnapp.util
 import android.content.Context
 import android.graphics.Typeface
 import android.view.View
+import android.view.View.GONE
+import android.view.View.INVISIBLE
+import android.view.View.VISIBLE
 import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isGone
@@ -174,13 +177,11 @@ private fun IncludeCertificateOverviewQrCardBinding.setGStatusBadge(
 ) {
     statusBadge.setBackgroundResource(color.admissionBadgeBg)
     statusBadge.text = item.admission.admissionBadgeText
+    val state = item.admission.state
     statusBadge.visibility = when {
-        item.admission.state == null -> View.INVISIBLE
-        item.admission.state.visible -> {
-            val notEmpty = item.admission.admissionBadgeText.isNotEmpty()
-            if (notEmpty) View.VISIBLE else View.INVISIBLE
-        }
-        else -> View.GONE
+        state == null -> INVISIBLE
+        state.visible -> if (item.admission.admissionBadgeText.isNotEmpty()) VISIBLE else INVISIBLE
+        else -> GONE
     }
 }
 
@@ -188,7 +189,12 @@ private fun IncludeCertificateOverviewQrCardBinding.setMaskBadge(
     item: PersonCertificateCard.Item,
     color: PersonColorShade
 ) {
-    maskBadge.isVisible = item.mask.state?.visible == true
+    val state = item.mask.state
+    maskBadge.visibility = when {
+        state == null -> INVISIBLE
+        state.visible -> if (item.mask.maskBadgeText.isNotEmpty()) VISIBLE else INVISIBLE
+        else -> GONE
+    }
     maskBadge.text = item.mask.maskBadgeText
     maskBadge.setBackgroundResource(color.maskLargeBadgeBg)
     maskBadge.setCompoundDrawablesWithIntrinsicBounds(color.maskIcon, 0, 0, 0)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CertificateStateHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CertificateStateHelper.kt
@@ -176,11 +176,11 @@ private fun IncludeCertificateOverviewQrCardBinding.setGStatusBadge(
     color: PersonColorShade
 ) {
     statusBadge.setBackgroundResource(color.admissionBadgeBg)
-    statusBadge.text = item.admission.admissionBadgeText
+    statusBadge.text = item.admission.text
     val state = item.admission.state
     statusBadge.visibility = when {
         state == null -> INVISIBLE
-        state.visible -> if (item.admission.admissionBadgeText.isNotEmpty()) VISIBLE else INVISIBLE
+        state.visible -> if (item.admission.text.isNotEmpty()) VISIBLE else INVISIBLE
         else -> GONE
     }
 }
@@ -192,10 +192,10 @@ private fun IncludeCertificateOverviewQrCardBinding.setMaskBadge(
     val state = item.mask.state
     maskBadge.visibility = when {
         state == null -> INVISIBLE
-        state.visible -> if (item.mask.maskBadgeText.isNotEmpty()) VISIBLE else INVISIBLE
+        state.visible -> if (item.mask.text.isNotEmpty()) VISIBLE else INVISIBLE
         else -> GONE
     }
-    maskBadge.text = item.mask.maskBadgeText
+    maskBadge.text = item.mask.text
     maskBadge.setBackgroundResource(color.maskLargeBadgeBg)
     maskBadge.setCompoundDrawablesWithIntrinsicBounds(color.maskIcon, 0, 0, 0)
     maskBadge.setTextColor(maskBadge.resources.getColor(color.maskBadgeTextColor, null))

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CertificateStateHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/CertificateStateHelper.kt
@@ -176,7 +176,10 @@ private fun IncludeCertificateOverviewQrCardBinding.setGStatusBadge(
     statusBadge.text = item.admission.admissionBadgeText
     statusBadge.visibility = when {
         item.admission.state == null -> View.INVISIBLE
-        item.admission.state.visible -> View.VISIBLE
+        item.admission.state.visible -> {
+            val notEmpty = item.admission.admissionBadgeText.isNotEmpty()
+            if (notEmpty) View.VISIBLE else View.INVISIBLE
+        }
         else -> View.GONE
     }
 }


### PR DESCRIPTION
Latest version of 2.27 displays an empty G-status badge 
- Check here and against branch 2.27 , you should see no empty badge 
## Before
<img width="439" alt="Screenshot 2022-09-16 at 10 14 41" src="https://user-images.githubusercontent.com/25054729/190591958-0fbc8abf-845d-428b-a4a0-4a27ca8d26cc.png">

## After
<img width="449" alt="Screenshot 2022-09-16 at 10 16 45" src="https://user-images.githubusercontent.com/25054729/190592023-2758a6c9-3c2e-49e5-a800-1716223f3f36.png">
