### PR TITLE
Fix: Device time check dialog after EOL (EXPOSUREAPP-14862)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragmentViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/main/home/HomeFragmentViewModel.kt
@@ -173,7 +173,11 @@ class HomeFragmentViewModel @AssistedInject constructor(
                 if (isDeviceTimeCorrect) {
                     singleLiveEvent.postValue(false)
                     wasDeviceTimeDialogShown = false
-                } else if (!wasDeviceTimeDialogShown && !cwaSettings.wasDeviceTimeIncorrectAcknowledged.first()) {
+                } else if (
+                    !wasDeviceTimeDialogShown &&
+                    !cwaSettings.wasDeviceTimeIncorrectAcknowledged.first() &&
+                    !appEol.isEol.first()
+                ) {
                     singleLiveEvent.postValue(true)
                     wasDeviceTimeDialogShown = true
                 }


### PR DESCRIPTION
Disable device time check dialog after EOL

## Ticket
https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14862