### PR TITLE
Tapped notification because of increased risk does not open the Status Tab EXPOSUREAPP-14231

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/changedetection/CombinedRiskLevelChangeDetector.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/risk/changedetection/CombinedRiskLevelChangeDetector.kt
@@ -12,8 +12,10 @@ import de.rki.coronawarnapp.risk.RiskLevelSettings
 import de.rki.coronawarnapp.risk.RiskState
 import de.rki.coronawarnapp.risk.storage.RiskLevelStorage
 import de.rki.coronawarnapp.storage.TracingSettings
+import de.rki.coronawarnapp.ui.main.MainActivity
 import de.rki.coronawarnapp.util.coroutine.AppScope
 import de.rki.coronawarnapp.util.di.AppContext
+import de.rki.coronawarnapp.util.notifications.NavDeepLinkBuilderFactory
 import de.rki.coronawarnapp.util.notifications.setContentTextExpandable
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.catch
@@ -37,7 +39,8 @@ class CombinedRiskLevelChangeDetector @Inject constructor(
     private val notificationManagerCompat: NotificationManagerCompat,
     private val notificationHelper: GeneralNotifications,
     private val tracingSettings: TracingSettings,
-    private val riskCardDisplayInfo: RiskCardDisplayInfo
+    private val riskCardDisplayInfo: RiskCardDisplayInfo,
+    private val deepLinkBuilderFactory: NavDeepLinkBuilderFactory,
 ) : Initializer {
 
     override fun initialize() {
@@ -159,8 +162,15 @@ class CombinedRiskLevelChangeDetector @Inject constructor(
     private fun sendNotification() {
         Timber.d("Notification Permission = ${notificationManagerCompat.areNotificationsEnabled()}")
 
+        val pendingIntent = deepLinkBuilderFactory.create(context)
+            .setGraph(R.navigation.nav_graph)
+            .setComponentName(MainActivity::class.java)
+            .setDestination(R.id.mainFragment)
+            .createPendingIntent()
+
         val notification = notificationHelper.newBaseBuilder()
             .setContentTitle(context.getString(R.string.notification_headline))
+            .setContentIntent(pendingIntent)
             .setContentTextExpandable(context.getString(R.string.notification_body))
             .build()
 

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/changedetection/CombinedRiskLevelChangeDetectorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/changedetection/CombinedRiskLevelChangeDetectorTest.kt
@@ -80,6 +80,7 @@ class CombinedRiskLevelChangeDetectorTest : BaseTest() {
         every { builder.setContentTextExpandable(any()) } returns builder
         every { builder.setContentText(any()) } returns builder
         every { builder.setStyle(any()) } returns builder
+        every { builder.setContentIntent(any()) } returns builder
         every { notificationHelper.newBaseBuilder() } returns builder
         every { notificationHelper.sendNotification(any(), any()) } just Runs
         every { context.getString(any()) } returns ""

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/changedetection/CombinedRiskLevelChangeDetectorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/risk/changedetection/CombinedRiskLevelChangeDetectorTest.kt
@@ -21,6 +21,7 @@ import de.rki.coronawarnapp.risk.result.EwAggregatedRiskResult
 import de.rki.coronawarnapp.risk.storage.RiskLevelStorage
 import de.rki.coronawarnapp.storage.TracingSettings
 import de.rki.coronawarnapp.util.TimeStamper
+import de.rki.coronawarnapp.util.notifications.NavDeepLinkBuilderFactory
 import de.rki.coronawarnapp.util.notifications.setContentTextExpandable
 import de.rki.coronawarnapp.util.toLocalDateUtc
 import io.kotest.matchers.shouldBe
@@ -32,6 +33,7 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.just
+import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
@@ -59,6 +61,7 @@ class CombinedRiskLevelChangeDetectorTest : BaseTest() {
     @MockK lateinit var builder: NotificationCompat.Builder
     @MockK lateinit var notification: Notification
     @MockK lateinit var riskCardDisplayInfo: RiskCardDisplayInfo
+    @MockK lateinit var deepLinkBuilderFactory: NavDeepLinkBuilderFactory
 
     private val dataStore = FakeDataStore()
     private val tracingSettings = TracingSettings(dataStore)
@@ -81,6 +84,7 @@ class CombinedRiskLevelChangeDetectorTest : BaseTest() {
         every { notificationHelper.sendNotification(any(), any()) } just Runs
         every { context.getString(any()) } returns ""
         coEvery { riskCardDisplayInfo.shouldShowRiskCard(any()) } returns true
+        every { deepLinkBuilderFactory.create(any()) } returns mockk(relaxed = true)
     }
 
     @AfterEach
@@ -141,7 +145,8 @@ class CombinedRiskLevelChangeDetectorTest : BaseTest() {
         riskLevelSettings = riskLevelSettings,
         notificationHelper = notificationHelper,
         tracingSettings = tracingSettings,
-        riskCardDisplayInfo = riskCardDisplayInfo
+        riskCardDisplayInfo = riskCardDisplayInfo,
+        deepLinkBuilderFactory = deepLinkBuilderFactory
     )
 
     @Test


### PR DESCRIPTION
[EXPOSUREAPP-14231](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14231)

Tapping notification should open "Status" tab always 