### PR TITLE
Missing presence tracing (EXPOSUREAPP-14413)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModel.kt
@@ -144,8 +144,7 @@ class CheckInsConsentViewModel @AssistedInject constructor(
 
     private fun initialSet(): Set<Long> = savedState.get(SET_KEY) ?: emptySet()
 
-    private fun resetPreviousSubmissionConsents() = launch {
-        try {
+    private suspend fun resetPreviousSubmissionConsents() = try {
             Timber.d("Trying to reset submission consents")
             checkInRepository.apply {
                 val ids = completedCheckIns.first().filter { it.hasSubmissionConsent }.map { it.id }
@@ -156,7 +155,6 @@ class CheckInsConsentViewModel @AssistedInject constructor(
         } catch (error: Exception) {
             Timber.e(error, "Failed to reset SubmissionConsents")
         }
-    }
 
     @AssistedFactory
     interface Factory : CWAViewModelFactory<CheckInsConsentViewModel> {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/presencetracing/attendee/checkins/consent/CheckInsConsentViewModel.kt
@@ -145,16 +145,16 @@ class CheckInsConsentViewModel @AssistedInject constructor(
     private fun initialSet(): Set<Long> = savedState.get(SET_KEY) ?: emptySet()
 
     private suspend fun resetPreviousSubmissionConsents() = try {
-            Timber.d("Trying to reset submission consents")
-            checkInRepository.apply {
-                val ids = completedCheckIns.first().filter { it.hasSubmissionConsent }.map { it.id }
-                updateSubmissionConsents(ids, consent = false)
-            }
-
-            Timber.d("Resetting submission consents was successful")
-        } catch (error: Exception) {
-            Timber.e(error, "Failed to reset SubmissionConsents")
+        Timber.d("Trying to reset submission consents")
+        checkInRepository.apply {
+            val ids = completedCheckIns.first().filter { it.hasSubmissionConsent }.map { it.id }
+            updateSubmissionConsents(ids, consent = false)
         }
+
+        Timber.d("Resetting submission consents was successful")
+    } catch (error: Exception) {
+        Timber.e(error, "Failed to reset SubmissionConsents")
+    }
 
     @AssistedFactory
     interface Factory : CWAViewModelFactory<CheckInsConsentViewModel> {


### PR DESCRIPTION
[Ticket](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14413)

Problem:
Current shareSelectedCheckIns() fun in CheckInsConsentViewModel produced following log:

2022-12-13T14:12:17.022Z D/CheckInsConsentViewModel: SelectedCheckIns=[2]
2022-12-13T14:12:19.900Z D/CheckInsConsentViewModel$shareSelectedCheckIns: Navigate to shareSelectedCheckIns
2022-12-13T14:12:19.900Z D/CheckInRepository: updateSubmissionConsents(checkInIds=[2], consent=true)
2022-12-13T14:12:19.901Z D/CheckInsConsentViewModel$resetPreviousSubmissionConsents: Trying to reset submission consents
2022-12-13T14:12:19.902Z D/CheckInsConsentViewModel$shareSelectedCheckIns: Navigate to SubmissionTestResultConsentGivenFragment
2022-12-13T14:12:19.909Z D/CheckInRepository: updateSubmissionConsents(checkInIds=[2], consent=false)

It seems like first launched resetPreviousSubmissionConsents() in this case is processed later in the task queue than updateSubmissionConsents. This sets the consent to true and then to false, resulting to behaviour that the checkin is not sent on submission: (see empty checkins)

2022-12-13T14:12:31.548Z D/SubmissionTask: Submitting SubmissionData(registrationToken=########-####-####-####-########39db, authCode=########-####-####-####-########92ab, temporaryExposureKeys=[# de.rki.coronawarnapp.server.protocols.external.exposurenotification.TemporaryExposureKeyExportOuterClass$TemporaryExposureKey@69cf4e69], consentToFederation=true, visitedCountries=[DE, IE, LV, HR, SI], unencryptedCheckIns=[], encryptedCheckIns=[], submissionType=SUBMISSION_TYPE_PCR_TEST)

Solution:
Changing resetPreviousSubmissionConsents() to a suspending function should ensure that checkInRepository.updateSubmissionConsents is not called until resetPreviousSubmissionConsents finished