### PR TITLE
Share symptoms back handling (EXPOSUREAPP-13918)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/submissiondone/SubmissionDoneFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/submissiondone/SubmissionDoneFragment.kt
@@ -14,7 +14,6 @@ import de.rki.coronawarnapp.ui.submission.viewmodel.SubmissionNavigationEvents
 import de.rki.coronawarnapp.util.ContextExtensions.getDrawableCompat
 import de.rki.coronawarnapp.util.di.AutoInject
 import de.rki.coronawarnapp.util.ui.observe2
-import de.rki.coronawarnapp.util.ui.popBackStack
 import de.rki.coronawarnapp.util.ui.viewBinding
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactoryProvider
 import de.rki.coronawarnapp.util.viewmodel.cwaViewModelsAssisted
@@ -59,13 +58,10 @@ class SubmissionDoneFragment : Fragment(R.layout.fragment_submission_done), Auto
         viewModel.routeToScreen.observe2(this) {
             when (it) {
                 SubmissionNavigationEvents.NavigateToMainActivity -> {
-                    if (args.comesFromDispatcherFragment) {
-                        findNavController().navigate(
-                            SubmissionDoneFragmentDirections.actionSubmissionDoneFragmentToMainFragment()
-                        )
-                    } else popBackStack()
+                    findNavController().navigate(
+                        SubmissionDoneFragmentDirections.actionSubmissionDoneFragmentToMainFragment()
+                    )
                 }
-
                 else -> Unit
             }
         }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/symptoms/calendar/SubmissionSymptomCalendarFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/symptoms/calendar/SubmissionSymptomCalendarFragment.kt
@@ -4,7 +4,6 @@ import android.content.res.ColorStateList
 import android.os.Bundle
 import android.view.View
 import android.widget.Button
-import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
@@ -16,7 +15,6 @@ import de.rki.coronawarnapp.util.di.AutoInject
 import de.rki.coronawarnapp.util.formatter.formatSymptomBackgroundButtonStyleByState
 import de.rki.coronawarnapp.util.formatter.formatSymptomButtonTextStyleByState
 import de.rki.coronawarnapp.util.ui.observe2
-import de.rki.coronawarnapp.util.ui.popBackStack
 import de.rki.coronawarnapp.util.ui.viewBinding
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactoryProvider
 import de.rki.coronawarnapp.util.viewmodel.cwaViewModelsAssisted
@@ -47,15 +45,6 @@ class SubmissionSymptomCalendarFragment :
         }
 
         viewModel.showCancelDialog.observe2(this) { submissionCancelDialog { viewModel.onCancelConfirmed() } }
-
-        viewModel.navigateBack.observe2(this) {
-            popBackStack()
-        }
-
-        val backCallback = object : OnBackPressedCallback(true) {
-            override fun handleOnBackPressed() = submissionCancelDialog { viewModel.onCancelConfirmed() }
-        }
-        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, backCallback)
 
         viewModel.routeToScreen.observe2(this) {
             findNavController().navigate(it)

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/symptoms/calendar/SubmissionSymptomCalendarViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/symptoms/calendar/SubmissionSymptomCalendarViewModel.kt
@@ -38,7 +38,6 @@ class SubmissionSymptomCalendarViewModel @AssistedInject constructor(
     val symptomStart = symptomStartInternal.asLiveData(context = dispatcherProvider.Default)
 
     val routeToScreen = SingleLiveEvent<NavDirections>()
-    val navigateBack = SingleLiveEvent<Unit>()
     val showCancelDialog = SingleLiveEvent<Unit>()
 
     fun onLastSevenDaysStart() {
@@ -100,11 +99,9 @@ class SubmissionSymptomCalendarViewModel @AssistedInject constructor(
         performSubmission {
             analyticsKeySubmissionCollector.reportSubmittedAfterCancel(testType)
         }
-        if (comesFromDispatcherFragment) {
-            routeToScreen.postValue(
-                SubmissionSymptomCalendarFragmentDirections.actionSubmissionSymptomCalendarFragmentToMainFragment()
-            )
-        } else navigateBack.postValue(Unit)
+        routeToScreen.postValue(
+            SubmissionSymptomCalendarFragmentDirections.actionSubmissionSymptomCalendarFragmentToMainFragment()
+        )
     }
 
     private fun performSubmission(onSubmitted: () -> Unit) {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/symptoms/introduction/SubmissionSymptomIntroductionFragment.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/symptoms/introduction/SubmissionSymptomIntroductionFragment.kt
@@ -4,7 +4,6 @@ import android.content.res.ColorStateList
 import android.os.Bundle
 import android.view.View
 import android.widget.Button
-import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
@@ -16,7 +15,6 @@ import de.rki.coronawarnapp.util.di.AutoInject
 import de.rki.coronawarnapp.util.formatter.formatSymptomBackgroundButtonStyleByState
 import de.rki.coronawarnapp.util.formatter.formatSymptomButtonTextStyleByState
 import de.rki.coronawarnapp.util.ui.observe2
-import de.rki.coronawarnapp.util.ui.popBackStack
 import de.rki.coronawarnapp.util.ui.viewBinding
 import de.rki.coronawarnapp.util.viewmodel.CWAViewModelFactoryProvider
 import de.rki.coronawarnapp.util.viewmodel.cwaViewModelsAssisted
@@ -51,15 +49,6 @@ class SubmissionSymptomIntroductionFragment :
         viewModel.navigation.observe2(this) {
             findNavController().navigate(it)
         }
-
-        viewModel.navigateBack.observe2(this) {
-            popBackStack()
-        }
-
-        val backCallback = object : OnBackPressedCallback(true) {
-            override fun handleOnBackPressed() = submissionCancelDialog { viewModel.onCancelConfirmed() }
-        }
-        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, backCallback)
 
         viewModel.showCancelDialog.observe2(this) { submissionCancelDialog { viewModel.onCancelConfirmed() } }
 

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/symptoms/introduction/SubmissionSymptomIntroductionViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/submission/symptoms/introduction/SubmissionSymptomIntroductionViewModel.kt
@@ -36,8 +36,6 @@ class SubmissionSymptomIntroductionViewModel @AssistedInject constructor(
 
     val navigation = SingleLiveEvent<NavDirections>()
 
-    val navigateBack = SingleLiveEvent<Unit>()
-
     val showCancelDialog = SingleLiveEvent<Unit>()
 
     fun onNextClicked() {
@@ -108,12 +106,10 @@ class SubmissionSymptomIntroductionViewModel @AssistedInject constructor(
     fun onCancelConfirmed() {
         Timber.d("Symptom submission was cancelled.")
         performSubmission()
-        if (comesFromDispatcherFragment) {
-            navigation.postValue(
-                SubmissionSymptomIntroductionFragmentDirections
-                    .actionSubmissionSymptomIntroductionFragmentToMainFragment()
-            )
-        } else navigateBack.postValue(Unit)
+        navigation.postValue(
+            SubmissionSymptomIntroductionFragmentDirections
+                .actionSubmissionSymptomIntroductionFragmentToMainFragment()
+        )
     }
 
     private fun performSubmission() {

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_done.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_done.xml
@@ -10,7 +10,7 @@
         android:background="@color/colorSurface"
         android:contentDescription="@string/submission_done_title"
         android:fillViewport="true"
-        tools:context=".ui.submission.fragment.SubmissionDoneFragment">
+        tools:context=".ui.submission.submissiondone.SubmissionDoneFragment">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_symptom_calendar.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_symptom_calendar.xml
@@ -11,7 +11,8 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/colorSurface"
-        android:fillViewport="true">
+        android:fillViewport="true"
+        tools:context=".ui.submission.symptoms.calendar.SubmissionSymptomCalendarFragment">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
@@ -40,8 +41,7 @@
                 android:layout_marginEnd="@dimen/spacing_normal"
                 android:fillViewport="true"
                 android:focusable="true"
-                android:orientation="vertical"
-                tools:context=".ui.submission.symptoms.calendar.SubmissionSymptomCalendarFragment">
+                android:orientation="vertical">
 
                 <TextView
                     android:id="@+id/submission_symptom_calendar_headline"

--- a/Corona-Warn-App/src/main/res/layout/fragment_submission_symptom_intro.xml
+++ b/Corona-Warn-App/src/main/res/layout/fragment_submission_symptom_intro.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/colorSurface"
-        android:fillViewport="true">
+        android:fillViewport="true"
+        tools:context=".ui.submission.symptoms.introduction.SubmissionSymptomIntroductionFragment">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"

--- a/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
+++ b/Corona-Warn-App/src/main/res/navigation/nav_graph.xml
@@ -338,8 +338,7 @@
         <action
             android:id="@+id/action_submissionResultReadyFragment_to_submissionSymptomIntroductionFragment"
             app:destination="@id/submissionSymptomIntroductionFragment"
-            app:popUpTo="@id/submissionResultReadyFragment"
-            app:popUpToInclusive="true" />
+            app:popUpTo="@id/submissionResultReadyFragment" />
     </fragment>
     <fragment
         android:id="@+id/submissionContactFragment"
@@ -365,8 +364,7 @@
         <action
             android:id="@+id/action_submissionSymptomIntroductionFragment_to_submissionSymptomCalendarFragment"
             app:destination="@id/submissionSymptomCalendarFragment"
-            app:popUpTo="@id/submissionSymptomIntroductionFragment"
-            app:popUpToInclusive="true" />
+            app:popUpTo="@id/submissionSymptomIntroductionFragment" />
         <action
             android:id="@+id/action_submissionSymptomIntroductionFragment_to_mainFragment"
             app:destination="@id/status_nav_graph"
@@ -375,8 +373,7 @@
         <action
             android:id="@+id/action_submissionSymptomIntroductionFragment_to_submissionDoneFragment"
             app:destination="@id/submissionDoneFragment"
-            app:popUpTo="@id/submissionSymptomIntroductionFragment"
-            app:popUpToInclusive="true" />
+            app:popUpTo="@id/submissionSymptomIntroductionFragment" />
     </fragment>
     <fragment
         android:id="@+id/submissionSymptomCalendarFragment"
@@ -395,7 +392,8 @@
             app:argType="boolean" />
         <action
             android:id="@+id/action_submissionCalendarFragment_to_submissionSymptomIntroductionFragment"
-            app:destination="@id/submissionSymptomIntroductionFragment" />
+            app:destination="@id/submissionSymptomIntroductionFragment"
+            app:popUpTo="@id/submissionSymptomCalendarFragment"/>
         <action
             android:id="@+id/action_submissionSymptomCalendarFragment_to_submissionResultPositiveOtherWarningFragment"
             app:destination="@id/submissionResultPositiveOtherWarningNoConsentFragment" />
@@ -407,8 +405,7 @@
         <action
             android:id="@+id/action_submissionSymptomCalendarFragment_to_submissionDoneFragment"
             app:destination="@id/submissionDoneFragment"
-            app:popUpTo="@id/submissionSymptomCalendarFragment"
-            app:popUpToInclusive="true" />
+            app:popUpTo="@id/submissionSymptomCalendarFragment" />
     </fragment>
     <fragment
         android:id="@+id/submissionConsentFragment"
@@ -459,8 +456,7 @@
         <action
             android:id="@+id/action_submissionTestResultConsentGivenFragment_to_submissionSymptomIntroductionFragment"
             app:destination="@id/submissionSymptomIntroductionFragment"
-            app:popUpTo="@id/submissionTestResultConsentGivenFragment"
-            app:popUpToInclusive="true" />
+            app:popUpTo="@id/submissionTestResultConsentGivenFragment" />
         <action
             android:id="@+id/action_submissionTestResultConsentGivenFragment_to_homeFragment"
             app:destination="@id/status_nav_graph"


### PR DESCRIPTION
PR addressing [comment](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-13918?focusedCommentId=1388766&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1388766)

On the sharing symptoms screens it should be possible to navigate back one screen

Testing:
Register a positive rat or pcr test with and without a checkin. On the share symptoms screens its possible now to navigate back or to cancel the submission flow and go back to main screen when pressing the cancel button.
