### PR TITLE
Fix: Installation time (EXPOSUREAPP-14249)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/installTime/InstallTimeProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/installTime/InstallTimeProvider.kt
@@ -1,30 +1,25 @@
 package de.rki.coronawarnapp.installTime
 
-import android.content.Context
-import de.rki.coronawarnapp.util.di.AppContext
+import de.rki.coronawarnapp.util.TimeStamper
+import de.rki.coronawarnapp.util.di.AppInstallTime
 import de.rki.coronawarnapp.util.toLocalDateUserTz
 import java.time.Instant
 import java.time.LocalDate
-import java.time.Period
+import java.time.temporal.ChronoUnit
 
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class InstallTimeProvider @Inject constructor(
-    @AppContext private val context: Context
+    @AppInstallTime private val installTime: Instant,
+    private val timeStamper: TimeStamper
 ) {
-    private val dayOfInstallation: LocalDate = Instant.ofEpochMilli(
-        context
-            .packageManager
-            .getPackageInfo(context.packageName, 0)
-            .firstInstallTime
-    )
-        .toLocalDateUserTz()
+    private val dayOfInstallation = installTime.toLocalDateUserTz()
 
     val today: LocalDate
-        get() = Instant.now().toLocalDateUserTz()
+        get() = timeStamper.nowUTC.toLocalDateUserTz()
 
     val daysSinceInstallation: Int
-        get() = Period.between(dayOfInstallation, today).days
+        get() = ChronoUnit.DAYS.between(dayOfInstallation, today).toInt()
 }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/di/AndroidModule.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/util/di/AndroidModule.kt
@@ -40,9 +40,12 @@ class AndroidModule {
     @Provides
     @AppInstallTime
     fun installTime(@AppContext context: Context): Instant =
-        context.packageManager.getPackageInfo(context.packageName, 0).firstInstallTime.run {
-            Instant.ofEpochMilli(this)
-        }
+        context
+            .packageManager
+            .getPackageInfo(context.packageName, 0)
+            .firstInstallTime.run {
+                Instant.ofEpochMilli(this)
+            }
 
     @Suppress("DEPRECATION")
     @Provides

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/installTime/InstallTimeProviderTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/installTime/InstallTimeProviderTest.kt
@@ -1,0 +1,60 @@
+package de.rki.coronawarnapp.installTime
+
+import de.rki.coronawarnapp.util.TimeStamper
+import io.kotest.matchers.shouldBe
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.time.Instant
+
+internal class InstallTimeProviderTest : BaseTest() {
+    @MockK lateinit var timeStamper: TimeStamper
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this)
+    }
+
+    @Test
+    fun `Days since installation across years`() {
+        every { timeStamper.nowUTC } returns Instant.parse("2022-11-03T05:35:16.000Z")
+
+        InstallTimeProvider(
+            installTime = Instant.parse("2020-11-03T05:35:16.000Z"),
+            timeStamper = timeStamper
+        ).daysSinceInstallation shouldBe 730
+    }
+
+    @Test
+    fun `Days since installation across months`() {
+        every { timeStamper.nowUTC } returns Instant.parse("2020-12-03T05:35:16.000Z")
+
+        InstallTimeProvider(
+            installTime = Instant.parse("2020-11-03T05:35:16.000Z"),
+            timeStamper = timeStamper
+        ).daysSinceInstallation shouldBe 30
+    }
+
+    @Test
+    fun `Days since installation across days`() {
+        every { timeStamper.nowUTC } returns Instant.parse("2022-11-03T05:35:16.000Z")
+
+        InstallTimeProvider(
+            installTime = Instant.parse("2022-10-24T05:35:16.000Z"),
+            timeStamper = timeStamper
+        ).daysSinceInstallation shouldBe 10
+    }
+
+    @Test
+    fun `Days since installation same day`() {
+        every { timeStamper.nowUTC } returns Instant.parse("2022-11-03T18:35:16.000Z")
+
+        InstallTimeProvider(
+            installTime = Instant.parse("2022-11-03T05:35:16.000Z"),
+            timeStamper = timeStamper
+        ).daysSinceInstallation shouldBe 0
+    }
+}


### PR DESCRIPTION
-  Days since installation note  in the risk card should not show up in the app if it is installed more than 14 days
## Ticket
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14249

