### PR TITLE
Error report censoring (EXPOSUREAPP-14698)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/qrcode/rapid/RapidQrCodeExtractor.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/coronatest/qrcode/rapid/RapidQrCodeExtractor.kt
@@ -25,12 +25,14 @@ abstract class RapidQrCodeExtractor : QrCodeExtractor<CoronaTestQRCode> {
         Timber.tag(loggingTag).v("extract(rawString=%s)", rawString)
         val payload = CleanPayload(extractData(rawString))
 
-        RapidQrCodeCensor.dataToCensor = RapidQrCodeCensor.CensorData(
-            rawString = rawString,
-            hash = payload.hash,
-            firstName = payload.firstName,
-            lastName = payload.lastName,
-            dateOfBirth = payload.dateOfBirth
+        RapidQrCodeCensor.dataToCensor.add(
+            RapidQrCodeCensor.CensorData(
+                rawString = rawString,
+                hash = payload.hash,
+                firstName = payload.firstName,
+                lastName = payload.lastName,
+                dateOfBirth = payload.dateOfBirth
+            )
         )
 
         payload.requireValidData()

--- a/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/RapidQrCodeCensorTest.kt
+++ b/Corona-Warn-App/src/test/java/de/rki/coronawarnapp/bugreporting/censors/RapidQrCodeCensorTest.kt
@@ -22,19 +22,21 @@ internal class RapidQrCodeCensorTest {
 
     @AfterEach
     fun teardown() {
-        RapidQrCodeCensor.dataToCensor = null
+        RapidQrCodeCensor.dataToCensor.clear()
     }
 
     private fun createInstance() = RapidQrCodeCensor()
 
     @Test
     fun `checkLog() should return censored LogLine`() = runTest {
-        RapidQrCodeCensor.dataToCensor = RapidQrCodeCensor.CensorData(
-            rawString = testRawString,
-            hash = testHash,
-            firstName = "Milhouse",
-            lastName = "Van Houten",
-            dateOfBirth = LocalDate.parse("1980-07-01")
+        RapidQrCodeCensor.dataToCensor.add(
+            RapidQrCodeCensor.CensorData(
+                rawString = testRawString,
+                hash = testHash,
+                firstName = "Milhouse",
+                lastName = "Van Houten",
+                dateOfBirth = LocalDate.parse("1980-07-01")
+            )
         )
 
         val censor = createInstance()
@@ -57,12 +59,14 @@ internal class RapidQrCodeCensorTest {
 
     @Test
     fun `checkLog() should return null if nothing should be censored`() = runTest {
-        RapidQrCodeCensor.dataToCensor = RapidQrCodeCensor.CensorData(
-            rawString = testRawString,
-            hash = testHash.replace("8", "9"),
-            firstName = null,
-            lastName = null,
-            dateOfBirth = null
+        RapidQrCodeCensor.dataToCensor.add(
+            RapidQrCodeCensor.CensorData(
+                rawString = testRawString,
+                hash = testHash.replace("8", "9"),
+                firstName = null,
+                lastName = null,
+                dateOfBirth = null
+            )
         )
 
         val censor = createInstance()


### PR DESCRIPTION
[Ticket](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14698)

This should fix a race condition, where names from all scanned test in a series are now added immediately to censoring.
Before, the last added name data would override the one before, so when logging recently added certificates with same names from a formerly overridden test censor data, the names where not censored. 

Now also uppercase names are added to censoring to also feature personGroupKey censoring 