### PR TITLE
Don't show delta interop after eol (EXPOSUREAPP-15008)

### DIFF
--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingLoadingViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingLoadingViewModel.kt
@@ -3,6 +3,7 @@ package de.rki.coronawarnapp.ui.onboarding
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import de.rki.coronawarnapp.environment.BuildConfigWrap
+import de.rki.coronawarnapp.eol.AppEol
 import de.rki.coronawarnapp.main.CWASettings
 import de.rki.coronawarnapp.storage.OnboardingSettings
 import de.rki.coronawarnapp.util.ui.SingleLiveEvent
@@ -12,7 +13,8 @@ import kotlinx.coroutines.flow.first
 
 class OnboardingLoadingViewModel @AssistedInject constructor(
     private val cwaSettings: CWASettings,
-    private val onboardingSettings: OnboardingSettings
+    private val onboardingSettings: OnboardingSettings,
+    private val appEol: AppEol
 ) : CWAViewModel() {
 
     val navigationEvents = SingleLiveEvent<OnboardingFragmentEvents>()
@@ -22,12 +24,17 @@ class OnboardingLoadingViewModel @AssistedInject constructor(
             !onboardingSettings.isOnboarded() -> {
                 navigationEvents.postValue(OnboardingFragmentEvents.ShowOnboarding)
             }
+
             !cwaSettings.wasInteroperabilityShownAtLeastOnce.first() -> {
-                navigationEvents.postValue(OnboardingFragmentEvents.ShowInteropDeltaOnboarding)
+                if (!appEol.isEol.first()) {
+                    navigationEvents.postValue(OnboardingFragmentEvents.ShowInteropDeltaOnboarding)
+                }
             }
+
             cwaSettings.lastChangelogVersion.first() / 10000 < BuildConfigWrap.VERSION_CODE / 10000 -> {
                 navigationEvents.postValue(OnboardingFragmentEvents.ShowNewReleaseFragment)
             }
+
             else -> {
                 navigationEvents.postValue(OnboardingFragmentEvents.OnboardingDone)
             }

--- a/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingLoadingViewModel.kt
+++ b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/ui/onboarding/OnboardingLoadingViewModel.kt
@@ -3,7 +3,6 @@ package de.rki.coronawarnapp.ui.onboarding
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import de.rki.coronawarnapp.environment.BuildConfigWrap
-import de.rki.coronawarnapp.eol.AppEol
 import de.rki.coronawarnapp.main.CWASettings
 import de.rki.coronawarnapp.storage.OnboardingSettings
 import de.rki.coronawarnapp.util.ui.SingleLiveEvent
@@ -13,8 +12,7 @@ import kotlinx.coroutines.flow.first
 
 class OnboardingLoadingViewModel @AssistedInject constructor(
     private val cwaSettings: CWASettings,
-    private val onboardingSettings: OnboardingSettings,
-    private val appEol: AppEol
+    private val onboardingSettings: OnboardingSettings
 ) : CWAViewModel() {
 
     val navigationEvents = SingleLiveEvent<OnboardingFragmentEvents>()
@@ -23,12 +21,6 @@ class OnboardingLoadingViewModel @AssistedInject constructor(
         when {
             !onboardingSettings.isOnboarded() -> {
                 navigationEvents.postValue(OnboardingFragmentEvents.ShowOnboarding)
-            }
-
-            !cwaSettings.wasInteroperabilityShownAtLeastOnce.first() -> {
-                if (!appEol.isEol.first()) {
-                    navigationEvents.postValue(OnboardingFragmentEvents.ShowInteropDeltaOnboarding)
-                }
             }
 
             cwaSettings.lastChangelogVersion.first() / 10000 < BuildConfigWrap.VERSION_CODE / 10000 -> {


### PR DESCRIPTION
[Ticket.](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-15008)

When the app was reset and onboarding was done again after eol, the app would show the delta interoperability screen the next time it was opened.