### PR TITLE
Alternative to the current dialog builder using a DSL builder (DEV)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialog.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialog.kt
@@ -1,6 +1,8 @@
 package de.rki.coronawarnapp.ui.dialog
 
 import android.os.Parcelable
+import androidx.annotation.LayoutRes
+import androidx.annotation.StringRes
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.RawValue
 
@@ -33,7 +35,7 @@ class CwaDialogBuilder {
     private var isDeleteDialog: Boolean = false
     private var customView: Int? = null
 
-    fun title(resource: Int) {
+    fun title(@StringRes resource: Int) {
         title = IntOrString.IntRes(resource)
     }
 
@@ -41,7 +43,7 @@ class CwaDialogBuilder {
         title = IntOrString.StringRes(text)
     }
 
-    fun message(resource: Int) {
+    fun message(@StringRes resource: Int) {
         message = IntOrString.IntRes(resource)
     }
 
@@ -49,7 +51,7 @@ class CwaDialogBuilder {
         message = IntOrString.StringRes(text)
     }
 
-    fun positiveButton(resource: Int, lambda: () -> Unit = { }) {
+    fun positiveButton(@StringRes resource: Int, lambda: () -> Unit = { }) {
         positiveButtonText = IntOrString.IntRes(resource)
         positiveButtonAction = lambda
     }
@@ -59,7 +61,7 @@ class CwaDialogBuilder {
         positiveButtonAction = lambda
     }
 
-    fun negativeButton(resource: Int, lambda: () -> Unit = { }) {
+    fun negativeButton(@StringRes resource: Int, lambda: () -> Unit = { }) {
         negativeButtonText = IntOrString.IntRes(resource)
         negativeButtonAction = lambda
     }
@@ -69,7 +71,7 @@ class CwaDialogBuilder {
         negativeButtonAction = lambda
     }
 
-    fun neutralButton(resource: Int, lambda: () -> Unit = { }) {
+    fun neutralButton(@StringRes resource: Int, lambda: () -> Unit = { }) {
         neutralButtonText = IntOrString.IntRes(resource)
         neutralButtonAction = lambda
     }
@@ -91,7 +93,7 @@ class CwaDialogBuilder {
         isDeleteDialog = isDelete
     }
 
-    fun customView(view: Int) {
+    fun customView(@LayoutRes view: Int) {
         customView = view
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialog.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialog.kt
@@ -3,7 +3,6 @@ package de.rki.coronawarnapp.ui.dialog
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.RawValue
-import kotlin.experimental.ExperimentalTypeInference
 
 @DslMarker
 annotation class CwaDialogDsl
@@ -34,50 +33,50 @@ class CwaDialogConfigBuilder {
     private var isDeleteDialog: Boolean = false
     private var customView: Int? = null
 
-    @OptIn(ExperimentalTypeInference::class)
-    @OverloadResolutionByLambdaReturnType
-    @JvmName("titleInt")
-    fun title(lambda: () -> Int) {
-        title = IntOrString.IntRes(lambda())
+    fun title(resource: Int) {
+        title = IntOrString.IntRes(resource)
     }
 
-    @OptIn(ExperimentalTypeInference::class)
-    @OverloadResolutionByLambdaReturnType
-    @JvmName("titleString")
-    fun title(lambda: () -> String) {
-        title = IntOrString.StringRes(lambda())
+    fun title(text: String) {
+        title = IntOrString.StringRes(text)
     }
 
-    @OptIn(ExperimentalTypeInference::class)
-    @OverloadResolutionByLambdaReturnType
-    @JvmName("messageInt")
-    fun message(lambda: () -> Int) {
-        message = IntOrString.IntRes(lambda())
+    fun message(resource: Int) {
+        message = IntOrString.IntRes(resource)
     }
 
-    @OptIn(ExperimentalTypeInference::class)
-    @OverloadResolutionByLambdaReturnType
-    @JvmName("messageString")
-    fun message(lambda: () -> String) {
-        message = IntOrString.StringRes(lambda())
+    fun message(text: String) {
+        message = IntOrString.StringRes(text)
     }
 
-    fun positiveButton(lambda: ButtonBuilder.() -> Unit) {
-        val contents = ButtonBuilder().apply(lambda).build()
-        positiveButtonText = contents.text
-        positiveButtonAction = contents.action
+    fun positiveButton(resource: Int, lambda: () -> Unit = { }) {
+        positiveButtonText = IntOrString.IntRes(resource)
+        positiveButtonAction = lambda
     }
 
-    fun negativeButton(lambda: ButtonBuilder.() -> Unit) {
-        val contents = ButtonBuilder().apply(lambda).build()
-        negativeButtonText = contents.text
-        negativeButtonAction = contents.action
+    fun positiveButton(text: String, lambda: () -> Unit = { }) {
+        positiveButtonText = IntOrString.StringRes(text)
+        positiveButtonAction = lambda
     }
 
-    fun neutralButton(lambda: ButtonBuilder.() -> Unit) {
-        val contents = ButtonBuilder().apply(lambda).build()
-        neutralButtonText = contents.text
-        neutralButtonAction = contents.action
+    fun negativeButton(resource: Int, lambda: () -> Unit = { }) {
+        negativeButtonText = IntOrString.IntRes(resource)
+        negativeButtonAction = lambda
+    }
+
+    fun negativeButton(text: String, lambda: () -> Unit = { }) {
+        negativeButtonText = IntOrString.StringRes(text)
+        negativeButtonAction = lambda
+    }
+
+    fun neutralButton(resource: Int, lambda: () -> Unit = { }) {
+        neutralButtonText = IntOrString.IntRes(resource)
+        neutralButtonAction = lambda
+    }
+
+    fun neutralButton(text: String, lambda: () -> Unit = { }) {
+        neutralButtonText = IntOrString.StringRes(text)
+        neutralButtonAction = lambda
     }
 
     fun dismissAction(lambda: () -> Unit) {
@@ -101,37 +100,6 @@ class CwaDialogConfigBuilder {
         CwaDialogActions(positiveButtonAction, negativeButtonAction, neutralButtonAction, dismissAction),
         CwaDialogOptions(isCancelable, isDeleteDialog, customView)
     )
-}
-
-data class Button(
-    val text: IntOrString,
-    val action: DialogAction = { }
-)
-
-@CwaDialogDsl
-class ButtonBuilder {
-    private var text = IntOrString()
-    private var action: DialogAction = { }
-
-    @OptIn(ExperimentalTypeInference::class)
-    @OverloadResolutionByLambdaReturnType
-    @JvmName("positiveButtonInt")
-    fun text(lambda: () -> Int) {
-        text = IntOrString.IntRes(lambda())
-    }
-
-    @OptIn(ExperimentalTypeInference::class)
-    @OverloadResolutionByLambdaReturnType
-    @JvmName("positiveButtonString")
-    fun text(lambda: () -> String) {
-        text = IntOrString.StringRes(lambda())
-    }
-
-    fun action(lambda: () -> Unit) {
-        action = { lambda() }
-    }
-
-    fun build() = Button(text, action)
 }
 
 data class CwaDialogActions(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialog.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialog.kt
@@ -1,0 +1,201 @@
+package de.rki.coronawarnapp.ui.dialog
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.RawValue
+import kotlin.experimental.ExperimentalTypeInference
+
+@DslMarker
+annotation class CwaDialogDsl
+
+typealias DialogAction = () -> Unit
+
+data class CwaDialog(
+    val texts: CwaDialogTexts,
+    val actions: CwaDialogActions,
+    val options: CwaDialogOptions
+)
+
+@CwaDialogDsl
+class CwaDialogBuilder {
+    private var config = CwaDialogTexts()
+    private var actions = CwaDialogActions()
+    private var options = CwaDialogOptions()
+
+    fun configureTexts(lambda: CwaDialogTextsBuilder.() -> Unit) {
+        config = CwaDialogTextsBuilder().apply(lambda).build()
+    }
+
+    fun configureActions(lambda: CwaDialogActionsBuilder.() -> Unit) {
+        actions = CwaDialogActionsBuilder().apply(lambda).build()
+    }
+
+    fun configureOptions(lambda: CwaDialogOptionsBuilder.() -> Unit) {
+        options = CwaDialogOptionsBuilder().apply(lambda).build()
+    }
+
+    fun build() = CwaDialog(config, actions, options)
+}
+
+@Parcelize
+data class CwaDialogTexts(
+    val title: @RawValue IntOrString? = null,
+    val message: @RawValue IntOrString? = null,
+    val positiveButton: @RawValue IntOrString? = null,
+    val negativeButton: @RawValue IntOrString? = null,
+    val neutralButton: @RawValue IntOrString? = null,
+) : Parcelable
+
+@CwaDialogDsl
+class CwaDialogTextsBuilder {
+    private var title = IntOrString()
+    private var message = IntOrString()
+    private var positiveButton = IntOrString()
+    private var negativeButton = IntOrString()
+    private var neutralButton = IntOrString()
+
+    @OptIn(ExperimentalTypeInference::class)
+    @OverloadResolutionByLambdaReturnType
+    @JvmName("titleInt")
+    fun title(lambda: () -> Int) {
+        title = IntOrString.IntRes(lambda())
+    }
+
+    @OptIn(ExperimentalTypeInference::class)
+    @OverloadResolutionByLambdaReturnType
+    @JvmName("titleString")
+    fun title(lambda: () -> String) {
+        title = IntOrString.StringRes(lambda())
+    }
+
+    @OptIn(ExperimentalTypeInference::class)
+    @OverloadResolutionByLambdaReturnType
+    @JvmName("messageInt")
+    fun message(lambda: () -> Int) {
+        message = IntOrString.IntRes(lambda())
+    }
+
+    @OptIn(ExperimentalTypeInference::class)
+    @OverloadResolutionByLambdaReturnType
+    @JvmName("messageString")
+    fun message(lambda: () -> String) {
+        message = IntOrString.StringRes(lambda())
+    }
+
+    @OptIn(ExperimentalTypeInference::class)
+    @OverloadResolutionByLambdaReturnType
+    @JvmName("positiveButtonInt")
+    fun positiveButton(lambda: () -> Int) {
+        positiveButton = IntOrString.IntRes(lambda())
+    }
+
+    @OptIn(ExperimentalTypeInference::class)
+    @OverloadResolutionByLambdaReturnType
+    @JvmName("positiveButtonString")
+    fun positiveButton(lambda: () -> String) {
+        positiveButton = IntOrString.StringRes(lambda())
+    }
+
+    @OptIn(ExperimentalTypeInference::class)
+    @OverloadResolutionByLambdaReturnType
+    @JvmName("negativeButtonInt")
+    fun negativeButton(lambda: () -> Int) {
+        negativeButton = IntOrString.IntRes(lambda())
+    }
+
+    @OptIn(ExperimentalTypeInference::class)
+    @OverloadResolutionByLambdaReturnType
+    @JvmName("negativeButtonString")
+    fun negativeButton(lambda: () -> String) {
+        negativeButton = IntOrString.StringRes(lambda())
+    }
+
+    @OptIn(ExperimentalTypeInference::class)
+    @OverloadResolutionByLambdaReturnType
+    @JvmName("neutralButtonInt")
+    fun neutralButton(lambda: () -> Int) {
+        neutralButton = IntOrString.IntRes(lambda())
+    }
+
+    @OptIn(ExperimentalTypeInference::class)
+    @OverloadResolutionByLambdaReturnType
+    @JvmName("neutralButtonString")
+    fun neutralButton(lambda: () -> String) {
+        neutralButton = IntOrString.StringRes(lambda())
+    }
+
+    fun build() = CwaDialogTexts(title, message, positiveButton, negativeButton, neutralButton)
+}
+
+data class CwaDialogActions(
+    val positiveAction: DialogAction = { },
+    val negativeAction: DialogAction = { },
+    val neutralAction: DialogAction = { },
+    val dismissAction: DialogAction = { }
+)
+
+class CwaDialogActionsBuilder {
+    private var positiveAction: DialogAction = { }
+    private var negativeAction: DialogAction = { }
+    private var neutralAction: DialogAction = { }
+    private var dismissAction: DialogAction = { }
+
+    fun positiveAction(lambda: () -> Unit) {
+        positiveAction = { lambda() }
+    }
+
+    fun negativeAction(lambda: () -> Unit) {
+        negativeAction = { lambda() }
+    }
+
+    fun neutralAction(lambda: () -> Unit) {
+        neutralAction = { lambda() }
+    }
+
+    fun dismissAction(lambda: () -> Unit) {
+        dismissAction = { lambda() }
+    }
+
+    fun build() = CwaDialogActions(positiveAction, negativeAction, neutralAction, dismissAction)
+}
+
+@Parcelize
+data class CwaDialogOptions(
+    val isCancelable: Boolean = true,
+    val isDeleteDialog: Boolean = false,
+    val customView: Int? = null
+) : Parcelable
+
+@CwaDialogDsl
+class CwaDialogOptionsBuilder {
+    private var isCancelable: Boolean = true
+    private var isDeleteDialog: Boolean = false
+    private var customView: Int? = null
+
+    fun isCancelable(lambda: () -> Boolean) {
+        isCancelable = lambda()
+    }
+
+    fun isDeleteDialog(lambda: () -> Boolean) {
+        isDeleteDialog = lambda()
+    }
+
+    fun customView(lambda: () -> Int) {
+        customView = lambda()
+    }
+
+    fun build() = CwaDialogOptions(isCancelable, isDeleteDialog, customView)
+}
+
+@Parcelize
+open class IntOrString : Parcelable {
+    @Parcelize
+    data class StringRes(
+        val stringResource: String
+    ) : Parcelable, IntOrString()
+
+    @Parcelize
+    data class IntRes(
+        val intResource: Int
+    ) : Parcelable, IntOrString()
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialog.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialog.kt
@@ -83,16 +83,16 @@ class CwaDialogBuilder {
         dismissAction = { lambda() }
     }
 
-    fun isCancelable(lambda: () -> Boolean) {
-        isCancelable = lambda()
+    fun setCancelable(cancelable: Boolean) {
+        isCancelable = cancelable
     }
 
-    fun isDeleteDialog(lambda: () -> Boolean) {
-        isDeleteDialog = lambda()
+    fun setDeleteDialog(isDelete: Boolean) {
+        isDeleteDialog = isDelete
     }
 
-    fun customView(lambda: () -> Int) {
-        customView = lambda()
+    fun customView(view: Int) {
+        customView = view
     }
 
     fun build() = Triple(

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialog.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialog.kt
@@ -93,7 +93,7 @@ class CwaDialogBuilder {
         isDeleteDialog = isDelete
     }
 
-    fun customView(@LayoutRes view: Int) {
+    fun setCustomView(@LayoutRes view: Int) {
         customView = view
     }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialog.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialog.kt
@@ -19,7 +19,7 @@ data class CwaDialogTexts(
 ) : Parcelable
 
 @CwaDialogDsl
-class CwaDialogConfigBuilder {
+class CwaDialogBuilder {
     private var title = IntOrString()
     private var message = IntOrString()
     private var positiveButtonText = IntOrString()

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialog.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialog.kt
@@ -36,48 +36,48 @@ class CwaDialogBuilder {
     private var customView: Int? = null
 
     fun title(@StringRes resource: Int) {
-        title = IntOrString.IntRes(resource)
+        title = IntOrString.IntResource(resource)
     }
 
     fun title(text: String) {
-        title = IntOrString.StringRes(text)
+        title = IntOrString.StringResource(text)
     }
 
     fun message(@StringRes resource: Int) {
-        message = IntOrString.IntRes(resource)
+        message = IntOrString.IntResource(resource)
     }
 
     fun message(text: String) {
-        message = IntOrString.StringRes(text)
+        message = IntOrString.StringResource(text)
     }
 
     fun positiveButton(@StringRes resource: Int, lambda: () -> Unit = { }) {
-        positiveButtonText = IntOrString.IntRes(resource)
+        positiveButtonText = IntOrString.IntResource(resource)
         positiveButtonAction = lambda
     }
 
     fun positiveButton(text: String, lambda: () -> Unit = { }) {
-        positiveButtonText = IntOrString.StringRes(text)
+        positiveButtonText = IntOrString.StringResource(text)
         positiveButtonAction = lambda
     }
 
     fun negativeButton(@StringRes resource: Int, lambda: () -> Unit = { }) {
-        negativeButtonText = IntOrString.IntRes(resource)
+        negativeButtonText = IntOrString.IntResource(resource)
         negativeButtonAction = lambda
     }
 
     fun negativeButton(text: String, lambda: () -> Unit = { }) {
-        negativeButtonText = IntOrString.StringRes(text)
+        negativeButtonText = IntOrString.StringResource(text)
         negativeButtonAction = lambda
     }
 
     fun neutralButton(@StringRes resource: Int, lambda: () -> Unit = { }) {
-        neutralButtonText = IntOrString.IntRes(resource)
+        neutralButtonText = IntOrString.IntResource(resource)
         neutralButtonAction = lambda
     }
 
     fun neutralButton(text: String, lambda: () -> Unit = { }) {
-        neutralButtonText = IntOrString.StringRes(text)
+        neutralButtonText = IntOrString.StringResource(text)
         neutralButtonAction = lambda
     }
 
@@ -121,12 +121,12 @@ data class CwaDialogOptions(
 @Parcelize
 open class IntOrString : Parcelable {
     @Parcelize
-    data class StringRes(
+    data class StringResource(
         val stringResource: String
     ) : Parcelable, IntOrString()
 
     @Parcelize
-    data class IntRes(
-        val intResource: Int
+    data class IntResource(
+        @StringRes val intResource: Int
     ) : Parcelable, IntOrString()
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialogFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialogFragment.kt
@@ -24,34 +24,34 @@ class CwaDialogFragment : DialogFragment() {
         return texts.run {
             MaterialAlertDialogBuilder(requireContext()).apply {
                 when (title) {
-                    is IntOrString.IntRes -> setTitle(title.intResource)
-                    is IntOrString.StringRes -> setTitle(title.stringResource)
+                    is IntOrString.IntResource -> setTitle(title.intResource)
+                    is IntOrString.StringResource -> setTitle(title.stringResource)
                 }
                 when (message) {
-                    is IntOrString.IntRes -> setMessage(message.intResource)
-                    is IntOrString.StringRes -> setMessage(message.stringResource)
+                    is IntOrString.IntResource -> setMessage(message.intResource)
+                    is IntOrString.StringResource -> setMessage(message.stringResource)
                 }
                 when (positiveButtonText) {
-                    is IntOrString.IntRes -> setPositiveButton(positiveButtonText.intResource) { _, _ ->
+                    is IntOrString.IntResource -> setPositiveButton(positiveButtonText.intResource) { _, _ ->
                         setAction(Action.PositiveButtonClicked)
                     }
-                    is IntOrString.StringRes -> setPositiveButton(positiveButtonText.stringResource) { _, _ ->
+                    is IntOrString.StringResource -> setPositiveButton(positiveButtonText.stringResource) { _, _ ->
                         setAction(Action.PositiveButtonClicked)
                     }
                 }
                 when (negativeButtonText) {
-                    is IntOrString.IntRes -> setNegativeButton(negativeButtonText.intResource) { _, _ ->
+                    is IntOrString.IntResource -> setNegativeButton(negativeButtonText.intResource) { _, _ ->
                         setAction(Action.NegativeButtonClicked)
                     }
-                    is IntOrString.StringRes -> setNegativeButton(negativeButtonText.stringResource) { _, _ ->
+                    is IntOrString.StringResource -> setNegativeButton(negativeButtonText.stringResource) { _, _ ->
                         setAction(Action.NegativeButtonClicked)
                     }
                 }
                 when (neutralButtonText) {
-                    is IntOrString.IntRes -> setNeutralButton(neutralButtonText.intResource) { _, _ ->
+                    is IntOrString.IntResource -> setNeutralButton(neutralButtonText.intResource) { _, _ ->
                         setAction(Action.NeutralButtonClicked)
                     }
-                    is IntOrString.StringRes -> setNeutralButton(neutralButtonText.stringResource) { _, _ ->
+                    is IntOrString.StringResource -> setNeutralButton(neutralButtonText.stringResource) { _, _ ->
                         setAction(Action.NeutralButtonClicked)
                     }
                 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialogFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialogFragment.kt
@@ -23,35 +23,35 @@ class CwaDialogFragment : DialogFragment() {
 
         return texts.run {
             MaterialAlertDialogBuilder(requireContext()).apply {
-                when (val title = title) {
+                when (title) {
                     is IntOrString.IntRes -> setTitle(title.intResource)
                     is IntOrString.StringRes -> setTitle(title.stringResource)
                 }
-                when (val message = message) {
+                when (message) {
                     is IntOrString.IntRes -> setMessage(message.intResource)
                     is IntOrString.StringRes -> setMessage(message.stringResource)
                 }
-                when (val positiveButton = positiveButton) {
-                    is IntOrString.IntRes -> setPositiveButton(positiveButton.intResource) { _, _ ->
+                when (positiveButtonText) {
+                    is IntOrString.IntRes -> setPositiveButton(positiveButtonText.intResource) { _, _ ->
                         setAction(Action.PositiveButtonClicked)
                     }
-                    is IntOrString.StringRes -> setPositiveButton(positiveButton.stringResource) { _, _ ->
+                    is IntOrString.StringRes -> setPositiveButton(positiveButtonText.stringResource) { _, _ ->
                         setAction(Action.PositiveButtonClicked)
                     }
                 }
-                when (val negativeButton = negativeButton) {
-                    is IntOrString.IntRes -> setNegativeButton(negativeButton.intResource) { _, _ ->
+                when (negativeButtonText) {
+                    is IntOrString.IntRes -> setNegativeButton(negativeButtonText.intResource) { _, _ ->
                         setAction(Action.NegativeButtonClicked)
                     }
-                    is IntOrString.StringRes -> setNegativeButton(negativeButton.stringResource) { _, _ ->
+                    is IntOrString.StringRes -> setNegativeButton(negativeButtonText.stringResource) { _, _ ->
                         setAction(Action.NegativeButtonClicked)
                     }
                 }
-                when (val neutralButton = neutralButton) {
-                    is IntOrString.IntRes -> setNeutralButton(neutralButton.intResource) { _, _ ->
+                when (neutralButtonText) {
+                    is IntOrString.IntRes -> setNeutralButton(neutralButtonText.intResource) { _, _ ->
                         setAction(Action.NeutralButtonClicked)
                     }
-                    is IntOrString.StringRes -> setNeutralButton(neutralButton.stringResource) { _, _ ->
+                    is IntOrString.StringRes -> setNeutralButton(neutralButtonText.stringResource) { _, _ ->
                         setAction(Action.NeutralButtonClicked)
                     }
                 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialogFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialogFragment.kt
@@ -1,0 +1,102 @@
+package de.rki.coronawarnapp.ui.dialog
+
+import android.app.Dialog
+import android.content.DialogInterface
+import android.os.Bundle
+import androidx.appcompat.app.AlertDialog
+import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.setFragmentResult
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import de.rki.coronawarnapp.R
+import de.rki.coronawarnapp.util.ContextExtensions.getColorCompat
+import timber.log.Timber
+
+class CwaDialogFragment : DialogFragment() {
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val texts = requireArguments().getParcelable<CwaDialogTexts>(CWA_DIALOG_TEXTS)
+        val options = requireArguments().getParcelable<CwaDialogOptions>(CWA_DIALOG_OPTIONS)
+        requireNotNull(texts) { "Could not retrieve dialog texts. Result is null" }
+        requireNotNull(options) { "Could not retrieve dialog options. Result is null" }
+        isCancelable = options.isCancelable
+
+        return texts.run {
+            MaterialAlertDialogBuilder(requireContext()).apply {
+                when (val title = title) {
+                    is IntOrString.IntRes -> setTitle(title.intResource)
+                    is IntOrString.StringRes -> setTitle(title.stringResource)
+                }
+                when (val message = message) {
+                    is IntOrString.IntRes -> setMessage(message.intResource)
+                    is IntOrString.StringRes -> setMessage(message.stringResource)
+                }
+                when (val positiveButton = positiveButton) {
+                    is IntOrString.IntRes -> setPositiveButton(positiveButton.intResource) { _, _ ->
+                        setAction(Action.PositiveButtonClicked)
+                    }
+                    is IntOrString.StringRes -> setPositiveButton(positiveButton.stringResource) { _, _ ->
+                        setAction(Action.PositiveButtonClicked)
+                    }
+                }
+                when (val negativeButton = negativeButton) {
+                    is IntOrString.IntRes -> setNegativeButton(negativeButton.intResource) { _, _ ->
+                        setAction(Action.NegativeButtonClicked)
+                    }
+                    is IntOrString.StringRes -> setNegativeButton(negativeButton.stringResource) { _, _ ->
+                        setAction(Action.NegativeButtonClicked)
+                    }
+                }
+                when (val neutralButton = neutralButton) {
+                    is IntOrString.IntRes -> setNeutralButton(neutralButton.intResource) { _, _ ->
+                        setAction(Action.NeutralButtonClicked)
+                    }
+                    is IntOrString.StringRes -> setNeutralButton(neutralButton.stringResource) { _, _ ->
+                        setAction(Action.NeutralButtonClicked)
+                    }
+                }
+                options.customView?.let { setView(it) }
+            }.create()
+        }
+    }
+
+    private fun setAction(action: Action) {
+        Timber.d("setAction(action=%s)", action)
+        setFragmentResult(REQUEST_KEY, bundleOf(PARAM_DIALOG_ACTION to action))
+    }
+
+    override fun onStart() {
+        super.onStart()
+        val options = requireArguments().getParcelable<CwaDialogOptions>(
+            CWA_DIALOG_OPTIONS
+        )
+        if (options?.isDeleteDialog == true) {
+            (dialog as AlertDialog).getButton(DialogInterface.BUTTON_POSITIVE)
+                ?.setTextColor(requireContext().getColorCompat(R.color.colorTextDeleteButtonDialog))
+        }
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        setAction(Action.Dismissed)
+        super.onDismiss(dialog)
+    }
+
+    enum class Action {
+        PositiveButtonClicked,
+        NegativeButtonClicked,
+        NeutralButtonClicked,
+        Dismissed
+    }
+
+    companion object {
+        val TAG: String = CwaDialogFragment::class.java.simpleName
+        val REQUEST_KEY = "${TAG}_REQUEST_KEY"
+        val PARAM_DIALOG_ACTION = "${TAG}_PARAM_DIALOG_ACTION"
+        private val CWA_DIALOG_TEXTS = "${TAG}_CWA_DIALOG_TEXTS"
+        private val CWA_DIALOG_OPTIONS = "${TAG}_CWA_DIALOG_OPTIONS"
+
+        fun newInstance(texts: CwaDialogTexts, options: CwaDialogOptions) = CwaDialogFragment().apply {
+            arguments = bundleOf(CWA_DIALOG_TEXTS to texts, CWA_DIALOG_OPTIONS to options)
+        }
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialogHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialogHelper.kt
@@ -10,9 +10,9 @@ import androidx.fragment.app.Fragment
  * createDialog {
  *     title { "Title example" }
  *     message { "Message example" }
- *     positiveButton("Positive button text") { action { foo1() }
- *     negativeButton("Negative button text") { action { foo2() }
- *     neutralButton("Neutral button text") { action { foo3() }
+ *     positiveButton("Positive button text") { foo1() }
+ *     negativeButton("Negative button text") { foo2() }
+ *     neutralButton("Neutral button text") { foo3() }
  *     dismissAction { foo4() }
  *     setCancelable(false)
  *     setDeleteDialog(true)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialogHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialogHelper.kt
@@ -16,7 +16,7 @@ import androidx.fragment.app.Fragment
  *     dismissAction { foo4() }
  *     setCancelable(false)
  *     setDeleteDialog(true)
- *     customView(R.id.dialog_view)
+ *     setCustomView(R.id.dialog_view)
  * }
  * ```
  */

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialogHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialogHelper.kt
@@ -16,7 +16,7 @@ import androidx.fragment.app.Fragment
  *     dismissAction { foo4() }
  *     setCancelable(false)
  *     setDeleteDialog(true)
- *     setCustomView(R.id.dialog_view)
+ *     setCustomView(R.layout.dialog_view)
  * }
  * ```
  */

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialogHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialogHelper.kt
@@ -10,18 +10,9 @@ import androidx.fragment.app.Fragment
  * createDialog {
  *     title { "Title example" }
  *     message { "Message example" }
- *     positiveButton {
- *         text { "Positive button text" }
- *         action { foo1() }
- *     }
- *     negativeButton {
- *         text { "Negative button text" }
- *         action { foo2() }
- *     }
- *     neutralButton {
- *         text { "Neutral button text" }
- *         action { foo3() }
- *     }
+ *     positiveButton("Positive button text") { action { foo1() }
+ *     negativeButton("Negative button text") { action { foo2() }
+ *     neutralButton("Neutral button text") { action { foo3() }
  *     dismissAction { foo4() }
  *     isCancelable { false }
  *     isDeleteDialog { true }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialogHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialogHelper.kt
@@ -8,51 +8,38 @@ import androidx.fragment.app.Fragment
  *
  * ```kotlin
  * createDialog {
- *     configureTexts {
- *         title { "Title example" }
- *         message { "Message example" }
- *         positiveButton { "Positive button text" }
- *         negativeButton { "Negative button text" }
- *         neutralButton { "Neutral button text" }
+ *     title { "Title example" }
+ *     message { "Message example" }
+ *     positiveButton {
+ *         text { "Positive button text" }
+ *         action { foo1() }
  *     }
- *     configureActions {
- *         positiveAction { foo1() }
- *         negativeAction { foo2() }
- *         neutralAction { foo3() }
- *         dismissAction { foo4() }
+ *     negativeButton {
+ *         text { "Negative button text" }
+ *         action { foo2() }
  *     }
- *     configureOptions {
- *         isCancelable { false }
- *         isDeleteDialog { true }
- *         customView { R.id.dialog_view }
+ *     neutralButton {
+ *         text { "Neutral button text" }
+ *         action { foo3() }
  *     }
+ *     dismissAction { foo4() }
+ *     isCancelable { false }
+ *     isDeleteDialog { true }
+ *     customView { R.id.dialog_view }
  * }
  * ```
- * @param title The text displayed for the dialog title. Accepts Int or String values. Can be omitted.
- * @param message The text displayed for the dialog message. Accepts Int or String values. Can be omitted.
- * @param positiveButton The text displayed for the dialog's positive button. Accepts Int or String. Can be omitted.
- * @param negativeButton The text displayed for the dialog's negative button. Accepts Int or String. Can be omitted.
- * @param neutralButton The text displayed for the dialog's neutral button. Accepts Int or String. Can be omitted.
- * @param positiveAction The action executed when tne positive button is pressed. Accepts a function. Can be omitted.
- * @param negativeAction The action executed when tne negative button is pressed. Accepts a function. Can be omitted.
- * @param neutralAction The action executed when tne neutral button is pressed. Accepts a function. Can be omitted.
- * @param dismissAction The action executed when tne dialog is dismissed. Accepts a function. Can be omitted.
- * @param isCancelable Tells the dialog fragment if the dialog is dismissible or not. Accepts Boolean. Can be omitted.
- * @param isDeleteDialog Makes the positive button red when set to true. Accepts Boolean. Can be omitted.
- * @param customView Sets a custom view to the dialog fragment. Accepts Int. Can be omitted.
- *
  */
 fun Fragment.createDialog(
-    lambda: CwaDialogBuilder.() -> Unit
+    lambda: CwaDialogConfigBuilder.() -> Unit
 ) {
-    val cwaDialog = CwaDialogBuilder().apply(lambda).build()
-    val texts = cwaDialog.texts
-    val actions = cwaDialog.actions
-    val options = cwaDialog.options
+    val cwaDialog = CwaDialogConfigBuilder().apply(lambda).build()
+    val texts = cwaDialog.first
+    val actions = cwaDialog.second
+    val options = cwaDialog.third
     val positiveButtonAction = actions.positiveAction
     val negativeButtonAction = actions.negativeAction
     val neutralButtonAction = actions.neutralAction
-    val dismissAction = cwaDialog.actions.dismissAction
+    val dismissAction = actions.dismissAction
     val dialog = CwaDialogFragment.newInstance(texts, options)
     childFragmentManager.also {
         it.setFragmentResultListener(CwaDialogFragment.REQUEST_KEY, viewLifecycleOwner) { _, bundle ->

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialogHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialogHelper.kt
@@ -14,9 +14,9 @@ import androidx.fragment.app.Fragment
  *     negativeButton("Negative button text") { action { foo2() }
  *     neutralButton("Neutral button text") { action { foo3() }
  *     dismissAction { foo4() }
- *     isCancelable { false }
- *     isDeleteDialog { true }
- *     customView { R.id.dialog_view }
+ *     setCancelable(false)
+ *     setDeleteDialog(true)
+ *     customView(R.id.dialog_view)
  * }
  * ```
  */

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialogHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialogHelper.kt
@@ -8,8 +8,8 @@ import androidx.fragment.app.Fragment
  *
  * ```kotlin
  * createDialog {
- *     title { "Title example" }
- *     message { "Message example" }
+ *     title("Title example")
+ *     message("Message example")
  *     positiveButton("Positive button text") { foo1() }
  *     negativeButton("Negative button text") { foo2() }
  *     neutralButton("Neutral button text") { foo3() }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialogHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialogHelper.kt
@@ -1,0 +1,75 @@
+package de.rki.coronawarnapp.ui.dialog
+
+import androidx.fragment.app.Fragment
+
+/**
+ * Helper function that creates a CwaDialog and displays it.
+ * Usage:
+ *
+ * ```kotlin
+ * createDialog {
+ *     configureTexts {
+ *         title { "Title example" }
+ *         message { "Message example" }
+ *         positiveButton { "Positive button text" }
+ *         negativeButton { "Negative button text" }
+ *         neutralButton { "Neutral button text" }
+ *     }
+ *     configureActions {
+ *         positiveAction { foo1() }
+ *         negativeAction { foo2() }
+ *         neutralAction { foo3() }
+ *         dismissAction { foo4() }
+ *     }
+ *     configureOptions {
+ *         isCancelable { false }
+ *         isDeleteDialog { true }
+ *         customView { R.id.dialog_view }
+ *     }
+ * }
+ * ```
+ * @param title The text displayed for the dialog title. Accepts Int or String values. Can be omitted.
+ * @param message The text displayed for the dialog message. Accepts Int or String values. Can be omitted.
+ * @param positiveButton The text displayed for the dialog's positive button. Accepts Int or String. Can be omitted.
+ * @param negativeButton The text displayed for the dialog's negative button. Accepts Int or String. Can be omitted.
+ * @param neutralButton The text displayed for the dialog's neutral button. Accepts Int or String. Can be omitted.
+ * @param positiveAction The action executed when tne positive button is pressed. Accepts a function. Can be omitted.
+ * @param negativeAction The action executed when tne negative button is pressed. Accepts a function. Can be omitted.
+ * @param neutralAction The action executed when tne neutral button is pressed. Accepts a function. Can be omitted.
+ * @param dismissAction The action executed when tne dialog is dismissed. Accepts a function. Can be omitted.
+ * @param isCancelable Tells the dialog fragment if the dialog is dismissible or not. Accepts Boolean. Can be omitted.
+ * @param isDeleteDialog Makes the positive button red when set to true. Accepts Boolean. Can be omitted.
+ * @param customView Sets a custom view to the dialog fragment. Accepts Int. Can be omitted.
+ *
+ */
+fun Fragment.createDialog(
+    lambda: CwaDialogBuilder.() -> Unit
+) {
+    val cwaDialog = CwaDialogBuilder().apply(lambda).build()
+    val texts = cwaDialog.texts
+    val actions = cwaDialog.actions
+    val options = cwaDialog.options
+    val positiveButtonAction = actions.positiveAction
+    val negativeButtonAction = actions.negativeAction
+    val neutralButtonAction = actions.neutralAction
+    val dismissAction = cwaDialog.actions.dismissAction
+    val dialog = CwaDialogFragment.newInstance(texts, options)
+    childFragmentManager.also {
+        it.setFragmentResultListener(CwaDialogFragment.REQUEST_KEY, viewLifecycleOwner) { _, bundle ->
+            val action = bundle.getSerializable(
+                CwaDialogFragment.PARAM_DIALOG_ACTION
+            ) as? CwaDialogFragment.Action
+
+            requireNotNull(action) { "Action is null" }
+
+            when (action) {
+                CwaDialogFragment.Action.PositiveButtonClicked -> positiveButtonAction()
+                CwaDialogFragment.Action.NegativeButtonClicked -> negativeButtonAction()
+                CwaDialogFragment.Action.NeutralButtonClicked -> neutralButtonAction()
+                CwaDialogFragment.Action.Dismissed -> dismissAction()
+            }
+        }
+
+        dialog.show(it, CwaDialogFragment.TAG)
+    }
+}

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialogHelper.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/dialog/CwaDialogHelper.kt
@@ -21,9 +21,9 @@ import androidx.fragment.app.Fragment
  * ```
  */
 fun Fragment.createDialog(
-    lambda: CwaDialogConfigBuilder.() -> Unit
+    lambda: CwaDialogBuilder.() -> Unit
 ) {
-    val cwaDialog = CwaDialogConfigBuilder().apply(lambda).build()
+    val cwaDialog = CwaDialogBuilder().apply(lambda).build()
     val texts = cwaDialog.first
     val actions = cwaDialog.second
     val options = cwaDialog.third

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragment.kt
@@ -124,7 +124,7 @@ class HomeFragment : Fragment(R.layout.home_fragment_layout), AutoInject {
             title { "New implementation" }
             message { "Putting the app in background won't cause a crash with the dialog open" }
             positiveButton {
-                text { "Ok"}
+                text { "Ok" }
                 action { dummyDialog1() }
             }
             negativeButton {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragment.kt
@@ -21,6 +21,7 @@ import de.rki.coronawarnapp.coronatest.type.BaseCoronaTest
 import de.rki.coronawarnapp.databinding.HomeFragmentLayoutBinding
 import de.rki.coronawarnapp.reyclebin.ui.dialog.recycleCertificateDialog
 import de.rki.coronawarnapp.tag
+import de.rki.coronawarnapp.ui.dialog.createDialog
 import de.rki.coronawarnapp.ui.dialog.displayDialog
 import de.rki.coronawarnapp.util.CWADebug
 import de.rki.coronawarnapp.util.ExternalActionHelper.openUrl
@@ -118,6 +119,23 @@ class HomeFragment : Fragment(R.layout.home_fragment_layout), AutoInject {
             }
         }
 
+        // Usage example of the new new builder
+        createDialog {
+            configureTexts {
+                title { "New implementation" }
+                message { "Putting the app in background won't cause a crash with the dialog open" }
+                positiveButton { "Ok" }
+                negativeButton { R.id.button_done }
+            }
+            configureActions {
+                positiveAction { dummyDialog1() }
+            }
+            configureOptions {
+                isCancelable { false }
+                isDeleteDialog { true }
+            }
+        }
+
         viewModel.markTestBadgesAsSeen.observe2(this) {
             Timber.tag(TAG).d("markTestBadgesAsSeen=${it.size}")
         }
@@ -129,6 +147,18 @@ class HomeFragment : Fragment(R.layout.home_fragment_layout), AutoInject {
         viewModel.refreshTests()
         viewModel.initAppShortcuts()
         binding.container.sendAccessibilityEvent(AccessibilityEvent.TYPE_ANNOUNCEMENT)
+    }
+
+    private fun dummyDialog1() = displayDialog {
+        setTitle("Old implementation 1")
+        setMessage("This dialog would crash if you put the app in background")
+        setPositiveButton("Ok") { _, _ -> dummyDialog2() }
+    }
+
+    private fun dummyDialog2() = displayDialog {
+        setTitle("Old implementation 2")
+        setMessage("This dialog will not crash because there is no action set for the OK button")
+        setPositiveButton("Ok", null)
     }
 
     private fun menuIconWithText(drawable: Drawable?, title: CharSequence): CharSequence {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragment.kt
@@ -125,8 +125,8 @@ class HomeFragment : Fragment(R.layout.home_fragment_layout), AutoInject {
             message("Putting the app in background won't cause a crash with the dialog open")
             positiveButton("Ok") { dummyDialog1() }
             negativeButton(R.id.button_done)
-            isCancelable { false }
-            isDeleteDialog { true }
+            setCancelable(false)
+            setDeleteDialog(true)
         }
 
         viewModel.markTestBadgesAsSeen.observe2(this) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragment.kt
@@ -124,7 +124,7 @@ class HomeFragment : Fragment(R.layout.home_fragment_layout), AutoInject {
             title("New implementation")
             message("Putting the app in background won't cause a crash with the dialog open")
             positiveButton("Ok") { dummyDialog1() }
-            negativeButton(R.id.button_done)
+            negativeButton(R.string.errors_generic_button_negative)
             setCancelable(false)
             setDeleteDialog(true)
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragment.kt
@@ -121,15 +121,10 @@ class HomeFragment : Fragment(R.layout.home_fragment_layout), AutoInject {
 
         // Usage example of the new new builder
         createDialog {
-            title { "New implementation" }
-            message { "Putting the app in background won't cause a crash with the dialog open" }
-            positiveButton {
-                text { "Ok" }
-                action { dummyDialog1() }
-            }
-            negativeButton {
-                text { R.id.button_done }
-            }
+            title("New implementation")
+            message("Putting the app in background won't cause a crash with the dialog open")
+            positiveButton("Ok") { dummyDialog1() }
+            negativeButton(R.id.button_done)
             isCancelable { false }
             isDeleteDialog { true }
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragment.kt
@@ -121,19 +121,17 @@ class HomeFragment : Fragment(R.layout.home_fragment_layout), AutoInject {
 
         // Usage example of the new new builder
         createDialog {
-            configureTexts {
-                title { "New implementation" }
-                message { "Putting the app in background won't cause a crash with the dialog open" }
-                positiveButton { "Ok" }
-                negativeButton { R.id.button_done }
+            title { "New implementation" }
+            message { "Putting the app in background won't cause a crash with the dialog open" }
+            positiveButton {
+                text { "Ok"}
+                action { dummyDialog1() }
             }
-            configureActions {
-                positiveAction { dummyDialog1() }
+            negativeButton {
+                text { R.id.button_done }
             }
-            configureOptions {
-                isCancelable { false }
-                isDeleteDialog { true }
-            }
+            isCancelable { false }
+            isDeleteDialog { true }
         }
 
         viewModel.markTestBadgesAsSeen.observe2(this) {


### PR DESCRIPTION
![alwayshasbeen](https://user-images.githubusercontent.com/19816790/198032404-680fec77-c44d-49be-9b59-deee5c9d65b5.jpg)

Unfortunately extending the `MaterialAlertDialogBuilder` does not fully work because the callbacks for the dialog buttons that are passed to the `DialogFragment` as lambdas in a bundle will cause the app to crash when the app is put in background because lambdas cannot be serialized propperly through a bundle [¯\_(ツ)_/¯](https://stackoverflow.com/a/48870902)

This "new new builder" DSL passes only the texts and the options of a dialog through the bundle and the actions for the dialogs are communicated sepparetely. 

I've included a small example of the usage in the HomeFragment with a comparison against the "old new builder". You can modify and test it to see that it's not crashing anymore. Also, let me know if you would like to use this DSL in a different way. 

If I get the green light, I will clean the code and merge it into the main dialog refactoring PR #5656 and change the dialogs to use this builder.