### PR TITLE
Process rebirth on environment change (EXPOSUREAPP-13973)

### DIFF
--- a/Corona-Warn-App/build.gradle
+++ b/Corona-Warn-App/build.gradle
@@ -527,6 +527,8 @@ dependencies {
     implementation "androidx.camera:camera-lifecycle:$camerax_version"
     implementation "androidx.camera:camera-view:$camerax_version"
     implementation "androidx.window:window:1.0.0"
+    // App process rebirth
+    deviceForTestersImplementation "com.jakewharton:process-phoenix:2.1.2"
 }
 
 sonarqube {

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragment.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragment.kt
@@ -13,6 +13,7 @@ import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import com.jakewharton.processphoenix.ProcessPhoenix
 import de.rki.coronawarnapp.R
@@ -46,7 +47,13 @@ class DebugOptionsFragment : Fragment(R.layout.fragment_test_debugoptions), Auto
             setOnCheckedChangeListener { group, checkedId ->
                 val chip = group.findViewById<RadioButton>(checkedId)
                 if (!chip.isPressed) return@setOnCheckedChangeListener
-                vm.selectEnvironmentType(chip.text.toString())
+                val type = chip.text.toString()
+                vm.selectEnvironmentType(type)
+                MaterialAlertDialogBuilder(requireContext())
+                    .setTitle("Restarting ↻")
+                    .setMessage("Configuring $type environment. It might take a few moments ⌛")
+                    .setCancelable(false)
+                    .show()
                 ProcessPhoenix.triggerRebirth(context)
             }
         }

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragment.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragment.kt
@@ -51,7 +51,7 @@ class DebugOptionsFragment : Fragment(R.layout.fragment_test_debugoptions), Auto
                 vm.selectEnvironmentType(type)
                 MaterialAlertDialogBuilder(requireContext())
                     .setTitle("Restarting ↻")
-                    .setMessage("Configuring $type environment. It might take a few moments ⌛")
+                    .setMessage("Configuring $type environment. Get yourself a glass of water \uD83D\uDEB0")
                     .setCancelable(false)
                     .show()
                 ProcessPhoenix.triggerRebirth(context)

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragment.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragment.kt
@@ -1,6 +1,7 @@
 package de.rki.coronawarnapp.test.debugoptions.ui
 
 import android.annotation.SuppressLint
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.widget.RadioButton
@@ -14,6 +15,7 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.snackbar.Snackbar
+import com.jakewharton.processphoenix.ProcessPhoenix
 import de.rki.coronawarnapp.R
 import de.rki.coronawarnapp.databinding.FragmentTestDebugoptionsBinding
 import de.rki.coronawarnapp.test.menu.ui.TestMenuItem
@@ -46,6 +48,7 @@ class DebugOptionsFragment : Fragment(R.layout.fragment_test_debugoptions), Auto
                 val chip = group.findViewById<RadioButton>(checkedId)
                 if (!chip.isPressed) return@setOnCheckedChangeListener
                 vm.selectEnvironmentType(chip.text.toString())
+                ProcessPhoenix.triggerRebirth(context)
             }
         }
 

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragment.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragment.kt
@@ -1,7 +1,6 @@
 package de.rki.coronawarnapp.test.debugoptions.ui
 
 import android.annotation.SuppressLint
-import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.widget.RadioButton

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragmentViewModel.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragmentViewModel.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.launch
 class DebugOptionsFragmentViewModel @AssistedInject constructor(
     private val envSetup: EnvironmentSetup,
     dispatcherProvider: DispatcherProvider,
-    private val environmentResetter: EnvironmentResetter,
+    private val environmentResetter: EnvironmentSunset,
     @AppScope private val appScope: CoroutineScope,
 ) : CWAViewModel(dispatcherProvider = dispatcherProvider) {
 
@@ -40,7 +40,6 @@ class DebugOptionsFragmentViewModel @AssistedInject constructor(
         envSetup.currentEnvironment = type.toEnvironmentType()
         envSetup.toEnvironmentState().let {
             environmentStateFlow.value = it
-            environmentStateChange.postValue(it)
         }
         cleanCachedData()
     }

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragmentViewModel.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragmentViewModel.kt
@@ -7,16 +7,20 @@ import de.rki.coronawarnapp.covidcertificate.signature.core.DscRepository
 import de.rki.coronawarnapp.environment.EnvironmentSetup
 import de.rki.coronawarnapp.environment.EnvironmentSetup.Type.Companion.toEnvironmentType
 import de.rki.coronawarnapp.test.debugoptions.ui.EnvironmentState.Companion.toEnvironmentState
+import de.rki.coronawarnapp.util.coroutine.AppScope
 import de.rki.coronawarnapp.util.coroutine.DispatcherProvider
 import de.rki.coronawarnapp.util.ui.SingleLiveEvent
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModel
 import de.rki.coronawarnapp.util.viewmodel.SimpleCWAViewModelFactory
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 
 class DebugOptionsFragmentViewModel @AssistedInject constructor(
     private val envSetup: EnvironmentSetup,
     dispatcherProvider: DispatcherProvider,
-    private val dscRepository: DscRepository
+    private val environmentResetter: EnvironmentResetter,
+    @AppScope private val appScope: CoroutineScope,
 ) : CWAViewModel(dispatcherProvider = dispatcherProvider) {
 
     private val environmentStateFlow = MutableStateFlow(envSetup.toEnvironmentState())
@@ -42,10 +46,8 @@ class DebugOptionsFragmentViewModel @AssistedInject constructor(
         cleanCachedData()
     }
 
-    private fun cleanCachedData() {
-        launch {
-            dscRepository.reset()
-        }
+    private fun cleanCachedData() = appScope.launch {
+        environmentResetter.reset()
     }
 
     @AssistedFactory

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragmentViewModel.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragmentViewModel.kt
@@ -3,7 +3,6 @@ package de.rki.coronawarnapp.test.debugoptions.ui
 import androidx.lifecycle.asLiveData
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import de.rki.coronawarnapp.covidcertificate.signature.core.DscRepository
 import de.rki.coronawarnapp.environment.EnvironmentSetup
 import de.rki.coronawarnapp.environment.EnvironmentSetup.Type.Companion.toEnvironmentType
 import de.rki.coronawarnapp.test.debugoptions.ui.EnvironmentState.Companion.toEnvironmentState

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragmentViewModel.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragmentViewModel.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.launch
 class DebugOptionsFragmentViewModel @AssistedInject constructor(
     private val envSetup: EnvironmentSetup,
     dispatcherProvider: DispatcherProvider,
-    private val environmentResetter: EnvironmentSunset,
+    private val environmentSunset: EnvironmentSunset,
     @AppScope private val appScope: CoroutineScope,
 ) : CWAViewModel(dispatcherProvider = dispatcherProvider) {
 
@@ -45,7 +45,7 @@ class DebugOptionsFragmentViewModel @AssistedInject constructor(
     }
 
     private fun cleanCachedData() = appScope.launch {
-        environmentResetter.reset()
+        environmentSunset.reset()
     }
 
     @AssistedFactory

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/EnvironmentResetter.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/EnvironmentResetter.kt
@@ -1,7 +1,6 @@
 package de.rki.coronawarnapp.test.debugoptions.ui
 
 import de.rki.coronawarnapp.appconfig.AppConfigProvider
-import de.rki.coronawarnapp.ccl.configuration.update.CclConfigurationUpdater
 import de.rki.coronawarnapp.ccl.configuration.update.CclSettings
 import de.rki.coronawarnapp.covidcertificate.signature.core.DscRepository
 import timber.log.Timber

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/EnvironmentResetter.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/EnvironmentResetter.kt
@@ -1,0 +1,26 @@
+package de.rki.coronawarnapp.test.debugoptions.ui
+
+import de.rki.coronawarnapp.appconfig.AppConfigProvider
+import de.rki.coronawarnapp.ccl.configuration.update.CclConfigurationUpdater
+import de.rki.coronawarnapp.ccl.configuration.update.CclSettings
+import de.rki.coronawarnapp.covidcertificate.signature.core.DscRepository
+import timber.log.Timber
+import javax.inject.Inject
+
+class EnvironmentResetter @Inject constructor(
+    private val dscRepository: DscRepository,
+    private val appConfigProvider: AppConfigProvider,
+    private val cclSettings: CclSettings,
+) {
+    suspend fun reset() {
+        runCatching {
+            Timber.d("reset() - START")
+            dscRepository.reset()
+            appConfigProvider.reset()
+            cclSettings.reset()
+            Timber.d("reset() - END")
+        }.onFailure {
+            Timber.d(it, "reset() failed")
+        }
+    }
+}

--- a/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/EnvironmentSunset.kt
+++ b/Corona-Warn-App/src/deviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/EnvironmentSunset.kt
@@ -2,14 +2,16 @@ package de.rki.coronawarnapp.test.debugoptions.ui
 
 import de.rki.coronawarnapp.appconfig.AppConfigProvider
 import de.rki.coronawarnapp.ccl.configuration.update.CclSettings
+import de.rki.coronawarnapp.covidcertificate.revocation.DccRevocationReset
 import de.rki.coronawarnapp.covidcertificate.signature.core.DscRepository
 import timber.log.Timber
 import javax.inject.Inject
 
-class EnvironmentResetter @Inject constructor(
+class EnvironmentSunset @Inject constructor(
     private val dscRepository: DscRepository,
     private val appConfigProvider: AppConfigProvider,
     private val cclSettings: CclSettings,
+    private val dccRevocationReset: DccRevocationReset
 ) {
     suspend fun reset() {
         runCatching {
@@ -17,6 +19,7 @@ class EnvironmentResetter @Inject constructor(
             dscRepository.reset()
             appConfigProvider.reset()
             cclSettings.reset()
+            dccRevocationReset.reset()
             Timber.d("reset() - END")
         }.onFailure {
             Timber.d(it, "reset() failed")

--- a/Corona-Warn-App/src/testDeviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragmentViewModelTest.kt
+++ b/Corona-Warn-App/src/testDeviceForTesters/java/de/rki/coronawarnapp/test/debugoptions/ui/DebugOptionsFragmentViewModelTest.kt
@@ -1,11 +1,11 @@
 package de.rki.coronawarnapp.test.debugoptions.ui
 
-import de.rki.coronawarnapp.covidcertificate.signature.core.DscRepository
 import de.rki.coronawarnapp.environment.EnvironmentSetup
 import io.kotest.matchers.shouldBe
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.test.TestScope
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -17,7 +17,7 @@ import testhelpers.extensions.getOrAwaitValue
 class DebugOptionsFragmentViewModelTest : testhelpers.BaseTest() {
 
     @MockK private lateinit var environmentSetup: EnvironmentSetup
-    @MockK private lateinit var dscRepository: DscRepository
+    @MockK private lateinit var environmentSunset: EnvironmentSunset
 
     private var currentEnvironment = EnvironmentSetup.Type.DEV
 
@@ -45,7 +45,8 @@ class DebugOptionsFragmentViewModelTest : testhelpers.BaseTest() {
     private fun createViewModel(): DebugOptionsFragmentViewModel = DebugOptionsFragmentViewModel(
         envSetup = environmentSetup,
         dispatcherProvider = TestDispatcherProvider(),
-        dscRepository = dscRepository,
+        environmentSunset = environmentSunset,
+        appScope = TestScope()
     )
 
     @Test


### PR DESCRIPTION
Background, switching from environment to another led sometimes to issues such as:
1- AppConfig is not updated
2- DSC List 
3- CCL 
and even when the respective data is cleaned up the URLs are not reflected unless app is killed and opened again.
- Now after switching env the app will restart again automatically.

## Ticket
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13973