### PR TITLE
Fix: Resetting checkins race conditions (EXPOSUREAPP-14556)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/srs/ui/symptoms/calendar/SrsSymptomsCalendarViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/srs/ui/symptoms/calendar/SrsSymptomsCalendarViewModel.kt
@@ -118,7 +118,7 @@ class SrsSymptomsCalendarViewModel @AssistedInject constructor(
         symptomStartInternal.value = startOf
     }
 
-    private fun resetPreviousSubmissionConsents() = launch {
+    private suspend fun resetPreviousSubmissionConsents() {
         try {
             Timber.d("Trying to reset submission consents")
             checkInRepository.apply {

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/srs/ui/symptoms/intro/SrsSymptomsIntroductionViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/srs/ui/symptoms/intro/SrsSymptomsIntroductionViewModel.kt
@@ -110,7 +110,7 @@ class SrsSymptomsIntroductionViewModel @AssistedInject constructor(
     fun onTruncatedDialogClick() =
         events.postValue(SrsSymptomsIntroductionNavigation.GoToThankYouScreen)
 
-    private fun resetPreviousSubmissionConsents() = launch {
+    private suspend fun resetPreviousSubmissionConsents() {
         try {
             Timber.d("Trying to reset submission consents")
             checkInRepository.apply {


### PR DESCRIPTION
- Make sure resetting old checkins consents happens before submission. smells like https://github.com/corona-warn-app/cwa-app-android/pull/5773

[Ticket](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14556)