### PR TITLE
Trigger calc on configuration loading (EXPOSUREAPP-14631)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/rampdown/RampDownDataProvider.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/rampdown/RampDownDataProvider.kt
@@ -1,32 +1,38 @@
 package de.rki.coronawarnapp.ui.main.home.rampdown
 
+import dagger.Reusable
+import de.rki.coronawarnapp.ccl.configuration.storage.CclConfigurationRepository
 import de.rki.coronawarnapp.ccl.rampdown.calculation.RampDownCalculation
 import de.rki.coronawarnapp.ccl.ui.text.CclTextFormatter
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import timber.log.Timber
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
+@Reusable
 class RampDownDataProvider @Inject constructor(
     format: CclTextFormatter,
-    rampDownCalculation: RampDownCalculation
+    rampDownCalculation: RampDownCalculation,
+    cclConfigurationRepository: CclConfigurationRepository,
 ) {
 
-    val rampDownNotice = flow {
-        val notice = try {
-            val rampDownOutput = rampDownCalculation.getStatusTabNotice()
-            RampDownNotice(
-                visible = rampDownOutput.visible,
-                title = format(rampDownOutput.titleText),
-                subtitle = format(rampDownOutput.subtitleText),
-                description = format(rampDownOutput.longText),
-                faqUrl = format(rampDownOutput.faqAnchor),
-            )
-        } catch (e: Exception) {
-            Timber.d(e, "RampDown failed")
-            null
+    val rampDownNotice = cclConfigurationRepository
+        .cclConfigurations
+        .distinctUntilChanged()
+        .map {
+            Timber.d("calculating rampDownNotice ...")
+            try {
+                val rampDownOutput = rampDownCalculation.getStatusTabNotice()
+                RampDownNotice(
+                    visible = rampDownOutput.visible,
+                    title = format(rampDownOutput.titleText),
+                    subtitle = format(rampDownOutput.subtitleText),
+                    description = format(rampDownOutput.longText),
+                    faqUrl = format(rampDownOutput.faqAnchor),
+                )
+            } catch (e: Exception) {
+                Timber.d(e, "RampDown failed")
+                null
+            }
         }
-        emit(notice)
-    }
 }

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/main/home/rampdown/RampDownDataProviderTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/ui/main/home/rampdown/RampDownDataProviderTest.kt
@@ -1,5 +1,6 @@
 package de.rki.coronawarnapp.ui.main.home.rampdown
 
+import de.rki.coronawarnapp.ccl.configuration.storage.CclConfigurationRepository
 import de.rki.coronawarnapp.ccl.rampdown.calculation.RampDownCalculation
 import de.rki.coronawarnapp.ccl.rampdown.model.RampDownOutput
 import de.rki.coronawarnapp.ccl.ui.text.CclTextFormatter
@@ -7,9 +8,11 @@ import de.rki.coronawarnapp.util.serialization.SerializationModule
 import io.kotest.matchers.shouldBe
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 
 import org.junit.jupiter.api.BeforeEach
@@ -20,20 +23,21 @@ import testhelpers.BaseTest
 internal class RampDownDataProviderTest : BaseTest() {
 
     @MockK lateinit var rampDownCalculation: RampDownCalculation
+    @MockK lateinit var cclConfigurationRepository: CclConfigurationRepository
 
     @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this)
 
-        coEvery {
-            rampDownCalculation.getStatusTabNotice(any())
-        } returns RampDownOutput(
+        coEvery { rampDownCalculation.getStatusTabNotice(any()) } returns RampDownOutput(
             visible = false,
             titleText = null,
             subtitleText = null,
             faqAnchor = null,
             longText = null
         )
+
+        every { cclConfigurationRepository.cclConfigurations } returns flowOf(emptyList())
     }
 
     @Test
@@ -43,7 +47,8 @@ internal class RampDownDataProviderTest : BaseTest() {
                 cclJsonFunctions = mockk(),
                 mapper = SerializationModule.jacksonBaseMapper
             ),
-            rampDownCalculation = rampDownCalculation
+            rampDownCalculation = rampDownCalculation,
+            cclConfigurationRepository = cclConfigurationRepository
         ).rampDownNotice.first() shouldBe RampDownNotice(
             visible = false,
             title = "",
@@ -64,7 +69,8 @@ internal class RampDownDataProviderTest : BaseTest() {
                 cclJsonFunctions = mockk(),
                 mapper = SerializationModule.jacksonBaseMapper
             ),
-            rampDownCalculation = rampDownCalculation
+            rampDownCalculation = rampDownCalculation,
+            cclConfigurationRepository = cclConfigurationRepository
         ).rampDownNotice.first() shouldBe null
     }
 }


### PR DESCRIPTION
- Sometimes calculation was triggered before loading CCL leading to not showing the EOL card.
- Now calculation is triggered on CCL updates to make sure subsequent loads will recover

```kotlin
2023-01-25T11:44:49.448Z D/RampDownDataProvider$rampDownNotice: RampDown failed
kotlin.UninitializedPropertyAccessException: lateinit property jsonFunctions has not been initialized
	at de.rki.coronawarnapp.ccl.dccwalletinfo.calculation.CclJsonFunctions$evaluateFunction$2.invokeSuspend(CclJsonFunctions.kt:94)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:9)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:107)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:79)

kotlin.UninitializedPropertyAccessException: lateinit property jsonFunctions has not been initialized
	at de.rki.coronawarnapp.ccl.dccwalletinfo.calculation.CclJsonFunctions$evaluateFunction$2.invokeSuspend(CclJsonFunctions.kt:94)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:9)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:107)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:79)
```

## 
[Ticket](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14631)