### PR TITLE
Use raw date values (EXPOSUREAPP-14006)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/core/CertificateDataInjector.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/core/CertificateDataInjector.kt
@@ -25,18 +25,21 @@ internal fun String.inject(
     .replaceFieldsOf(cert)
 
 private fun String.replaceFieldsOf(cert: CwaCovidCertificate) = when (cert) {
-    is VaccinationCertificate -> replace("\$vp", cert.vaccineTypeName.sanitize())
+    is VaccinationCertificate -> this
+        .replace("\$vp", cert.vaccineTypeName.sanitize())
         .replace("\$mp", cert.medicalProductName.sanitize())
         .replace("\$ma", cert.vaccineManufacturer.sanitize())
         .replace("\$dn", cert.rawCertificate.vaccination.doseNumber.toString())
         .replace("\$sd", cert.rawCertificate.vaccination.totalSeriesOfDoses.toString())
         .replace("\$dt", cert.rawCertificate.vaccination.dt)
 
-    is RecoveryCertificate -> replace("\$fr", cert.testedPositiveOnFormatted)
+    is RecoveryCertificate -> this
+        .replace("\$fr", cert.rawCertificate.recovery.fr)
         .replace("\$df", cert.rawCertificate.recovery.df)
         .replace("\$du", cert.rawCertificate.recovery.du)
 
-    is TestCertificate -> replace("\$tt", cert.testType)
+    is TestCertificate -> this
+        .replace("\$tt", cert.testType)
         .replace("\$nm", cert.testName.orEmpty())
         .replace("\$ma", cert.testNameAndManufacturer.orEmpty().sanitize())
         .replace("\$sc", cert.rawCertificate.test.sc)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/core/CertificateDataInjector.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/core/CertificateDataInjector.kt
@@ -16,32 +16,32 @@ internal fun String.inject(
     cert: CwaCovidCertificate
 ): String = this
     .replace("\$nam", cert.fullNameFormatted.sanitize())
-    .replace("\$dob", cert.dateOfBirthFormatted.sanitize())
+    .replace("\$dob", cert.rawCertificate.dob.sanitize())
     .replace("\$ci", cert.uniqueCertificateIdentifier.sanitize().removePrefix(CI_PREFIX))
     .replace("\$tg", cert.targetDisease.sanitize())
     .replace("\$co", cert.rawCertificate.payload.certificateCountry.sanitize())
     .replace("\$qr", cert.qrCodeBase64())
-    .replace("\$is", cert.certificateIssuer.sanitize())
+    .replace("\$is", cert.rawCertificate.payload.certificateIssuer.sanitize())
     .replaceFieldsOf(cert)
 
 private fun String.replaceFieldsOf(cert: CwaCovidCertificate) = when (cert) {
     is VaccinationCertificate -> replace("\$vp", cert.vaccineTypeName.sanitize())
         .replace("\$mp", cert.medicalProductName.sanitize())
         .replace("\$ma", cert.vaccineManufacturer.sanitize())
-        .replace("\$dn", cert.doseNumber.toString())
-        .replace("\$sd", cert.totalSeriesOfDoses.toString())
-        .replace("\$dt", cert.vaccinatedOnFormatted)
+        .replace("\$dn", cert.rawCertificate.vaccination.doseNumber.toString())
+        .replace("\$sd", cert.rawCertificate.vaccination.totalSeriesOfDoses.toString())
+        .replace("\$dt", cert.rawCertificate.vaccination.dt)
 
     is RecoveryCertificate -> replace("\$fr", cert.testedPositiveOnFormatted)
-        .replace("\$df", cert.validFromFormatted)
-        .replace("\$du", cert.validUntilFormatted)
+        .replace("\$df", cert.rawCertificate.recovery.df)
+        .replace("\$du", cert.rawCertificate.recovery.du)
 
     is TestCertificate -> replace("\$tt", cert.testType)
         .replace("\$nm", cert.testName.orEmpty())
         .replace("\$ma", cert.testNameAndManufacturer.orEmpty().sanitize())
-        .replace("\$sc", cert.sampleCollectedAtFormatted)
+        .replace("\$sc", cert.rawCertificate.test.sc)
         .replace("\$tr", cert.testResult.sanitize())
-        .replace("\$tc", cert.testCenter.toString())
+        .replace("\$tc", cert.rawCertificate.test.testCenter.toString())
 
     else -> throw UnsupportedOperationException("${cert::class.simpleName} isn't supported")
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/core/CertificateDataInjector.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/covidcertificate/pdf/core/CertificateDataInjector.kt
@@ -25,21 +25,18 @@ internal fun String.inject(
     .replaceFieldsOf(cert)
 
 private fun String.replaceFieldsOf(cert: CwaCovidCertificate) = when (cert) {
-    is VaccinationCertificate -> this
-        .replace("\$vp", cert.vaccineTypeName.sanitize())
+    is VaccinationCertificate -> replace("\$vp", cert.vaccineTypeName.sanitize())
         .replace("\$mp", cert.medicalProductName.sanitize())
         .replace("\$ma", cert.vaccineManufacturer.sanitize())
         .replace("\$dn", cert.rawCertificate.vaccination.doseNumber.toString())
         .replace("\$sd", cert.rawCertificate.vaccination.totalSeriesOfDoses.toString())
         .replace("\$dt", cert.rawCertificate.vaccination.dt)
 
-    is RecoveryCertificate -> this
-        .replace("\$fr", cert.rawCertificate.recovery.fr)
+    is RecoveryCertificate -> replace("\$fr", cert.rawCertificate.recovery.fr)
         .replace("\$df", cert.rawCertificate.recovery.df)
         .replace("\$du", cert.rawCertificate.recovery.du)
 
-    is TestCertificate -> this
-        .replace("\$tt", cert.testType)
+    is TestCertificate -> replace("\$tt", cert.testType)
         .replace("\$nm", cert.testName.orEmpty())
         .replace("\$ma", cert.testNameAndManufacturer.orEmpty().sanitize())
         .replace("\$sc", cert.rawCertificate.test.sc)

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/pdf/core/CertificateDataInjectorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/pdf/core/CertificateDataInjectorTest.kt
@@ -22,18 +22,17 @@ internal class CertificateDataInjectorTest : BaseTest() {
     fun `test VC injector`() {
         val vc = mockk<VaccinationCertificate>().apply {
             every { fullNameFormatted } returns "Full Name"
-            every { dateOfBirthFormatted } returns "1990-10-10"
+            every { rawCertificate.dob } returns "1990-10-10"
+            every { rawCertificate.vaccination.dt } returns "2020-10-12"
+            every { rawCertificate.vaccination.totalSeriesOfDoses } returns 2
+            every { rawCertificate.vaccination.doseNumber } returns 1
+            every { rawCertificate.payload.certificateIssuer } returns "Robert Koch"
+            every { rawCertificate.payload.certificateCountry } returns "Germany"
             every { uniqueCertificateIdentifier } returns "UNIQUE_CERTIFICATE_IDENTIFIER"
             every { targetDisease } returns "Covid 19"
-            every { certificateCountry } returns "Germany"
-            every { rawCertificate.payload.certificateCountry } returns "DE"
             every { qrCodeBase64() } returns "1234"
-            every { certificateIssuer } returns "Robert Koch"
             every { medicalProductName } returns "mRNa"
             every { vaccineManufacturer } returns "BionTech"
-            every { doseNumber } returns 1
-            every { totalSeriesOfDoses } returns 2
-            every { vaccinatedOnFormatted } returns "2020-10-12"
             every { vaccineTypeName } returns "Astra"
         }
 
@@ -45,16 +44,16 @@ internal class CertificateDataInjectorTest : BaseTest() {
     fun `test RC injector`() {
         val rc = mockk<RecoveryCertificate>().apply {
             every { fullNameFormatted } returns "Full Name"
-            every { dateOfBirthFormatted } returns "1990-10-10"
             every { uniqueCertificateIdentifier } returns "UNIQUE_CERTIFICATE_IDENTIFIER"
             every { targetDisease } returns "Covid 19"
-            every { certificateCountry } returns "Germany"
             every { rawCertificate.payload.certificateCountry } returns "DE"
             every { qrCodeBase64() } returns "1234"
-            every { certificateIssuer } returns "Robert Koch"
-            every { validFromFormatted } returns "2020-12-10"
-            every { validUntilFormatted } returns "2021-12-10"
-            every { testedPositiveOnFormatted } returns "2021-11-10"
+            every { rawCertificate.dob } returns "1990-10-10"
+            every { rawCertificate.recovery.df } returns "2020-12-10"
+            every { rawCertificate.recovery.du } returns "2021-12-10"
+            every { rawCertificate.recovery.fr } returns "2021-11-10"
+            every { rawCertificate.payload.certificateIssuer } returns "Robert Koch"
+            every { rawCertificate.payload.certificateCountry } returns "Germany"
         }
 
         template(fileName = "template/de_rc_v4.1.svg").inject(rc).contains("\$") shouldBe false
@@ -68,16 +67,16 @@ internal class CertificateDataInjectorTest : BaseTest() {
             every { dateOfBirthFormatted } returns "1990-10-10"
             every { uniqueCertificateIdentifier } returns "UNIQUE_CERTIFICATE_IDENTIFIER"
             every { targetDisease } returns "Covid 19"
-            every { certificateCountry } returns "Germany"
-            every { rawCertificate.payload.certificateCountry } returns "DE"
             every { qrCodeBase64() } returns "1234"
-            every { certificateIssuer } returns "Robert Koch"
             every { testName } returns "Rapid"
             every { testNameAndManufacturer } returns "Robert Koch"
-            every { sampleCollectedAtFormatted } returns "2020-10-20"
             every { testResult } returns "Negative"
-            every { testCenter } returns "TestIQ"
             every { testType } returns "Rapid"
+            every { rawCertificate.dob } returns "1990-10-10"
+            every { rawCertificate.payload.certificateIssuer } returns "Robert Koch"
+            every { rawCertificate.payload.certificateCountry } returns "Germany"
+            every { rawCertificate.test.sc } returns "2020-10-20"
+            every { rawCertificate.test.testCenter } returns "TestIQ"
         }
 
         template(fileName = "template/de_tc_v4.1.svg").inject(tc).contains("\$") shouldBe false

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/pdf/ui/exportAll/DccExportAllOverviewViewModelTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/covidcertificate/pdf/ui/exportAll/DccExportAllOverviewViewModelTest.kt
@@ -58,7 +58,7 @@ internal class DccExportAllOverviewViewModelTest : BaseTest() {
 
         val vc = mockk<VaccinationCertificate>().apply {
             every { fullNameFormatted } returns "Full Name"
-            every { dateOfBirthFormatted } returns "1990-10-10"
+            every { rawCertificate.dob } returns "1990-10-10"
             every { uniqueCertificateIdentifier } returns "UNIQUE_CERTIFICATE_IDENTIFIER"
             every { targetDisease } returns "Covid 19"
             every { certificateCountry } returns "Germany"
@@ -74,11 +74,15 @@ internal class DccExportAllOverviewViewModelTest : BaseTest() {
             every { rawCertificate.payload.certificateCountry } returns "DE"
             every { vaccinatedOn } returns LocalDate.now()
             every { fullName } returns "A"
+            every { rawCertificate.vaccination.totalSeriesOfDoses } returns 2
+            every { rawCertificate.vaccination.doseNumber } returns 1
+            every { rawCertificate.vaccination.dt } returns "2020-10-12"
+            every { rawCertificate.payload.certificateIssuer } returns "Robert Koch"
+            every { rawCertificate.payload.certificateCountry } returns "Germany"
         }
 
         val rc = mockk<RecoveryCertificate>().apply {
             every { fullNameFormatted } returns "Full Name"
-            every { dateOfBirthFormatted } returns "1990-10-10"
             every { uniqueCertificateIdentifier } returns "UNIQUE_CERTIFICATE_IDENTIFIER"
             every { targetDisease } returns "Covid 19"
             every { certificateCountry } returns "Germany"
@@ -92,12 +96,16 @@ internal class DccExportAllOverviewViewModelTest : BaseTest() {
             every { validUntil } returns LocalDate.now()
             every { fullName } returns "A"
             every { testedPositiveOn } returns LocalDate.now()
-            every { rawCertificate.payload.certificateCountry } returns "DE"
+            every { rawCertificate.dob } returns "1990-10-10"
+            every { rawCertificate.recovery.df } returns "2020-12-10"
+            every { rawCertificate.recovery.du } returns "2021-12-10"
+            every { rawCertificate.recovery.fr } returns "2021-11-10"
+            every { rawCertificate.payload.certificateIssuer } returns "Robert Koch"
+            every { rawCertificate.payload.certificateCountry } returns "Germany"
         }
 
         val tc = mockk<TestCertificate>().apply {
             every { fullNameFormatted } returns "Full Name"
-            every { dateOfBirthFormatted } returns "1990-10-10"
             every { uniqueCertificateIdentifier } returns "UNIQUE_CERTIFICATE_IDENTIFIER"
             every { targetDisease } returns "Covid 19"
             every { certificateCountry } returns "Germany"
@@ -112,7 +120,11 @@ internal class DccExportAllOverviewViewModelTest : BaseTest() {
             every { state } returns CwaCovidCertificate.State.Valid(Instant.now())
             every { sampleCollectedAt } returns Instant.now()
             every { fullName } returns "A"
-            every { rawCertificate.payload.certificateCountry } returns "DE"
+            every { rawCertificate.dob } returns "1990-10-10"
+            every { rawCertificate.payload.certificateIssuer } returns "Robert Koch"
+            every { rawCertificate.payload.certificateCountry } returns "Germany"
+            every { rawCertificate.test.sc } returns "2020-10-20"
+            every { rawCertificate.test.testCenter } returns "TestIQ"
         }
         every { template.invoke(any()) } returns "Template"
         every { personCertificatesProvider.certificateContainer } returns flowOf(


### PR DESCRIPTION
According to [specs](https://github.com/corona-warn-app/cwa-app-tech-spec/blob/main/docs/spec/dgc-overview-client.md#generating-a-pdf-for-a-dgc) raw dates should be used directly in PDF without any formatting 


## Ticket
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14006