### PR TITLE
Fix statistics scroll (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/StatisticsHomeCard.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/statistics/ui/homecards/StatisticsHomeCard.kt
@@ -69,12 +69,6 @@ class StatisticsHomeCard(
             if (resources.isPhone()) {
                 PagerSnapHelper().attachToRecyclerView(statisticsRecyclerview)
             }
-            statisticsCardAdapter.registerAdapterDataObserver(object : AdapterDataObserver() {
-                override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
-                    super.onItemRangeInserted(positionStart, itemCount)
-                    scrollToCard(2)
-                }
-            })
         }
     }
 
@@ -95,6 +89,11 @@ class StatisticsHomeCard(
             }
         }.let {
             statisticsCardAdapter.update(it)
+            statisticsCardAdapter.registerAdapterDataObserver(object : AdapterDataObserver() {
+                override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
+                    scrollToCard(2)
+                }
+            })
         }
     }
 


### PR DESCRIPTION
The observer was registering in the wrong place. If you left the home screen and opened any other screen, when returning to the home screen the scroll position would always be set to number 2, no matter where it previously was.